### PR TITLE
Move and sort multiple integration imports (A & B)

### DIFF
--- a/homeassistant/components/aftership/sensor.py
+++ b/homeassistant/components/aftership/sensor.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+from pyaftership.tracker import Tracking
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -11,6 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,8 +58,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the AfterShip sensor platform."""
-    from pyaftership.tracker import Tracking
-
     apikey = config[CONF_API_KEY]
     name = config[CONF_NAME]
 

--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -1,7 +1,9 @@
 """Support for AirVisual air quality sensors."""
-from logging import getLogger
 from datetime import timedelta
+from logging import getLogger
 
+from pyairvisual import Client
+from pyairvisual.errors import AirVisualError
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -14,8 +16,8 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MONITORED_CONDITIONS,
     CONF_SCAN_INTERVAL,
-    CONF_STATE,
     CONF_SHOW_ON_MAP,
+    CONF_STATE,
 )
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -97,8 +99,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Configure the platform and add the sensors."""
-    from pyairvisual import Client
-
     city = config.get(CONF_CITY)
     state = config.get(CONF_STATE)
     country = config.get(CONF_COUNTRY)
@@ -249,8 +249,6 @@ class AirVisualData:
 
     async def _async_update(self):
         """Update AirVisual data."""
-        from pyairvisual.errors import AirVisualError
-
         try:
             if self.city and self.state and self.country:
                 resp = await self._client.api.city(self.city, self.state, self.country)

--- a/homeassistant/components/aladdin_connect/cover.py
+++ b/homeassistant/components/aladdin_connect/cover.py
@@ -1,21 +1,22 @@
 """Platform for the Aladdin Connect cover component."""
 import logging
 
+from aladdin_connect import AladdinConnectClient
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    CoverDevice,
     PLATFORM_SCHEMA,
-    SUPPORT_OPEN,
     SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    CoverDevice,
 )
 from homeassistant.const import (
-    CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_USERNAME,
     STATE_CLOSED,
-    STATE_OPENING,
     STATE_CLOSING,
     STATE_OPEN,
+    STATE_OPENING,
 )
 import homeassistant.helpers.config_validation as cv
 
@@ -40,8 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Aladdin Connect platform."""
-    from aladdin_connect import AladdinConnectClient
-
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     acc = AladdinConnectClient(username, password)

--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -1,14 +1,17 @@
 """Support for AlarmDecoder devices."""
+from datetime import timedelta
 import logging
 
-from datetime import timedelta
+from alarmdecoder import AlarmDecoder
+from alarmdecoder.devices import SerialDevice, SocketDevice, USBDevice
+from alarmdecoder.util import NoDeviceError
 import voluptuous as vol
 
+from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_HOST
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.util import dt as dt_util
-from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,9 +112,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up for the AlarmDecoder devices."""
-    from alarmdecoder import AlarmDecoder
-    from alarmdecoder.devices import SocketDevice, SerialDevice, USBDevice
-
     conf = config.get(DOMAIN)
 
     restart = False
@@ -134,8 +134,6 @@ def setup(hass, config):
 
     def open_connection(now=None):
         """Open a connection to AlarmDecoder."""
-        from alarmdecoder.util import NoDeviceError
-
         nonlocal restart
         try:
             controller.open(baud)

--- a/homeassistant/components/alarmdotcom/alarm_control_panel.py
+++ b/homeassistant/components/alarmdotcom/alarm_control_panel.py
@@ -2,6 +2,7 @@
 import logging
 import re
 
+from pyalarmdotcom import Alarmdotcom
 import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
@@ -49,8 +50,6 @@ class AlarmDotCom(alarm.AlarmControlPanel):
 
     def __init__(self, hass, name, code, username, password):
         """Initialize the Alarm.com status."""
-        from pyalarmdotcom import Alarmdotcom
-
         _LOGGER.debug("Setting up Alarm.com...")
         self._hass = hass
         self._name = name

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 import logging
 
+from alpha_vantage.foreignexchange import ForeignExchange
+from alpha_vantage.timeseries import TimeSeries
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -62,9 +64,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Alpha Vantage sensor."""
-    from alpha_vantage.timeseries import TimeSeries
-    from alpha_vantage.foreignexchange import ForeignExchange
-
     api_key = config.get(CONF_API_KEY)
     symbols = config.get(CONF_SYMBOLS, [])
     conversions = config.get(CONF_FOREIGN_EXCHANGE, [])

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -7,8 +7,8 @@ import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
-    ATTR_NAME,
     ATTR_LOCATION,
+    ATTR_NAME,
     CONF_API_KEY,
     EVENT_HOMEASSISTANT_STOP,
 )

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow to configure the Ambient PWS component."""
+from aioambient import Client
+from aioambient.errors import AmbientError
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -40,9 +42,6 @@ class AmbientStationFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
-        from aioambient import Client
-        from aioambient.errors import AmbientError
-
         if not user_input:
             return await self._show_form()
 

--- a/homeassistant/components/ampio/air_quality.py
+++ b/homeassistant/components/ampio/air_quality.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+from asmog import AmpioSmog
 import voluptuous as vol
 
 from homeassistant.components.air_quality import PLATFORM_SCHEMA, AirQualityEntity
@@ -23,8 +24,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Ampio Smog air quality platform."""
-    from asmog import AmpioSmog
-
     name = config.get(CONF_NAME)
     station_id = config[CONF_STATION_ID]
 

--- a/homeassistant/components/android_ip_webcam/__init__.py
+++ b/homeassistant/components/android_ip_webcam/__init__.py
@@ -1,34 +1,35 @@
 """Support for Android IP Webcam."""
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
+from pydroid_ipcam import PyDroidIPCam
 import voluptuous as vol
 
-from homeassistant.core import callback
+from homeassistant.components.mjpeg.camera import CONF_MJPEG_URL, CONF_STILL_IMAGE_URL
 from homeassistant.const import (
-    CONF_NAME,
     CONF_HOST,
-    CONF_PORT,
-    CONF_USERNAME,
+    CONF_NAME,
     CONF_PASSWORD,
+    CONF_PLATFORM,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
     CONF_SENSORS,
     CONF_SWITCHES,
     CONF_TIMEOUT,
-    CONF_SCAN_INTERVAL,
-    CONF_PLATFORM,
+    CONF_USERNAME,
 )
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.core import callback
 from homeassistant.helpers import discovery
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
-    async_dispatcher_send,
     async_dispatcher_connect,
+    async_dispatcher_send,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
-from homeassistant.components.mjpeg.camera import CONF_MJPEG_URL, CONF_STILL_IMAGE_URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -187,8 +188,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the IP Webcam component."""
-    from pydroid_ipcam import PyDroidIPCam
-
     webcams = hass.data[DATA_IP_WEBCAM] = {}
     websession = async_get_clientsession(hass)
 

--- a/homeassistant/components/anel_pwrctrl/switch.py
+++ b/homeassistant/components/anel_pwrctrl/switch.py
@@ -1,13 +1,14 @@
 """Support for ANEL PwrCtrl switches."""
+from datetime import timedelta
 import logging
 import socket
-from datetime import timedelta
 
+from anel_pwrctrl import DeviceMaster
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,8 +36,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     password = config.get(CONF_PASSWORD)
     port_recv = config.get(CONF_PORT_RECV)
     port_send = config.get(CONF_PORT_SEND)
-
-    from anel_pwrctrl import DeviceMaster
 
     try:
         master = DeviceMaster(

--- a/homeassistant/components/anthemav/media_player.py
+++ b/homeassistant/components/anthemav/media_player.py
@@ -1,9 +1,10 @@
 """Support for Anthem Network Receivers and Processors."""
 import logging
 
+import anthemav
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
@@ -46,8 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up our socket to the AVR."""
-    import anthemav
-
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     name = config.get(CONF_NAME)

--- a/homeassistant/components/apcupsd/__init__.py
+++ b/homeassistant/components/apcupsd/__init__.py
@@ -1,7 +1,8 @@
 """Support for APCUPSd via its Network Information Server (NIS)."""
-import logging
 from datetime import timedelta
+import logging
 
+from apcaccess import status
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -64,8 +65,6 @@ class APCUPSdData:
 
     def __init__(self, host, port):
         """Initialize the data object."""
-        from apcaccess import status
-
         self._host = host
         self._port = port
         self._status = None

--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -1,10 +1,10 @@
 """Support for tracking the online status of a UPS."""
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components import apcupsd
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components import apcupsd
 
 DEFAULT_NAME = "UPS Online Status"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -1,12 +1,13 @@
 """Support for APCUPSd sensors."""
 import logging
 
+from apcaccess.status import ALL_UNITS
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components import apcupsd
-from homeassistant.const import TEMP_CELSIUS, CONF_RESOURCES, POWER_WATT
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_RESOURCES, POWER_WATT, TEMP_CELSIUS
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -135,8 +136,6 @@ def infer_unit(value):
     Split the unit off the end of the value and return the value, unit tuple
     pair. Else return the original value and None as the unit.
     """
-    from apcaccess.status import ALL_UNITS
-
     for unit in ALL_UNITS:
         if value.endswith(unit):
             return value[: -len(unit)], INFERRED_UNITS.get(unit, unit.strip())

--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -1,13 +1,10 @@
 """APNS Notification platform."""
 import logging
 
+from apns2.client import APNsClient
+from apns2.errors import Unregistered
+from apns2.payload import Payload
 import voluptuous as vol
-
-from homeassistant.config import load_yaml_config_file
-from homeassistant.const import ATTR_NAME, CONF_NAME, CONF_PLATFORM
-from homeassistant.helpers import template as template_helper
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import track_state_change
 
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -16,6 +13,11 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.config import load_yaml_config_file
+from homeassistant.const import ATTR_NAME, CONF_NAME, CONF_PLATFORM
+from homeassistant.helpers import template as template_helper
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import track_state_change
 
 APNS_DEVICES = "apns.yaml"
 CONF_CERTFILE = "cert_file"
@@ -213,10 +215,6 @@ class ApnsNotificationService(BaseNotificationService):
 
     def send_message(self, message=None, **kwargs):
         """Send push message to registered devices."""
-        from apns2.client import APNsClient
-        from apns2.payload import Payload
-        from apns2.errors import Unregistered
-
         apns = APNsClient(
             self.certificate, use_sandbox=self.sandbox, use_alternative_port=False
         )

--- a/homeassistant/components/asterisk_mbox/__init__.py
+++ b/homeassistant/components/asterisk_mbox/__init__.py
@@ -1,6 +1,12 @@
 """Support for Asterisk Voicemail interface."""
 import logging
 
+from asterisk_mbox import Client as asteriskClient
+from asterisk_mbox.commands import (
+    CMD_MESSAGE_CDR,
+    CMD_MESSAGE_CDR_AVAILABLE,
+    CMD_MESSAGE_LIST,
+)
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
@@ -51,8 +57,6 @@ class AsteriskData:
 
     def __init__(self, hass, host, port, password, config):
         """Init the Asterisk data object."""
-        from asterisk_mbox import Client as asteriskClient
-
         self.hass = hass
         self.config = config
         self.messages = None
@@ -76,12 +80,6 @@ class AsteriskData:
     @callback
     def handle_data(self, command, msg):
         """Handle changes to the mailbox."""
-        from asterisk_mbox.commands import (
-            CMD_MESSAGE_LIST,
-            CMD_MESSAGE_CDR_AVAILABLE,
-            CMD_MESSAGE_CDR,
-        )
-
         if command == CMD_MESSAGE_LIST:
             _LOGGER.debug("AsteriskVM sent updated message list: Len %d", len(msg))
             old_messages = self.messages

--- a/homeassistant/components/asterisk_mbox/mailbox.py
+++ b/homeassistant/components/asterisk_mbox/mailbox.py
@@ -1,6 +1,8 @@
 """Support for the Asterisk Voicemail interface."""
 import logging
 
+from asterisk_mbox import ServerError
+
 from homeassistant.components.mailbox import CONTENT_TYPE_MPEG, Mailbox, StreamError
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -50,8 +52,6 @@ class AsteriskMailbox(Mailbox):
 
     async def async_get_media(self, msgid):
         """Return the media blob for the msgid."""
-        from asterisk_mbox import ServerError
-
         client = self.hass.data[ASTERISK_DOMAIN].client
         try:
             return client.mp3(msgid, sync=True)

--- a/homeassistant/components/asuswrt/__init__.py
+++ b/homeassistant/components/asuswrt/__init__.py
@@ -1,15 +1,16 @@
 """Support for ASUSWRT devices."""
 import logging
 
+from aioasuswrt.asuswrt import AsusWrt
 import voluptuous as vol
 
 from homeassistant.const import (
     CONF_HOST,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_PORT,
     CONF_MODE,
+    CONF_PASSWORD,
+    CONF_PORT,
     CONF_PROTOCOL,
+    CONF_USERNAME,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -53,8 +54,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the asuswrt component."""
-    from aioasuswrt.asuswrt import AsusWrt
-
     conf = config[DOMAIN]
 
     api = AsusWrt(

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -1,18 +1,20 @@
 """Support for August devices."""
-import logging
 from datetime import timedelta
+import logging
 
+from august.api import Api
+from august.authenticator import AuthenticationState, Authenticator, ValidationResult
+from requests import RequestException, Session
 import voluptuous as vol
-from requests import RequestException
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_TIMEOUT,
+    CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,8 +64,6 @@ def request_configuration(hass, config, api, authenticator):
 
     def august_configuration_callback(data):
         """Run when the configuration callback is called."""
-        from august.authenticator import ValidationResult
-
         result = authenticator.validate_verification_code(data.get("verification_code"))
 
         if result == ValidationResult.INVALID_VERIFICATION_CODE:
@@ -94,8 +94,6 @@ def request_configuration(hass, config, api, authenticator):
 
 def setup_august(hass, config, api, authenticator):
     """Set up the August component."""
-    from august.authenticator import AuthenticationState
-
     authentication = None
     try:
         authentication = authenticator.authenticate()
@@ -134,10 +132,6 @@ def setup_august(hass, config, api, authenticator):
 
 def setup(hass, config):
     """Set up the August component."""
-    from august.api import Api
-    from august.authenticator import Authenticator
-    from requests import Session
-
     conf = config[DOMAIN]
     api_http_session = None
     try:

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -2,6 +2,9 @@
 from datetime import datetime, timedelta
 import logging
 
+from august.activity import ActivityType
+from august.lock import LockDoorStatus
+
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
 from . import DATA_AUGUST
@@ -26,16 +29,12 @@ def _retrieve_online_state(data, doorbell):
 
 
 def _retrieve_motion_state(data, doorbell):
-    from august.activity import ActivityType
-
     return _activity_time_based_state(
         data, doorbell, [ActivityType.DOORBELL_MOTION, ActivityType.DOORBELL_DING]
     )
 
 
 def _retrieve_ding_state(data, doorbell):
-    from august.activity import ActivityType
-
     return _activity_time_based_state(data, doorbell, [ActivityType.DOORBELL_DING])
 
 
@@ -64,8 +63,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the August binary sensors."""
     data = hass.data[DATA_AUGUST]
     devices = []
-
-    from august.lock import LockDoorStatus
 
     for door in data.locks:
         for sensor_type in SENSOR_TYPES_DOOR:
@@ -135,8 +132,6 @@ class AugustDoorBinarySensor(BinarySensorDevice):
         state_provider = SENSOR_TYPES_DOOR[self._sensor_type][2]
         self._state = state_provider(self._data, self._door)
         self._available = self._state is not None
-
-        from august.lock import LockDoorStatus
 
         self._state = self._state == LockDoorStatus.OPEN
 

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -2,6 +2,9 @@
 from datetime import timedelta
 import logging
 
+from august.activity import ActivityType
+from august.lock import LockStatus
+
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import ATTR_BATTERY_LEVEL
 
@@ -51,8 +54,6 @@ class AugustLock(LockDevice):
 
         self._lock_detail = self._data.get_lock_detail(self._lock.device_id)
 
-        from august.activity import ActivityType
-
         activity = self._data.get_latest_device_activity(
             self._lock.device_id, ActivityType.LOCK_OPERATION
         )
@@ -73,8 +74,6 @@ class AugustLock(LockDevice):
     @property
     def is_locked(self):
         """Return true if device is on."""
-        from august.lock import LockStatus
-
         return self._lock_status is LockStatus.LOCKED
 
     @property

--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -1,9 +1,9 @@
 """Support for the Awair indoor air quality monitor."""
-
 from datetime import timedelta
 import logging
 import math
 
+from python_awair import AwairClient
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -105,8 +105,6 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
 # used at this time is the `uuid` value.
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Connect to the Awair API and find devices."""
-    from python_awair import AwairClient
-
     token = config[CONF_ACCESS_TOKEN]
     client = AwairClient(token, session=async_get_clientsession(hass))
 

--- a/homeassistant/components/baidu/tts.py
+++ b/homeassistant/components/baidu/tts.py
@@ -1,6 +1,7 @@
 """Support for Baidu speech service."""
 import logging
 
+from aip import AipSpeech
 import voluptuous as vol
 
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
@@ -106,8 +107,6 @@ class BaiduTTSProvider(Provider):
 
     def get_tts_audio(self, message, language, options=None):
         """Load TTS from BaiduTTS."""
-        from aip import AipSpeech
-
         aip_speech = AipSpeech(
             self._app_data["appid"],
             self._app_data["apikey"],

--- a/homeassistant/components/bitcoin/sensor.py
+++ b/homeassistant/components/bitcoin/sensor.py
@@ -1,11 +1,12 @@
 """Bitcoin information service that uses blockchain.info."""
-import logging
 from datetime import timedelta
+import logging
 
+from blockchain import exchangerates, statistics
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_DISPLAY_OPTIONS, ATTR_ATTRIBUTION, CONF_CURRENCY
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_CURRENCY, CONF_DISPLAY_OPTIONS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
@@ -55,8 +56,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Bitcoin sensors."""
-    from blockchain import exchangerates
-
     currency = config.get(CONF_CURRENCY)
 
     if currency not in exchangerates.get_ticker():
@@ -169,7 +168,5 @@ class BitcoinData:
 
     def update(self):
         """Get the latest data from blockchain.info."""
-        from blockchain import statistics, exchangerates
-
         self.stats = statistics.get()
         self.ticker = exchangerates.get_ticker()

--- a/homeassistant/components/blackbird/media_player.py
+++ b/homeassistant/components/blackbird/media_player.py
@@ -2,9 +2,11 @@
 import logging
 import socket
 
+from pyblackbird import get_blackbird
+from serial import SerialException
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     DOMAIN,
     SUPPORT_SELECT_SOURCE,
@@ -71,9 +73,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     port = config.get(CONF_PORT)
     host = config.get(CONF_HOST)
-
-    from pyblackbird import get_blackbird
-    from serial import SerialException
 
     connection = None
     if port is not None:

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -1,22 +1,24 @@
 """Support for Blink Home Camera System."""
-import logging
 from datetime import timedelta
+import logging
+
+from blinkpy import blinkpy
 import voluptuous as vol
 
-from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.const import (
-    CONF_USERNAME,
-    CONF_PASSWORD,
-    CONF_NAME,
-    CONF_SCAN_INTERVAL,
     CONF_BINARY_SENSORS,
-    CONF_SENSORS,
     CONF_FILENAME,
-    CONF_MONITORED_CONDITIONS,
     CONF_MODE,
+    CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
     CONF_OFFSET,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_SENSORS,
+    CONF_USERNAME,
     TEMP_FAHRENHEIT,
 )
+from homeassistant.helpers import config_validation as cv, discovery
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,8 +99,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up Blink System."""
-    from blinkpy import blinkpy
-
     conf = config[BLINK_DATA]
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]

--- a/homeassistant/components/blinksticklight/light.py
+++ b/homeassistant/components/blinksticklight/light.py
@@ -1,15 +1,16 @@
 """Support for Blinkstick lights."""
 import logging
 
+from blinkstick import blinkstick
 import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
+    PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     Light,
-    PLATFORM_SCHEMA,
 )
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
@@ -33,8 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Blinkstick device specified by serial number."""
-    from blinkstick import blinkstick
-
     name = config.get(CONF_NAME)
     serial = config.get(CONF_SERIAL)
 

--- a/homeassistant/components/blockchain/sensor.py
+++ b/homeassistant/components/blockchain/sensor.py
@@ -1,12 +1,13 @@
 """Support for Blockchain.info sensors."""
-import logging
 from datetime import timedelta
+import logging
 
+from pyblockchain import get_balance, validate_address
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,8 +32,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Blockchain.info sensors."""
-    from pyblockchain import validate_address
-
     addresses = config.get(CONF_ADDRESSES)
     name = config.get(CONF_NAME)
 
@@ -81,6 +80,4 @@ class BlockchainSensor(Entity):
 
     def update(self):
         """Get the latest state of the sensor."""
-        from pyblockchain import get_balance
-
         self._state = get_balance(self.addresses)

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -1,12 +1,14 @@
 """Reads vehicle status from BMW connected drive portal."""
 import logging
 
+from bimmer_connected.account import ConnectedDriveAccount
+from bimmer_connected.country_selector import get_region_from_name
 import voluptuous as vol
 
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import discovery
-from homeassistant.helpers.event import track_utc_time_change
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import track_utc_time_change
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,9 +120,6 @@ class BMWConnectedDriveAccount:
         self, username: str, password: str, region_str: str, name: str, read_only
     ) -> None:
         """Constructor."""
-        from bimmer_connected.account import ConnectedDriveAccount
-        from bimmer_connected.country_selector import get_region_from_name
-
         region = get_region_from_name(region_str)
 
         self.read_only = read_only

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -1,6 +1,8 @@
 """Reads vehicle status from BMW connected drive portal."""
 import logging
 
+from bimmer_connected.state import ChargingState, LockState
+
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import LENGTH_KILOMETERS
 
@@ -141,9 +143,6 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
 
     def update(self):
         """Read new state data from the library."""
-        from bimmer_connected.state import LockState
-        from bimmer_connected.state import ChargingState
-
         vehicle_state = self._vehicle.state
 
         # device class opening: On means open, Off means closed

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -1,6 +1,8 @@
 """Support for BMW car locks with BMW ConnectedDrive."""
 import logging
 
+from bimmer_connected.state import LockState
+
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 
@@ -87,8 +89,6 @@ class BMWLock(LockDevice):
 
     def update(self):
         """Update state of the lock."""
-        from bimmer_connected.state import LockState
-
         _LOGGER.debug("%s: updating data for %s", self._vehicle.name, self._attribute)
         vehicle_state = self._vehicle.state
 

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -1,6 +1,8 @@
 """Support for reading vehicle status from BMW connected drive portal."""
 import logging
 
+from bimmer_connected.state import ChargingState
+
 from homeassistant.const import (
     CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_KILOMETERS,
@@ -97,8 +99,6 @@ class BMWConnectedDriveSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        from bimmer_connected.state import ChargingState
-
         vehicle_state = self._vehicle.state
         charging_state = vehicle_state.charging_status in [ChargingState.CHARGING]
 

--- a/homeassistant/components/bom/camera.py
+++ b/homeassistant/components/bom/camera.py
@@ -1,4 +1,5 @@
 """Provide animated GIF loops of BOM radar imagery."""
+from bomradarloop import BOMRadarLoop
 import voluptuous as vol
 
 from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
@@ -119,8 +120,6 @@ class BOMRadarCam(Camera):
 
     def __init__(self, name, location, radar_id, delta, frames, outfile):
         """Initialize the component."""
-        from bomradarloop import BOMRadarLoop
-
         super().__init__()
         self._name = name
         self._cam = BOMRadarLoop(location, radar_id, delta, frames, outfile)

--- a/homeassistant/components/bom/sensor.py
+++ b/homeassistant/components/bom/sensor.py
@@ -12,19 +12,19 @@ import zipfile
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS,
-    TEMP_CELSIUS,
-    CONF_NAME,
     ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
+    TEMP_CELSIUS,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
 
 _RESOURCE = "http://www.bom.gov.au/fwo/{}/{}.{}.json"
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -1,18 +1,18 @@
 """Support for Brunt Blind Engine covers."""
-
 import logging
 
+from brunt import BruntAPI
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    CoverDevice,
     PLATFORM_SCHEMA,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
+    CoverDevice,
 )
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_PASSWORD, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,9 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the brunt platform."""
-    # pylint: disable=no-name-in-module
-    from brunt import BruntAPI
-
     username = config[CONF_USERNAME]
     password = config[CONF_PASSWORD]
 

--- a/homeassistant/components/bt_smarthub/device_tracker.py
+++ b/homeassistant/components/bt_smarthub/device_tracker.py
@@ -1,15 +1,16 @@
 """Support for BT Smart Hub (Sometimes referred to as BT Home Hub 6)."""
 import logging
 
+import btsmarthub_devicelist
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
 from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,8 +75,6 @@ class BTSmartHubScanner(DeviceScanner):
 
     def get_bt_smarthub_data(self):
         """Retrieve data from BT Smart Hub and return parsed result."""
-        import btsmarthub_devicelist
-
         # Request data from bt smarthub into a list of dicts.
         data = btsmarthub_devicelist.get_devicelist(
             router_ip=self.host, only_active_devices=True

--- a/homeassistant/components/buienradar/camera.py
+++ b/homeassistant/components/buienradar/camera.py
@@ -1,7 +1,7 @@
 """Provide animated GIF loops of Buienradar imagery."""
 import asyncio
-import logging
 from datetime import datetime, timedelta
+import logging
 from typing import Optional
 
 import aiohttp
@@ -9,12 +9,9 @@ import voluptuous as vol
 
 from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
 from homeassistant.const import CONF_NAME
-
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-
 from homeassistant.util import dt as dt_util
-
 
 CONF_DIMENSION = "dimension"
 CONF_DELTA = "delta"

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -1,18 +1,28 @@
 """Support for Buienradar.nl weather service."""
 import logging
 
+from buienradar.constants import (
+    CONDCODE,
+    CONDITION,
+    DATETIME,
+    MAX_TEMP,
+    MIN_TEMP,
+    RAIN,
+    WINDAZIMUTH,
+    WINDSPEED,
+)
 import voluptuous as vol
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
-    PLATFORM_SCHEMA,
-    WeatherEntity,
-    ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_WIND_BEARING,
     ATTR_FORECAST_WIND_SPEED,
+    PLATFORM_SCHEMA,
+    WeatherEntity,
 )
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, TEMP_CELSIUS
 from homeassistant.helpers import config_validation as cv
@@ -110,8 +120,6 @@ class BrWeather(WeatherEntity):
     @property
     def condition(self):
         """Return the current condition."""
-        from buienradar.constants import CONDCODE
-
         if self._data and self._data.condition:
             ccode = self._data.condition.get(CONDCODE)
             if ccode:
@@ -161,17 +169,6 @@ class BrWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        from buienradar.constants import (
-            CONDITION,
-            CONDCODE,
-            RAIN,
-            DATETIME,
-            MIN_TEMP,
-            MAX_TEMP,
-            WINDAZIMUTH,
-            WINDSPEED,
-        )
-
         if not self._forecast:
             return None
 


### PR DESCRIPTION
## Description:

This PR moves and sorts imports in multiple integrations (trying to reduce all single change import PR's). I've excluded integrations that do have PR open already.

Integrations:
- aftership
- airvisual
- aladdin_connect
- alarm_decode
- alarmdotcom
- alpha_vantage
- ambient_station
- ampio
- android_ip_webcam
- anel_pwrctl
- anthemav
- apcupsd
- apns
- asterisk_mbox
- asuswrt
- august
- awair
- baidu
- bitcoin
- blackbird
- blink
- blinksticklight
- blockchain
- bmw_connected_drive
- bom
- brunt
- bt_smarthub
- buienradar


**Related issue (if applicable):** related to #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
