### PR TITLE
Bump RtmAPI to 0.7.2

### DIFF
--- a/homeassistant/components/remember_the_milk/manifest.json
+++ b/homeassistant/components/remember_the_milk/manifest.json
@@ -3,7 +3,7 @@
   "name": "Remember the milk",
   "documentation": "https://www.home-assistant.io/integrations/remember_the_milk",
   "requirements": [
-    "RtmAPI==0.7.0",
+    "RtmAPI==0.7.2",
     "httplib2==0.10.3"
   ],
   "dependencies": ["configurator"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -85,7 +85,7 @@ PyXiaomiGateway==0.12.4
 # RPi.GPIO==0.6.5
 
 # homeassistant.components.remember_the_milk
-RtmAPI==0.7.0
+RtmAPI==0.7.2
 
 # homeassistant.components.travisci
 TravisPy==0.3.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.1.3
 PyTransportNSW==0.1.1
 
 # homeassistant.components.remember_the_milk
-RtmAPI==0.7.0
+RtmAPI==0.7.2
 
 # homeassistant.components.yessssms
 YesssSMS==0.4.1


### PR DESCRIPTION
## Description:
Bump RtmAPI to 0.7.2

https://bitbucket.org/rtmapi/rtmapi/commits/all

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
