### PR TITLE
Add default retain value specific to birth and lastwill MQTT messages

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -101,6 +101,7 @@ DEFAULT_PORT = 1883
 DEFAULT_KEEPALIVE = 60
 DEFAULT_QOS = 0
 DEFAULT_RETAIN = False
+DEFAULT_WILL_BIRTH_RETAIN = True
 DEFAULT_PROTOCOL = PROTOCOL_311
 DEFAULT_DISCOVERY_PREFIX = "homeassistant"
 DEFAULT_TLS_PROTOCOL = "auto"
@@ -195,7 +196,7 @@ MQTT_WILL_BIRTH_SCHEMA = vol.Schema(
         vol.Required(ATTR_TOPIC): valid_publish_topic,
         vol.Required(ATTR_PAYLOAD, CONF_PAYLOAD): cv.string,
         vol.Optional(ATTR_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA,
-        vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
+        vol.Optional(ATTR_RETAIN, default=DEFAULT_WILL_BIRTH_RETAIN): cv.boolean,
     },
     required=True,
 )

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -733,7 +733,7 @@ def test_birth_message(hass):
     mqtt_client.publish.side_effect = lambda *args: calls.append(args)
     hass.data["mqtt"]._mqtt_on_connect(None, None, 0, 0)
     yield from hass.async_block_till_done()
-    assert calls[-1] == ("birth", "birth", 0, False)
+    assert calls[-1] == ("birth", "birth", 0, True)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Breaking Change:
MQTT birth and will messages will now be published with retain flag set by default in line with the documentation.

**Description**:

The documentation states that the retain flags defaults to True for birth / lastwill messages. Through testing, the retain flag defaults to False. Either the default should be changed or the documenation updated to reflect the reality. I have a fix and a PR is incoming.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

fixes #27573 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
