### PR TITLE
Filled services.yaml for logbook integration

### DIFF
--- a/homeassistant/components/logbook/services.yaml
+++ b/homeassistant/components/logbook/services.yaml
@@ -1,0 +1,15 @@
+log:
+  description: Create a custom entry in your logbook.
+  fields:
+    name:
+      description: Custom name for an entity, can be referenced with entity_id
+      example: "Kitchen"
+    message:
+      description: Message of the custom logbook entry
+      example: "is being used"
+    entity_id:
+      description: Entity to reference in custom logbook entry [Optional]
+      example: "light.kitchen"
+    domain:
+      description: Icon of domain to display in custom logbook entry [Optional]
+      example: "light"


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Filled entries in service.yaml for the logbook integration.

Result:
![grafik](https://user-images.githubusercontent.com/46536646/66707577-ef4df980-ed42-11e9-8eb3-ef17a3e149d6.png)


**Related issue (if applicable):**  #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
