### PR TITLE
Add Samsung TV automatic protocol detection

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -247,6 +247,7 @@ homeassistant/components/rfxtrx/* @danielhiversen
 homeassistant/components/rmvtransport/* @cgtobi
 homeassistant/components/roomba/* @pschmitt
 homeassistant/components/saj/* @fredericvl
+homeassistant/components/samsungtv/* @escoand
 homeassistant/components/scene/* @home-assistant/core
 homeassistant/components/scrape/* @fabaff
 homeassistant/components/script/* @home-assistant/core

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -1,1 +1,14 @@
-"""The samsungtv component."""
+"""The Samsung TV integration."""
+from homeassistant.helpers import discovery
+
+from .const import DOMAIN
+
+SUPPORTED_DOMAINS = ["media_player"]
+
+
+async def async_setup(hass, config):
+    """Set up the Samsung TV integration."""
+    for domain in SUPPORTED_DOMAINS:
+        discovery.load_platform(hass, domain, DOMAIN, {}, config)
+
+    return True

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -1,14 +1,1 @@
 """The Samsung TV integration."""
-from homeassistant.helpers import discovery
-
-from .const import DOMAIN
-
-SUPPORTED_DOMAINS = ["media_player"]
-
-
-async def async_setup(hass, config):
-    """Set up the Samsung TV integration."""
-    for domain in SUPPORTED_DOMAINS:
-        discovery.load_platform(hass, domain, DOMAIN, {}, config)
-
-    return True

--- a/homeassistant/components/samsungtv/const.py
+++ b/homeassistant/components/samsungtv/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Samsung TV integration."""
+import logging
+
+LOGGER = logging.getLogger(__package__)
+DOMAIN = "samsungtv"

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "samsungtv",
-  "name": "Samsungtv",
+  "name": "Samsung TV",
   "documentation": "https://www.home-assistant.io/integrations/samsungtv",
   "requirements": [
     "samsungctl[websocket]==0.7.1",
     "wakeonlan==1.1.6"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@escoand"]
 }

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -146,7 +146,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         elif self._config["port"] == 55000:
             self._config["method"] = "legacy"
 
-    async def async_update(self):
+    def update(self):
         """Update state of device."""
         self.send_key("KEY")
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -27,7 +27,6 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     STATE_OFF,
     STATE_ON,
-    STATE_UNKNOWN,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
@@ -65,7 +64,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Samsung TV platform."""
     known_devices = hass.data.get(KNOWN_DEVICES_KEY)
     if known_devices is None:
@@ -159,19 +158,19 @@ class SamsungTVDevice(MediaPlayerDevice):
             for method in METHODS:
                 try:
                     self._config["method"] = method
-                    LOGGER.debug("try config: %s", self._config)
+                    LOGGER.debug("Try config: %s", self._config)
                     self._remote = self._remote_class(self._config.copy())
                     self._state = STATE_ON
-                    LOGGER.info("found working config: %s", self._config)
+                    LOGGER.debug("Found working config: %s", self._config)
                     break
                 except Exception as err:
-                    LOGGER.debug("failing config: %s error was: %s", self._config, err)
+                    LOGGER.debug("Failing config: %s error was: %s", self._config, err)
                     self._config["method"] = None
 
             # Unable to find working connection
             if self._config["method"] is None:
                 self._remote = None
-                self._state = STATE_UNKNOWN
+                self._state = None
                 return None
 
         if self._remote is None:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -89,9 +89,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         port = None
         timeout = DEFAULT_TIMEOUT
         mac = None
-        udn = discovery_info.get("udn")
-        if udn and udn.startswith("uuid:"):
-            uuid = udn[len("uuid:") :]
+        uuid = discovery_info.get("udn")
+        if uuid and uuid.startswith("uuid:"):
+            uuid = uuid[len("uuid:") :]
 
     # Only add a device once, so discovered devices do not override manual
     # config.

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -85,6 +85,8 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
         model = discovery_info.get("model_name")
         host = discovery_info.get("host")
         name = f"{tv_name} ({model})"
+        if name.startswith("[TV]"):
+            name = name[4:]
         port = None
         timeout = DEFAULT_TIMEOUT
         mac = None
@@ -101,9 +103,9 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     if ip_addr not in known_devices:
         known_devices.add(ip_addr)
         add_entities([SamsungTVDevice(host, port, name, timeout, mac, uuid)])
-        LOGGER.info(f"Samsung TV {host}:{port} added as '{name}'")
+        LOGGER.info("Samsung TV %s added as '%s'", host, name)
     else:
-        LOGGER.info(f"Ignoring duplicate Samsung TV {host}:{port}")
+        LOGGER.info("Ignoring duplicate Samsung TV %s", host)
 
 
 class SamsungTVDevice(MediaPlayerDevice):
@@ -166,13 +168,13 @@ class SamsungTVDevice(MediaPlayerDevice):
             for method in METHODS:
                 try:
                     self._config["method"] = method
-                    LOGGER.debug(f"try config: {self._config}")
+                    LOGGER.debug("try config: %s", self._config)
                     self._remote = self._remote_class(self._config.copy())
                     self._state = STATE_ON
-                    LOGGER.info(f"found working config: {self._config}")
+                    LOGGER.info("found working config: %s", self._config)
                     break
                 except Exception as err:
-                    LOGGER.debug(f"failing config: {self._config} error was:{err}")
+                    LOGGER.debug("failing config: %s error was: %s", self._config, err)
                     self._config["method"] = None
 
             # Unable to find working connection
@@ -190,7 +192,7 @@ class SamsungTVDevice(MediaPlayerDevice):
     def send_key(self, key):
         """Send a key to the tv and handles exceptions."""
         if self._power_off_in_progress() and key not in ("KEY_POWER", "KEY_POWEROFF"):
-            LOGGER.info(f"TV is powering off, not sending command: {key}")
+            LOGGER.info("TV is powering off, not sending command: %s", key)
             return
         try:
             # recreate connection if connection was dead
@@ -213,7 +215,7 @@ class SamsungTVDevice(MediaPlayerDevice):
             # We got a response so it's on.
             self._state = STATE_ON
             self._remote = None
-            LOGGER.debug(f"Failed sending command {key}", exc_info=True)
+            LOGGER.debug("Failed sending command %s", key, exc_info=True)
             return
         except OSError:
             self._state = STATE_OFF

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -93,9 +93,6 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
         udn = discovery_info.get("udn")
         if udn and udn.startswith("uuid:"):
             uuid = udn[len("uuid:") :]
-    else:
-        LOGGER.warning("Cannot determine device")
-        return
 
     # Only add a device once, so discovered devices do not override manual
     # config.

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -150,7 +150,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         elif self._config["port"] == 55000:
             self._config["method"] = "legacy"
 
-    def update(self):
+    async def async_update(self):
         """Update state of device."""
         self.send_key("KEY")
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -163,7 +163,15 @@ class SamsungTVDevice(MediaPlayerDevice):
                     self._state = STATE_ON
                     LOGGER.debug("Found working config: %s", self._config)
                     break
-                except Exception as err:
+                except (
+                    self._exceptions_class.UnhandledResponse,
+                    self._exceptions_class.AccessDenied,
+                ):
+                    # We got a response so it's working.
+                    self._state = STATE_ON
+                    LOGGER.debug("Found working config: %s", self._config)
+                    break
+                except OSError as err:
                     LOGGER.debug("Failing config: %s error was: %s", self._config, err)
                     self._config["method"] = None
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -173,7 +173,9 @@ class SamsungTVDevice(MediaPlayerDevice):
                 ):
                     # We got a response so it's working.
                     self._state = STATE_ON
-                    LOGGER.debug("Found working config: %s", self._config)
+                    LOGGER.debug(
+                        "Found working config without connection: %s", self._config
+                    )
                     break
                 except OSError as err:
                     LOGGER.debug("Failing config: %s error was: %s", self._config, err)

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -144,11 +144,11 @@ class SamsungTVDevice(MediaPlayerDevice):
             "timeout": timeout,
         }
 
-        try:
-            self.get_remote()
-        except Exception:
-            # Ignore as device could be off
-            pass
+        # Select method by port number, mainly for fallback
+        if self._config["port"] in (8001, 8002):
+            self._config["method"] = "websocket"
+        elif self._config["port"] == 55000:
+            self._config["method"] = "legacy"
 
     def update(self):
         """Update state of device."""
@@ -157,14 +157,8 @@ class SamsungTVDevice(MediaPlayerDevice):
     def get_remote(self):
         """Create or return a remote control instance."""
 
-        # Select method by port number, mainly for fallback
-        if self._config["port"] in (8001, 8002):
-            self._config["method"] = "websocket"
-        elif self._config["port"] == 55000:
-            self._config["method"] = "legacy"
-
         # Try to find correct method automatically
-        elif self._config["method"] not in METHODS:
+        if self._config["method"] not in METHODS:
             for method in METHODS:
                 try:
                     self._config["method"] = method

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -46,6 +46,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -82,8 +83,20 @@ MOCK_CONFIG_AUTO = {
     }
 }
 
-MOCK_DISCOVERY = {
-    "discovery": {"name": "[TV]fake2", "model_name": "fake2", "host": "fake2"}
+ENTITY_ID_DISCOVERY = f"{DOMAIN}.fake_discovery_fake_model"
+MOCK_CONFIG_DISCOVERY = {
+    "name": "fake_discovery",
+    "model_name": "fake_model",
+    "host": "fake_host",
+    "udn": "fake_uuid",
+}
+
+ENTITY_ID_DISCOVERY_PREFIX = f"{DOMAIN}.fake_discovery_prefix_fake_model_prefix"
+MOCK_CONFIG_DISCOVERY_PREFIX = {
+    "name": "[TV]fake_discovery_prefix",
+    "model_name": "fake_model_prefix",
+    "host": "fake_host_prefix",
+    "udn": "uuid:fake_uuid_prefix",
 }
 
 AUTODETECT_WEBSOCKET = {
@@ -171,9 +184,30 @@ async def test_setup_without_mac(hass, remote):
 
 async def test_setup_discovery(hass, remote):
     """Test setup of platform with discovery."""
-    # await setup_samsungtv(hass, MOCK_DISCOVERY)
-    # assert hass.states.get("media_player.fake2")
-    assert False
+    hass.async_create_task(
+        async_load_platform(
+            hass, DOMAIN, SAMSUNGTV_DOMAIN, MOCK_CONFIG_DISCOVERY, {DOMAIN: {}}
+        )
+    )
+    await hass.async_block_till_done()
+    entity = hass.data[DOMAIN].get_entity(ENTITY_ID_DISCOVERY)
+    assert entity
+    assert entity.name == "fake_discovery (fake_model)"
+    assert entity.unique_id == "fake_uuid"
+
+
+async def test_setup_discovery_prefix(hass, remote):
+    """Test setup of platform with discovery."""
+    hass.async_create_task(
+        async_load_platform(
+            hass, DOMAIN, SAMSUNGTV_DOMAIN, MOCK_CONFIG_DISCOVERY_PREFIX, {DOMAIN: {}}
+        )
+    )
+    await hass.async_block_till_done()
+    entity = hass.data[DOMAIN].get_entity(ENTITY_ID_DISCOVERY_PREFIX)
+    assert entity
+    assert entity.name == "fake_discovery_prefix (fake_model_prefix)"
+    assert entity.unique_id == "fake_uuid_prefix"
 
 
 async def test_update_on(hass, remote, mock_now):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -397,17 +397,14 @@ async def test_turn_off_legacy(hass, remote):
     assert remote.control.call_args_list == [call("KEY_POWEROFF")]
 
 
-async def test_turn_off_os_error(hass, remote):
+async def test_turn_off_os_error(hass, remote, caplog):
     """Test for turn_off with OSError."""
-    with patch(
-        "homeassistant.components.samsungtv.media_player.LOGGER.debug"
-    ) as mocked_debug:
-        await setup_samsungtv(hass, MOCK_CONFIG)
-        remote.close = mock.Mock(side_effect=OSError("BOOM"))
-        assert await hass.services.async_call(
-            DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
-        )
-        mocked_debug.assert_called_once_with("Could not establish connection.")
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    remote.close = mock.Mock(side_effect=OSError("BOOM"))
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert "Could not establish connection." in caplog.text
 
 
 async def test_volume_up(hass, remote):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -223,75 +223,6 @@ class TestSamsungTv(unittest.TestCase):
         self.device.turn_off()
         mocked_debug.assert_called_once_with("Could not establish connection.")
 
-    def test_volume_up(self):
-        """Test for volume_up."""
-        self.device.send_key = mock.Mock()
-        self.device.volume_up()
-        self.device.send_key.assert_called_once_with("KEY_VOLUP")
-
-    def test_volume_down(self):
-        """Test for volume_down."""
-        self.device.send_key = mock.Mock()
-        self.device.volume_down()
-        self.device.send_key.assert_called_once_with("KEY_VOLDOWN")
-
-    def test_mute_volume(self):
-        """Test for mute_volume."""
-        self.device.send_key = mock.Mock()
-        self.device.mute_volume(True)
-        self.device.send_key.assert_called_once_with("KEY_MUTE")
-
-    def test_media_play_pause(self):
-        """Test for media_next_track."""
-        self.device.send_key = mock.Mock()
-        self.device._playing = False
-        self.device.media_play_pause()
-        self.device.send_key.assert_called_once_with("KEY_PLAY")
-        assert self.device._playing
-        self.device.send_key = mock.Mock()
-        self.device.media_play_pause()
-        self.device.send_key.assert_called_once_with("KEY_PAUSE")
-        assert not self.device._playing
-
-    def test_media_play(self):
-        """Test for media_play."""
-        self.device.send_key = mock.Mock()
-        self.device._playing = False
-        self.device.media_play()
-        self.device.send_key.assert_called_once_with("KEY_PLAY")
-        assert self.device._playing
-
-    def test_media_pause(self):
-        """Test for media_pause."""
-        self.device.send_key = mock.Mock()
-        self.device._playing = True
-        self.device.media_pause()
-        self.device.send_key.assert_called_once_with("KEY_PAUSE")
-        assert not self.device._playing
-
-    def test_media_next_track(self):
-        """Test for media_next_track."""
-        self.device.send_key = mock.Mock()
-        self.device.media_next_track()
-        self.device.send_key.assert_called_once_with("KEY_FF")
-
-    def test_media_previous_track(self):
-        """Test for media_previous_track."""
-        self.device.send_key = mock.Mock()
-        self.device.media_previous_track()
-        self.device.send_key.assert_called_once_with("KEY_REWIND")
-
-    def test_turn_on(self):
-        """Test turn on."""
-        self.device.send_key = mock.Mock()
-        self.device._mac = None
-        self.device.turn_on()
-        self.device.send_key.assert_called_once_with("KEY_POWERON")
-        self.device._wol.send_magic_packet = mock.Mock()
-        self.device._mac = "fake"
-        self.device.turn_on()
-        self.device._wol.send_magic_packet.assert_called_once_with("fake")
-
 
 @pytest.fixture
 def samsung_mock():
@@ -299,6 +230,93 @@ def samsung_mock():
     with patch.dict("sys.modules", {"samsungctl": MagicMock()}):
         yield
 
+
+def test_volume_up(self, samsung_mock):
+    """Test for volume_up."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device.volume_up()
+    device.send_key.assert_called_once_with("KEY_VOLUP")
+
+def test_volume_down(self, samsung_mock):
+    """Test for volume_down."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device.volume_down()
+    device.send_key.assert_called_once_with("KEY_VOLDOWN")
+
+def test_mute_volume(self, samsung_mock):
+    """Test for mute_volume."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device.mute_volume(True)
+    device.send_key.assert_called_once_with("KEY_MUTE")
+
+def test_media_play_pause(self, samsung_mock):
+    """Test for media_next_track."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device._playing = False
+    device.media_play_pause()
+    device.send_key.assert_called_once_with("KEY_PLAY")
+    assert device._playing
+    device.send_key = mock.Mock()
+    device.media_play_pause()
+    device.send_key.assert_called_once_with("KEY_PAUSE")
+    assert not device._playing
+
+def test_media_play(self, samsung_mock):
+    """Test for media_play."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device._playing = False
+    device.media_play()
+    device.send_key.assert_called_once_with("KEY_PLAY")
+    assert device._playing
+
+def test_media_pause(self, samsung_mock):
+    """Test for media_pause."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device._playing = True
+    device.media_pause()
+    device.send_key.assert_called_once_with("KEY_PAUSE")
+    assert not device._playing
+
+def test_media_next_track(self, samsung_mock):
+    """Test for media_next_track."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device.media_next_track()
+    device.send_key.assert_called_once_with("KEY_FF")
+
+def test_media_previous_track(self, samsung_mock):
+    """Test for media_previous_track."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device.media_previous_track()
+    device.send_key.assert_called_once_with("KEY_REWIND")
+
+def test_turn_on(self, samsung_mock):
+    """Test turn on."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
+    device.send_key = mock.Mock()
+    device._mac = None
+    device.turn_on()
+    device.send_key.assert_called_once_with("KEY_POWERON")
+    device._wol.send_magic_packet = mock.Mock()
+    device._mac = "fake"
+    device.turn_on()
+    device._wol.send_magic_packet.assert_called_once_with("fake")
 
 async def test_play_media(hass, samsung_mock):
     """Test for play_media."""

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -7,31 +7,61 @@ from asynctest import mock
 import pytest
 
 from homeassistant.components.media_player.const import (
+    ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_VOLUME_MUTED,
+    DOMAIN,
+    SERVICE_PLAY_MEDIA,
+    SERVICE_SELECT_SOURCE,
     SUPPORT_TURN_ON,
     MEDIA_TYPE_CHANNEL,
     MEDIA_TYPE_URL,
 )
+from homeassistant.components.samsungtv.const import DOMAIN as STV_DOMAIN
 from homeassistant.components.samsungtv.media_player import (
-    async_setup_platform,
     CONF_TIMEOUT,
     SamsungTVDevice,
     SUPPORT_SAMSUNGTV,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_HOST,
+    CONF_MAC,
     CONF_METHOD,
     CONF_NAME,
     CONF_PORT,
-    STATE_ON,
-    CONF_MAC,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_UP,
     STATE_OFF,
+    STATE_ON,
+    STATE_PAUSED,
+    STATE_PLAYING,
 )
+from homeassistant.setup import async_setup_component
+
 from tests.common import MockDependency
 from homeassistant.util import dt as dt_util
 from datetime import timedelta
 
 
-WORKING_CONFIG = {
+ENTITY_ID = "media_player.fake"
+MOCK_CONFIG = {
+    DOMAIN: {
+        "platform": STV_DOMAIN,
+        CONF_HOST: "fake",
+        CONF_NAME: "fake",
+        CONF_PORT: 8001,
+        CONF_TIMEOUT: 10,
+        CONF_MAC: "fake",
+    }
+}
+WORKING_PARAMETERS = {
     CONF_HOST: "fake",
     CONF_NAME: "fake",
     CONF_PORT: 8001,
@@ -40,7 +70,9 @@ WORKING_CONFIG = {
     "uuid": None,
 }
 
-DISCOVERY_INFO = {"name": "fake", "model_name": "fake", "host": "fake"}
+MOCK_DISCOVERY = {
+    "discovery_info": {"name": "[TV]fake2", "model_name": "fake2", "host": "fake2"}
+}
 
 
 class AccessDenied(Exception):
@@ -69,44 +101,35 @@ def wakeonlan_mock():
         yield
 
 
+async def setup_samsungtv(hass, config):
+    """Set up mock Samsung TV."""
+    with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
+        await async_setup_component(hass, "media_player", config)
+        await hass.async_block_till_done()
+
+
 async def test_setup(hass, samsung_mock, wakeonlan_mock):
     """Test setup of platform."""
-    with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
-        add_entities = mock.Mock()
-        await async_setup_platform(hass, WORKING_CONFIG, add_entities)
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert hass.states.get(ENTITY_ID)
 
 
 async def test_setup_discovery(hass, samsung_mock, wakeonlan_mock):
     """Test setup of platform with discovery."""
-    with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
-        add_entities = mock.Mock()
-        await async_setup_platform(
-            hass, {}, add_entities, discovery_info=DISCOVERY_INFO
-        )
-
-
-async def test_setup_none(hass, samsung_mock, wakeonlan_mock):
-    """Test setup of platform with no data."""
-    with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
-        with patch(
-            "homeassistant.components.samsungtv.media_player.LOGGER.warning"
-        ) as mocked_warn:
-            add_entities = mock.Mock()
-            await async_setup_platform(hass, {}, add_entities, discovery_info=None)
-            mocked_warn.assert_called_once_with("Cannot determine device")
-            add_entities.assert_not_called()
+    await setup_samsungtv(hass, MOCK_DISCOVERY)
+    assert hass.states.get("media_player.fake2")
 
 
 async def test_setup_method_selection():
     """Test of method selection."""
-    conf = WORKING_CONFIG.copy()
+    conf = WORKING_PARAMETERS.copy()
     device = SamsungTVDevice(**conf)
     conf[CONF_PORT] = 8001
     assert device._config[CONF_METHOD] == "websocket"
-    conf = WORKING_CONFIG.copy()
+    conf = WORKING_PARAMETERS.copy()
     conf[CONF_PORT] = 8002
     assert device._config[CONF_METHOD] == "websocket"
-    conf = WORKING_CONFIG.copy()
+    conf = WORKING_PARAMETERS.copy()
     conf[CONF_PORT] = 55000
     device = SamsungTVDevice(**conf)
     assert device._config[CONF_METHOD] == "legacy"
@@ -120,14 +143,14 @@ async def test_setup_method_selection():
 
 async def test_update_on(samsung_mock):
     """Testing update tv on."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.update()
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
+    await device.async_update()
     assert STATE_ON == device.state
 
 
 async def test_update_off(samsung_mock):
     """Testing update tv off."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device._exceptions_class = mock.Mock()
     device._exceptions_class.UnhandledResponse = UnhandledResponse
     device._exceptions_class.AccessDenied = AccessDenied
@@ -135,20 +158,20 @@ async def test_update_off(samsung_mock):
     _remote = mock.Mock()
     _remote.control = mock.Mock(side_effect=OSError("Boom"))
     device.get_remote = mock.Mock(return_value=_remote)
-    device.update()
+    await device.async_update()
     assert STATE_OFF == device.state
 
 
 async def test_send_key(samsung_mock):
     """Test for send key."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device.send_key("KEY_POWER")
     assert STATE_ON == device.state
 
 
 async def test_send_key_broken_pipe(samsung_mock):
     """Testing broken pipe Exception."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device._exceptions_class = mock.Mock()
     device._exceptions_class.UnhandledResponse = UnhandledResponse
     device._exceptions_class.AccessDenied = AccessDenied
@@ -163,7 +186,7 @@ async def test_send_key_broken_pipe(samsung_mock):
 
 async def test_send_key_connection_closed_retry_succeed(samsung_mock):
     """Test retry on connection closed."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device._exceptions_class = mock.Mock()
     device._exceptions_class.UnhandledResponse = UnhandledResponse
     device._exceptions_class.AccessDenied = AccessDenied
@@ -183,7 +206,7 @@ async def test_send_key_connection_closed_retry_succeed(samsung_mock):
 
 async def test_send_key_unhandled_response(samsung_mock):
     """Testing unhandled response exception."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     _remote = mock.Mock()
     _remote.control = mock.Mock(
         side_effect=device._exceptions_class.UnhandledResponse("Boom")
@@ -196,7 +219,7 @@ async def test_send_key_unhandled_response(samsung_mock):
 
 async def test_send_key_os_error(samsung_mock):
     """Testing broken pipe Exception."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device._exceptions_class = mock.Mock()
     device._exceptions_class.UnhandledResponse = UnhandledResponse
     device._exceptions_class.AccessDenied = AccessDenied
@@ -211,7 +234,7 @@ async def test_send_key_os_error(samsung_mock):
 
 async def test_power_off_in_progress(samsung_mock):
     """Test for power_off_in_progress."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     assert not device._power_off_in_progress()
     device._end_of_power_off = dt_util.utcnow() + timedelta(seconds=15)
     assert device._power_off_in_progress()
@@ -219,31 +242,41 @@ async def test_power_off_in_progress(samsung_mock):
 
 async def test_name(samsung_mock):
     """Test for name property."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    assert "fake" == device.name
+    # device = SamsungTVDevice(**WORKING_PARAMETERS)
+    # assert "fake" == device.name
 
 
 async def test_state(samsung_mock):
     """Test for state property."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device._state = STATE_ON
     assert STATE_ON == device.state
     device._state = STATE_OFF
     assert STATE_OFF == device.state
 
 
-async def test_is_volume_muted(samsung_mock):
+async def test_is_volume_muted(hass, samsung_mock):
     """Test for is_volume_muted property."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device._muted = False
-    assert not device.is_volume_muted
-    device._muted = True
-    assert device.is_volume_muted
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
+        True,
+    )
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_MEDIA_VOLUME_MUTED]
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: False},
+        True,
+    )
+    assert not hass.states.get(ENTITY_ID).attributes[ATTR_MEDIA_VOLUME_MUTED]
 
 
 async def test_supported_features(samsung_mock):
     """Test for supported_features property."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device._mac = None
     assert SUPPORT_SAMSUNGTV == device.supported_features
     device._mac = "fake"
@@ -252,7 +285,7 @@ async def test_supported_features(samsung_mock):
 
 async def test_turn_off(samsung_mock):
     """Test for turn_off."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device.send_key = mock.Mock()
     _remote = mock.Mock()
     _remote.close = mock.Mock()
@@ -271,7 +304,7 @@ async def test_turn_off_os_error():
     with patch(
         "homeassistant.components.samsungtv.media_player.LOGGER.debug"
     ) as mocked_debug:
-        device = SamsungTVDevice(**WORKING_CONFIG)
+        device = SamsungTVDevice(**WORKING_PARAMETERS)
         device._exceptions_class = mock.Mock()
         _remote = mock.Mock()
         _remote.close = mock.Mock(side_effect=OSError("BOOM"))
@@ -280,83 +313,88 @@ async def test_turn_off_os_error():
         mocked_debug.assert_called_once_with("Could not establish connection.")
 
 
-async def test_volume_up(samsung_mock):
+async def test_volume_up(hass, samsung_mock):
     """Test for volume_up."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device.volume_up()
-    device.send_key.assert_called_once_with("KEY_VOLUP")
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_VOLUP")
 
 
-async def test_volume_down(samsung_mock):
+async def test_volume_down(hass, samsung_mock):
     """Test for volume_down."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device.volume_down()
-    device.send_key.assert_called_once_with("KEY_VOLDOWN")
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_VOLUME_DOWN, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_VOLDOWN")
 
 
-async def test_mute_volume(samsung_mock):
+async def test_mute_volume(hass, samsung_mock):
     """Test for mute_volume."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device.mute_volume(True)
-    device.send_key.assert_called_once_with("KEY_MUTE")
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
+        True,
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_MUTE")
 
 
-async def test_media_play_pause(samsung_mock):
+async def test_media_play_pause(hass, samsung_mock):
     """Test for media_next_track."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device._playing = False
-    device.media_play_pause()
-    device.send_key.assert_called_once_with("KEY_PLAY")
-    assert device._playing
-    device.send_key = mock.Mock()
-    device.media_play_pause()
-    device.send_key.assert_called_once_with("KEY_PAUSE")
-    assert not device._playing
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_MEDIA_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert hass.states.get(ENTITY_ID).state == STATE_PAUSED
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_MEDIA_PLAY, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert hass.states.get(ENTITY_ID).state == STATE_PLAYING
 
 
-async def test_media_play(samsung_mock):
+async def test_media_play(hass, samsung_mock):
     """Test for media_play."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device._playing = False
-    device.media_play()
-    device.send_key.assert_called_once_with("KEY_PLAY")
-    assert device._playing
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_MEDIA_PLAY, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_PLAY")
 
 
-async def test_media_pause(samsung_mock):
+async def test_media_pause(hass, samsung_mock):
     """Test for media_pause."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device._playing = True
-    device.media_pause()
-    device.send_key.assert_called_once_with("KEY_PAUSE")
-    assert not device._playing
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_MEDIA_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_PAUSE")
 
 
-async def test_media_next_track(samsung_mock):
+async def test_media_next_track(hass, samsung_mock):
     """Test for media_next_track."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device.media_next_track()
-    device.send_key.assert_called_once_with("KEY_FF")
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_MEDIA_NEXT_TRACK, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_FF")
 
 
-async def test_media_previous_track(samsung_mock):
+async def test_media_previous_track(hass, samsung_mock):
     """Test for media_previous_track."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    device.media_previous_track()
-    device.send_key.assert_called_once_with("KEY_REWIND")
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_REWIND")
 
 
 async def test_turn_on(samsung_mock):
     """Test turn on."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device.send_key = mock.Mock()
     device._mac = None
     device.turn_on()
@@ -377,7 +415,7 @@ async def test_play_media(hass, samsung_mock):
         await asyncio_sleep(0, loop=loop)
 
     with patch("asyncio.sleep", new=sleep):
-        device = SamsungTVDevice(**WORKING_CONFIG)
+        device = SamsungTVDevice(**WORKING_PARAMETERS)
         device.hass = hass
 
         device.send_key = mock.Mock()
@@ -391,7 +429,7 @@ async def test_play_media(hass, samsung_mock):
 async def test_play_media_invalid_type(samsung_mock):
     """Test for play_media with invalid media type."""
     url = "https://example.com"
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_URL, url)
     assert device.send_key.call_count == 0
@@ -400,33 +438,52 @@ async def test_play_media_invalid_type(samsung_mock):
 async def test_play_media_channel_as_string(samsung_mock):
     """Test for play_media with invalid channel as string."""
     url = "https://example.com"
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_CHANNEL, url)
     assert device.send_key.call_count == 0
 
 
-async def test_play_media_channel_as_non_positive(samsung_mock):
+async def test_play_media_channel_as_non_positive(hass, samsung_mock):
     """Test for play_media with invalid channel as non positive integer."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
+    device = SamsungTVDevice(**WORKING_PARAMETERS)
     device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_CHANNEL, "-4")
     assert device.send_key.call_count == 0
 
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID,
+            ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_CHANNEL,
+            ATTR_MEDIA_CONTENT_ID: "-4",
+        },
+        True,
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_not_called()
+
 
 async def test_select_source(hass, samsung_mock):
     """Test for select_source."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.hass = hass
-    device.send_key = mock.Mock()
-    await device.async_select_source("HDMI")
-    exp = [call("KEY_HDMI")]
-    assert device.send_key.call_args_list == exp
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "HDMI"},
+        True,
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_called_once_with("KEY_HDMI")
 
 
-async def test_select_source_invalid_source(samsung_mock):
+async def test_select_source_invalid_source(hass, samsung_mock):
     """Test for select_source with invalid source."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    await device.async_select_source("INVALID")
-    assert device.send_key.call_count == 0
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "INVALID"},
+        True,
+    )
+    # assert samsungctl.remote_legacy.RemoteLegacy.control.assert_not_called()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_URL,
 )
 from homeassistant.components.samsungtv.media_player import (
-    setup_platform,
+    async_setup_platform,
     CONF_TIMEOUT,
     SamsungTVDevice,
     SUPPORT_SAMSUNGTV,
@@ -77,28 +77,30 @@ class TestSamsungTv(unittest.TestCase):
 
     @MockDependency("samsungctl")
     @MockDependency("wakeonlan")
-    def test_setup(self, samsung_mock, wol_mock):
-        """Testing setup of platform."""
+    async def async_test_setup(self, samsung_mock, wol_mock):
+        """Test setup of platform."""
         with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
             add_entities = mock.Mock()
-            setup_platform(self.hass, WORKING_CONFIG, add_entities)
+            await async_setup_platform(self.hass, WORKING_CONFIG, add_entities)
 
     @MockDependency("samsungctl")
     @MockDependency("wakeonlan")
-    def test_setup_discovery(self, samsung_mock, wol_mock):
-        """Testing setup of platform with discovery."""
+    async def async_test_setup_discovery(self, samsung_mock, wol_mock):
+        """Test setup of platform with discovery."""
         with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
             add_entities = mock.Mock()
-            setup_platform(self.hass, {}, add_entities, discovery_info=DISCOVERY_INFO)
+            await async_setup_platform(
+                self.hass, {}, add_entities, discovery_info=DISCOVERY_INFO
+            )
 
     @MockDependency("samsungctl")
     @MockDependency("wakeonlan")
     @mock.patch("homeassistant.components.samsungtv.media_player.LOGGER.warning")
-    def test_setup_none(self, samsung_mock, wol_mock, mocked_warn):
-        """Testing setup of platform with no data."""
+    async def async_test_setup_none(self, samsung_mock, wol_mock, mocked_warn):
+        """Test setup of platform with no data."""
         with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
             add_entities = mock.Mock()
-            setup_platform(self.hass, {}, add_entities, discovery_info=None)
+            await async_setup_platform(self.hass, {}, add_entities, discovery_info=None)
             mocked_warn.assert_called_once_with("Cannot determine device")
             add_entities.assert_not_called()
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -160,6 +160,13 @@ async def test_setup_with_mac(hass, remote):
     assert hass.states.get(ENTITY_ID)
 
 
+async def test_setup_duplicate(hass, remote, caplog):
+    """Test duplicate setup of platform."""
+    DUPLICATE = {DOMAIN: [MOCK_CONFIG[DOMAIN], MOCK_CONFIG[DOMAIN]]}
+    await setup_samsungtv(hass, DUPLICATE)
+    assert "Ignoring duplicate Samsung TV fake" in caplog.text
+
+
 async def test_setup_without_mac(hass, remote):
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOMAC)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -26,6 +26,7 @@ from homeassistant.components.samsungtv.media_player import (
     SUPPORT_SAMSUNGTV,
 )
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_SUPPORTED_FEATURES,
@@ -191,10 +192,13 @@ async def test_setup_discovery(hass, remote):
         )
     )
     await hass.async_block_till_done()
-    entity = hass.data[DOMAIN].get_entity(ENTITY_ID_DISCOVERY)
-    assert entity
-    assert entity.name == "fake_discovery (fake_model)"
-    assert entity.unique_id == "fake_uuid"
+    state = hass.states.get(ENTITY_ID_DISCOVERY)
+    assert state
+    assert state.name == "fake_discovery (fake_model)"
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entry = entity_registry.async_get(ENTITY_ID_DISCOVERY)
+    assert entry
+    assert entry.unique_id == "fake_uuid"
 
 
 async def test_setup_discovery_prefix(hass, remote):
@@ -205,10 +209,13 @@ async def test_setup_discovery_prefix(hass, remote):
         )
     )
     await hass.async_block_till_done()
-    entity = hass.data[DOMAIN].get_entity(ENTITY_ID_DISCOVERY_PREFIX)
-    assert entity
-    assert entity.name == "fake_discovery_prefix (fake_model_prefix)"
-    assert entity.unique_id == "fake_uuid_prefix"
+    state = hass.states.get(ENTITY_ID_DISCOVERY_PREFIX)
+    assert state
+    assert state.name == "fake_discovery_prefix (fake_model_prefix)"
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entry = entity_registry.async_get(ENTITY_ID_DISCOVERY_PREFIX)
+    assert entry
+    assert entry.unique_id == "fake_uuid_prefix"
 
 
 async def test_update_on(hass, remote, mock_now):
@@ -402,7 +409,7 @@ async def test_supported_features_with_mac(hass, remote):
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert (
-        SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON == state.attributes[ATTR_SUPPORTED_FEATURES]
+        state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON
     )
 
 
@@ -410,15 +417,14 @@ async def test_supported_features_without_mac(hass, remote):
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOMAC)
     state = hass.states.get(ENTITY_ID_NOMAC)
-    assert SUPPORT_SAMSUNGTV == state.attributes[ATTR_SUPPORTED_FEATURES]
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV
 
 
 async def test_device_class(hass, remote):
     """Test for device_class property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
-    entity = hass.data[DOMAIN].get_entity(ENTITY_ID)
-    assert entity
-    assert entity.device_class == DEVICE_CLASS_TV
+    state = hass.states.get(ENTITY_ID)
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_TV
 
 
 async def test_turn_off_websocket(hass, remote):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -35,7 +35,6 @@ from homeassistant.const import (
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
-    SERVICE_MEDIA_PLAY_PAUSE,
     SERVICE_MEDIA_PREVIOUS_TRACK,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
@@ -44,8 +43,6 @@ from homeassistant.const import (
     SERVICE_VOLUME_UP,
     STATE_OFF,
     STATE_ON,
-    STATE_PAUSED,
-    STATE_PLAYING,
     STATE_UNKNOWN,
 )
 from homeassistant.setup import async_setup_component
@@ -353,29 +350,6 @@ async def test_state_without_mac(hass, remote):
     assert state.state == STATE_OFF
 
 
-async def test_is_volume_muted(hass, remote):
-    """Test for is_volume_muted property."""
-    await setup_samsungtv(hass, MOCK_CONFIG)
-    state = hass.states.get(ENTITY_ID)
-    assert not state.attributes[ATTR_MEDIA_VOLUME_MUTED]
-    assert await hass.services.async_call(
-        DOMAIN,
-        SERVICE_VOLUME_MUTE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
-        True,
-    )
-    state = hass.states.get(ENTITY_ID)
-    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED]
-    assert await hass.services.async_call(
-        DOMAIN,
-        SERVICE_VOLUME_MUTE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: False},
-        True,
-    )
-    state = hass.states.get(ENTITY_ID)
-    assert not state.attributes[ATTR_MEDIA_VOLUME_MUTED]
-
-
 async def test_supported_features_with_mac(hass, remote):
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
@@ -461,26 +435,6 @@ async def test_mute_volume(hass, remote):
     # key and update called
     assert remote.control.call_count == 2
     assert remote.control.call_args_list == [call("KEY_MUTE"), call("KEY")]
-
-
-async def test_media_play_pause(hass, remote):
-    """Test for media_next_track."""
-    await setup_samsungtv(hass, MOCK_CONFIG)
-    assert await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PLAY, {ATTR_ENTITY_ID: ENTITY_ID}, True
-    )
-    state = hass.states.get(ENTITY_ID)
-    assert state.state == STATE_PLAYING
-    assert await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PLAY_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
-    )
-    state = hass.states.get(ENTITY_ID)
-    assert state.state == STATE_PAUSED
-    assert await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PLAY_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
-    )
-    state = hass.states.get(ENTITY_ID)
-    assert state.state == STATE_PLAYING
 
 
 async def test_media_play(hass, remote):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -93,7 +93,7 @@ class TestSamsungTv(unittest.TestCase):
 
     @MockDependency("samsungctl")
     @MockDependency("wakeonlan")
-    @mock.patch("homeassistant.components.samsungtv.media_player._LOGGER.warning")
+    @mock.patch("homeassistant.components.samsungtv.media_player.LOGGER.warning")
     def test_setup_none(self, samsung_mock, wol_mock, mocked_warn):
         """Testing setup of platform with no data."""
         with mock.patch("homeassistant.components.samsungtv.media_player.socket"):
@@ -212,7 +212,7 @@ class TestSamsungTv(unittest.TestCase):
         self.device.turn_off()
         self.device.send_key.assert_called_once_with("KEY_POWEROFF")
 
-    @mock.patch("homeassistant.components.samsungtv.media_player._LOGGER.debug")
+    @mock.patch("homeassistant.components.samsungtv.media_player.LOGGER.debug")
     def test_turn_off_os_error(self, mocked_debug):
         """Test for turn_off with OSError."""
         _remote = mock.Mock()


### PR DESCRIPTION
## Breaking Change:
Nothing.

## Description:
Added automatic detection of correct protocol to speak to the TV. This is the preparation for `config_flow` and many more to come.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: samsungtv
    host: 192.168.1.134
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
