### PR TITLE
Move imports in rfxtrx component

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -1,7 +1,8 @@
 """Support for RFXtrx devices."""
 from collections import OrderedDict
+import binascii
 import logging
-
+import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -113,9 +114,6 @@ def setup(hass, config):
         for subscriber in RECEIVED_EVT_SUBSCRIBERS:
             subscriber(event)
 
-    # Try to load the RFXtrx module.
-    import RFXtrx as rfxtrxmod
-
     device = config[DOMAIN][ATTR_DEVICE]
     debug = config[DOMAIN][ATTR_DEBUG]
     dummy_connection = config[DOMAIN][ATTR_DUMMY]
@@ -144,8 +142,6 @@ def setup(hass, config):
 
 def get_rfx_object(packetid):
     """Return the RFXObject with the packetid."""
-    import RFXtrx as rfxtrxmod
-
     try:
         binarypacket = bytearray.fromhex(packetid)
     except ValueError:
@@ -167,7 +163,6 @@ def get_pt2262_deviceid(device_id, nb_data_bits):
     """Extract and return the address bits from a Lighting4/PT2262 packet."""
     if nb_data_bits is None:
         return
-    import binascii
 
     try:
         data = bytearray.fromhex(device_id)

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for RFXtrx binary sensors."""
 import logging
-
+import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.components import rfxtrx
@@ -54,8 +54,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Binary Sensor platform to RFXtrx."""
-    import RFXtrx as rfxtrxmod
-
     sensors = []
 
     for packet_id, entity in config[CONF_DEVICES].items():

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -1,4 +1,5 @@
 """Support for RFXtrx covers."""
+import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.components import rfxtrx
@@ -34,8 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx cover."""
-    import RFXtrx as rfxtrxmod
-
     covers = rfxtrx.get_devices_from_config(config, RfxtrxCover)
     add_entities(covers)
 

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -1,6 +1,6 @@
 """Support for RFXtrx lights."""
 import logging
-
+import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.components import rfxtrx
@@ -45,8 +45,6 @@ SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
-    import RFXtrx as rfxtrxmod
-
     lights = rfxtrx.get_devices_from_config(config, RfxtrxLight)
     add_entities(lights)
 

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -1,7 +1,8 @@
 """Support for RFXtrx sensors."""
 import logging
-
 import voluptuous as vol
+
+from RFXtrx import SensorEvent
 
 from homeassistant.components import rfxtrx
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -43,8 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
-    from RFXtrx import SensorEvent
-
     sensors = []
     for packet_id, entity_info in config[CONF_DEVICES].items():
         event = rfxtrx.get_rfx_object(packet_id)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -1,6 +1,6 @@
 """Support for RFXtrx switches."""
 import logging
-
+import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.components import rfxtrx
@@ -38,8 +38,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the RFXtrx platform."""
-    import RFXtrx as rfxtrxmod
-
     # Add switch from config file
     switches = rfxtrx.get_devices_from_config(config, RfxtrxSwitch)
     add_entities_callback(switches)

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -1,7 +1,7 @@
 """The tests for the Rfxtrx cover platform."""
 import unittest
-
 import pytest
+import RFXtrx as rfxtrxmod
 
 from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
@@ -141,8 +141,6 @@ class TestCoverRfxtrx(unittest.TestCase):
                 }
             },
         )
-
-        import RFXtrx as rfxtrxmod
 
         rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -1,7 +1,7 @@
 """The tests for the Rfxtrx light platform."""
 import unittest
-
 import pytest
+import RFXtrx as rfxtrxmod
 
 from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
@@ -108,8 +108,6 @@ class TestLightRfxtrx(unittest.TestCase):
                 }
             },
         )
-
-        import RFXtrx as rfxtrxmod
 
         rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -1,7 +1,7 @@
 """The tests for the Rfxtrx switch platform."""
 import unittest
-
 import pytest
+import RFXtrx as rfxtrxmod
 
 from homeassistant.setup import setup_component
 from homeassistant.components import rfxtrx as rfxtrx_core
@@ -166,8 +166,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
             },
         )
 
-        import RFXtrx as rfxtrxmod
-
         rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport
         )
@@ -199,8 +197,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
                 }
             },
         )
-
-        import RFXtrx as rfxtrxmod
 
         rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Moved import from function to top-level as requested in #27284
**Related issue (if applicable):** fixes 27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
