### PR TITLE
Google Assistant Local SDK

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -110,14 +110,17 @@ class CloudClient(Interface):
         if not self.cloud.is_logged_in:
             return
 
-        if self.alexa_config.should_report_state:
+        if self.alexa_config.enabled and self.alexa_config.should_report_state:
             try:
                 await self.alexa_config.async_enable_proactive_mode()
             except alexa_errors.NoTokenAvailable:
                 pass
 
-        if self.google_config.should_report_state:
-            self.google_config.async_enable_report_state()
+        if self.google_config.enabled:
+            self.google_config.async_enable_local_sdk()
+
+            if self.google_config.should_report_state:
+                self.google_config.async_enable_report_state()
 
     async def cleanups(self) -> None:
         """Cleanup some stuff after logout."""

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -16,6 +16,7 @@ PREF_OVERRIDE_NAME = "override_name"
 PREF_DISABLE_2FA = "disable_2fa"
 PREF_ALIASES = "aliases"
 PREF_SHOULD_EXPOSE = "should_expose"
+PREF_GOOGLE_LOCAL_WEBHOOK_ID = "google_local_webhook_id"
 DEFAULT_SHOULD_EXPOSE = True
 DEFAULT_DISABLE_2FA = False
 DEFAULT_ALEXA_REPORT_STATE = False

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.util.decorator import Registry
 
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, __version__
 
 from .const import (
     ERR_PROTOCOL_ERROR,
@@ -24,9 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_handle_message(hass, config, user_id, message):
     """Handle incoming API messages."""
-    request_id: str = message.get("requestId")
-
-    data = RequestData(config, user_id, request_id)
+    data = RequestData(config, user_id, message["requestId"], message.get("devices"))
 
     response = await _process(hass, data, message)
 
@@ -67,6 +65,7 @@ async def _process(hass, data, message):
 
     if result is None:
         return None
+
     return {"requestId": data.request_id, "payload": result}
 
 
@@ -74,7 +73,7 @@ async def _process(hass, data, message):
 async def async_devices_sync(hass, data, payload):
     """Handle action.devices.SYNC request.
 
-    https://developers.google.com/actions/smarthome/create-app#actiondevicessync
+    https://developers.google.com/assistant/smarthome/develop/process-intents#SYNC
     """
     hass.bus.async_fire(
         EVENT_SYNC_RECEIVED, {"request_id": data.request_id}, context=data.context
@@ -84,7 +83,7 @@ async def async_devices_sync(hass, data, payload):
         *(
             entity.sync_serialize()
             for entity in async_get_entities(hass, data.config)
-            if data.config.should_expose(entity.state)
+            if entity.should_expose()
         )
     )
 
@@ -100,7 +99,7 @@ async def async_devices_sync(hass, data, payload):
 async def async_devices_query(hass, data, payload):
     """Handle action.devices.QUERY request.
 
-    https://developers.google.com/actions/smarthome/create-app#actiondevicesquery
+    https://developers.google.com/assistant/smarthome/develop/process-intents#QUERY
     """
     devices = {}
     for device in payload.get("devices", []):
@@ -128,7 +127,7 @@ async def async_devices_query(hass, data, payload):
 async def handle_devices_execute(hass, data, payload):
     """Handle action.devices.EXECUTE request.
 
-    https://developers.google.com/actions/smarthome/create-app#actiondevicesexecute
+    https://developers.google.com/assistant/smarthome/develop/process-intents#EXECUTE
     """
     entities = {}
     results = {}
@@ -196,10 +195,48 @@ async def handle_devices_execute(hass, data, payload):
 async def async_devices_disconnect(hass, data: RequestData, payload):
     """Handle action.devices.DISCONNECT request.
 
-    https://developers.google.com/actions/smarthome/create#actiondevicesdisconnect
+    https://developers.google.com/assistant/smarthome/develop/process-intents#DISCONNECT
     """
     await data.config.async_deactivate_report_state()
     return None
+
+
+@HANDLERS.register("action.devices.IDENTIFY")
+async def async_devices_identify(hass, data: RequestData, payload):
+    """Handle action.devices.IDENTIFY request.
+
+    https://developers.google.com/assistant/smarthome/develop/local#implement_the_identify_handler
+    """
+    return {
+        "device": {
+            "id": data.config.agent_user_id,
+            "isLocalOnly": True,
+            "isProxy": True,
+            "deviceInfo": {
+                "hwVersion": "UNKNOWN_HW_VERSION",
+                "manufacturer": "Home Assistant",
+                "model": "Home Assistant",
+                "swVersion": __version__,
+            },
+        }
+    }
+
+
+@HANDLERS.register("action.devices.REACHABLE_DEVICES")
+async def async_devices_reachable(hass, data: RequestData, payload):
+    """Handle action.devices.REACHABLE_DEVICES request.
+
+    https://developers.google.com/actions/smarthome/create#actiondevicesdisconnect
+    """
+    google_ids = set(dev["id"] for dev in (data.devices or []))
+
+    return {
+        "devices": [
+            entity.reachable_device_serialize()
+            for entity in async_get_entities(hass, data.config)
+            if entity.entity_id in google_ids and entity.should_expose()
+        ]
+    }
 
 
 def turned_off_response(message):

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -128,6 +128,7 @@ class ApiConfig:
         """Initialize a new API config object."""
         self.host = host
         self.port = port
+        self.use_ssl = use_ssl
 
         host = host.rstrip("/")
         if host.startswith(("http://", "https://")):

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -1,7 +1,7 @@
 """Webhooks for Home Assistant."""
 import logging
 
-from aiohttp.web import Response
+from aiohttp.web import Response, Request
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -98,9 +98,11 @@ class WebhookView(HomeAssistantView):
     url = URL_WEBHOOK_PATH
     name = "api:webhook"
     requires_auth = False
+    cors_allowed = True
 
-    async def _handle(self, request, webhook_id):
+    async def _handle(self, request: Request, webhook_id):
         """Handle webhook call."""
+        _LOGGER.debug("Handling webhook %s payload for %s", request.method, webhook_id)
         hass = request.app["hass"]
         return await async_handle_webhook(hass, webhook_id, request)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -230,7 +230,6 @@ def get_test_instance_port():
     return _TEST_INSTANCE_PORT
 
 
-@ha.callback
 def async_mock_service(hass, domain, service, schema=None):
     """Set up a fake service & return a calls log list to this service."""
     calls = []

--- a/tests/components/cloud/__init__.py
+++ b/tests/components/cloud/__init__.py
@@ -25,4 +25,4 @@ def mock_cloud_prefs(hass, prefs={}):
     }
     prefs_to_set.update(prefs)
     hass.data[cloud.DOMAIN].client._prefs._prefs = prefs_to_set
-    return prefs_to_set
+    return hass.data[cloud.DOMAIN].client._prefs

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -61,7 +61,7 @@ async def test_handler_alexa(hass):
 
 async def test_handler_alexa_disabled(hass, mock_cloud_fixture):
     """Test handler Alexa when user has disabled it."""
-    mock_cloud_fixture[PREF_ENABLE_ALEXA] = False
+    mock_cloud_fixture._prefs[PREF_ENABLE_ALEXA] = False
     cloud = hass.data["cloud"]
 
     resp = await cloud.client.async_alexa_message(
@@ -125,7 +125,7 @@ async def test_handler_google_actions(hass):
 
 async def test_handler_google_actions_disabled(hass, mock_cloud_fixture):
     """Test handler Google Actions when user has disabled it."""
-    mock_cloud_fixture[PREF_ENABLE_GOOGLE] = False
+    mock_cloud_fixture._prefs[PREF_ENABLE_GOOGLE] = False
 
     with patch("hass_nabucasa.Cloud.start", return_value=mock_coro()):
         assert await async_setup_component(hass, "cloud", {})

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -10,13 +10,7 @@ from hass_nabucasa.const import STATE_CONNECTED
 
 from homeassistant.core import State
 from homeassistant.auth.providers import trusted_networks as tn_auth
-from homeassistant.components.cloud.const import (
-    PREF_ENABLE_GOOGLE,
-    PREF_ENABLE_ALEXA,
-    PREF_GOOGLE_SECURE_DEVICES_PIN,
-    DOMAIN,
-    RequireRelink,
-)
+from homeassistant.components.cloud.const import DOMAIN, RequireRelink
 from homeassistant.components.google_assistant.helpers import GoogleEntity
 from homeassistant.components.alexa.entities import LightCapabilities
 from homeassistant.components.alexa import errors as alexa_errors
@@ -474,9 +468,9 @@ async def test_websocket_update_preferences(
     hass, hass_ws_client, aioclient_mock, setup_api, mock_cloud_login
 ):
     """Test updating preference."""
-    assert setup_api[PREF_ENABLE_GOOGLE]
-    assert setup_api[PREF_ENABLE_ALEXA]
-    assert setup_api[PREF_GOOGLE_SECURE_DEVICES_PIN] is None
+    assert setup_api.google_enabled
+    assert setup_api.alexa_enabled
+    assert setup_api.google_secure_devices_pin is None
     client = await hass_ws_client(hass)
     await client.send_json(
         {
@@ -490,9 +484,9 @@ async def test_websocket_update_preferences(
     response = await client.receive_json()
 
     assert response["success"]
-    assert not setup_api[PREF_ENABLE_GOOGLE]
-    assert not setup_api[PREF_ENABLE_ALEXA]
-    assert setup_api[PREF_GOOGLE_SECURE_DEVICES_PIN] == "1234"
+    assert not setup_api.google_enabled
+    assert not setup_api.alexa_enabled
+    assert setup_api.google_secure_devices_pin == "1234"
 
 
 async def test_websocket_update_preferences_require_relink(

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -12,12 +12,23 @@ class MockConfig(helpers.AbstractConfig):
         should_expose=None,
         entity_config=None,
         hass=None,
+        local_sdk_webhook_id=None,
+        local_sdk_user_id=None,
+        enabled=True,
     ):
         """Initialize config."""
         super().__init__(hass)
         self._should_expose = should_expose
         self._secure_devices_pin = secure_devices_pin
         self._entity_config = entity_config or {}
+        self._local_sdk_webhook_id = local_sdk_webhook_id
+        self._local_sdk_user_id = local_sdk_user_id
+        self._enabled = enabled
+
+    @property
+    def enabled(self):
+        """Return if Google is enabled."""
+        return self._enabled
 
     @property
     def secure_devices_pin(self):
@@ -28,6 +39,16 @@ class MockConfig(helpers.AbstractConfig):
     def entity_config(self):
         """Return secure devices pin."""
         return self._entity_config
+
+    @property
+    def local_sdk_webhook_id(self):
+        """Return local SDK webhook id."""
+        return self._local_sdk_webhook_id
+
+    @property
+    def local_sdk_user_id(self):
+        """Return local SDK webhook id."""
+        return self._local_sdk_user_id
 
     def should_expose(self, state):
         """Expose it all."""

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -1,0 +1,130 @@
+"""Test Google Assistant helpers."""
+from unittest.mock import Mock
+from homeassistant.setup import async_setup_component
+from homeassistant.components.google_assistant import helpers
+from homeassistant.components.google_assistant.const import EVENT_COMMAND_RECEIVED
+from . import MockConfig
+
+from tests.common import async_capture_events, async_mock_service
+
+
+async def test_google_entity_sync_serialize_with_local_sdk(hass):
+    """Test sync serialize attributes of a GoogleEntity."""
+    hass.states.async_set("light.ceiling_lights", "off")
+    hass.config.api = Mock(port=1234, use_ssl=True)
+    config = MockConfig(
+        hass=hass,
+        local_sdk_webhook_id="mock-webhook-id",
+        local_sdk_user_id="mock-user-id",
+    )
+    entity = helpers.GoogleEntity(hass, config, hass.states.get("light.ceiling_lights"))
+
+    serialized = await entity.sync_serialize()
+    assert "otherDeviceIds" not in serialized
+    assert "customData" not in serialized
+
+    config.async_enable_local_sdk()
+
+    serialized = await entity.sync_serialize()
+    assert serialized["otherDeviceIds"] == [{"deviceId": "light.ceiling_lights"}]
+    assert serialized["customData"] == {
+        "httpPort": 1234,
+        "httpSSL": True,
+        "proxyDeviceId": None,
+        "webhookId": "mock-webhook-id",
+    }
+
+
+async def test_config_local_sdk(hass, hass_client):
+    """Test the local SDK."""
+    command_events = async_capture_events(hass, EVENT_COMMAND_RECEIVED)
+    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+    hass.states.async_set("light.ceiling_lights", "off")
+
+    assert await async_setup_component(hass, "webhook", {})
+
+    config = MockConfig(
+        hass=hass,
+        local_sdk_webhook_id="mock-webhook-id",
+        local_sdk_user_id="mock-user-id",
+    )
+
+    client = await hass_client()
+
+    config.async_enable_local_sdk()
+
+    resp = await client.post(
+        "/api/webhook/mock-webhook-id",
+        json={
+            "inputs": [
+                {
+                    "context": {"locale_country": "US", "locale_language": "en"},
+                    "intent": "action.devices.EXECUTE",
+                    "payload": {
+                        "commands": [
+                            {
+                                "devices": [{"id": "light.ceiling_lights"}],
+                                "execution": [
+                                    {
+                                        "command": "action.devices.commands.OnOff",
+                                        "params": {"on": True},
+                                    }
+                                ],
+                            }
+                        ],
+                        "structureData": {},
+                    },
+                }
+            ],
+            "requestId": "mock-req-id",
+        },
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["requestId"] == "mock-req-id"
+
+    assert len(command_events) == 1
+    assert command_events[0].context.user_id == config.local_sdk_user_id
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].context is command_events[0].context
+
+    config.async_disable_local_sdk()
+
+    # Webhook is no longer active
+    resp = await client.post("/api/webhook/mock-webhook-id")
+    assert resp.status == 200
+    assert await resp.read() == b""
+
+
+async def test_config_local_sdk_if_disabled(hass, hass_client):
+    """Test the local SDK."""
+    assert await async_setup_component(hass, "webhook", {})
+
+    config = MockConfig(
+        hass=hass,
+        local_sdk_webhook_id="mock-webhook-id",
+        local_sdk_user_id="mock-user-id",
+        enabled=False,
+    )
+
+    client = await hass_client()
+
+    config.async_enable_local_sdk()
+
+    resp = await client.post(
+        "/api/webhook/mock-webhook-id", json={"requestId": "mock-req-id"}
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {
+        "payload": {"errorCode": "deviceTurnedOff"},
+        "requestId": "mock-req-id",
+    }
+
+    config.async_disable_local_sdk()
+
+    # Webhook is no longer active
+    resp = await client.post("/api/webhook/mock-webhook-id")
+    assert resp.status == 200
+    assert await resp.read() == b""

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, Mock
 import pytest
 
 from homeassistant.core import State, EVENT_CALL_SERVICE
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS, __version__
 from homeassistant.setup import async_setup_component
 from homeassistant.components import camera
 from homeassistant.components.climate.const import (
@@ -733,4 +733,138 @@ async def test_trait_execute_adding_query_data(hass):
                 }
             ]
         },
+    }
+
+
+async def test_identify(hass):
+    """Test identify message."""
+    result = await sh.async_handle_message(
+        hass,
+        BASIC_CONFIG,
+        None,
+        {
+            "requestId": REQ_ID,
+            "inputs": [
+                {
+                    "intent": "action.devices.IDENTIFY",
+                    "payload": {
+                        "device": {
+                            "mdnsScanData": {
+                                "additionals": [
+                                    {
+                                        "type": "TXT",
+                                        "class": "IN",
+                                        "name": "devhome._home-assistant._tcp.local",
+                                        "ttl": 4500,
+                                        "data": [
+                                            "version=0.101.0.dev0",
+                                            "base_url=http://192.168.1.101:8123",
+                                            "requires_api_password=true",
+                                        ],
+                                    }
+                                ]
+                            }
+                        },
+                        "structureData": {},
+                    },
+                }
+            ],
+            "devices": [
+                {
+                    "id": "light.ceiling_lights",
+                    "customData": {
+                        "httpPort": 8123,
+                        "httpSSL": False,
+                        "proxyDeviceId": BASIC_CONFIG.agent_user_id,
+                        "webhookId": "dde3b9800a905e886cc4d38e226a6e7e3f2a6993d2b9b9f63d13e42ee7de3219",
+                    },
+                }
+            ],
+        },
+    )
+
+    assert result == {
+        "requestId": REQ_ID,
+        "payload": {
+            "device": {
+                "id": BASIC_CONFIG.agent_user_id,
+                "isLocalOnly": True,
+                "isProxy": True,
+                "deviceInfo": {
+                    "hwVersion": "UNKNOWN_HW_VERSION",
+                    "manufacturer": "Home Assistant",
+                    "model": "Home Assistant",
+                    "swVersion": __version__,
+                },
+            }
+        },
+    }
+
+
+async def test_reachable_devices(hass):
+    """Test REACHABLE_DEVICES intent."""
+    # Matching passed in device.
+    hass.states.async_set("light.ceiling_lights", "on")
+
+    # Unsupported entity
+    hass.states.async_set("not_supported.entity", "something")
+
+    # Excluded via config
+    hass.states.async_set("light.not_expose", "on")
+
+    # Not passed in as google_id
+    hass.states.async_set("light.not_mentioned", "on")
+
+    config = MockConfig(
+        should_expose=lambda state: state.entity_id != "light.not_expose"
+    )
+
+    result = await sh.async_handle_message(
+        hass,
+        config,
+        None,
+        {
+            "requestId": REQ_ID,
+            "inputs": [
+                {
+                    "intent": "action.devices.REACHABLE_DEVICES",
+                    "payload": {
+                        "device": {
+                            "proxyDevice": {
+                                "id": "6a04f0f7-6125-4356-a846-861df7e01497",
+                                "customData": "{}",
+                                "proxyData": "{}",
+                            }
+                        },
+                        "structureData": {},
+                    },
+                }
+            ],
+            "devices": [
+                {
+                    "id": "light.ceiling_lights",
+                    "customData": {
+                        "httpPort": 8123,
+                        "httpSSL": False,
+                        "proxyDeviceId": BASIC_CONFIG.agent_user_id,
+                        "webhookId": "dde3b9800a905e886cc4d38e226a6e7e3f2a6993d2b9b9f63d13e42ee7de3219",
+                    },
+                },
+                {
+                    "id": "light.not_expose",
+                    "customData": {
+                        "httpPort": 8123,
+                        "httpSSL": False,
+                        "proxyDeviceId": BASIC_CONFIG.agent_user_id,
+                        "webhookId": "dde3b9800a905e886cc4d38e226a6e7e3f2a6993d2b9b9f63d13e42ee7de3219",
+                    },
+                },
+                {"id": BASIC_CONFIG.agent_user_id, "customData": {}},
+            ],
+        },
+    )
+
+    assert result == {
+        "requestId": REQ_ID,
+        "payload": {"devices": [{"verificationId": "light.ceiling_lights"}]},
     }

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -48,11 +48,11 @@ _LOGGER = logging.getLogger(__name__)
 
 REQ_ID = "ff36a3cc-ec34-11e6-b1a0-64510650abcf"
 
-BASIC_DATA = helpers.RequestData(BASIC_CONFIG, "test-agent", REQ_ID)
+BASIC_DATA = helpers.RequestData(BASIC_CONFIG, "test-agent", REQ_ID, None)
 
 PIN_CONFIG = MockConfig(secure_devices_pin="1234")
 
-PIN_DATA = helpers.RequestData(PIN_CONFIG, "test-agent", REQ_ID)
+PIN_DATA = helpers.RequestData(PIN_CONFIG, "test-agent", REQ_ID, None)
 
 
 async def test_brightness_light(hass):


### PR DESCRIPTION
## Description:
Add support for the Google Assistant Local SDK messages.

This is superduper alpha. There are a ton of bugs still on Google's side. This is what I have been able to cobble together and got it working. One bug is that your Google Assistant device will restart when it fails to do an HTTP request (ie when you restart Home Assistant).

Also, according to Google engineers that I have been in touch with, some of the things that we're doing are not supposed to work like that. So eh, we'll see. Wanted to get it out there so we can iterate on it.

The zeroconf integration has been updated to make sure that we only start broadcasting when Home Assistant is done starting up. This way we avoid broadcasting Home Assistant without being able to receive HTTP requests.

The JS receiver that runs on Google Assistant devices can be found here: https://github.com/NabuCasa/home-assistant-google-assistant-local-sdk

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
