### PR TITLE
Reset states when connection to MPC-HC is lost

### DIFF
--- a/homeassistant/components/mpchc/media_player.py
+++ b/homeassistant/components/mpchc/media_player.py
@@ -69,6 +69,7 @@ class MpcHcDevice(MediaPlayerDevice):
         self._name = name
         self._url = url
         self._player_variables = dict()
+        self._available = False
 
     def update(self):
         """Get the latest details."""
@@ -79,9 +80,11 @@ class MpcHcDevice(MediaPlayerDevice):
 
             for var in mpchc_variables:
                 self._player_variables[var[0]] = var[1].lower()
+            self._available = True
         except requests.exceptions.RequestException:
             _LOGGER.error("Could not connect to MPC-HC at: %s", self._url)
             self._player_variables = dict()
+            self._available = False
 
     def _send_command(self, command_id):
         """Send a command to MPC-HC via its window message ID."""
@@ -111,6 +114,11 @@ class MpcHcDevice(MediaPlayerDevice):
             return STATE_PAUSED
 
         return STATE_IDLE
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
 
     @property
     def media_title(self):

--- a/homeassistant/components/mpchc/media_player.py
+++ b/homeassistant/components/mpchc/media_player.py
@@ -81,6 +81,7 @@ class MpcHcDevice(MediaPlayerDevice):
                 self._player_variables[var[0]] = var[1].lower()
         except requests.exceptions.RequestException:
             _LOGGER.error("Could not connect to MPC-HC at: %s", self._url)
+            self._player_variables = dict()
 
     def _send_command(self, command_id):
         """Send a command to MPC-HC via its window message ID."""


### PR DESCRIPTION
## Description:
The states are remained even when MPC-HC is closed on PC.
I think the states should be reset when connection is lost.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
