### PR TITLE
Bump haanna to 0.12.3

### DIFF
--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -3,6 +3,6 @@
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
   "dependencies": [],
-  "codeowners": ["@laetificat","@CoMPaTech","bouwew"],
+  "codeowners": ["@laetificat","@CoMPaTech","@bouwew"],
   "requirements": ["haanna==0.12.3"]
 }

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -3,6 +3,6 @@
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
   "dependencies": [],
-  "codeowners": ["@laetificat","@CoMPaTech"],
-  "requirements": ["haanna==0.10.1"]
+  "codeowners": ["@laetificat","@CoMPaTech","bouwew"],
+  "requirements": ["haanna==0.12.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -601,7 +601,7 @@ ha-ffmpeg==2.0
 ha-philipsjs==0.0.8
 
 # homeassistant.components.plugwise
-haanna==0.10.1
+haanna==0.12.3
 
 # homeassistant.components.habitica
 habitipy==0.2.0


### PR DESCRIPTION
## Description:
Updates to haanna:
- Add getting illuminance, boiler_temperature and boiler_pressure values (user request, only for firmware version 3.x)
- Add getting domestic_hot_water_status and cooling_status (user requests, only for firmware version 3.x)

**Related issue (if applicable):** fixes #26520

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
