### PR TITLE
Update PostNL to also contain distributions and letters

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -237,6 +237,7 @@ homeassistant/components/plant/* @ChristianKuehnel
 homeassistant/components/plex/* @jjlawren
 homeassistant/components/plugwise/* @laetificat @CoMPaTech @bouwew
 homeassistant/components/point/* @fredrike
+homeassistant/components/postnl/* @peternijssen
 homeassistant/components/ps4/* @ktnrg45
 homeassistant/components/ptvsd/* @swamp-ig
 homeassistant/components/push/* @dgomes

--- a/homeassistant/components/postnl/manifest.json
+++ b/homeassistant/components/postnl/manifest.json
@@ -6,5 +6,7 @@
     "postnl_api==1.2.2"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@peternijssen"
+  ]
 }

--- a/homeassistant/components/postnl/sensor.py
+++ b/homeassistant/components/postnl/sensor.py
@@ -63,8 +63,8 @@ class PostNLDelivery(Entity):
         self._name = name + "_delivery"
         self._attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            'enroute': [],
-            'delivered': [],
+            "enroute": [],
+            "delivered": [],
         }
         self._state = None
         self._api = api
@@ -82,7 +82,7 @@ class PostNLDelivery(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return 'packages'
+        return "packages"
 
     @property
     def device_state_attributes(self):
@@ -99,16 +99,16 @@ class PostNLDelivery(Entity):
         """Update device state."""
         shipments = self._api.get_deliveries()
 
-        self._attributes['enroute'] = []
-        self._attributes['delivered'] = []
+        self._attributes["enroute"] = []
+        self._attributes["delivered"] = []
 
         for shipment in shipments:
             if shipment.delivery_date is None:
-                self._attributes['enroute'].append(vars(shipment))
+                self._attributes["enroute"].append(vars(shipment))
             else:
-                self._attributes['delivered'].append(vars(shipment))
+                self._attributes["delivered"].append(vars(shipment))
 
-        self._state = len(self._attributes['enroute'])
+        self._state = len(self._attributes["enroute"])
 
 
 class PostNLDistribution(Entity):
@@ -119,8 +119,8 @@ class PostNLDistribution(Entity):
         self._name = name + "_distribution"
         self._attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            'enroute': [],
-            'delivered': [],
+            "enroute": [],
+            "delivered": [],
         }
         self._state = None
         self._api = api
@@ -138,7 +138,7 @@ class PostNLDistribution(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return 'packages'
+        return "packages"
 
     @property
     def device_state_attributes(self):
@@ -155,16 +155,16 @@ class PostNLDistribution(Entity):
         """Update device state."""
         shipments = self._api.get_distributions()
 
-        self._attributes['enroute'] = []
-        self._attributes['delivered'] = []
+        self._attributes["enroute"] = []
+        self._attributes["delivered"] = []
 
         for shipment in shipments:
             if shipment.delivery_date is None:
-                self._attributes['enroute'].append(vars(shipment))
+                self._attributes["enroute"].append(vars(shipment))
             else:
-                self._attributes['delivered'].append(vars(shipment))
+                self._attributes["delivered"].append(vars(shipment))
 
-        self._state = len(self._attributes['enroute'])
+        self._state = len(self._attributes["enroute"])
 
 
 class PostNLLetter(Entity):
@@ -175,8 +175,8 @@ class PostNLLetter(Entity):
         self._name = name + "_letters"
         self._attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            'letters': [],
-            'enabled': False,
+            "letters": [],
+            "enabled": False,
         }
         self._state = None
         self._api = api
@@ -194,7 +194,7 @@ class PostNLLetter(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return 'letters'
+        return "letters"
 
     @property
     def device_state_attributes(self):
@@ -209,13 +209,13 @@ class PostNLLetter(Entity):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update device state."""
-        self._attributes['enabled'] = self._api.is_letters_activated
+        self._attributes["enabled"] = self._api.is_letters_activated
 
-        if self._attributes['enabled']:
+        if self._attributes["enabled"]:
             letters = self._api.get_letters()
 
-            self._attributes['letters'] = []
+            self._attributes["letters"] = []
 
             for letter in letters:
-                self._attributes['letters'].append(vars(letter))
+                self._attributes["letters"].append(vars(letter))
             self._state = len(letters)

--- a/homeassistant/components/postnl/sensor.py
+++ b/homeassistant/components/postnl/sensor.py
@@ -19,9 +19,13 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTRIBUTION = "Information provided by PostNL"
 
+ATTR_ENTROUTE = "enroute"
+ATTR_DELIVERED = "delivered"
+
 DEFAULT_NAME = "postnl"
 
-ICON = "mdi:package-variant-closed"
+PACKAGE_ICON = "mdi:package-variant-closed"
+LETTER_ICON = "mdi:email"
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
@@ -56,15 +60,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class PostNLDelivery(Entity):
-    """Delivery Packages."""
+    """Object holding all PostNL packages for delivery."""
 
     def __init__(self, api, name):
-        """Initialize the PostNL sensor."""
-        self._name = name + "_delivery"
+        """Initialize the PostNL delivery sensor."""
+        self._name = f"{name}_delivery"
         self._attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "enroute": [],
-            "delivered": [],
+            ATTR_ENTROUTE: [],
+            ATTR_DELIVERED: [],
         }
         self._state = None
         self._api = api
@@ -92,35 +96,35 @@ class PostNLDelivery(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return "mdi:package-variant-closed"
+        return PACKAGE_ICON
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update device state."""
         shipments = self._api.get_deliveries()
 
-        self._attributes["enroute"] = []
-        self._attributes["delivered"] = []
+        self._attributes[ATTR_ENTROUTE] = []
+        self._attributes[ATTR_DELIVERED] = []
 
         for shipment in shipments:
             if shipment.delivery_date is None:
-                self._attributes["enroute"].append(vars(shipment))
+                self._attributes[ATTR_ENTROUTE].append(vars(shipment))
             else:
-                self._attributes["delivered"].append(vars(shipment))
+                self._attributes[ATTR_DELIVERED].append(vars(shipment))
 
-        self._state = len(self._attributes["enroute"])
+        self._state = len(self._attributes[ATTR_ENTROUTE])
 
 
 class PostNLDistribution(Entity):
-    """Distribution Packages."""
+    """Object holding all PostNL packages for distribution."""
 
     def __init__(self, api, name):
-        """Initialize the PostNL sensor."""
-        self._name = name + "_distribution"
+        """Initialize the PostNL distribution sensor."""
+        self._name = f"{name}_distribution"
         self._attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            "enroute": [],
-            "delivered": [],
+            ATTR_ENTROUTE: [],
+            ATTR_DELIVERED: [],
         }
         self._state = None
         self._api = api
@@ -148,31 +152,31 @@ class PostNLDistribution(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return "mdi:package-variant-closed"
+        return PACKAGE_ICON
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update device state."""
         shipments = self._api.get_distributions()
 
-        self._attributes["enroute"] = []
-        self._attributes["delivered"] = []
+        self._attributes[ATTR_ENTROUTE] = []
+        self._attributes[ATTR_DELIVERED] = []
 
         for shipment in shipments:
             if shipment.delivery_date is None:
-                self._attributes["enroute"].append(vars(shipment))
+                self._attributes[ATTR_ENTROUTE].append(vars(shipment))
             else:
-                self._attributes["delivered"].append(vars(shipment))
+                self._attributes[ATTR_DELIVERED].append(vars(shipment))
 
-        self._state = len(self._attributes["enroute"])
+        self._state = len(self._attributes[ATTR_ENTROUTE])
 
 
 class PostNLLetter(Entity):
-    """Letters."""
+    """Object holding all PostNL letters for delivery."""
 
     def __init__(self, api, name):
-        """Initialize the PostNL sensor."""
-        self._name = name + "_letters"
+        """Initialize the PostNL letter sensor."""
+        self._name = f"{name}_letters"
         self._attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             "letters": [],
@@ -204,7 +208,7 @@ class PostNLLetter(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return "mdi:email"
+        return LETTER_ICON
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/postnl/sensor.py
+++ b/homeassistant/components/postnl/sensor.py
@@ -44,21 +44,28 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     try:
         api = PostNL_API(username, password)
+        _LOGGER.debug("Connection with PostNL API succeeded")
 
     except UnauthorizedException:
         _LOGGER.exception("Can't connect to the PostNL webservice")
         return
 
-    add_entities([PostNLSensor(api, name)], True)
+    add_entities([PostNLDelivery(api, name)], True)
+    add_entities([PostNLDistribution(api, name)], True)
+    add_entities([PostNLLetter(api, name)], True)
 
 
-class PostNLSensor(Entity):
-    """Representation of a PostNL sensor."""
+class PostNLDelivery(Entity):
+    """Delivery Packages."""
 
     def __init__(self, api, name):
         """Initialize the PostNL sensor."""
-        self._name = name
-        self._attributes = {ATTR_ATTRIBUTION: ATTRIBUTION, "shipments": []}
+        self._name = name + "_delivery"
+        self._attributes = {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            'enroute': [],
+            'delivered': [],
+        }
         self._state = None
         self._api = api
 
@@ -75,7 +82,7 @@ class PostNLSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return "packages"
+        return 'packages'
 
     @property
     def device_state_attributes(self):
@@ -85,16 +92,130 @@ class PostNLSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON
+        return "mdi:package-variant-closed"
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update device state."""
-        shipments = self._api.get_relevant_deliveries()
+        shipments = self._api.get_deliveries()
 
-        self._attributes["shipments"] = []
+        self._attributes['enroute'] = []
+        self._attributes['delivered'] = []
 
         for shipment in shipments:
-            self._attributes["shipments"].append(vars(shipment))
+            if shipment.delivery_date is None:
+                self._attributes['enroute'].append(vars(shipment))
+            else:
+                self._attributes['delivered'].append(vars(shipment))
 
-        self._state = len(shipments)
+        self._state = len(self._attributes['enroute'])
+
+
+class PostNLDistribution(Entity):
+    """Distribution Packages."""
+
+    def __init__(self, api, name):
+        """Initialize the PostNL sensor."""
+        self._name = name + "_distribution"
+        self._attributes = {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            'enroute': [],
+            'delivered': [],
+        }
+        self._state = None
+        self._api = api
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return 'packages'
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return "mdi:package-variant-closed"
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update device state."""
+        shipments = self._api.get_distributions()
+
+        self._attributes['enroute'] = []
+        self._attributes['delivered'] = []
+
+        for shipment in shipments:
+            if shipment.delivery_date is None:
+                self._attributes['enroute'].append(vars(shipment))
+            else:
+                self._attributes['delivered'].append(vars(shipment))
+
+        self._state = len(self._attributes['enroute'])
+
+
+class PostNLLetter(Entity):
+    """Letters."""
+
+    def __init__(self, api, name):
+        """Initialize the PostNL sensor."""
+        self._name = name + "_letters"
+        self._attributes = {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            'letters': [],
+            'enabled': False,
+        }
+        self._state = None
+        self._api = api
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return 'letters'
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return "mdi:email"
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update device state."""
+        self._attributes['enabled'] = self._api.is_letters_activated
+
+        if self._attributes['enabled']:
+            letters = self._api.get_letters()
+
+            self._attributes['letters'] = []
+
+            for letter in letters:
+                self._attributes['letters'].append(vars(letter))
+            self._state = len(letters)


### PR DESCRIPTION
## Breaking Change:
The PostNL component now also contains distribution of packages and letters, next to the already existing delivery of packages. `sensor.postnl` has now been renamed to `sensor.postnl_delivery`. Additionally, `sensor.postnl_distribution` and `sensor.postnl_letters` became available. This component is now fully compatible with the [PostNL Lovelace card.](https://community.home-assistant.io/t/lovelace-postnl/112433)

## Description:
The component now also adds distributions and letters and can nicely work together with a custom Lovelace card.

I've marked the following issue as solved, as the original suggestion was to have a custom Lovelace card, which is now possible.
**Related issue (if applicable):** fixes #20696

**Pull request with documentation for home-assistant.io (if applicable):** home-assistant/home-assistant.io#10749

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
