### PR TITLE
Handle empty service in script action gracefully

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -386,6 +386,7 @@ def remove_falsy(value: List[T]) -> List[T]:
 def service(value):
     """Validate service."""
     # Services use same format as entities so we can use same helper.
+    value = string(value).lower()
     if valid_entity_id(value):
         return value
     raise vol.Invalid("Service {} does not match format <domain>.<name>".format(value))

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -842,6 +842,25 @@ async def test_automation_with_error_in_script(hass, caplog):
     assert "Service not found" in caplog.text
 
 
+async def test_automation_with_error_in_script_2(hass, caplog):
+    """Test automation with an error in script."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "action": {"service": None, "entity_id": "hello.world"},
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert "string value is None" in caplog.text
+
+
 async def test_automation_restore_last_triggered_with_initial_state(hass):
     """Ensure last_triggered is restored, even when initial state is set."""
     time = dt_util.utcnow()


### PR DESCRIPTION
## Description:
Handle empty service in script action gracefully

**Related issue (if applicable):** fixes #24164

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
