### PR TITLE
Move imports in startca component to top-level

### DIFF
--- a/homeassistant/components/startca/sensor.py
+++ b/homeassistant/components/startca/sensor.py
@@ -1,10 +1,11 @@
 """Support for Start.ca Bandwidth Monitor."""
 from datetime import timedelta
-from xml.parsers.expat import ExpatError
 import logging
-import async_timeout
+from xml.parsers.expat import ExpatError
 
+import async_timeout
 import voluptuous as vol
+import xmltodict
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_API_KEY, CONF_MONITORED_VARIABLES, CONF_NAME
@@ -138,8 +139,6 @@ class StartcaData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Get the Start.ca bandwidth data from the web service."""
-        import xmltodict
-
         _LOGGER.debug("Updating Start.ca usage data")
         url = "https://www.start.ca/support/usage/api?key=" + self.api_key
         with async_timeout.timeout(REQUEST_TIMEOUT):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Moved import from function to top-level as requested in #27284

Related issue (if applicable): fixes #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
