### PR TITLE
Refactor Tradfri LightGroup, part 1

### DIFF
--- a/homeassistant/components/tradfri/light.py
+++ b/homeassistant/components/tradfri/light.py
@@ -1,8 +1,6 @@
 """Support for IKEA Tradfri lights."""
 import logging
 
-from pytradfri.error import PytradfriError
-
 import homeassistant.util.color as color_util
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -14,7 +12,6 @@ from homeassistant.components.light import (
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
 )
-from homeassistant.core import callback
 from .base_class import TradfriBaseDevice
 from .const import (
     ATTR_DIMMER,
@@ -22,12 +19,12 @@ from .const import (
     ATTR_SAT,
     ATTR_TRANSITION_TIME,
     SUPPORTED_LIGHT_FEATURES,
-    SUPPORTED_GROUP_FEATURES,
     CONF_GATEWAY_ID,
     CONF_IMPORT_GROUPS,
     KEY_GATEWAY,
     KEY_API,
 )
+from .light_group import TradfriLightGroup
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,99 +45,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         groups_commands = await api(gateway.get_groups())
         groups = await api(groups_commands)
         if groups:
-            async_add_entities(TradfriGroup(group, api, gateway_id) for group in groups)
-
-
-class TradfriGroup(Light):
-    """The platform class required by hass."""
-
-    def __init__(self, group, api, gateway_id):
-        """Initialize a Group."""
-        self._api = api
-        self._unique_id = f"group-{gateway_id}-{group.id}"
-        self._group = group
-        self._name = group.name
-
-        self._refresh(group)
-
-    async def async_added_to_hass(self):
-        """Start thread when added to hass."""
-        self._async_start_observe()
-
-    @property
-    def unique_id(self):
-        """Return unique ID for this group."""
-        return self._unique_id
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORTED_GROUP_FEATURES
-
-    @property
-    def name(self):
-        """Return the display name of this group."""
-        return self._name
-
-    @property
-    def is_on(self):
-        """Return true if group lights are on."""
-        return self._group.state
-
-    @property
-    def brightness(self):
-        """Return the brightness of the group lights."""
-        return self._group.dimmer
-
-    async def async_turn_off(self, **kwargs):
-        """Instruct the group lights to turn off."""
-        await self._api(self._group.set_state(0))
-
-    async def async_turn_on(self, **kwargs):
-        """Instruct the group lights to turn on, or dim."""
-        keys = {}
-        if ATTR_TRANSITION in kwargs:
-            keys["transition_time"] = int(kwargs[ATTR_TRANSITION]) * 10
-
-        if ATTR_BRIGHTNESS in kwargs:
-            if kwargs[ATTR_BRIGHTNESS] == 255:
-                kwargs[ATTR_BRIGHTNESS] = 254
-
-            await self._api(self._group.set_dimmer(kwargs[ATTR_BRIGHTNESS], **keys))
-        else:
-            await self._api(self._group.set_state(1))
-
-    @callback
-    def _async_start_observe(self, exc=None):
-        """Start observation of light."""
-        if exc:
-            _LOGGER.warning("Observation failed for %s", self._name, exc_info=exc)
-
-        try:
-            cmd = self._group.observe(
-                callback=self._observe_update,
-                err_callback=self._async_start_observe,
-                duration=0,
+            async_add_entities(
+                TradfriLightGroup(group, api, gateway_id) for group in groups
             )
-            self.hass.async_create_task(self._api(cmd))
-        except PytradfriError as err:
-            _LOGGER.warning("Observation failed, trying again", exc_info=err)
-            self._async_start_observe()
-
-    def _refresh(self, group):
-        """Refresh the light data."""
-        self._group = group
-        self._name = group.name
-
-    @callback
-    def _observe_update(self, tradfri_device):
-        """Receive new state data for this light."""
-        self._refresh(tradfri_device)
-        self.async_schedule_update_ha_state()
-
-    async def async_update(self):
-        """Fetch new state data for the group."""
-        await self._api(self._group.update())
 
 
 class TradfriLight(TradfriBaseDevice, Light):

--- a/homeassistant/components/tradfri/light_group.py
+++ b/homeassistant/components/tradfri/light_group.py
@@ -1,0 +1,102 @@
+"""Support for IKEA Tradfri light groups."""
+import logging
+
+from pytradfri.error import PytradfriError
+
+from homeassistant.components.light import Light, ATTR_TRANSITION, ATTR_BRIGHTNESS
+from homeassistant.core import callback
+from .const import SUPPORTED_GROUP_FEATURES
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TradfriLightGroup(Light):
+    """The platform class required by hass."""
+
+    def __init__(self, group, api, gateway_id):
+        """Initialize a Group."""
+        self._api = api
+        self._unique_id = f"group-{gateway_id}-{group.id}"
+        self._group = group
+        self._name = group.name
+
+        self._refresh(group)
+
+    async def async_added_to_hass(self):
+        """Start thread when added to hass."""
+        self._async_start_observe()
+
+    @property
+    def unique_id(self):
+        """Return unique ID for this group."""
+        return self._unique_id
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORTED_GROUP_FEATURES
+
+    @property
+    def name(self):
+        """Return the display name of this group."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if group lights are on."""
+        return self._group.state
+
+    @property
+    def brightness(self):
+        """Return the brightness of the group lights."""
+        return self._group.dimmer
+
+    async def async_turn_off(self, **kwargs):
+        """Instruct the group lights to turn off."""
+        await self._api(self._group.set_state(0))
+
+    async def async_turn_on(self, **kwargs):
+        """Instruct the group lights to turn on, or dim."""
+        keys = {}
+        if ATTR_TRANSITION in kwargs:
+            keys["transition_time"] = int(kwargs[ATTR_TRANSITION]) * 10
+
+        if ATTR_BRIGHTNESS in kwargs:
+            if kwargs[ATTR_BRIGHTNESS] == 255:
+                kwargs[ATTR_BRIGHTNESS] = 254
+
+            await self._api(self._group.set_dimmer(kwargs[ATTR_BRIGHTNESS], **keys))
+        else:
+            await self._api(self._group.set_state(1))
+
+    @callback
+    def _async_start_observe(self, exc=None):
+        """Start observation of light."""
+        if exc:
+            _LOGGER.warning("Observation failed for %s", self._name, exc_info=exc)
+
+        try:
+            cmd = self._group.observe(
+                callback=self._observe_update,
+                err_callback=self._async_start_observe,
+                duration=0,
+            )
+            self.hass.async_create_task(self._api(cmd))
+        except PytradfriError as err:
+            _LOGGER.warning("Observation failed, trying again", exc_info=err)
+            self._async_start_observe()
+
+    def _refresh(self, group):
+        """Refresh the light data."""
+        self._group = group
+        self._name = group.name
+
+    @callback
+    def _observe_update(self, tradfri_device):
+        """Receive new state data for this light."""
+        self._refresh(tradfri_device)
+        self.async_schedule_update_ha_state()
+
+    async def async_update(self):
+        """Fetch new state data for the group."""
+        await self._api(self._group.update())


### PR DESCRIPTION
## Description:
This is a continuation of the refactoring of the Tradfri library. This PR moves the LightGroup class to a separate file. I'd prefer to have `Light` and `LightGroup` separate. In part two of this PR, I'll refactor the actual code.

Related issue (if applicable): relates to #26863

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
