### PR TITLE
Typing misc fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,4 @@ repos:
     rev: v0.730
     hooks:
     -   id: mypy
+        exclude: ^script/scaffold/templates/

--- a/homeassistant/components/binary_sensor/device_condition.py
+++ b/homeassistant/components/binary_sensor/device_condition.py
@@ -1,5 +1,5 @@
 """Implemenet device conditions for binary sensor."""
-from typing import List
+from typing import Dict, List
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
@@ -193,9 +193,11 @@ CONDITION_SCHEMA = cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_conditions(hass: HomeAssistant, device_id: str) -> List[dict]:
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> List[Dict[str, str]]:
     """List device conditions."""
-    conditions: List[dict] = []
+    conditions: List[Dict[str, str]] = []
     entity_registry = await async_get_registry(hass)
     entries = [
         entry

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -205,7 +205,7 @@ async def async_get_actions(
 
 async def async_get_conditions(
     hass: HomeAssistant, device_id: str, domain: str
-) -> List[dict]:
+) -> List[Dict[str, str]]:
     """List device conditions."""
     return await _async_get_automations(hass, device_id, ENTITY_CONDITIONS, domain)
 

--- a/homeassistant/components/light/device_condition.py
+++ b/homeassistant/components/light/device_condition.py
@@ -1,5 +1,5 @@
 """Provides device conditions for lights."""
-from typing import List
+from typing import Dict, List
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
@@ -24,7 +24,9 @@ def async_condition_from_config(
     return toggle_entity.async_condition_from_config(config)
 
 
-async def async_get_conditions(hass: HomeAssistant, device_id: str) -> List[dict]:
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> List[Dict[str, str]]:
     """List device conditions."""
     return await toggle_entity.async_get_conditions(hass, device_id, DOMAIN)
 

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -1,5 +1,5 @@
 """Provides device conditions for sensors."""
-from typing import List
+from typing import Dict, List
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
@@ -80,9 +80,11 @@ CONDITION_SCHEMA = vol.All(
 )
 
 
-async def async_get_conditions(hass: HomeAssistant, device_id: str) -> List[dict]:
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> List[Dict[str, str]]:
     """List device conditions."""
-    conditions: List[dict] = []
+    conditions: List[Dict[str, str]] = []
     entity_registry = await async_get_registry(hass)
     entries = [
         entry

--- a/homeassistant/components/switch/device_condition.py
+++ b/homeassistant/components/switch/device_condition.py
@@ -1,5 +1,5 @@
 """Provides device conditions for switches."""
-from typing import List
+from typing import Dict, List
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
@@ -24,7 +24,9 @@ def async_condition_from_config(
     return toggle_entity.async_condition_from_config(config)
 
 
-async def async_get_conditions(hass: HomeAssistant, device_id: str) -> List[dict]:
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> List[Dict[str, str]]:
     """List device conditions."""
     return await toggle_entity.async_get_conditions(hass, device_id, DOMAIN)
 

--- a/script/scaffold/templates/device_condition/integration/device_condition.py
+++ b/script/scaffold/templates/device_condition/integration/device_condition.py
@@ -1,5 +1,5 @@
 """Provides device automations for NEW_NAME."""
-from typing import List
+from typing import Dict, List
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -29,7 +29,9 @@ CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_conditions(hass: HomeAssistant, device_id: str) -> List[dict]:
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> List[Dict[str, str]]:
     """List device conditions for NEW_NAME devices."""
     registry = await entity_registry.async_get_registry(hass)
     conditions = []


### PR DESCRIPTION
## Description:

Make mypy succeed when run on scripts, make async_get_conditions return type hint more specific.

**Related issue (if applicable):** #27487

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
