### PR TITLE
Add spotify search service

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -316,6 +316,20 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             position = random.randint(0, results["total"] - 1)
             kwargs["offset"] = {"position": position}
         self._player.start_playback(**kwargs)
+        
+    def search(self, media_type, search_query, **kwargs):
+        """Search spotify."""
+        if media_type not in ['album', 'artist', 'playlist', 'track']:
+            _LOGGER.error("media type %s is not supported by spotify search api", media_type)
+        try:
+            search_result = self._player.search(q=search_query, type=media_type)[media_type + 's']['items'][0]
+        except IndexError:
+            _LOGGER.error("no result found for search query %s", search_query)
+            return
+        except:
+            _LOGGER.error("an error occured while calling the spotify search api")
+            return
+        return search_result
 
     @property
     def name(self):

--- a/homeassistant/components/spotify/services.yaml
+++ b/homeassistant/components/spotify/services.yaml
@@ -7,3 +7,12 @@ play_playlist:
     random_song:
       description: True to select random song at start, False to start from beginning.
       example: true
+search:
+  description: Start a search request on Spotify.
+  fields:
+    media_type:
+      description: The type of media to search for (track, artist, album or playlist).
+      example: 'track'
+    search_query:
+      description: The search query.
+      example: 'Adele'


### PR DESCRIPTION
## Description:
the spotipy search function that enables the user to send a search request to the Spotify API is implemented as a method of the spotify media_player component and by that made available as a homeassistant service for more convenience.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
