### PR TITLE
Use URI provided by Plex for local connections

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -89,9 +89,10 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.error("Invalid credentials provided, config not created")
             errors["base"] = "faulty_credentials"
         except (plexapi.exceptions.NotFound, requests.exceptions.ConnectionError):
-            _LOGGER.error(
-                "Plex server could not be reached: %s", server_config[CONF_URL]
+            server_identifier = (
+                server_config.get(CONF_URL) or plex_server.server_choice or "Unknown"
             )
+            _LOGGER.error("Plex server could not be reached: %s", server_identifier)
             errors["base"] = "not_found"
 
         except ServerNotSpecified as available_servers:

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -39,6 +39,7 @@ class PlexServer:
         self._server_name = server_config.get(CONF_SERVER)
         self._verify_ssl = server_config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
         self.options = options
+        self.server_choice = None
 
     def connect(self):
         """Connect to a Plex server directly, obtaining direct URL if necessary."""
@@ -56,10 +57,10 @@ class PlexServer:
             if not self._server_name and len(available_servers) > 1:
                 raise ServerNotSpecified(available_servers)
 
-            server_choice = (
+            self.server_choice = (
                 self._server_name if self._server_name else available_servers[0][0]
             )
-            self._plex_server = account.resource(server_choice).connect()
+            self._plex_server = account.resource(self.server_choice).connect()
 
         def _connect_with_url():
             session = None

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -60,7 +60,7 @@ class PlexServer:
                 self._server_name if self._server_name else available_servers[0][0]
             )
             connections = account.resource(server_choice).connections
-            local_url = [x.httpuri for x in connections if x.local]
+            local_url = [x.uri for x in connections if x.local]
             remote_url = [x.uri for x in connections if not x.local]
             self._url = local_url[0] if local_url else remote_url[0]
 

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -43,7 +43,7 @@ class PlexServer:
     def connect(self):
         """Connect to a Plex server directly, obtaining direct URL if necessary."""
 
-        def _set_missing_url():
+        def _connect_with_token():
             account = plexapi.myplex.MyPlexAccount(token=self._token)
             available_servers = [
                 (x.name, x.clientIdentifier)
@@ -59,10 +59,7 @@ class PlexServer:
             server_choice = (
                 self._server_name if self._server_name else available_servers[0][0]
             )
-            connections = account.resource(server_choice).connections
-            local_url = [x.uri for x in connections if x.local]
-            remote_url = [x.uri for x in connections if not x.local]
-            self._url = local_url[0] if local_url else remote_url[0]
+            self._plex_server = account.resource(server_choice).connect()
 
         def _connect_with_url():
             session = None
@@ -73,10 +70,10 @@ class PlexServer:
                 self._url, self._token, session
             )
 
-        if self._token and not self._url:
-            _set_missing_url()
-
-        _connect_with_url()
+        if self._url:
+            _connect_with_url()
+        else:
+            _connect_with_token()
 
     def clients(self):
         """Pass through clients call to plexapi."""

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -29,32 +29,10 @@ class MockResource:
         ]
         self.provides = ["server"]
         self._mock_plex_server = MockPlexServer(index)
-        self._connections = []
-        for connection in range(2):
-            self._connections.append(MockConnection(connection))
-
-    @property
-    def connections(self):
-        """Mock the resource connection listing method."""
-        return self._connections
 
     def connect(self):
         """Mock the resource connect method."""
         return self._mock_plex_server
-
-
-class MockConnection:  # pylint: disable=too-few-public-methods
-    """Mock a single account resource connection object."""
-
-    def __init__(self, index, ssl=True):
-        """Initialize the object."""
-        prefix = "https" if ssl else "http"
-        self.httpuri = (
-            f"http://{MOCK_SERVERS[index][CONF_HOST]}:{MOCK_SERVERS[index][CONF_PORT]}"
-        )
-        self.uri = f"{prefix}://{MOCK_SERVERS[index][CONF_HOST]}:{MOCK_SERVERS[index][CONF_PORT]}"
-        # Only first server is local
-        self.local = not bool(index)
 
 
 class MockPlexAccount:


### PR DESCRIPTION
## Description:
A user reported not being able to connect with the new Plex config flow, and we tracked it down to a Plex server setting which requires SSL connections. There was previously an assumption that local connections would allow non-SSL connections as a fallback.

This change uses the full URI provided by Plex to connect to local servers. This is a FQDN which will resolve to the local IP and can pass SSL validation checks.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html