### PR TITLE
Refactor Tradfri base class

### DIFF
--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -82,6 +82,7 @@ class TradfriBaseClass(Entity):
         """Refresh the device data."""
         self._device = device
         self._name = device.name
+        self._available = device.reachable
 
 
 class TradfriBaseDevice(TradfriBaseClass):
@@ -103,8 +104,3 @@ class TradfriBaseDevice(TradfriBaseClass):
             "sw_version": info.firmware_version,
             "via_device": (DOMAIN, self._gateway_id),
         }
-
-    def _refresh(self, device):
-        """Refresh the device data."""
-        super()._refresh(device)
-        self._available = device.reachable

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -10,12 +10,14 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class TradfriBaseDevice(Entity):
-    """Base class for a TRADFRI device."""
+class TradfriBaseClass(Entity):
+    """Base class for IKEA TRADFRI.
+
+    All devices and groups should inherit from this class.
+    """
 
     def __init__(self, device, api, gateway_id):
         """Initialize a device."""
-        self._available = True
         self._api = api
         self._device = None
         self._device_control = None
@@ -50,25 +52,6 @@ class TradfriBaseDevice(Entity):
         self._async_start_observe()
 
     @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._available
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        info = self._device.device_info
-
-        return {
-            "identifiers": {(DOMAIN, self._device.id)},
-            "manufacturer": info.manufacturer,
-            "model": info.model_number,
-            "name": self._name,
-            "sw_version": info.firmware_version,
-            "via_device": (DOMAIN, self._gateway_id),
-        }
-
-    @property
     def name(self):
         """Return the display name of this device."""
         return self._name
@@ -93,4 +76,39 @@ class TradfriBaseDevice(Entity):
         """Refresh the device data."""
         self._device = device
         self._name = device.name
+
+
+class TradfriBaseDevice(TradfriBaseClass):
+    """Base class for a TRADFRI device.
+
+    All devices should inherit from this class.
+    """
+
+    def __init__(self, device, api, gateway_id):
+        """Initialize a device."""
+        super().__init__(device, api, gateway_id)
+        self._available = True
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        info = self._device.device_info
+
+        return {
+            "identifiers": {(DOMAIN, self._device.id)},
+            "manufacturer": info.manufacturer,
+            "model": info.model_number,
+            "name": self._name,
+            "sw_version": info.firmware_version,
+            "via_device": (DOMAIN, self._gateway_id),
+        }
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    def _refresh(self, device):
+        """Refresh the device data."""
+        super()._refresh(device)
         self._available = device.reachable

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 class TradfriBaseClass(Entity):
     """Base class for IKEA TRADFRI.
 
-    All devices and groups should inherit from this class.
+    All devices and groups should ultimately inherit from this class.
     """
 
     def __init__(self, device, api, gateway_id):

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -18,6 +18,7 @@ class TradfriBaseClass(Entity):
 
     def __init__(self, device, api, gateway_id):
         """Initialize a device."""
+        self._available = True
         self._api = api
         self._device = None
         self._device_control = None
@@ -87,7 +88,6 @@ class TradfriBaseDevice(TradfriBaseClass):
     def __init__(self, device, api, gateway_id):
         """Initialize a device."""
         super().__init__(device, api, gateway_id)
-        self._available = True
 
     @property
     def device_info(self):

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -53,6 +53,11 @@ class TradfriBaseClass(Entity):
         self._async_start_observe()
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @property
     def name(self):
         """Return the display name of this device."""
         return self._name
@@ -85,10 +90,6 @@ class TradfriBaseDevice(TradfriBaseClass):
     All devices should inherit from this class.
     """
 
-    def __init__(self, device, api, gateway_id):
-        """Initialize a device."""
-        super().__init__(device, api, gateway_id)
-
     @property
     def device_info(self):
         """Return the device info."""
@@ -102,11 +103,6 @@ class TradfriBaseDevice(TradfriBaseClass):
             "sw_version": info.firmware_version,
             "via_device": (DOMAIN, self._gateway_id),
         }
-
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._available
 
     def _refresh(self, device):
         """Refresh the device data."""


### PR DESCRIPTION
## Description:
This is a continuation of the refactoring of the Tradfri library.

This PR refactors the new Tradfri base class into one class that will be the common denominator for devices and groups and one class that will be inherited by devices (cover, light, sensor, switch).

Related issue (if applicable): relates to #26863

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
