### PR TITLE
Round system monitor load averages to 2 decimal digits

### DIFF
--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -218,8 +218,8 @@ class SystemMonitorSensor(Entity):
                 dt_util.utc_from_timestamp(psutil.boot_time())
             ).isoformat()
         elif self.type == "load_1m":
-            self._state = os.getloadavg()[0]
+            self._state = round(os.getloadavg()[0], 2)
         elif self.type == "load_5m":
-            self._state = os.getloadavg()[1]
+            self._state = round(os.getloadavg()[1], 2)
         elif self.type == "load_15m":
-            self._state = os.getloadavg()[2]
+            self._state = round(os.getloadavg()[2], 2)


### PR DESCRIPTION
## Description:

On a Raspberry Pi 3, Python 3.7.4:

```
  # python3 -c "import os; print(os.getloadavg())"
  (0.2724609375, 0.3505859375, 0.3515625)
```

Numbers like that don't look that nice in the UI.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
