### PR TITLE
Change state values for Worx Landroid sensor

### DIFF
--- a/homeassistant/components/worxlandroid/sensor.py
+++ b/homeassistant/components/worxlandroid/sensor.py
@@ -141,16 +141,9 @@ class WorxLandroidSensor(Entity):
         state = self.get_error(obj)
 
         if state is None:
-            state_obj = obj["settaggi"]
+            if obj["batteryChargerState"] == "charging":
+                return obj["batteryChargerState"]
 
-            if state_obj[14] == 1:
-                return "manual-stop"
-            if state_obj[5] == 1 and state_obj[13] == 0:
-                return "charging"
-            if state_obj[5] == 1 and state_obj[13] == 1:
-                return "charging-complete"
-            if state_obj[15] == 1:
-                return "going-home"
-            return "mowing"
+            return obj["state"]
 
         return state


### PR DESCRIPTION
## Breaking Change:

The worxlandroid sensor has been changed to not return the hard coded state values "manual-stop", "charging", "charging-complete", "going-home", "mowing" and instead use the states given from the landroid to Home Assistant. This includes the state "idle" which means that something is broken with the mower and you can use this as notification to check the physical state of the mower. Users need to update any automations that depend on the state of the sensor.


## Description:
The obj["state"] contains already several named return states as
following: "grass cutting", "trapped recovery", "searching wire",
           "following wire", "searching home", "home", "idle"
And with the batteryChargerState also the "charging"

Fixes https://github.com/home-assistant/hassio/issues/455

**Related issue (if applicable):**
fixes https://github.com/home-assistant/hassio/issues/455

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
