### PR TITLE
Bump pygatt to 4.0.5

### DIFF
--- a/homeassistant/components/bluetooth_le_tracker/manifest.json
+++ b/homeassistant/components/bluetooth_le_tracker/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bluetooth le tracker",
   "documentation": "https://www.home-assistant.io/integrations/bluetooth_le_tracker",
   "requirements": [
-    "pygatt[GATTTOOL]==4.0.1"
+    "pygatt[GATTTOOL]==4.0.5"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/skybeacon/manifest.json
+++ b/homeassistant/components/skybeacon/manifest.json
@@ -3,7 +3,7 @@
   "name": "Skybeacon",
   "documentation": "https://www.home-assistant.io/integrations/skybeacon",
   "requirements": [
-    "pygatt[GATTTOOL]==4.0.1"
+    "pygatt[GATTTOOL]==4.0.5"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1202,7 +1202,7 @@ pyfttt==0.3
 
 # homeassistant.components.bluetooth_le_tracker
 # homeassistant.components.skybeacon
-pygatt[GATTTOOL]==4.0.1
+pygatt[GATTTOOL]==4.0.5
 
 # homeassistant.components.gogogate2
 pygogogate2==0.1.1


### PR DESCRIPTION
## Description:
Bumps [pygatt](https://github.com/peplin/pygatt) from 4.0.1 to 4.0.5.
<details>
<summary>Changelog</summary>

*Sourced from [pygatt's changelog](https://github.com/peplin/pygatt/blob/v4.0.5/CHANGELOG.rst).*

> V4.0.5
> ======
> 
> Same as 4.0.4. Re-released to fix PyPi upload.
> 
> V4.0.4
> ======
> 
> -   Improvement: Remove Bluetooth specification PDFs, refer to bluetooth.com to avoid copyright issues.
> -   Improvement: Add wait\_for\_response option to subscription methods
> 
> V4.0.3
> ======
> 
> -   Fix: Regression with receiving indications with GATTTOOL backend
> -   Fix: Regression with subscribing to characteristics with GATTTOOL (need to use writes, not commands) ([#234](https://github-redirect.dependabot.com/peplin/pygatt/issues/234))
> -   Improvement: Don't require sudo for removing bonding ([#234](https://github-redirect.dependabot.com/peplin/pygatt/issues/234))
</details>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
