### PR TITLE
New sensor platform integration for Orange and Rockland Utility smart energy meter

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -478,6 +478,7 @@ omit =
     homeassistant/components/openweathermap/weather.py
     homeassistant/components/opple/light.py
     homeassistant/components/orangepi_gpio/*
+    homeassistant/components/oru/*
     homeassistant/components/orvibo/switch.py
     homeassistant/components/osramlightify/light.py
     homeassistant/components/otp/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -213,6 +213,7 @@ homeassistant/components/opentherm_gw/* @mvn23
 homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff
 homeassistant/components/orangepi_gpio/* @pascallj
+homeassistant/components/oru/* @bvlaicu
 homeassistant/components/owlet/* @oblogic7
 homeassistant/components/panel_custom/* @home-assistant/frontend
 homeassistant/components/panel_iframe/* @home-assistant/frontend

--- a/homeassistant/components/oru/__init__.py
+++ b/homeassistant/components/oru/__init__.py
@@ -1,0 +1,1 @@
+"""The Orange and Rockland Utility smart energy meter integration."""

--- a/homeassistant/components/oru/manifest.json
+++ b/homeassistant/components/oru/manifest.json
@@ -1,0 +1,8 @@
+{
+    "domain": "oru",
+    "name": "Orange and Rockland Utility Smart Energy Meter Sensor",
+    "documentation": "https://www.home-assistant.io/components/",
+    "dependencies": [],
+    "codeowners": ["@bvlaicu"],
+    "requirements": ["oru==0.1.6"]
+}

--- a/homeassistant/components/oru/manifest.json
+++ b/homeassistant/components/oru/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "oru",
     "name": "Orange and Rockland Utility Smart Energy Meter Sensor",
-    "documentation": "https://www.home-assistant.io/components/oru",
+    "documentation": "https://www.home-assistant.io/integrations/oru",
     "dependencies": [],
     "codeowners": ["@bvlaicu"],
     "requirements": ["oru==0.1.9"]

--- a/homeassistant/components/oru/manifest.json
+++ b/homeassistant/components/oru/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "oru",
     "name": "Orange and Rockland Utility Smart Energy Meter Sensor",
-    "documentation": "https://www.home-assistant.io/components/",
+    "documentation": "https://www.home-assistant.io/components/oru",
     "dependencies": [],
     "codeowners": ["@bvlaicu"],
     "requirements": ["oru==0.1.9"]

--- a/homeassistant/components/oru/manifest.json
+++ b/homeassistant/components/oru/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://www.home-assistant.io/components/",
     "dependencies": [],
     "codeowners": ["@bvlaicu"],
-    "requirements": ["oru==0.1.6"]
+    "requirements": ["oru==0.1.9"]
 }

--- a/homeassistant/components/oru/sensor.py
+++ b/homeassistant/components/oru/sensor.py
@@ -1,8 +1,14 @@
 """Platform for sensor integration."""
+from datetime import timedelta
 import logging
+
+import voluptuous as vol
 
 from oru import Meter
 from oru import MeterError
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import ENERGY_KILO_WATT_HOUR
 from homeassistant.helpers.entity import Entity
 
@@ -10,15 +16,25 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_METER_NUMBER = "meter_number"
 
+SCAN_INTERVAL = timedelta(minutes=15)
+
 SENSOR_NAME = "ORU Current Energy Usage"
 SENSOR_ICON = "mdi:counter"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_METER_NUMBER): cv.string})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
 
     meter_number = str(config.get(CONF_METER_NUMBER, None))
-    meter = Meter(meter_number)
+
+    try:
+        meter = Meter(meter_number)
+
+    except MemoryError:
+        _LOGGER.error("Unable to create Oru meter")
+        return
 
     add_entities([CurrentEnergyUsageSensor(meter)])
 
@@ -33,6 +49,11 @@ class CurrentEnergyUsageSensor(Entity):
         self._state = None
         self._available = None
         self.meter = meter
+
+    @property
+    def unique_id(self):
+        """Return a unique, HASS-friendly identifier for this entity."""
+        return self.meter.meter_id
 
     @property
     def name(self):
@@ -62,7 +83,9 @@ class CurrentEnergyUsageSensor(Entity):
             self._state = last_read
             self._available = True
 
-            _LOGGER.info("%s = %s %s", self.name, self._state, self.unit_of_measurement)
+            _LOGGER.debug(
+                "%s = %s %s", self.name, self._state, self.unit_of_measurement
+            )
         except MeterError as err:
             self._available = False
 

--- a/homeassistant/components/oru/sensor.py
+++ b/homeassistant/components/oru/sensor.py
@@ -27,18 +27,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_METER_NUMBER): cv.st
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
 
-    meter_number = str(config.get(CONF_METER_NUMBER, None))
+    meter_number = config[CONF_METER_NUMBER]
 
     try:
         meter = Meter(meter_number)
 
-    except MemoryError:
+    except MeterError:
         _LOGGER.error("Unable to create Oru meter")
         return
 
-    add_entities([CurrentEnergyUsageSensor(meter)])
+    add_entities([CurrentEnergyUsageSensor(meter)], True)
 
-    _LOGGER.debug("meter_number = %s", meter_number)
+    _LOGGER.debug("Oru meter_number = %s", meter_number)
 
 
 class CurrentEnergyUsageSensor(Entity):
@@ -89,4 +89,4 @@ class CurrentEnergyUsageSensor(Entity):
         except MeterError as err:
             self._available = False
 
-            _LOGGER.error("Unexpected oru meter error: %s", str(err))
+            _LOGGER.error("Unexpected oru meter error: %s", err)

--- a/homeassistant/components/oru/sensor.py
+++ b/homeassistant/components/oru/sensor.py
@@ -1,0 +1,69 @@
+"""Platform for sensor integration."""
+import logging
+
+from oru import Meter
+from oru import MeterError
+from homeassistant.const import ENERGY_KILO_WATT_HOUR
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_METER_NUMBER = "meter_number"
+
+SENSOR_NAME = "ORU Current Energy Usage"
+SENSOR_ICON = "mdi:counter"
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+
+    meter_number = str(config.get(CONF_METER_NUMBER, None))
+    meter = Meter(meter_number)
+
+    add_entities([CurrentEnergyUsageSensor(meter)])
+
+    _LOGGER.debug("meter_number = %s", meter_number)
+
+
+class CurrentEnergyUsageSensor(Entity):
+    """Representation of the sensor."""
+
+    def __init__(self, meter):
+        """Initialize the sensor."""
+        self._state = None
+        self._available = None
+        self.meter = meter
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return SENSOR_NAME
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return SENSOR_ICON
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return ENERGY_KILO_WATT_HOUR
+
+    def update(self):
+        """Fetch new state data for the sensor."""
+        try:
+            last_read = self.meter.last_read()
+
+            self._state = last_read
+            self._available = True
+
+            _LOGGER.info("%s = %s %s", self.name, self._state, self.unit_of_measurement)
+        except MeterError as err:
+            self._available = False
+
+            _LOGGER.error("Unexpected oru meter error: %s", str(err))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -914,7 +914,7 @@ openwebifpy==3.1.1
 openwrt-luci-rpc==1.1.1
 
 # homeassistant.components.oru
-oru==0.1.6
+oru==0.1.9
 
 # homeassistant.components.orvibo
 orvibo==1.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -913,6 +913,9 @@ openwebifpy==3.1.1
 # homeassistant.components.luci
 openwrt-luci-rpc==1.1.1
 
+# homeassistant.components.oru
+oru==0.1.6
+
 # homeassistant.components.orvibo
 orvibo==1.1.1
 


### PR DESCRIPTION
## Description:


New sensor platform integration for [Orange and Rockland Utility](https://oru.com) smart energy meter.
Orange and Rockland Utility is an energy provider in NY and NJ, USA.
The sensor provides the last energy meter read in kWh.

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/10725

## Example entry for `configuration.yaml`:
```yaml
sensor:
  - platform: oru
    meter_number: 701138804
```

The meter number can be found on the energy bill, on the top left corner, alongside the account number. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
