### PR TITLE
Add device action support to the lock integration

### DIFF
--- a/homeassistant/components/lock/device_action.py
+++ b/homeassistant/components/lock/device_action.py
@@ -4,6 +4,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
     CONF_DOMAIN,
     CONF_TYPE,
     CONF_DEVICE_ID,
@@ -15,9 +16,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, Context
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
-from . import DOMAIN
+from . import DOMAIN, SUPPORT_OPEN
 
-# TODO specify your supported action types.
 ACTION_TYPES = {"lock", "unlock", "open"}
 
 ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
@@ -55,14 +55,19 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
                 CONF_TYPE: "unlock",
             }
         )
-        actions.append(
-            {
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "open",
-            }
-        )
+
+        state = hass.states.get(entry.entity_id)
+        if state:
+            features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+            if features & (SUPPORT_OPEN):
+                actions.append(
+                    {
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_ENTITY_ID: entry.entity_id,
+                        CONF_TYPE: "open",
+                    }
+                )
 
     return actions
 

--- a/homeassistant/components/lock/device_action.py
+++ b/homeassistant/components/lock/device_action.py
@@ -1,0 +1,87 @@
+"""Provides device automations for Lock."""
+from typing import Optional, List
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DOMAIN,
+    CONF_TYPE,
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+    SERVICE_LOCK,
+    SERVICE_OPEN,
+    SERVICE_UNLOCK,
+)
+from homeassistant.core import HomeAssistant, Context
+from homeassistant.helpers import entity_registry
+import homeassistant.helpers.config_validation as cv
+from . import DOMAIN
+
+# TODO specify your supported action types.
+ACTION_TYPES = {"lock", "unlock", "open"}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+    }
+)
+
+
+async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device actions for Lock devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    actions = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        # Add actions for each entity that belongs to this integration
+        actions.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "lock",
+            }
+        )
+        actions.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "unlock",
+            }
+        )
+        actions.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "open",
+            }
+        )
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Optional[Context]
+) -> None:
+    """Execute a device action."""
+    config = ACTION_SCHEMA(config)
+
+    service_data = {ATTR_ENTITY_ID: config[CONF_ENTITY_ID]}
+
+    if config[CONF_TYPE] == "lock":
+        service = SERVICE_LOCK
+    elif config[CONF_TYPE] == "unlock":
+        service = SERVICE_UNLOCK
+    elif config[CONF_TYPE] == "open":
+        service = SERVICE_OPEN
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, blocking=True, context=context
+    )

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -1,5 +1,10 @@
 {
   "device_automation": {
+    "action_type": {
+      "lock": "Lock {entity_name}",
+      "open": "Open {entity_name}",
+      "unlock": "Unlock {entity_name}"
+    },
     "condition_type": {
       "is_locked": "{entity_name} is locked",
       "is_unlocked": "{entity_name} is unlocked"

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -1,0 +1,122 @@
+"""The tests for Lock device actions."""
+import pytest
+
+from homeassistant.components.lock import DOMAIN
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_get_actions(hass, device_reg, entity_reg):
+    """Test we get the expected actions from a lock."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_actions = [
+        {
+            "domain": DOMAIN,
+            "type": "lock",
+            "device_id": device_entry.id,
+            "entity_id": "lock.test_5678",
+        },
+        {
+            "domain": DOMAIN,
+            "type": "unlock",
+            "device_id": device_entry.id,
+            "entity_id": "lock.test_5678",
+        },
+        {
+            "domain": DOMAIN,
+            "type": "open",
+            "device_id": device_entry.id,
+            "entity_id": "lock.test_5678",
+        },
+    ]
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    assert_lists_same(actions, expected_actions)
+
+
+async def test_action(hass):
+    """Test for lock actions."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_lock"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "lock.entity",
+                        "type": "lock",
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_unlock"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "lock.entity",
+                        "type": "unlock",
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_open"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "lock.entity",
+                        "type": "open",
+                    },
+                },
+            ]
+        },
+    )
+
+    lock_calls = async_mock_service(hass, "lock", "lock")
+    unlock_calls = async_mock_service(hass, "lock", "unlock")
+    open_calls = async_mock_service(hass, "lock", "open")
+
+    hass.bus.async_fire("test_event_lock")
+    await hass.async_block_till_done()
+    assert len(lock_calls) == 1
+    assert len(unlock_calls) == 0
+    assert len(open_calls) == 0
+
+    hass.bus.async_fire("test_event_unlock")
+    await hass.async_block_till_done()
+    assert len(lock_calls) == 1
+    assert len(unlock_calls) == 1
+    assert len(open_calls) == 0
+
+    hass.bus.async_fire("test_event_open")
+    await hass.async_block_till_done()
+    assert len(lock_calls) == 1
+    assert len(unlock_calls) == 1
+    assert len(open_calls) == 1

--- a/tests/testing_config/custom_components/test/lock.py
+++ b/tests/testing_config/custom_components/test/lock.py
@@ -1,0 +1,54 @@
+"""
+Provide a mock lock platform.
+
+Call init before using it in your tests to ensure clean test data.
+"""
+from homeassistant.components.lock import LockDevice, SUPPORT_OPEN
+from tests.common import MockEntity
+
+ENTITIES = {}
+
+
+def init(empty=False):
+    """Initialize the platform with entities."""
+    global ENTITIES
+
+    ENTITIES = (
+        {}
+        if empty
+        else {
+            "support_open": MockLock(
+                name=f"Support open Lock",
+                is_locked=True,
+                supported_features=SUPPORT_OPEN,
+                unique_id="unique_support_open",
+            ),
+            "no_support_open": MockLock(
+                name=f"No support open Lock",
+                is_locked=True,
+                supported_features=0,
+                unique_id="unique_no_support_open",
+            ),
+        }
+    )
+
+
+async def async_setup_platform(
+    hass, config, async_add_entities_callback, discovery_info=None
+):
+    """Return mock entities."""
+    async_add_entities_callback(list(ENTITIES.values()))
+
+
+class MockLock(MockEntity, LockDevice):
+    """Mock Lock class."""
+
+    @property
+    def is_locked(self):
+        """Return true if the lock is locked."""
+        return self._handle("is_locked")
+
+    @property
+    def supported_features(self):
+        """Return the class of this sensor."""
+        return self._handle("supported_features")


### PR DESCRIPTION
## Description:
Add device action support to the lock integration

**Related issue (if applicable):** fixes #26989 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
