### PR TITLE
Show all UPNP/IGD sensors in one device

### DIFF
--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -162,6 +162,7 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
         identifiers={(DOMAIN, device.udn)},
         name=device.name,
         manufacturer=device.manufacturer,
+        model=device.model_name,
     )
 
     # set up sensors

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -83,6 +83,11 @@ class Device:
         """Get the manufacturer."""
         return self._igd_device.manufacturer
 
+    @property
+    def model_name(self):
+        """Get the model name."""
+        return self._igd_device.model_name
+
     async def async_add_port_mappings(self, ports, local_ip):
         """Add port mappings."""
         if local_ip == "127.0.0.1":

--- a/homeassistant/components/upnp/sensor.py
+++ b/homeassistant/components/upnp/sensor.py
@@ -96,7 +96,7 @@ class UpnpSensor(Entity):
         return {
             "connections": {(dr.CONNECTION_UPNP, self._device.udn)},
             "identifiers": {(DOMAIN_UPNP, self.unique_id)},
-            "name": self.name,
+            "name": self._device.name,
             "manufacturer": self._device.manufacturer,
             "model": self._device.model_name,
         }

--- a/homeassistant/components/upnp/sensor.py
+++ b/homeassistant/components/upnp/sensor.py
@@ -2,6 +2,7 @@
 import logging
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
@@ -93,9 +94,11 @@ class UpnpSensor(Entity):
     def device_info(self):
         """Get device info."""
         return {
+            "connections": {(dr.CONNECTION_UPNP, self._device.udn)},
             "identifiers": {(DOMAIN_UPNP, self.unique_id)},
             "name": self.name,
             "manufacturer": self._device.manufacturer,
+            "model": self._device.model_name,
         }
 
 

--- a/homeassistant/components/upnp/sensor.py
+++ b/homeassistant/components/upnp/sensor.py
@@ -95,7 +95,7 @@ class UpnpSensor(Entity):
         """Get device info."""
         return {
             "connections": {(dr.CONNECTION_UPNP, self._device.udn)},
-            "identifiers": {(DOMAIN_UPNP, self.unique_id)},
+            "identifiers": {(DOMAIN_UPNP, self._device.udn)},
             "name": self._device.name,
             "manufacturer": self._device.manufacturer,
             "model": self._device.model_name,


### PR DESCRIPTION
## Breaking Change:
You have to remove and re-add the integration to get rid of the wrong devices.

## Description:
show all UPNP/IGD sensors in one device

**Related issue (if applicable):** fixes #27516

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
Added with `config_flow`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
