### PR TITLE
Add strings to device automatoins scaffold templates

### DIFF
--- a/script/scaffold/docs.py
+++ b/script/scaffold/docs.py
@@ -38,6 +38,7 @@ that can occur in the state will cause the right service to be called.
             f"""
 Device trigger base has been added to the {info.domain} integration:
  - {info.integration_dir / "device_trigger.py"}
+ - {info.integration_dir / "strings.json"} (translations)
  - {info.tests_dir / "test_device_trigger.py"}
 
 You will now need to update the code to make sure that relevant triggers
@@ -50,6 +51,7 @@ are exposed.
             f"""
 Device condition base has been added to the {info.domain} integration:
  - {info.integration_dir / "device_condition.py"}
+ - {info.integration_dir / "strings.json"} (translations)
  - {info.tests_dir / "test_device_condition.py"}
 
 You will now need to update the code to make sure that relevant condtions
@@ -62,6 +64,7 @@ are exposed.
             f"""
 Device action base has been added to the {info.domain} integration:
  - {info.integration_dir / "device_action.py"}
+ - {info.integration_dir / "strings.json"} (translations)
  - {info.tests_dir / "test_device_action.py"}
 
 You will now need to update the code to make sure that relevant services

--- a/script/scaffold/generate.py
+++ b/script/scaffold/generate.py
@@ -68,6 +68,39 @@ def _custom_tasks(template, info) -> None:
 
         info.update_manifest(**changes)
 
+    if template == "device_trigger":
+        info.update_strings(
+            device_automation={
+                **info.strings().get("device_automation", {}),
+                "trigger_type": {
+                    "turned_on": "{entity_name} turned on",
+                    "turned_off": "{entity_name} turned off",
+                },
+            }
+        )
+
+    if template == "device_condition":
+        info.update_strings(
+            device_automation={
+                **info.strings().get("device_automation", {}),
+                "condtion_type": {
+                    "is_on": "{entity_name} is on",
+                    "is_off": "{entity_name} is off",
+                },
+            }
+        )
+
+    if template == "device_action":
+        info.update_strings(
+            device_automation={
+                **info.strings().get("device_automation", {}),
+                "action_type": {
+                    "turn_on": "Turn on {entity_name}",
+                    "turn_off": "Turn off {entity_name}",
+                },
+            }
+        )
+
     if template == "config_flow":
         info.update_manifest(config_flow=True)
         info.update_strings(


### PR DESCRIPTION
## Description:
Generate strings for translations when generating device automations.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
