### PR TITLE
Fix for ecobee unknown sensor state

### DIFF
--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -105,6 +105,10 @@ class EcobeeBinarySensor(BinarySensorDevice):
         """Get the latest state of the sensor."""
         await self.data.update()
         for sensor in self.data.ecobee.get_remote_sensors(self.index):
+            if sensor["name"] != self.sensor_name:
+                continue
             for item in sensor["capability"]:
-                if item["type"] == "occupancy" and self.sensor_name == sensor["name"]:
-                    self._state = item["value"]
+                if item["type"] != "occupancy":
+                    continue
+                self._state = item["value"]
+                break

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -112,7 +112,7 @@ class EcobeeSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self._state in [ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN]:
+        if self._state in [ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN, "unknown"]:
             return None
 
         if self.type == "temperature":
@@ -129,6 +129,10 @@ class EcobeeSensor(Entity):
         """Get the latest state of the sensor."""
         await self.data.update()
         for sensor in self.data.ecobee.get_remote_sensors(self.index):
+            if sensor["name"] != self.sensor_name:
+                continue
             for item in sensor["capability"]:
-                if item["type"] == self.type and self.sensor_name == sensor["name"]:
-                    self._state = item["value"]
+                if item["type"] != self.type:
+                    continue
+                self._state = item["value"]
+                break


### PR DESCRIPTION
## Description:

The sensor platform was not catching all possible return values from the ecobee API for processing, resulting in the issue which this PR fixes. Now also catch the returned value "unknown". Also rewrote the async_update method to add guard clauses for greater efficiency in returning the state value.

Should be considered for a point release.

**Related issue (if applicable):** fixes #27489 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
