### PR TITLE
Add config flow for growatt server

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -259,6 +259,7 @@ omit =
     homeassistant/components/greenwave/light.py
     homeassistant/components/group/notify.py
     homeassistant/components/growatt_server/sensor.py
+    homeassistant/components/growatt_server/__init__.py
     homeassistant/components/gstreamer/media_player.py
     homeassistant/components/gtfs/sensor.py
     homeassistant/components/gtt/sensor.py

--- a/homeassistant/components/growatt_server/.translations/en.json
+++ b/homeassistant/components/growatt_server/.translations/en.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "title": "Growatt Server",
+    "step": {
+      "init": {
+        "title": "Enter your growatt information",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "plant_id": "Plant Id",
+          "name": "Name"
+        }
+      }
+    },
+    "error": {
+      "multiple_plants": "Multiple plants have been found on this account, please enter a plant id.",
+      "auth_error": "Username or password is incorrect"
+    }
+  }
+}

--- a/homeassistant/components/growatt_server/.translations/en.json
+++ b/homeassistant/components/growatt_server/.translations/en.json
@@ -3,11 +3,10 @@
     "title": "Growatt Server",
     "step": {
       "user": {
-        "title": "Enter your growatt information",
+        "title": "Enter your Growatt information",
         "data": {
           "username": "Username",
           "password": "Password",
-          "plant_id": "Plant Id",
           "name": "Name"
         }
       },
@@ -19,7 +18,9 @@
       }
     },
     "error": {
-      "auth_error": "Username or password is incorrect",
+      "auth_error": "Username or password is incorrect"
+    },
+    "abort": {
       "no_plants": "No plants have been found on this account"
     }
   }

--- a/homeassistant/components/growatt_server/.translations/en.json
+++ b/homeassistant/components/growatt_server/.translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "title": "Growatt Server",
     "step": {
-      "init": {
+      "user": {
         "title": "Enter your growatt information",
         "data": {
           "username": "Username",

--- a/homeassistant/components/growatt_server/.translations/en.json
+++ b/homeassistant/components/growatt_server/.translations/en.json
@@ -13,7 +13,6 @@
       }
     },
     "error": {
-      "multiple_plants": "Multiple plants have been found on this account, please enter a plant id.",
       "auth_error": "Username or password is incorrect"
     }
   }

--- a/homeassistant/components/growatt_server/.translations/en.json
+++ b/homeassistant/components/growatt_server/.translations/en.json
@@ -10,10 +10,17 @@
           "plant_id": "Plant Id",
           "name": "Name"
         }
+      },
+      "plant": {
+        "title": "Select your plant",
+        "data": {
+          "plant_id": "Plant"
+        }
       }
     },
     "error": {
-      "auth_error": "Username or password is incorrect"
+      "auth_error": "Username or password is incorrect",
+      "no_plants": "No plants have been found on this account"
     }
   }
 }

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -1,19 +1,45 @@
 """The Growatt server PV inverter sensor integration."""
+import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.helpers.typing import HomeAssistantType
-from .const import DOMAIN
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
+from .const import DOMAIN, CONF_PLANT_ID, DEFAULT_PLANT_ID, DEFAULT_NAME
+
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.All(
+            cv.ensure_list,
+            [
+                vol.Schema(
+                    {
+                        vol.Required(CONF_USERNAME): cv.string,
+                        vol.Required(CONF_PASSWORD): cv.string,
+                        vol.Optional(CONF_NAME): cv.string,
+                        vol.Optional(CONF_PLANT_ID): cv.string,
+                    }
+                )
+            ],
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 async def async_setup(hass, config):
     """Set up this integration."""
     if DOMAIN in config:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_IMPORT},
-                data=config[DOMAIN],
+        for device in config[DOMAIN]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT},
+                    data=device,
+                )
             )
-        )
     return True
 
 

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -1,10 +1,20 @@
 """The Growatt server PV inverter sensor integration."""
 from homeassistant import config_entries
 from homeassistant.helpers.typing import HomeAssistantType
+from .const import DOMAIN
 
 
 async def async_setup(hass, config):
     """Set up this integration."""
+    if DOMAIN in config:
+        for server in config[DOMAIN]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT},
+                    data=server,
+                )
+            )
     return True
 
 

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -4,9 +4,8 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
-from .const import DOMAIN, CONF_PLANT_ID, DEFAULT_PLANT_ID, DEFAULT_NAME
+from .const import DOMAIN, CONF_PLANT_ID
 
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -2,8 +2,6 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN
-
 
 async def async_setup(hass, config):
     """Platform setup, do nothing."""

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -7,14 +7,13 @@ from .const import DOMAIN
 async def async_setup(hass, config):
     """Set up this integration."""
     if DOMAIN in config:
-        for server in config[DOMAIN]:
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN,
-                    context={"source": config_entries.SOURCE_IMPORT},
-                    data=server,
-                )
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_IMPORT},
+                data=config[DOMAIN],
             )
+        )
     return True
 
 

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -1,14 +1,14 @@
 """The Growatt server PV inverter sensor integration."""
-from homeassistant.config_entries import ConfigEntry
+from homeassistant import config_entries
 from homeassistant.helpers.typing import HomeAssistantType
 
 
 async def async_setup(hass, config):
-    """Platform setup, do nothing."""
+    """Set up this integration."""
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistantType, entry: config_entries.ConfigEntry):
     """Load the saved entities."""
 
     hass.async_create_task(
@@ -19,7 +19,4 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    )
-    return True
+    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -1,1 +1,27 @@
 """The Growatt server PV inverter sensor integration."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN
+
+
+async def async_setup(hass, config):
+    """Platform setup, do nothing."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Load the saved entities."""
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    )
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    )
+    return True

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -23,7 +23,7 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
-        if CONF_PLANT_ID in import_config:
+        if CONF_PLANT_ID in import_config and CONF_NAME in import_config:
             return self.async_create_entry(
                 title=import_config[CONF_NAME], data=import_config
             )
@@ -35,8 +35,13 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         plant_info = await self.hass.async_add_executor_job(
             self.api.plant_list, user_id
         )
-
-        import_config[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
+        self.plants = {}
+        for plant in plant_info["data"]:
+            self.plants[plant["plantId"]] = plant["plantName"]
+        if CONF_PLANT_ID not in import_config:
+            import_config[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
+        if CONF_NAME not in import_config:
+            import_config[CONF_NAME] = self.plants[import_config[CONF_PLANT_ID]]
 
         return self.async_create_entry(
             title=import_config[CONF_NAME], data=import_config

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -1,0 +1,58 @@
+"""Config flow for growatt server integration"""
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
+from .const import DOMAIN, CONF_PLANT_ID, DEFAULT_NAME
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class GrowattServerConfigFlow(config_entries.ConfigFlow):
+    """Config flow class"""
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        return await self.async_step_user(user_input)
+
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
+        data_schema = vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+                vol.Optional(CONF_PLANT_ID): str,
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        if not user_input:
+            return await self._show_form()
+
+        import growattServer
+
+        api = growattServer.GrowattApi()
+        login_response = api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+
+        if not login_response["success"] and login_response["errCode"] == "102":
+            return await self._show_form({"base": "auth_error"})
+        user_id = login_response["userId"]
+
+        if CONF_PLANT_ID not in user_input:
+            plant_info = api.plant_list(user_id)
+            if len(plant_info["data"]) > 1:
+                return await self._show_form({CONF_PLANT_ID: "multiple_plants"})
+            user_input[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
+
+        return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -1,6 +1,8 @@
 """Config flow for growatt server integration."""
 import voluptuous as vol
 
+import growattServer
+
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
 from .const import DOMAIN, CONF_PLANT_ID, DEFAULT_NAME
@@ -13,16 +15,24 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    def __init__(self):
+        """Initialise growatt server flow."""
+        self.user_input = {}
+
     async def async_step_init(self, user_input=None):
         """Handle a flow initialized by the user."""
         return await self.async_step_user(user_input)
 
-    async def _show_form(self, errors=None):
+    async def async_step_plant(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        user_input = {**self.user_input, **user_input}
+        return await self.async_step_user(user_input)
+
+    async def _show_user_form(self, errors=None):
         """Show the form to the user."""
         data_schema = vol.Schema(
             {
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-                vol.Optional(CONF_PLANT_ID): str,
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
             }
@@ -32,22 +42,37 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow):
             step_id="init", data_schema=data_schema, errors=errors
         )
 
+    async def _show_plant_id_form(self, errors=None, plants={}):
+        """Show the form to the user."""
+        data_schema = vol.Schema({vol.Optional(CONF_PLANT_ID): vol.In(plants)})
+
+        return self.async_show_form(
+            step_id="plant", data_schema=data_schema, errors=errors
+        )
+
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
         if not user_input:
-            return await self._show_form()
-
-        import growattServer
+            return await self._show_user_form()
 
         api = growattServer.GrowattApi()
         login_response = api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
 
         if not login_response["success"] and login_response["errCode"] == "102":
-            return await self._show_form({"base": "auth_error"})
+            return await self._show_user_form({"base": "auth_error"})
         user_id = login_response["userId"]
 
         if CONF_PLANT_ID not in user_input:
             plant_info = api.plant_list(user_id)
+
+            if len(plant_info["data"]) == 0:
+                return await self._show_user_form({"base": "no_plants"})
+            if len(plant_info["data"]) > 1:
+                plants = {}
+                for plant in plant_info["data"]:
+                    plants[plant["plantId"]] = plant["plantName"]
+                self.user_input = user_input
+                return await self._show_plant_id_form(None, plants)
             user_input[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
 
         return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for growatt server integration"""
+"""Config flow for growatt server integration."""
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -8,7 +8,8 @@ from .const import DOMAIN, CONF_PLANT_ID, DEFAULT_NAME
 
 @config_entries.HANDLERS.register(DOMAIN)
 class GrowattServerConfigFlow(config_entries.ConfigFlow):
-    """Config flow class"""
+    """Config flow class."""
+
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -32,10 +32,6 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow):
             step_id="init", data_schema=data_schema, errors=errors
         )
 
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user(import_config)
-
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
         if not user_input:

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -5,7 +5,7 @@ import growattServer
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
-from .const import DOMAIN, CONF_PLANT_ID, DEFAULT_NAME
+from .const import DOMAIN, CONF_PLANT_ID  # noqa # pylint: disable=unused-import
 
 
 class GrowattServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -18,47 +18,22 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialise growatt server flow."""
         self.user_input = {}
         self.api = growattServer.GrowattApi()
-
-    async def async_step_plant(self, user_input=None):
-        """Handle a flow initialized by the user."""
-        user_input = {**self.user_input, **user_input}
-
-        if CONF_PLANT_ID not in user_input:
-            login_response = self.api.login(
-                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
-            )
-            user_id = login_response["userId"]
-            plant_info = self.api.plant_list(user_id)
-
-            if len(plant_info["data"]) == 0:
-                return await self._show_user_form({"base": "no_plants"})
-            if len(plant_info["data"]) > 1:
-                plants = {}
-                for plant in plant_info["data"]:
-                    plants[plant["plantId"]] = plant["plantName"]
-                self.user_input = user_input
-                return await self._show_plant_id_form(None, plants)
-            user_input[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
-
-        return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+        self.plants = {}
+        self.user_id = None
 
     async def _show_user_form(self, errors=None):
         """Show the form to the user."""
         data_schema = vol.Schema(
-            {
-                vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-                vol.Required(CONF_USERNAME): str,
-                vol.Required(CONF_PASSWORD): str,
-            }
+            {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
         )
 
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
         )
 
-    async def _show_plant_id_form(self, errors=None, plants=None):
+    async def _show_plant_id_form(self, errors=None):
         """Show the form to the user."""
-        data_schema = vol.Schema({vol.Required(CONF_PLANT_ID): vol.In(plants or {})})
+        data_schema = vol.Schema({vol.Required(CONF_PLANT_ID): vol.In(self.plants)})
 
         return self.async_show_form(
             step_id="plant", data_schema=data_schema, errors=errors
@@ -69,11 +44,36 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             return await self._show_user_form()
 
-        login_response = self.api.login(
-            user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+        login_response = await self.hass.async_add_executor_job(
+            self.api.login, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
         )
 
         if not login_response["success"] and login_response["errCode"] == "102":
             return await self._show_user_form({"base": "auth_error"})
+        self.user_id = login_response["userId"]
 
         return await self.async_step_plant(user_input)
+
+    async def async_step_plant(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        user_input = {**self.user_input, **user_input}
+
+        if CONF_PLANT_ID not in user_input:
+            plant_info = await self.hass.async_add_executor_job(
+                self.api.plant_list, self.user_id
+            )
+
+            if len(plant_info["data"]) == 0:
+                return self.async_abort(reason="no_plants")
+
+            self.plants = {}
+            for plant in plant_info["data"]:
+                self.plants[plant["plantId"]] = plant["plantName"]
+            self.user_input = user_input
+
+            if len(plant_info["data"]) > 1:
+                return await self._show_plant_id_form(None)
+            user_input[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
+
+        user_input[CONF_NAME] = self.plants[user_input[CONF_PLANT_ID]]
+        return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -8,8 +8,7 @@ from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
 from .const import DOMAIN, CONF_PLANT_ID, DEFAULT_NAME
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class GrowattServerConfigFlow(config_entries.ConfigFlow):
+class GrowattServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow class."""
 
     VERSION = 1
@@ -18,52 +17,18 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow):
     def __init__(self):
         """Initialise growatt server flow."""
         self.user_input = {}
-
-    async def async_step_init(self, user_input=None):
-        """Handle a flow initialized by the user."""
-        return await self.async_step_user(user_input)
+        self.api = growattServer.GrowattApi()
 
     async def async_step_plant(self, user_input=None):
         """Handle a flow initialized by the user."""
         user_input = {**self.user_input, **user_input}
-        return await self.async_step_user(user_input)
-
-    async def _show_user_form(self, errors=None):
-        """Show the form to the user."""
-        data_schema = vol.Schema(
-            {
-                vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-                vol.Required(CONF_USERNAME): str,
-                vol.Required(CONF_PASSWORD): str,
-            }
-        )
-
-        return self.async_show_form(
-            step_id="init", data_schema=data_schema, errors=errors
-        )
-
-    async def _show_plant_id_form(self, errors=None, plants={}):
-        """Show the form to the user."""
-        data_schema = vol.Schema({vol.Optional(CONF_PLANT_ID): vol.In(plants)})
-
-        return self.async_show_form(
-            step_id="plant", data_schema=data_schema, errors=errors
-        )
-
-    async def async_step_user(self, user_input=None):
-        """Handle the start of the config flow."""
-        if not user_input:
-            return await self._show_user_form()
-
-        api = growattServer.GrowattApi()
-        login_response = api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
-
-        if not login_response["success"] and login_response["errCode"] == "102":
-            return await self._show_user_form({"base": "auth_error"})
-        user_id = login_response["userId"]
 
         if CONF_PLANT_ID not in user_input:
-            plant_info = api.plant_list(user_id)
+            login_response = self.api.login(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            )
+            user_id = login_response["userId"]
+            plant_info = self.api.plant_list(user_id)
 
             if len(plant_info["data"]) == 0:
                 return await self._show_user_form({"base": "no_plants"})
@@ -76,3 +41,39 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow):
             user_input[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
 
         return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+
+    async def _show_user_form(self, errors=None):
+        """Show the form to the user."""
+        data_schema = vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )
+
+    async def _show_plant_id_form(self, errors=None, plants=None):
+        """Show the form to the user."""
+        data_schema = vol.Schema({vol.Required(CONF_PLANT_ID): vol.In(plants or {})})
+
+        return self.async_show_form(
+            step_id="plant", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        if not user_input:
+            return await self._show_user_form()
+
+        login_response = self.api.login(
+            user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+        )
+
+        if not login_response["success"] and login_response["errCode"] == "102":
+            return await self._show_user_form({"base": "auth_error"})
+
+        return await self.async_step_plant(user_input)

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -52,8 +52,6 @@ class GrowattServerConfigFlow(config_entries.ConfigFlow):
 
         if CONF_PLANT_ID not in user_input:
             plant_info = api.plant_list(user_id)
-            if len(plant_info["data"]) > 1:
-                return await self._show_form({CONF_PLANT_ID: "multiple_plants"})
             user_input[CONF_PLANT_ID] = plant_info["data"][0]["plantId"]
 
         return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)

--- a/homeassistant/components/growatt_server/const.py
+++ b/homeassistant/components/growatt_server/const.py
@@ -1,0 +1,8 @@
+"""Define constants for the Growatt Server component."""
+CONF_PLANT_ID = "plant_id"
+
+DEFAULT_PLANT_ID = "0"
+
+DEFAULT_NAME = "Growatt"
+
+DOMAIN = "growatt_server"

--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "growatt_server",
   "name": "Growatt Server",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/growatt_server/",
   "requirements": [
     "growattServer==0.0.1"

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -105,7 +105,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 async def async_setup_entry(hass, config_entry, add_entities):
     """Set up growatt server from Config Flow."""
-    hass.async_add_executor_job(setup_platform(hass, config_entry.data, add_entities))
+    hass.async_add_executor_job(setup_platform, hass, config_entry.data, add_entities)
 
 
 class GrowattInverter(Entity):

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -104,7 +104,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 async def async_setup_entry(hass, config, add_entities):
-    """Set up growatt server from Config Flow"""
+    """Set up growatt server from Config Flow."""
     setup_platform(hass, config.data, add_entities)
 
 

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -12,12 +12,10 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
+from .const import CONF_PLANT_ID, DEFAULT_PLANT_ID, DEFAULT_NAME
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_PLANT_ID = "plant_id"
-DEFAULT_PLANT_ID = "0"
-DEFAULT_NAME = "Growatt"
 SCAN_INTERVAL = datetime.timedelta(minutes=5)
 
 TOTAL_SENSOR_TYPES = {
@@ -103,6 +101,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             )
 
     add_entities(entities, True)
+
+
+async def async_setup_entry(hass, config, add_entities):
+    """Set up growatt server from Config Flow"""
+    setup_platform(hass, config.data, add_entities)
 
 
 class GrowattInverter(Entity):

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -5,14 +5,11 @@ import logging
 import datetime
 
 import growattServer
-import voluptuous as vol
 
 from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
-from .const import CONF_PLANT_ID, DEFAULT_PLANT_ID, DEFAULT_NAME
+from .const import CONF_PLANT_ID, DEFAULT_PLANT_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,15 +45,6 @@ INVERTER_SENSOR_TYPES = {
 }
 
 SENSOR_TYPES = {**TOTAL_SENSOR_TYPES, **INVERTER_SENSOR_TYPES}
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PLANT_ID, default=DEFAULT_PLANT_ID): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-    }
-)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -103,9 +103,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(entities, True)
 
 
-async def async_setup_entry(hass, config, add_entities):
+async def async_setup_entry(hass, config_entry, add_entities):
     """Set up growatt server from Config Flow."""
-    setup_platform(hass, config.data, add_entities)
+    hass.async_add_executor_job(setup_platform(hass, config_entry.data, add_entities))
 
 
 class GrowattInverter(Entity):

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -10,10 +10,17 @@
           "plant_id": "Plant Id",
           "name": "Name",
         }
+      },
+      "plant": {
+        "title": "Select your plant",
+        "data": {
+          "plant_id": "Plant"
+        }
       }
     },
     "error": {
-      "auth_error": "Username or password is incorrect"
+      "auth_error": "Username or password is incorrect",
+      "no_plants": "No plants have been found on this account"
     }
   }
 }

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "title": "Growatt Server",
+    "step": {
+      "init": {
+        "title": "Enter your growatt information",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "plant_id": "Plant Id",
+          "name": "Name",
+        }
+      }
+    },
+    "error": {
+      "multiple_plants": "Multiple plants have been found on this account, please enter a plant id.",
+      "auth_error": "Username or password is incorrect"
+    }
+  }
+}

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -3,12 +3,11 @@
     "title": "Growatt Server",
     "step": {
       "user": {
-        "title": "Enter your growatt information",
+        "title": "Enter your Growatt information",
         "data": {
           "username": "Username",
           "password": "Password",
-          "plant_id": "Plant Id",
-          "name": "Name",
+          "name": "Name"
         }
       },
       "plant": {
@@ -19,7 +18,9 @@
       }
     },
     "error": {
-      "auth_error": "Username or password is incorrect",
+      "auth_error": "Username or password is incorrect"
+    },
+    "abort": {
       "no_plants": "No plants have been found on this account"
     }
   }

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "title": "Growatt Server",
     "step": {
-      "init": {
+      "user": {
         "title": "Enter your growatt information",
         "data": {
           "username": "Username",

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -13,7 +13,6 @@
       }
     },
     "error": {
-      "multiple_plants": "Multiple plants have been found on this account, please enter a plant id.",
       "auth_error": "Username or password is incorrect"
     }
   }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -22,6 +22,7 @@ FLOWS = [
     "geofency",
     "geonetnz_quakes",
     "gpslogger",
+    "growatt_server",
     "hangouts",
     "heos",
     "homekit_controller",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -208,6 +208,9 @@ google-api-python-client==1.6.4
 # homeassistant.components.google_pubsub
 google-cloud-pubsub==0.39.1
 
+# homeassistant.components.growatt_server
+growattServer==0.0.1
+
 # homeassistant.components.ffmpeg
 ha-ffmpeg==2.0
 

--- a/tests/components/growatt_server/__init__.py
+++ b/tests/components/growatt_server/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the growatt_server component."""

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -10,32 +10,33 @@ FIXTURE_USER_INPUT = {
     CONF_NAME: DEFAULT_NAME,
     CONF_PLANT_ID: None,
     CONF_USERNAME: "username",
-    CONF_PASSWORD: "password"
+    CONF_PASSWORD: "password",
 }
 
 GROWATT_PLANT_LIST_RESPONSE = {
-    'data': [
-    {
-        'plantMoneyText': '474.9 (€)',
-        'plantName': 'Plant name',
-        'plantId': '123456',
-        'isHaveStorage': 'false',
-        'todayEnergy': '2.6 kWh',
-        'totalEnergy': '2.37 MWh',
-        'currentPower': '628.8 W'
-    }
+    "data": [
+        {
+            "plantMoneyText": "474.9 (€)",
+            "plantName": "Plant name",
+            "plantId": "123456",
+            "isHaveStorage": "false",
+            "todayEnergy": "2.6 kWh",
+            "totalEnergy": "2.37 MWh",
+            "currentPower": "628.8 W",
+        }
     ],
-    'totalData': {
-        'currentPowerSum': '628.8 W',
-        'CO2Sum': '2.37 KT',
-        'isHaveStorage': 'false',
-        'eTotalMoneyText': '474.9 (€)',
-        'todayEnergySum': '2.6 kWh',
-        'totalEnergySum': '2.37 MWh'
+    "totalData": {
+        "currentPowerSum": "628.8 W",
+        "CO2Sum": "2.37 KT",
+        "isHaveStorage": "false",
+        "eTotalMoneyText": "474.9 (€)",
+        "todayEnergySum": "2.6 kWh",
+        "totalEnergySum": "2.37 MWh",
     },
-    'success': True
+    "success": True,
 }
-GROWATT_LOGIN_RESPONSE = {'userId': 123456, 'userLevel': 1, 'success': True}
+GROWATT_LOGIN_RESPONSE = {"userId": 123456, "userLevel": 1, "success": True}
+
 
 async def test_show_authenticate_form(hass):
     """Test that the setup form is served."""
@@ -46,31 +47,45 @@ async def test_show_authenticate_form(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
+
 async def test_incorrect_username(hass):
     """Test that it shows the appropriate error when an incorrect username is entered."""
     flow = config_flow.GrowattServerConfigFlow()
     flow.hass = hass
-    with patch('growattServer.GrowattApi.login', return_value={'errCode': '102', 'success': False}):
+    with patch(
+        "growattServer.GrowattApi.login",
+        return_value={"errCode": "102", "success": False},
+    ):
         result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
         assert result["errors"] == {"base": "auth_error"}
+
 
 async def test_multiple_plants(hass):
     """Test that it shows an error when no plant_id is entered and multiple plants are available on the account."""
     flow = config_flow.GrowattServerConfigFlow()
     flow.hass = hass
     growatt_list_response_more_plants = GROWATT_PLANT_LIST_RESPONSE
-    growatt_list_response_more_plants["data"].append(growatt_list_response_more_plants["data"][0])
-    with patch('growattServer.GrowattApi.login', return_value=GROWATT_LOGIN_RESPONSE):
-        with patch('growattServer.GrowattApi.plant_list', return_value=GROWATT_PLANT_LIST_RESPONSE):
+    growatt_list_response_more_plants["data"].append(
+        growatt_list_response_more_plants["data"][0]
+    )
+    with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
+        with patch(
+            "growattServer.GrowattApi.plant_list",
+            return_value=GROWATT_PLANT_LIST_RESPONSE,
+        ):
             result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
             assert result["errors"] == {"base": "multiple_plants"}
+
 
 async def test_full_flow_implementation(hass):
     """Test registering an integration and finishing flow works."""
     flow = config_flow.GrowattServerConfigFlow()
     flow.hass = hass
-    with patch('growattServer.GrowattApi.login', return_value=GROWATT_LOGIN_RESPONSE):
-        with patch('growattServer.GrowattApi.plant_list', return_value=GROWATT_PLANT_LIST_RESPONSE):
+    with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
+        with patch(
+            "growattServer.GrowattApi.plant_list",
+            return_value=GROWATT_PLANT_LIST_RESPONSE,
+        ):
             result = await flow.async_step_user(user_input=None)
             assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
             assert result["step_id"] == "init"
@@ -79,7 +94,9 @@ async def test_full_flow_implementation(hass):
             assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
             assert result["title"] == FIXTURE_USER_INPUT[CONF_NAME]
             assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
-            assert result["data"][CONF_PLANT_ID] == GROWATT_PLANT_LIST_RESPONSE["data"][0]["plantId"]
+            assert (
+                result["data"][CONF_PLANT_ID]
+                == GROWATT_PLANT_LIST_RESPONSE["data"][0]["plantId"]
+            )
             assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
             assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
-

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_multiple_plants(hass):
             return_value=growatt_list_response_more_plants,
         ):
             result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
-            assert result["errors"] == {"base": "multiple_plants"}
+            assert result["errors"] == {CONF_PLANT_ID: "multiple_plants"}
 
 
 async def test_full_flow_implementation(hass):

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -68,7 +68,8 @@ async def test_no_plants_on_account(hass):
         with patch("growattServer.GrowattApi.plant_list", return_value=plant_list):
 
             result = await flow.async_step_user(user_input=user_input)
-            assert result["errors"] == {"base": "no_plants"}
+            assert result["type"] == "abort"
+            assert result["reason"] == "no_plants"
 
 
 async def test_multiple_plant_ids(hass):

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -60,23 +60,6 @@ async def test_incorrect_username(hass):
         assert result["errors"] == {"base": "auth_error"}
 
 
-async def test_multiple_plants(hass):
-    """Test that it shows an error when no plant_id is entered and multiple plants are available on the account."""
-    flow = config_flow.GrowattServerConfigFlow()
-    flow.hass = hass
-    growatt_list_response_more_plants = GROWATT_PLANT_LIST_RESPONSE
-    growatt_list_response_more_plants["data"].append(
-        growatt_list_response_more_plants["data"][0]
-    )
-    with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
-        with patch(
-            "growattServer.GrowattApi.plant_list",
-            return_value=growatt_list_response_more_plants,
-        ):
-            result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
-            assert result["errors"] == {CONF_PLANT_ID: "multiple_plants"}
-
-
 async def test_full_flow_implementation(hass):
     """Test registering an integration and finishing flow works."""
     flow = config_flow.GrowattServerConfigFlow()

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -71,9 +71,27 @@ async def test_entered_plant_id(hass):
             "growattServer.GrowattApi.plant_list",
             return_value=GROWATT_PLANT_LIST_RESPONSE,
         ):
-            result = await flow.async_step_user(user_input=None)
-            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-            assert result["step_id"] == "init"
+
+            result = await flow.async_step_user(user_input=user_input)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_PLANT_ID] == user_input[CONF_PLANT_ID]
+            assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
+            assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
+
+
+async def test_not_entered_plant_id(hass):
+    """Test registering an integration and finishing flow with an entered plant_id."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    user_input = FIXTURE_USER_INPUT
+
+    with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
+        with patch(
+            "growattServer.GrowattApi.plant_list",
+            return_value=GROWATT_PLANT_LIST_RESPONSE,
+        ):
 
             result = await flow.async_step_user(user_input=user_input)
             assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -60,6 +60,30 @@ async def test_incorrect_username(hass):
         assert result["errors"] == {"base": "auth_error"}
 
 
+async def test_entered_plant_id(hass):
+    """Test registering an integration and finishing flow with an entered plant_id."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    user_input = FIXTURE_USER_INPUT
+    user_input[CONF_PLANT_ID] = "123456"
+
+    with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
+        with patch(
+            "growattServer.GrowattApi.plant_list",
+            return_value=GROWATT_PLANT_LIST_RESPONSE,
+        ):
+            result = await flow.async_step_user(user_input=None)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result["step_id"] == "init"
+
+            result = await flow.async_step_user(user_input=user_input)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
+            assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
+
+
 async def test_full_flow_implementation(hass):
     """Test registering an integration and finishing flow works."""
     flow = config_flow.GrowattServerConfigFlow()

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -8,7 +8,6 @@ from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
 
 FIXTURE_USER_INPUT = {
     CONF_NAME: DEFAULT_NAME,
-    CONF_PLANT_ID: None,
     CONF_USERNAME: "username",
     CONF_PASSWORD: "password",
 }

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -71,7 +71,7 @@ async def test_multiple_plants(hass):
     with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
         with patch(
             "growattServer.GrowattApi.plant_list",
-            return_value=GROWATT_PLANT_LIST_RESPONSE,
+            return_value=growatt_list_response_more_plants,
         ):
             result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
             assert result["errors"] == {"base": "multiple_plants"}
@@ -94,9 +94,5 @@ async def test_full_flow_implementation(hass):
             assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
             assert result["title"] == FIXTURE_USER_INPUT[CONF_NAME]
             assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
-            assert (
-                result["data"][CONF_PLANT_ID]
-                == GROWATT_PLANT_LIST_RESPONSE["data"][0]["plantId"]
-            )
             assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
             assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -79,3 +79,24 @@ async def test_full_flow_implementation(hass):
             assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
             assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
             assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
+
+
+async def test_full_flow_implementation_via_init(hass):
+    """Test registering an integration and finishing flow works."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
+        with patch(
+            "growattServer.GrowattApi.plant_list",
+            return_value=GROWATT_PLANT_LIST_RESPONSE,
+        ):
+            result = await flow.async_step_init(user_input=None)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result["step_id"] == "init"
+
+            result = await flow.async_step_init(user_input=FIXTURE_USER_INPUT)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
+            assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -129,3 +129,16 @@ async def test_full_flow_implementation(hass):
             assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
             assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
             assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
+
+
+async def test_import(hass):
+    """Test importing from yaml."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    with patch("growattServer.GrowattApi.login", return_value=GROWATT_LOGIN_RESPONSE):
+        with patch(
+            "growattServer.GrowattApi.plant_list",
+            return_value=GROWATT_PLANT_LIST_RESPONSE,
+        ):
+            result = await flow.async_step_import(FIXTURE_USER_INPUT)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -4,14 +4,10 @@ from copy import deepcopy
 
 from homeassistant import data_entry_flow
 from homeassistant.components.growatt_server import config_flow
-from homeassistant.components.growatt_server.const import CONF_PLANT_ID, DEFAULT_NAME
-from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.components.growatt_server.const import CONF_PLANT_ID
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
-FIXTURE_USER_INPUT = {
-    CONF_NAME: DEFAULT_NAME,
-    CONF_USERNAME: "username",
-    CONF_PASSWORD: "password",
-}
+FIXTURE_USER_INPUT = {CONF_USERNAME: "username", CONF_PASSWORD: "password"}
 
 GROWATT_PLANT_LIST_RESPONSE = {
     "data": [
@@ -92,7 +88,6 @@ async def test_multiple_plant_ids(hass):
             user_input[CONF_PLANT_ID] = "123456"
             result = await flow.async_step_plant(user_input=user_input)
 
-            assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
             assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
             assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
             assert result["data"][CONF_PLANT_ID] == user_input[CONF_PLANT_ID]
@@ -112,7 +107,6 @@ async def test_one_plant_on_account(hass):
 
             result = await flow.async_step_user(user_input=user_input)
             assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-            assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
             assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
             assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
 
@@ -132,7 +126,5 @@ async def test_full_flow_implementation(hass):
 
             result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
             assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-            assert result["title"] == FIXTURE_USER_INPUT[CONF_NAME]
-            assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
             assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
             assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -1,0 +1,85 @@
+"""Tests for the Growatt server config flow."""
+from unittest.mock import patch
+
+from homeassistant import data_entry_flow
+from homeassistant.components.growatt_server import config_flow
+from homeassistant.components.growatt_server.const import CONF_PLANT_ID, DEFAULT_NAME
+from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
+
+FIXTURE_USER_INPUT = {
+    CONF_NAME: DEFAULT_NAME,
+    CONF_PLANT_ID: None,
+    CONF_USERNAME: "username",
+    CONF_PASSWORD: "password"
+}
+
+GROWATT_PLANT_LIST_RESPONSE = {
+    'data': [
+    {
+        'plantMoneyText': '474.9 (€)',
+        'plantName': 'Plant name',
+        'plantId': '123456',
+        'isHaveStorage': 'false',
+        'todayEnergy': '2.6 kWh',
+        'totalEnergy': '2.37 MWh',
+        'currentPower': '628.8 W'
+    }
+    ],
+    'totalData': {
+        'currentPowerSum': '628.8 W',
+        'CO2Sum': '2.37 KT',
+        'isHaveStorage': 'false',
+        'eTotalMoneyText': '474.9 (€)',
+        'todayEnergySum': '2.6 kWh',
+        'totalEnergySum': '2.37 MWh'
+    },
+    'success': True
+}
+GROWATT_LOGIN_RESPONSE = {'userId': 123456, 'userLevel': 1, 'success': True}
+
+async def test_show_authenticate_form(hass):
+    """Test that the setup form is served."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    result = await flow.async_step_user(user_input=None)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+async def test_incorrect_username(hass):
+    """Test that it shows the appropriate error when an incorrect username is entered."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    with patch('growattServer.GrowattApi.login', return_value={'errCode': '102', 'success': False}):
+        result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
+        assert result["errors"] == {"base": "auth_error"}
+
+async def test_multiple_plants(hass):
+    """Test that it shows an error when no plant_id is entered and multiple plants are available on the account."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    growatt_list_response_more_plants = GROWATT_PLANT_LIST_RESPONSE
+    growatt_list_response_more_plants["data"].append(growatt_list_response_more_plants["data"][0])
+    with patch('growattServer.GrowattApi.login', return_value=GROWATT_LOGIN_RESPONSE):
+        with patch('growattServer.GrowattApi.plant_list', return_value=GROWATT_PLANT_LIST_RESPONSE):
+            result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
+            assert result["errors"] == {"base": "multiple_plants"}
+
+async def test_full_flow_implementation(hass):
+    """Test registering an integration and finishing flow works."""
+    flow = config_flow.GrowattServerConfigFlow()
+    flow.hass = hass
+    with patch('growattServer.GrowattApi.login', return_value=GROWATT_LOGIN_RESPONSE):
+        with patch('growattServer.GrowattApi.plant_list', return_value=GROWATT_PLANT_LIST_RESPONSE):
+            result = await flow.async_step_user(user_input=None)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result["step_id"] == "init"
+
+            result = await flow.async_step_user(user_input=FIXTURE_USER_INPUT)
+            assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_NAME] == FIXTURE_USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_PLANT_ID] == GROWATT_PLANT_LIST_RESPONSE["data"][0]["plantId"]
+            assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
+            assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
+


### PR DESCRIPTION
# Description:

I have added a config flow to the growatt_server integration so it can be set up from the front-end.

Documentation update PR: home-assistant/home-assistant.io#10748

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
