### PR TITLE
Bump pyMetno to 0.5.0

### DIFF
--- a/homeassistant/components/met/manifest.json
+++ b/homeassistant/components/met/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/met",
   "requirements": [
-    "pyMetno==0.4.6"
+    "pyMetno==0.5.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/norway_air/manifest.json
+++ b/homeassistant/components/norway_air/manifest.json
@@ -3,7 +3,7 @@
   "name": "Norway air",
   "documentation": "https://www.home-assistant.io/integrations/norway_air",
   "requirements": [
-    "pyMetno==0.4.6"
+    "pyMetno==0.5.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1039,7 +1039,7 @@ pyHS100==0.3.5
 
 # homeassistant.components.met
 # homeassistant.components.norway_air
-pyMetno==0.4.6
+pyMetno==0.5.0
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.23

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -369,7 +369,7 @@ pyHS100==0.3.5
 
 # homeassistant.components.met
 # homeassistant.components.norway_air
-pyMetno==0.4.6
+pyMetno==0.5.0
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.23


### PR DESCRIPTION
## Description:
Bumps [pymetno](https://github.com/Danielhiversen/pyMetno) from 0.4.6 to 0.5.0.
<details>
<summary>Commits</summary>

- [`00e8b08`](https://github.com/Danielhiversen/pyMetno/commit/00e8b0812fd583351f396d77000073fafe58b739) 0.5.0
- [`d12fa19`](https://github.com/Danielhiversen/pyMetno/commit/d12fa19400d37eab94c5895aeb7e913879ada6e5) Lightning ([#9](https://github-redirect.dependabot.com/Danielhiversen/pyMetno/issues/9))
- [`ec23934`](https://github.com/Danielhiversen/pyMetno/commit/ec23934a9e6ecf45e9a60306cdd0180bb9e0c42a) Create stale.yml
</details>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
