### PR TITLE
Handle marker attrs that may not exist

### DIFF
--- a/homeassistant/components/cups/sensor.py
+++ b/homeassistant/components/cups/sensor.py
@@ -276,11 +276,11 @@ class MarkerSensor(Entity):
         if self._attributes is None:
             return None
 
-        high_level = self._attributes[self._printer]["marker-high-levels"]
+        high_level = self._attributes[self._printer].get("marker-high-levels")
         if isinstance(high_level, list):
             high_level = high_level[self._index]
 
-        low_level = self._attributes[self._printer]["marker-low-levels"]
+        low_level = self._attributes[self._printer].get("marker-low-levels")
         if isinstance(low_level, list):
             low_level = low_level[self._index]
 


### PR DESCRIPTION
## Description:
In CUPS sensor, marker-high-levels and marker-low-levels may not exist in printer attributes returned by CUPS, so we should use reasonable defaults to avoid this:
`KeyError: 'marker-high-levels'`

100 for high and 0 for low seem to be reasonable defaults, per
https://www.cups.org/doc/spec-ipp.html#marker-high-levels

**Related issue (if applicable):** fixes #27518

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
