### PR TITLE
Improve neato tests

### DIFF
--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -92,10 +92,7 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up config entry."""
-    if entry.data[CONF_VENDOR] == "neato":
-        hass.data[NEATO_LOGIN] = NeatoHub(hass, entry.data, Account, Neato)
-    elif entry.data[CONF_VENDOR] == "vorwerk":
-        hass.data[NEATO_LOGIN] = NeatoHub(hass, entry.data, Account, Vorwerk)
+    hass.data[NEATO_LOGIN] = NeatoHub(hass, entry.data, Account)
 
     hub = hass.data[NEATO_LOGIN]
     await hass.async_add_executor_job(hub.login)
@@ -132,12 +129,16 @@ async def async_unload_entry(hass, entry):
 class NeatoHub:
     """A My Neato hub wrapper class."""
 
-    def __init__(self, hass, domain_config, neato, vendor):
+    def __init__(self, hass, domain_config, neato):
         """Initialize the Neato hub."""
         self.config = domain_config
         self._neato = neato
         self._hass = hass
-        self._vendor = vendor
+
+        if self.config[CONF_VENDOR] == "vorwerk":
+            self._vendor = Vorwerk()
+        else:  # Neato
+            self._vendor = Neato()
 
         self.my_neato = None
         self.logged_in = False

--- a/tests/components/neato/test_init.py
+++ b/tests/components/neato/test_init.py
@@ -33,7 +33,7 @@ INVALID_CONFIG = {
 }
 
 
-@pytest.fixture(name="account")
+@pytest.fixture(name="configflow")
 def mock_config_flow_login():
     """Mock a successful login."""
     with patch("homeassistant.components.neato.config_flow.Account", return_value=True):
@@ -53,7 +53,7 @@ async def test_no_config_entry(hass):
     assert res is True
 
 
-async def test_create_valid_config_entry(hass, account, hub):
+async def test_create_valid_config_entry(hass, configflow, hub):
     """There is something in configuration.yaml."""
     assert hass.config_entries.async_entries(NEATO_DOMAIN) == []
     assert await async_setup_component(hass, NEATO_DOMAIN, {NEATO_DOMAIN: VALID_CONFIG})
@@ -81,7 +81,7 @@ async def test_config_entries_in_sync(hass, hub):
     assert entries[0].data[CONF_VENDOR] == VENDOR_NEATO
 
 
-async def test_config_entries_not_in_sync(hass, account, hub):
+async def test_config_entries_not_in_sync(hass, configflow, hub):
     """The config entry and configuration.yaml are not in sync."""
     MockConfigEntry(domain=NEATO_DOMAIN, data=DIFFERENT_CONFIG).add_to_hass(hass)
 

--- a/tests/components/neato/test_init.py
+++ b/tests/components/neato/test_init.py
@@ -2,6 +2,8 @@
 import pytest
 from unittest.mock import patch
 
+from pybotvac.exceptions import NeatoLoginException
+
 from homeassistant.components.neato.const import CONF_VENDOR, NEATO_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
@@ -102,8 +104,8 @@ async def test_config_entries_not_in_sync_error(hass):
 
     assert hass.config_entries.async_entries(NEATO_DOMAIN)
     with patch(
-        "homeassistant.components.neato.config_flow.NeatoConfigFlow.try_login",
-        return_value="custom_error",
+        "homeassistant.components.neato.config_flow.Account",
+        side_effect=NeatoLoginException(),
     ):
         assert not await async_setup_component(
             hass, NEATO_DOMAIN, {NEATO_DOMAIN: DIFFERENT_CONFIG}

--- a/tests/components/neato/test_init.py
+++ b/tests/components/neato/test_init.py
@@ -33,7 +33,7 @@ INVALID_CONFIG = {
 }
 
 
-@pytest.fixture(name="configflow")
+@pytest.fixture(name="config_flow")
 def mock_config_flow_login():
     """Mock a successful login."""
     with patch("homeassistant.components.neato.config_flow.Account", return_value=True):
@@ -53,7 +53,7 @@ async def test_no_config_entry(hass):
     assert res is True
 
 
-async def test_create_valid_config_entry(hass, configflow, hub):
+async def test_create_valid_config_entry(hass, config_flow, hub):
     """There is something in configuration.yaml."""
     assert hass.config_entries.async_entries(NEATO_DOMAIN) == []
     assert await async_setup_component(hass, NEATO_DOMAIN, {NEATO_DOMAIN: VALID_CONFIG})
@@ -81,7 +81,7 @@ async def test_config_entries_in_sync(hass, hub):
     assert entries[0].data[CONF_VENDOR] == VENDOR_NEATO
 
 
-async def test_config_entries_not_in_sync(hass, configflow, hub):
+async def test_config_entries_not_in_sync(hass, config_flow, hub):
     """The config entry and configuration.yaml are not in sync."""
     MockConfigEntry(domain=NEATO_DOMAIN, data=DIFFERENT_CONFIG).add_to_hass(hass)
 

--- a/tests/components/neato/test_init.py
+++ b/tests/components/neato/test_init.py
@@ -20,6 +20,12 @@ VALID_CONFIG = {
     CONF_VENDOR: VENDOR_NEATO,
 }
 
+DIFFERENT_CONFIG = {
+    CONF_USERNAME: "anotherUsername",
+    CONF_PASSWORD: "anotherPassword",
+    CONF_VENDOR: VENDOR_VORWERK,
+}
+
 INVALID_CONFIG = {
     CONF_USERNAME: USERNAME,
     CONF_PASSWORD: PASSWORD,
@@ -28,9 +34,16 @@ INVALID_CONFIG = {
 
 
 @pytest.fixture(name="account")
-def mock_controller_login():
+def mock_config_flow_login():
     """Mock a successful login."""
     with patch("homeassistant.components.neato.config_flow.Account", return_value=True):
+        yield
+
+
+@pytest.fixture(name="hub")
+def mock_controller_login():
+    """Mock a successful login."""
+    with patch("homeassistant.components.neato.Account", return_value=True):
         yield
 
 
@@ -40,7 +53,20 @@ async def test_no_config_entry(hass):
     assert res is True
 
 
-async def test_config_entries_in_sync(hass, account):
+async def test_create_valid_config_entry(hass, account, hub):
+    """There is something in configuration.yaml."""
+    assert hass.config_entries.async_entries(NEATO_DOMAIN) == []
+    assert await async_setup_component(hass, NEATO_DOMAIN, {NEATO_DOMAIN: VALID_CONFIG})
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(NEATO_DOMAIN)
+    assert entries
+    assert entries[0].data[CONF_USERNAME] == USERNAME
+    assert entries[0].data[CONF_PASSWORD] == PASSWORD
+    assert entries[0].data[CONF_VENDOR] == VENDOR_NEATO
+
+
+async def test_config_entries_in_sync(hass, hub):
     """The config entry and configuration.yaml are in sync."""
     MockConfigEntry(domain=NEATO_DOMAIN, data=VALID_CONFIG).add_to_hass(hass)
 
@@ -55,12 +81,33 @@ async def test_config_entries_in_sync(hass, account):
     assert entries[0].data[CONF_VENDOR] == VENDOR_NEATO
 
 
-async def test_config_entries_not_in_sync(hass, account):
+async def test_config_entries_not_in_sync(hass, account, hub):
     """The config entry and configuration.yaml are not in sync."""
-    MockConfigEntry(domain=NEATO_DOMAIN, data=INVALID_CONFIG).add_to_hass(hass)
+    MockConfigEntry(domain=NEATO_DOMAIN, data=DIFFERENT_CONFIG).add_to_hass(hass)
 
     assert hass.config_entries.async_entries(NEATO_DOMAIN)
     assert await async_setup_component(hass, NEATO_DOMAIN, {NEATO_DOMAIN: VALID_CONFIG})
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(NEATO_DOMAIN)
+    assert entries
+    assert entries[0].data[CONF_USERNAME] == USERNAME
+    assert entries[0].data[CONF_PASSWORD] == PASSWORD
+    assert entries[0].data[CONF_VENDOR] == VENDOR_NEATO
+
+
+async def test_config_entries_not_in_sync_error(hass):
+    """The config entry and configuration.yaml are not in sync, the new configuration is wrong."""
+    MockConfigEntry(domain=NEATO_DOMAIN, data=VALID_CONFIG).add_to_hass(hass)
+
+    assert hass.config_entries.async_entries(NEATO_DOMAIN)
+    with patch(
+        "homeassistant.components.neato.config_flow.NeatoConfigFlow.try_login",
+        return_value="custom_error",
+    ):
+        assert not await async_setup_component(
+            hass, NEATO_DOMAIN, {NEATO_DOMAIN: DIFFERENT_CONFIG}
+        )
     await hass.async_block_till_done()
 
     entries = hass.config_entries.async_entries(NEATO_DOMAIN)


### PR DESCRIPTION
## Breaking Change:

Nothing breaks

## Description:
There were some tests that did IO. The corresponding modules are now mocked.
There are also some small improvements to the code.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
