### PR TITLE
Bump python-slugify to 3.0.6

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,7 @@ importlib-metadata==0.23
 jinja2>=2.10.1
 netdisco==2.6.0
 pip>=8.0.3
-python-slugify==3.0.4
+python-slugify==3.0.6
 pytz>=2019.03
 pyyaml==5.1.2
 requests==2.22.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ jinja2>=2.10.1
 PyJWT==1.7.1
 cryptography==2.7
 pip>=8.0.3
-python-slugify==3.0.4
+python-slugify==3.0.6
 pytz>=2019.03
 pyyaml==5.1.2
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ REQUIRES = [
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==2.7",
     "pip>=8.0.3",
-    "python-slugify==3.0.4",
+    "python-slugify==3.0.6",
     "pytz>=2019.03",
     "pyyaml==5.1.2",
     "requests==2.22.0",


### PR DESCRIPTION
## Description:
Bump python-slugify to 3.0.6

https://github.com/un33k/python-slugify/blob/master/CHANGELOG.md

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
