### PR TITLE
Display correct nzbget units

### DIFF
--- a/homeassistant/components/nzbget/sensor.py
+++ b/homeassistant/components/nzbget/sensor.py
@@ -34,9 +34,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = discovery_info["client_name"]
 
     devices = []
-    for sensor_type, sensor_config in SENSOR_TYPES.items():
+    for sensor_config in SENSOR_TYPES.values():
         new_sensor = NZBGetSensor(
-            nzbget_data, sensor_type, name, sensor_config[0], sensor_config[1]
+            nzbget_data, sensor_config[0], name, sensor_config[1], sensor_config[2]
         )
         devices.append(new_sensor)
 
@@ -50,8 +50,8 @@ class NZBGetSensor(Entity):
         self, nzbget_data, sensor_type, client_name, sensor_name, unit_of_measurement
     ):
         """Initialize a new NZBGet sensor."""
-        self._name = f"{client_name} {sensor_type}"
-        self.type = sensor_name
+        self._name = f"{client_name} {sensor_name}"
+        self.type = sensor_type
         self.client_name = client_name
         self.nzbget_data = nzbget_data
         self._state = None


### PR DESCRIPTION
## Description:
Making nzbget display the proper units.

**Related issue (if applicable):** fixes #27437 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

![image](https://user-images.githubusercontent.com/266816/66691656-bc293e80-ec4c-11e9-87de-9b15919a522d.png)