### PR TITLE
fill services.yaml for downloader

### DIFF
--- a/homeassistant/components/downloader/services.yaml
+++ b/homeassistant/components/downloader/services.yaml
@@ -1,0 +1,15 @@
+download_file:
+  description: Downloads a file to the download location.
+  fields:
+    url: 
+      description: The URL of the file to download.
+      example: 'http://example.org/myfile'
+    subdir:
+      description: Download into subdirectory.
+      example: 'download_dir'
+    filename:
+      description: Determine the filename.
+      example: 'my_file_name'
+    overwrite:
+      description: Whether to overwrite the file or not.
+      example: 'false'


### PR DESCRIPTION
## Description:
Adds entries for the service.yaml of dowloader component.

**Related issue (if applicable):** adresses #27289 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
