### PR TITLE
deCONZ - Add battery sensor when state available

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -26,13 +26,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     entity_handler = DeconzEntityHandler(gateway)
 
     @callback
-    def async_add_sensor(sensors):
+    def async_add_sensor(sensors, new=True):
         """Add binary sensor from deCONZ."""
         entities = []
 
         for sensor in sensors:
 
-            if sensor.BINARY:
+            if new and sensor.BINARY:
                 new_sensor = DeconzBinarySensor(sensor, gateway)
                 entity_handler.add_entity(new_sensor)
                 entities.append(new_sensor)

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -31,13 +31,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway = get_gateway_from_config_entry(hass, config_entry)
 
     @callback
-    def async_add_climate(sensors):
+    def async_add_climate(sensors, new=True):
         """Add climate devices from deCONZ."""
         entities = []
 
         for sensor in sensors:
 
-            if sensor.type in Thermostat.ZHATYPE:
+            if new and sensor.type in Thermostat.ZHATYPE:
                 entities.append(DeconzThermostat(sensor, gateway))
 
         async_add_entities(entities, True)

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -3,7 +3,10 @@ from pydeconz.sensor import Consumption, Daylight, LightLevel, Power, Switch, Th
 
 from homeassistant.const import ATTR_TEMPERATURE, ATTR_VOLTAGE, DEVICE_CLASS_BATTERY
 from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
@@ -25,21 +28,23 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway = get_gateway_from_config_entry(hass, config_entry)
 
     batteries = set()
+    battery_handler = DeconzBatteryHandler(gateway)
     entity_handler = DeconzEntityHandler(gateway)
 
     @callback
-    def async_add_sensor(sensors):
+    def async_add_sensor(sensors, new=True):
         """Add sensors from deCONZ.
 
         Create DeconzEvent if part of ZHAType list.
         Create DeconzSensor if not a ZHAType and not a binary sensor.
         Create DeconzBattery if sensor has a battery attribute.
+        If new is false it means an existing sensor has got a battery state reported.
         """
         entities = []
 
         for sensor in sensors:
 
-            if sensor.type in Switch.ZHATYPE:
+            if new and sensor.type in Switch.ZHATYPE:
 
                 if gateway.option_allow_clip_sensor or not sensor.type.startswith(
                     "CLIP"
@@ -48,7 +53,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     hass.async_create_task(new_event.async_update_device_registry())
                     gateway.events.append(new_event)
 
-            elif not sensor.BINARY and sensor.type not in Thermostat.ZHATYPE:
+            elif new and not sensor.BINARY and sensor.type not in Thermostat.ZHATYPE:
 
                 new_sensor = DeconzSensor(sensor, gateway)
                 entity_handler.add_entity(new_sensor)
@@ -59,6 +64,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 if new_battery.unique_id not in batteries:
                     batteries.add(new_battery.unique_id)
                     entities.append(new_battery)
+                    battery_handler.remove_tracker(sensor)
+            else:
+                battery_handler.create_tracker(sensor)
 
         async_add_entities(entities, True)
 
@@ -176,3 +184,54 @@ class DeconzBattery(DeconzDevice):
                     attr[ATTR_EVENT_ID] = event.event_id
 
         return attr
+
+
+class DeconzSensorStateTracker:
+    """Track sensors without a battery state and signal when battery state exist."""
+
+    def __init__(self, sensor, gateway):
+        """Set up tracker."""
+        self.sensor = sensor
+        self.gateway = gateway
+        sensor.register_async_callback(self.async_update_callback)
+
+    @callback
+    def close(self):
+        """Clean up tracker."""
+        self.sensor.remove_callback(self.async_update_callback)
+        self.gateway = None
+        self.sensor = None
+
+    @callback
+    def async_update_callback(self):
+        """Sensor state updated."""
+        if "battery" in self.sensor.changed_keys:
+            async_dispatcher_send(
+                self.gateway.hass,
+                self.gateway.async_signal_new_device(NEW_SENSOR),
+                [self.sensor],
+                False,
+            )
+
+
+class DeconzBatteryHandler:
+    """Creates and stores trackers for sensors without a battery state."""
+
+    def __init__(self, gateway):
+        """Set up battery handler."""
+        self.gateway = gateway
+        self._trackers = set()
+
+    @callback
+    def create_tracker(self, sensor):
+        """Create new tracker for battery state."""
+        self._trackers.add(DeconzSensorStateTracker(sensor, self.gateway))
+
+    @callback
+    def remove_tracker(self, sensor):
+        """Remove tracker of battery state."""
+        for tracker in self._trackers:
+            if sensor == tracker.sensor:
+                tracker.close()
+                self._trackers.remove(tracker)
+                break


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Covers the case where a device might not report battery state if deCONZ has been restarted. Now we will track devices without battery state and when it gets reported we create a battery sensor for it.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
