### PR TITLE
Move imports in trend component to top level

### DIFF
--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -3,6 +3,7 @@ from collections import deque
 import logging
 import math
 
+import numpy as np
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -17,9 +18,9 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_ENTITY_ID,
     CONF_FRIENDLY_NAME,
-    STATE_UNKNOWN,
-    STATE_UNAVAILABLE,
     CONF_SENSORS,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -207,8 +208,6 @@ class SensorTrend(BinarySensorDevice):
 
         This need run inside executor.
         """
-        import numpy as np
-
         timestamps = np.array([t for t, _ in self.samples])
         values = np.array([s for _, s in self.samples])
         coeffs = np.polyfit(timestamps, values, 1)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved import from function to top-level as requested in #27284

Related issue (if applicable): fixes #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
