### PR TITLE
Update yandex transport after api change

### DIFF
--- a/homeassistant/components/yandex_transport/manifest.json
+++ b/homeassistant/components/yandex_transport/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yandex Transport",
   "documentation": "https://www.home-assistant.io/integrations/yandex_transport",
   "requirements": [
-    "ya_ma==0.3.7"
+    "ya_ma==0.3.8"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/yandex_transport/sensor.py
+++ b/homeassistant/components/yandex_transport/sensor.py
@@ -90,13 +90,12 @@ class DiscoverMoscowYandexTransport(Entity):
                    if "Estimated" not in event:
                        continue
                     for event in thread["BriefSchedule"]["Events"]:
-                        if "Estimated" in event:
-                            posix_time_next = int(event["Estimated"]["value"])
-                            if closer_time is None or closer_time > posix_time_next:
-                                closer_time = posix_time_next
-                            if route not in attrs:
-                                attrs[route] = []
-                            attrs[route].append(event["Estimated"]["text"])
+                        posix_time_next = int(event["Estimated"]["value"])
+                        if closer_time is None or closer_time > posix_time_next:
+                            closer_time = posix_time_next
+                        if route not in attrs:
+                            attrs[route] = []
+                        attrs[route].append(event["Estimated"]["text"])
         attrs[STOP_NAME] = stop_name
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         if closer_time is None:

--- a/homeassistant/components/yandex_transport/sensor.py
+++ b/homeassistant/components/yandex_transport/sensor.py
@@ -84,11 +84,11 @@ class DiscoverMoscowYandexTransport(Entity):
                     # skip unnecessary route info
                     continue
                 if "Events" not in thread["BriefSchedule"]:
-                   continue
+                    continue
                
-               for event in thread["BriefSchedule"]["Events"]:
-                   if "Estimated" not in event:
-                       continue
+                for event in thread["BriefSchedule"]["Events"]:
+                    if "Estimated" not in event:
+                        continue
                     for event in thread["BriefSchedule"]["Events"]:
                         posix_time_next = int(event["Estimated"]["value"])
                         if closer_time is None or closer_time > posix_time_next:

--- a/homeassistant/components/yandex_transport/sensor.py
+++ b/homeassistant/components/yandex_transport/sensor.py
@@ -83,7 +83,12 @@ class DiscoverMoscowYandexTransport(Entity):
                 if self._routes and route not in self._routes:
                     # skip unnecessary route info
                     continue
-                if "Events" in thread["BriefSchedule"]:
+                if "Events" not in thread["BriefSchedule"]:
+                   continue
+               
+               for event in thread["BriefSchedule"]["Events"]:
+                   if "Estimated" not in event:
+                       continue
                     for event in thread["BriefSchedule"]["Events"]:
                         if "Estimated" in event:
                             posix_time_next = int(event["Estimated"]["value"])

--- a/homeassistant/components/yandex_transport/sensor.py
+++ b/homeassistant/components/yandex_transport/sensor.py
@@ -85,17 +85,15 @@ class DiscoverMoscowYandexTransport(Entity):
                     continue
                 if "Events" not in thread["BriefSchedule"]:
                     continue
-               
                 for event in thread["BriefSchedule"]["Events"]:
                     if "Estimated" not in event:
                         continue
-                    for event in thread["BriefSchedule"]["Events"]:
-                        posix_time_next = int(event["Estimated"]["value"])
-                        if closer_time is None or closer_time > posix_time_next:
-                            closer_time = posix_time_next
-                        if route not in attrs:
-                            attrs[route] = []
-                        attrs[route].append(event["Estimated"]["text"])
+                    posix_time_next = int(event["Estimated"]["value"])
+                    if closer_time is None or closer_time > posix_time_next:
+                        closer_time = posix_time_next
+                    if route not in attrs:
+                        attrs[route] = []
+                    attrs[route].append(event["Estimated"]["text"])
         attrs[STOP_NAME] = stop_name
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         if closer_time is None:

--- a/homeassistant/components/yandex_transport/sensor.py
+++ b/homeassistant/components/yandex_transport/sensor.py
@@ -79,18 +79,19 @@ class DiscoverMoscowYandexTransport(Entity):
         transport_list = stop_metadata["Transport"]
         for transport in transport_list:
             route = transport["name"]
-            if self._routes and route not in self._routes:
-                # skip unnecessary route info
-                continue
-            if "Events" in transport["BriefSchedule"]:
-                for event in transport["BriefSchedule"]["Events"]:
-                    if "Estimated" in event:
-                        posix_time_next = int(event["Estimated"]["value"])
-                        if closer_time is None or closer_time > posix_time_next:
-                            closer_time = posix_time_next
-                        if route not in attrs:
-                            attrs[route] = []
-                        attrs[route].append(event["Estimated"]["text"])
+            for thread in transport["threads"]:
+                if self._routes and route not in self._routes:
+                    # skip unnecessary route info
+                    continue
+                if "Events" in thread["BriefSchedule"]:
+                    for event in thread["BriefSchedule"]["Events"]:
+                        if "Estimated" in event:
+                            posix_time_next = int(event["Estimated"]["value"])
+                            if closer_time is None or closer_time > posix_time_next:
+                                closer_time = posix_time_next
+                            if route not in attrs:
+                                attrs[route] = []
+                            attrs[route].append(event["Estimated"]["text"])
         attrs[STOP_NAME] = stop_name
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         if closer_time is None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1996,7 +1996,7 @@ xmltodict==0.12.0
 xs1-api-client==2.3.5
 
 # homeassistant.components.yandex_transport
-ya_ma==0.3.7
+ya_ma==0.3.8
 
 # homeassistant.components.yweather
 yahooweather==0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -623,7 +623,7 @@ withings-api==2.0.0b8
 xmltodict==0.12.0
 
 # homeassistant.components.yandex_transport
-ya_ma==0.3.7
+ya_ma==0.3.8
 
 # homeassistant.components.yweather
 yahooweather==0.10

--- a/tests/components/yandex_transport/test_yandex_transport_sensor.py
+++ b/tests/components/yandex_transport/test_yandex_transport_sensor.py
@@ -38,14 +38,14 @@ TEST_CONFIG = {
 }
 
 FILTERED_ATTRS = {
-    "т36": ["21:43", "21:47", "22:02"],
-    "т47": ["21:40", "22:01"],
-    "м10": ["21:48", "22:00"],
+    "т36": ["16:10", "16:17", "16:26"],
+    "т47": ["16:09", "16:10"],
+    "м10": ["16:12", "16:20"],
     "stop_name": "7-й автобусный парк",
     "attribution": "Data provided by maps.yandex.ru",
 }
 
-RESULT_STATE = dt_util.utc_from_timestamp(1568659253).isoformat(timespec="seconds")
+RESULT_STATE = dt_util.utc_from_timestamp(1570972183).isoformat(timespec="seconds")
 
 
 async def assert_setup_sensor(hass, config, count=1):

--- a/tests/fixtures/yandex_transport_reply.json
+++ b/tests/fixtures/yandex_transport_reply.json
@@ -1,2106 +1,1560 @@
 {
-    "data": {
-        "geometries": [
-            {
-                "type": "Point",
-                "coordinates": [
-                    37.565280044,
-                    55.851959656
-                ]
-            }
-        ],
-        "geometry": {
-            "type": "Point",
-            "coordinates": [
-                37.565280044,
-                55.851959656
+  "data": {
+    "geometries": [
+      {
+        "type": "Point",
+        "coordinates": [
+          37.565280044,
+          55.851959656
+        ]
+      }
+    ],
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        37.565280044,
+        55.851959656
+      ]
+    },
+    "properties": {
+      "name": "7-й автобусный парк",
+      "description": "7-й автобусный парк",
+      "currentTime": 1570971868567,
+      "tzOffset": 10800,
+      "StopMetaData": {
+        "id": "stop__9639579",
+        "name": "7-й автобусный парк",
+        "type": "urban",
+        "region": {
+          "id": 213,
+          "type": 6,
+          "parent_id": 1,
+          "capital_id": 0,
+          "geo_parent_id": 0,
+          "city_id": 213,
+          "name": "moscow",
+          "native_name": "",
+          "iso_name": "RU MOW",
+          "is_main": true,
+          "en_name": "Moscow",
+          "short_en_name": "MSK",
+          "phone_code": "495 499",
+          "phone_code_old": "095",
+          "zip_code": "",
+          "population": 12506468,
+          "synonyms": "Moskau, Moskva",
+          "latitude": 55.753215,
+          "longitude": 37.622504,
+          "latitude_size": 0.878654,
+          "longitude_size": 1.164423,
+          "zoom": 10,
+          "tzname": "Europe/Moscow",
+          "official_languages": "ru",
+          "widespread_languages": "ru",
+          "suggest_list": [],
+          "is_eu": false,
+          "services_names": [
+            "bs",
+            "yaca",
+            "weather",
+            "afisha",
+            "maps",
+            "tv",
+            "ad",
+            "etrain",
+            "subway",
+            "delivery",
+            "route"
+          ],
+          "ename": "moscow",
+          "bounds": [
+            [
+              37.0402925,
+              55.31141404514547
+            ],
+            [
+              38.2047155,
+              56.190068045145466
             ]
-        },
-        "properties": {
-            "name": "7-й автобусный парк",
-            "description": "7-й автобусный парк",
-            "currentTime": "Mon Sep 16 2019 21:40:40 GMT+0300 (Moscow Standard Time)",
-            "StopMetaData": {
-                "id": "stop__9639579",
-                "name": "7-й автобусный парк",
-                "type": "urban",
-                "region": {
-                    "id": 213,
-                    "type": 6,
-                    "parent_id": 1,
-                    "capital_id": 0,
-                    "geo_parent_id": 0,
-                    "city_id": 213,
-                    "name": "moscow",
-                    "native_name": "",
-                    "iso_name": "RU MOW",
-                    "is_main": true,
-                    "en_name": "Moscow",
-                    "short_en_name": "MSK",
-                    "phone_code": "495 499",
-                    "phone_code_old": "095",
-                    "zip_code": "",
-                    "population": 12506468,
-                    "synonyms": "Moskau, Moskva",
-                    "latitude": 55.753215,
-                    "longitude": 37.622504,
-                    "latitude_size": 0.878654,
-                    "longitude_size": 1.164423,
-                    "zoom": 10,
-                    "tzname": "Europe/Moscow",
-                    "official_languages": "ru",
-                    "widespread_languages": "ru",
-                    "suggest_list": [],
-                    "is_eu": false,
-                    "services_names": [
-                        "bs",
-                        "yaca",
-                        "weather",
-                        "afisha",
-                        "maps",
-                        "tv",
-                        "ad",
-                        "etrain",
-                        "subway",
-                        "delivery",
-                        "route"
-                    ],
-                    "ename": "moscow",
-                    "bounds": [
-                        [
-                            37.0402925,
-                            55.31141404514547
-                        ],
-                        [
-                            38.2047155,
-                            56.190068045145466
-                        ]
-                    ],
-                    "names": {
-                        "ablative": "",
-                        "accusative": "Москву",
-                        "dative": "Москве",
-                        "directional": "",
-                        "genitive": "Москвы",
-                        "instrumental": "Москвой",
-                        "locative": "",
-                        "nominative": "Москва",
-                        "preposition": "в",
-                        "prepositional": "Москве"
-                    },
-                    "parent": {
-                        "id": 1,
-                        "type": 5,
-                        "parent_id": 3,
-                        "capital_id": 213,
-                        "geo_parent_id": 0,
-                        "city_id": 213,
-                        "name": "moscow-and-moscow-oblast",
-                        "native_name": "",
-                        "iso_name": "RU-MOS",
-                        "is_main": true,
-                        "en_name": "Moscow and Moscow Oblast",
-                        "short_en_name": "RU-MOS",
-                        "phone_code": "495 496 498 499",
-                        "phone_code_old": "",
-                        "zip_code": "",
-                        "population": 7503385,
-                        "synonyms": "Московская область, Подмосковье, Podmoskovye",
-                        "latitude": 55.815792,
-                        "longitude": 37.380031,
-                        "latitude_size": 2.705659,
-                        "longitude_size": 5.060749,
-                        "zoom": 8,
-                        "tzname": "Europe/Moscow",
-                        "official_languages": "ru",
-                        "widespread_languages": "ru",
-                        "suggest_list": [
-                            213,
-                            10716,
-                            10747,
-                            10758,
-                            20728,
-                            10740,
-                            10738,
-                            20523,
-                            10735,
-                            10734,
-                            10743,
-                            21622
-                        ],
-                        "is_eu": false,
-                        "services_names": [
-                            "bs",
-                            "yaca",
-                            "ad"
-                        ],
-                        "ename": "moscow-and-moscow-oblast",
-                        "bounds": [
-                            [
-                                34.8496565,
-                                54.439456064325434
-                            ],
-                            [
-                                39.9104055,
-                                57.14511506432543
-                            ]
-                        ],
-                        "names": {
-                            "ablative": "",
-                            "accusative": "Москву и Московскую область",
-                            "dative": "Москве и Московской области",
-                            "directional": "",
-                            "genitive": "Москвы и Московской области",
-                            "instrumental": "Москвой и Московской областью",
-                            "locative": "",
-                            "nominative": "Москва и Московская область",
-                            "preposition": "в",
-                            "prepositional": "Москве и Московской области"
-                        },
-                        "parent": {
-                            "id": 225,
-                            "type": 3,
-                            "parent_id": 10001,
-                            "capital_id": 213,
-                            "geo_parent_id": 0,
-                            "city_id": 213,
-                            "name": "russia",
-                            "native_name": "",
-                            "iso_name": "RU",
-                            "is_main": false,
-                            "en_name": "Russia",
-                            "short_en_name": "RU",
-                            "phone_code": "7",
-                            "phone_code_old": "",
-                            "zip_code": "",
-                            "population": 146880432,
-                            "synonyms": "Russian Federation,Российская Федерация",
-                            "latitude": 61.698653,
-                            "longitude": 99.505405,
-                            "latitude_size": 40.700127,
-                            "longitude_size": 171.643239,
-                            "zoom": 3,
-                            "tzname": "",
-                            "official_languages": "ru",
-                            "widespread_languages": "ru",
-                            "suggest_list": [
-                                213,
-                                2,
-                                65,
-                                54,
-                                47,
-                                43,
-                                66,
-                                51,
-                                56,
-                                172,
-                                39,
-                                62
-                            ],
-                            "is_eu": false,
-                            "services_names": [
-                                "bs",
-                                "yaca",
-                                "ad"
-                            ],
-                            "ename": "russia",
-                            "bounds": [
-                                [
-                                    13.683785499999999,
-                                    35.290400699917846
-                                ],
-                                [
-                                    -174.6729755,
-                                    75.99052769991785
-                                ]
-                            ],
-                            "names": {
-                                "ablative": "",
-                                "accusative": "Россию",
-                                "dative": "России",
-                                "directional": "",
-                                "genitive": "России",
-                                "instrumental": "Россией",
-                                "locative": "",
-                                "nominative": "Россия",
-                                "preposition": "в",
-                                "prepositional": "России"
-                            }
-                        }
-                    }
-                },
-                "Transport": [
-                    {
-                        "lineId": "2036925416",
-                        "name": "194",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "2036927196",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9711780",
-                                        "name": "Метро Петровско-Разумовская"
-                                    },
-                                    {
-                                        "id": "stop__9648742",
-                                        "name": "Коровино"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659860",
-                                                "tzOffset": 10800,
-                                                "text": "21:51"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660760",
-                                                "tzOffset": 10800,
-                                                "text": "22:06"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568661840",
-                                                "tzOffset": 10800,
-                                                "text": "22:24"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:51"
-                                }
-                            }
-                        ],
-                        "threadId": "2036927196",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9711780",
-                                "name": "Метро Петровско-Разумовская"
-                            },
-                            {
-                                "id": "stop__9648742",
-                                "name": "Коровино"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659860",
-                                        "tzOffset": 10800,
-                                        "text": "21:51"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660760",
-                                        "tzOffset": 10800,
-                                        "text": "22:06"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568661840",
-                                        "tzOffset": 10800,
-                                        "text": "22:24"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:51"
-                        }
-                    },
-                    {
-                        "lineId": "213_114_bus_mosgortrans",
-                        "name": "114",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213B_114_bus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9647199",
-                                        "name": "Метро Войковская"
-                                    },
-                                    {
-                                        "id": "stop__9639588",
-                                        "name": "Коровинское шоссе"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [],
-                                    "Frequency": {
-                                        "text": "15 мин",
-                                        "value": 900,
-                                        "begin": {
-                                            "value": "1568603405",
-                                            "tzOffset": 10800,
-                                            "text": "6:10"
-                                        },
-                                        "end": {
-                                            "value": "1568672165",
-                                            "tzOffset": 10800,
-                                            "text": "1:16"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213B_114_bus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9647199",
-                                "name": "Метро Войковская"
-                            },
-                            {
-                                "id": "stop__9639588",
-                                "name": "Коровинское шоссе"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [],
-                            "Frequency": {
-                                "text": "15 мин",
-                                "value": 900,
-                                "begin": {
-                                    "value": "1568603405",
-                                    "tzOffset": 10800,
-                                    "text": "6:10"
-                                },
-                                "end": {
-                                    "value": "1568672165",
-                                    "tzOffset": 10800,
-                                    "text": "1:16"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_154_bus_mosgortrans",
-                        "name": "154",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213B_154_bus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9642548",
-                                        "name": "ВДНХ (южная)"
-                                    },
-                                    {
-                                        "id": "stop__9711744",
-                                        "name": "Станция Ховрино"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659260",
-                                                "tzOffset": 10800,
-                                                "text": "21:41"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568659252",
-                                                "tzOffset": 10800,
-                                                "text": "21:40"
-                                            },
-                                            "vehicleId": "codd%5Fnew|1054764%5F191500"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660580",
-                                                "tzOffset": 10800,
-                                                "text": "22:03"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568661900",
-                                                "tzOffset": 10800,
-                                                "text": "22:25"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:41"
-                                }
-                            }
-                        ],
-                        "threadId": "213B_154_bus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9642548",
-                                "name": "ВДНХ (южная)"
-                            },
-                            {
-                                "id": "stop__9711744",
-                                "name": "Станция Ховрино"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659260",
-                                        "tzOffset": 10800,
-                                        "text": "21:41"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568659252",
-                                        "tzOffset": 10800,
-                                        "text": "21:40"
-                                    },
-                                    "vehicleId": "codd%5Fnew|1054764%5F191500"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660580",
-                                        "tzOffset": 10800,
-                                        "text": "22:03"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568661900",
-                                        "tzOffset": 10800,
-                                        "text": "22:25"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:41"
-                        }
-                    },
-                    {
-                        "lineId": "213_179_bus_mosgortrans",
-                        "name": "179",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213B_179_bus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9647199",
-                                        "name": "Метро Войковская"
-                                    },
-                                    {
-                                        "id": "stop__9639480",
-                                        "name": "Платформа Лианозово"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659920",
-                                                "tzOffset": 10800,
-                                                "text": "21:52"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568659351",
-                                                "tzOffset": 10800,
-                                                "text": "21:42"
-                                            },
-                                            "vehicleId": "codd%5Fnew|59832%5F31359"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660760",
-                                                "tzOffset": 10800,
-                                                "text": "22:06"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568661660",
-                                                "tzOffset": 10800,
-                                                "text": "22:21"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:52"
-                                }
-                            }
-                        ],
-                        "threadId": "213B_179_bus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9647199",
-                                "name": "Метро Войковская"
-                            },
-                            {
-                                "id": "stop__9639480",
-                                "name": "Платформа Лианозово"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659920",
-                                        "tzOffset": 10800,
-                                        "text": "21:52"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568659351",
-                                        "tzOffset": 10800,
-                                        "text": "21:42"
-                                    },
-                                    "vehicleId": "codd%5Fnew|59832%5F31359"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660760",
-                                        "tzOffset": 10800,
-                                        "text": "22:06"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568661660",
-                                        "tzOffset": 10800,
-                                        "text": "22:21"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:52"
-                        }
-                    },
-                    {
-                        "lineId": "213_191m_minibus_default",
-                        "name": "591",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_191m_minibus_default",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9647199",
-                                        "name": "Метро Войковская"
-                                    },
-                                    {
-                                        "id": "stop__9711744",
-                                        "name": "Станция Ховрино"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Estimated": {
-                                                "value": "1568660525",
-                                                "tzOffset": 10800,
-                                                "text": "22:02"
-                                            },
-                                            "vehicleId": "codd%5Fnew|38278%5F9345312"
-                                        }
-                                    ],
-                                    "Frequency": {
-                                        "text": "22 мин",
-                                        "value": 1320,
-                                        "begin": {
-                                            "value": "1568602033",
-                                            "tzOffset": 10800,
-                                            "text": "5:47"
-                                        },
-                                        "end": {
-                                            "value": "1568672233",
-                                            "tzOffset": 10800,
-                                            "text": "1:17"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213A_191m_minibus_default",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9647199",
-                                "name": "Метро Войковская"
-                            },
-                            {
-                                "id": "stop__9711744",
-                                "name": "Станция Ховрино"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Estimated": {
-                                        "value": "1568660525",
-                                        "tzOffset": 10800,
-                                        "text": "22:02"
-                                    },
-                                    "vehicleId": "codd%5Fnew|38278%5F9345312"
-                                }
-                            ],
-                            "Frequency": {
-                                "text": "22 мин",
-                                "value": 1320,
-                                "begin": {
-                                    "value": "1568602033",
-                                    "tzOffset": 10800,
-                                    "text": "5:47"
-                                },
-                                "end": {
-                                    "value": "1568672233",
-                                    "tzOffset": 10800,
-                                    "text": "1:17"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_206m_minibus_default",
-                        "name": "206к",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_206m_minibus_default",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9640756",
-                                        "name": "Метро Петровско-Разумовская"
-                                    },
-                                    {
-                                        "id": "stop__9640553",
-                                        "name": "Лобненская улица"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [],
-                                    "Frequency": {
-                                        "text": "22 мин",
-                                        "value": 1320,
-                                        "begin": {
-                                            "value": "1568601239",
-                                            "tzOffset": 10800,
-                                            "text": "5:33"
-                                        },
-                                        "end": {
-                                            "value": "1568671439",
-                                            "tzOffset": 10800,
-                                            "text": "1:03"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213A_206m_minibus_default",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9640756",
-                                "name": "Метро Петровско-Разумовская"
-                            },
-                            {
-                                "id": "stop__9640553",
-                                "name": "Лобненская улица"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [],
-                            "Frequency": {
-                                "text": "22 мин",
-                                "value": 1320,
-                                "begin": {
-                                    "value": "1568601239",
-                                    "tzOffset": 10800,
-                                    "text": "5:33"
-                                },
-                                "end": {
-                                    "value": "1568671439",
-                                    "tzOffset": 10800,
-                                    "text": "1:03"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_215_bus_mosgortrans",
-                        "name": "215",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213B_215_bus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9711780",
-                                        "name": "Метро Петровско-Разумовская"
-                                    },
-                                    {
-                                        "id": "stop__9711744",
-                                        "name": "Станция Ховрино"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [],
-                                    "Frequency": {
-                                        "text": "27 мин",
-                                        "value": 1620,
-                                        "begin": {
-                                            "value": "1568601276",
-                                            "tzOffset": 10800,
-                                            "text": "5:34"
-                                        },
-                                        "end": {
-                                            "value": "1568671476",
-                                            "tzOffset": 10800,
-                                            "text": "1:04"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213B_215_bus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9711780",
-                                "name": "Метро Петровско-Разумовская"
-                            },
-                            {
-                                "id": "stop__9711744",
-                                "name": "Станция Ховрино"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [],
-                            "Frequency": {
-                                "text": "27 мин",
-                                "value": 1620,
-                                "begin": {
-                                    "value": "1568601276",
-                                    "tzOffset": 10800,
-                                    "text": "5:34"
-                                },
-                                "end": {
-                                    "value": "1568671476",
-                                    "tzOffset": 10800,
-                                    "text": "1:04"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_282_bus_mosgortrans",
-                        "name": "282",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_282_bus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9641102",
-                                        "name": "Улица Корнейчука"
-                                    },
-                                    {
-                                        "id": "2532226085",
-                                        "name": "Метро Войковская"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Estimated": {
-                                                "value": "1568659888",
-                                                "tzOffset": 10800,
-                                                "text": "21:51"
-                                            },
-                                            "vehicleId": "codd%5Fnew|34874%5F9345408"
-                                        }
-                                    ],
-                                    "Frequency": {
-                                        "text": "15 мин",
-                                        "value": 900,
-                                        "begin": {
-                                            "value": "1568602180",
-                                            "tzOffset": 10800,
-                                            "text": "5:49"
-                                        },
-                                        "end": {
-                                            "value": "1568673460",
-                                            "tzOffset": 10800,
-                                            "text": "1:37"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213A_282_bus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9641102",
-                                "name": "Улица Корнейчука"
-                            },
-                            {
-                                "id": "2532226085",
-                                "name": "Метро Войковская"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Estimated": {
-                                        "value": "1568659888",
-                                        "tzOffset": 10800,
-                                        "text": "21:51"
-                                    },
-                                    "vehicleId": "codd%5Fnew|34874%5F9345408"
-                                }
-                            ],
-                            "Frequency": {
-                                "text": "15 мин",
-                                "value": 900,
-                                "begin": {
-                                    "value": "1568602180",
-                                    "tzOffset": 10800,
-                                    "text": "5:49"
-                                },
-                                "end": {
-                                    "value": "1568673460",
-                                    "tzOffset": 10800,
-                                    "text": "1:37"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_294m_minibus_default",
-                        "name": "994",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_294m_minibus_default",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9640756",
-                                        "name": "Метро Петровско-Разумовская"
-                                    },
-                                    {
-                                        "id": "stop__9649459",
-                                        "name": "Метро Алтуфьево"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [],
-                                    "Frequency": {
-                                        "text": "30 мин",
-                                        "value": 1800,
-                                        "begin": {
-                                            "value": "1568601527",
-                                            "tzOffset": 10800,
-                                            "text": "5:38"
-                                        },
-                                        "end": {
-                                            "value": "1568671727",
-                                            "tzOffset": 10800,
-                                            "text": "1:08"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213A_294m_minibus_default",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9640756",
-                                "name": "Метро Петровско-Разумовская"
-                            },
-                            {
-                                "id": "stop__9649459",
-                                "name": "Метро Алтуфьево"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [],
-                            "Frequency": {
-                                "text": "30 мин",
-                                "value": 1800,
-                                "begin": {
-                                    "value": "1568601527",
-                                    "tzOffset": 10800,
-                                    "text": "5:38"
-                                },
-                                "end": {
-                                    "value": "1568671727",
-                                    "tzOffset": 10800,
-                                    "text": "1:08"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_36_trolleybus_mosgortrans",
-                        "name": "т36",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_36_trolleybus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9642550",
-                                        "name": "ВДНХ (южная)"
-                                    },
-                                    {
-                                        "id": "stop__9640641",
-                                        "name": "Дмитровское шоссе, 155"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659680",
-                                                "tzOffset": 10800,
-                                                "text": "21:48"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568659426",
-                                                "tzOffset": 10800,
-                                                "text": "21:43"
-                                            },
-                                            "vehicleId": "codd%5Fnew|1084829%5F430260"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660520",
-                                                "tzOffset": 10800,
-                                                "text": "22:02"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568659656",
-                                                "tzOffset": 10800,
-                                                "text": "21:47"
-                                            },
-                                            "vehicleId": "codd%5Fnew|1117016%5F430280"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568661900",
-                                                "tzOffset": 10800,
-                                                "text": "22:25"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568660538",
-                                                "tzOffset": 10800,
-                                                "text": "22:02"
-                                            },
-                                            "vehicleId": "codd%5Fnew|1054576%5F430226"
-                                        }
-                                    ],
-                                    "departureTime": "21:48"
-                                }
-                            }
-                        ],
-                        "threadId": "213A_36_trolleybus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9642550",
-                                "name": "ВДНХ (южная)"
-                            },
-                            {
-                                "id": "stop__9640641",
-                                "name": "Дмитровское шоссе, 155"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659680",
-                                        "tzOffset": 10800,
-                                        "text": "21:48"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568659426",
-                                        "tzOffset": 10800,
-                                        "text": "21:43"
-                                    },
-                                    "vehicleId": "codd%5Fnew|1084829%5F430260"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660520",
-                                        "tzOffset": 10800,
-                                        "text": "22:02"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568659656",
-                                        "tzOffset": 10800,
-                                        "text": "21:47"
-                                    },
-                                    "vehicleId": "codd%5Fnew|1117016%5F430280"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568661900",
-                                        "tzOffset": 10800,
-                                        "text": "22:25"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568660538",
-                                        "tzOffset": 10800,
-                                        "text": "22:02"
-                                    },
-                                    "vehicleId": "codd%5Fnew|1054576%5F430226"
-                                }
-                            ],
-                            "departureTime": "21:48"
-                        }
-                    },
-                    {
-                        "lineId": "213_47_trolleybus_mosgortrans",
-                        "name": "т47",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213B_47_trolleybus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9639568",
-                                        "name": "Бескудниковский переулок"
-                                    },
-                                    {
-                                        "id": "stop__9641903",
-                                        "name": "Бескудниковский переулок"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659980",
-                                                "tzOffset": 10800,
-                                                "text": "21:53"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568659253",
-                                                "tzOffset": 10800,
-                                                "text": "21:40"
-                                            },
-                                            "vehicleId": "codd%5Fnew|1112219%5F430329"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660940",
-                                                "tzOffset": 10800,
-                                                "text": "22:09"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568660519",
-                                                "tzOffset": 10800,
-                                                "text": "22:01"
-                                            },
-                                            "vehicleId": "codd%5Fnew|1139620%5F430382"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568663580",
-                                                "tzOffset": 10800,
-                                                "text": "22:53"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:53"
-                                }
-                            }
-                        ],
-                        "threadId": "213B_47_trolleybus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9639568",
-                                "name": "Бескудниковский переулок"
-                            },
-                            {
-                                "id": "stop__9641903",
-                                "name": "Бескудниковский переулок"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659980",
-                                        "tzOffset": 10800,
-                                        "text": "21:53"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568659253",
-                                        "tzOffset": 10800,
-                                        "text": "21:40"
-                                    },
-                                    "vehicleId": "codd%5Fnew|1112219%5F430329"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660940",
-                                        "tzOffset": 10800,
-                                        "text": "22:09"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568660519",
-                                        "tzOffset": 10800,
-                                        "text": "22:01"
-                                    },
-                                    "vehicleId": "codd%5Fnew|1139620%5F430382"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568663580",
-                                        "tzOffset": 10800,
-                                        "text": "22:53"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:53"
-                        }
-                    },
-                    {
-                        "lineId": "213_56_trolleybus_mosgortrans",
-                        "name": "т56",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_56_trolleybus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9639561",
-                                        "name": "Коровинское шоссе"
-                                    },
-                                    {
-                                        "id": "stop__9639588",
-                                        "name": "Коровинское шоссе"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Estimated": {
-                                                "value": "1568660675",
-                                                "tzOffset": 10800,
-                                                "text": "22:04"
-                                            },
-                                            "vehicleId": "codd%5Fnew|146304%5F31207"
-                                        }
-                                    ],
-                                    "Frequency": {
-                                        "text": "8 мин",
-                                        "value": 480,
-                                        "begin": {
-                                            "value": "1568606244",
-                                            "tzOffset": 10800,
-                                            "text": "6:57"
-                                        },
-                                        "end": {
-                                            "value": "1568670144",
-                                            "tzOffset": 10800,
-                                            "text": "0:42"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213A_56_trolleybus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9639561",
-                                "name": "Коровинское шоссе"
-                            },
-                            {
-                                "id": "stop__9639588",
-                                "name": "Коровинское шоссе"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Estimated": {
-                                        "value": "1568660675",
-                                        "tzOffset": 10800,
-                                        "text": "22:04"
-                                    },
-                                    "vehicleId": "codd%5Fnew|146304%5F31207"
-                                }
-                            ],
-                            "Frequency": {
-                                "text": "8 мин",
-                                "value": 480,
-                                "begin": {
-                                    "value": "1568606244",
-                                    "tzOffset": 10800,
-                                    "text": "6:57"
-                                },
-                                "end": {
-                                    "value": "1568670144",
-                                    "tzOffset": 10800,
-                                    "text": "0:42"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_63_bus_mosgortrans",
-                        "name": "63",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_63_bus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9640554",
-                                        "name": "Лобненская улица"
-                                    },
-                                    {
-                                        "id": "stop__9640553",
-                                        "name": "Лобненская улица"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Estimated": {
-                                                "value": "1568659369",
-                                                "tzOffset": 10800,
-                                                "text": "21:42"
-                                            },
-                                            "vehicleId": "codd%5Fnew|38921%5F9215306"
-                                        },
-                                        {
-                                            "Estimated": {
-                                                "value": "1568660136",
-                                                "tzOffset": 10800,
-                                                "text": "21:55"
-                                            },
-                                            "vehicleId": "codd%5Fnew|38918%5F9215303"
-                                        }
-                                    ],
-                                    "Frequency": {
-                                        "text": "17 мин",
-                                        "value": 1020,
-                                        "begin": {
-                                            "value": "1568600987",
-                                            "tzOffset": 10800,
-                                            "text": "5:29"
-                                        },
-                                        "end": {
-                                            "value": "1568670227",
-                                            "tzOffset": 10800,
-                                            "text": "0:43"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213A_63_bus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9640554",
-                                "name": "Лобненская улица"
-                            },
-                            {
-                                "id": "stop__9640553",
-                                "name": "Лобненская улица"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Estimated": {
-                                        "value": "1568659369",
-                                        "tzOffset": 10800,
-                                        "text": "21:42"
-                                    },
-                                    "vehicleId": "codd%5Fnew|38921%5F9215306"
-                                },
-                                {
-                                    "Estimated": {
-                                        "value": "1568660136",
-                                        "tzOffset": 10800,
-                                        "text": "21:55"
-                                    },
-                                    "vehicleId": "codd%5Fnew|38918%5F9215303"
-                                }
-                            ],
-                            "Frequency": {
-                                "text": "17 мин",
-                                "value": 1020,
-                                "begin": {
-                                    "value": "1568600987",
-                                    "tzOffset": 10800,
-                                    "text": "5:29"
-                                },
-                                "end": {
-                                    "value": "1568670227",
-                                    "tzOffset": 10800,
-                                    "text": "0:43"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_677_bus_mosgortrans",
-                        "name": "677",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213B_677_bus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9639495",
-                                        "name": "Метро Петровско-Разумовская"
-                                    },
-                                    {
-                                        "id": "stop__9639480",
-                                        "name": "Платформа Лианозово"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Estimated": {
-                                                "value": "1568659369",
-                                                "tzOffset": 10800,
-                                                "text": "21:42"
-                                            },
-                                            "vehicleId": "codd%5Fnew|11731%5F31376"
-                                        }
-                                    ],
-                                    "Frequency": {
-                                        "text": "4 мин",
-                                        "value": 240,
-                                        "begin": {
-                                            "value": "1568600940",
-                                            "tzOffset": 10800,
-                                            "text": "5:29"
-                                        },
-                                        "end": {
-                                            "value": "1568672640",
-                                            "tzOffset": 10800,
-                                            "text": "1:24"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "213B_677_bus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9639495",
-                                "name": "Метро Петровско-Разумовская"
-                            },
-                            {
-                                "id": "stop__9639480",
-                                "name": "Платформа Лианозово"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Estimated": {
-                                        "value": "1568659369",
-                                        "tzOffset": 10800,
-                                        "text": "21:42"
-                                    },
-                                    "vehicleId": "codd%5Fnew|11731%5F31376"
-                                }
-                            ],
-                            "Frequency": {
-                                "text": "4 мин",
-                                "value": 240,
-                                "begin": {
-                                    "value": "1568600940",
-                                    "tzOffset": 10800,
-                                    "text": "5:29"
-                                },
-                                "end": {
-                                    "value": "1568672640",
-                                    "tzOffset": 10800,
-                                    "text": "1:24"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "213_692_bus_mosgortrans",
-                        "name": "692",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "2036928706",
-                                "EssentialStops": [
-                                    {
-                                        "id": "3163417967",
-                                        "name": "Платформа Дегунино"
-                                    },
-                                    {
-                                        "id": "3163417967",
-                                        "name": "Платформа Дегунино"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660280",
-                                                "tzOffset": 10800,
-                                                "text": "21:58"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568660255",
-                                                "tzOffset": 10800,
-                                                "text": "21:57"
-                                            },
-                                            "vehicleId": "codd%5Fnew|63029%5F31485"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568693340",
-                                                "tzOffset": 10800,
-                                                "text": "7:09"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568696940",
-                                                "tzOffset": 10800,
-                                                "text": "8:09"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:58"
-                                }
-                            }
-                        ],
-                        "threadId": "2036928706",
-                        "EssentialStops": [
-                            {
-                                "id": "3163417967",
-                                "name": "Платформа Дегунино"
-                            },
-                            {
-                                "id": "3163417967",
-                                "name": "Платформа Дегунино"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660280",
-                                        "tzOffset": 10800,
-                                        "text": "21:58"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568660255",
-                                        "tzOffset": 10800,
-                                        "text": "21:57"
-                                    },
-                                    "vehicleId": "codd%5Fnew|63029%5F31485"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568693340",
-                                        "tzOffset": 10800,
-                                        "text": "7:09"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568696940",
-                                        "tzOffset": 10800,
-                                        "text": "8:09"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:58"
-                        }
-                    },
-                    {
-                        "lineId": "213_78_trolleybus_mosgortrans",
-                        "name": "т78",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "213A_78_trolleybus_mosgortrans",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9887464",
-                                        "name": "9-я Северная линия"
-                                    },
-                                    {
-                                        "id": "stop__9887464",
-                                        "name": "9-я Северная линия"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659620",
-                                                "tzOffset": 10800,
-                                                "text": "21:47"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568659898",
-                                                "tzOffset": 10800,
-                                                "text": "21:51"
-                                            },
-                                            "vehicleId": "codd%5Fnew|147522%5F31184"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660760",
-                                                "tzOffset": 10800,
-                                                "text": "22:06"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568661900",
-                                                "tzOffset": 10800,
-                                                "text": "22:25"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:47"
-                                }
-                            }
-                        ],
-                        "threadId": "213A_78_trolleybus_mosgortrans",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9887464",
-                                "name": "9-я Северная линия"
-                            },
-                            {
-                                "id": "stop__9887464",
-                                "name": "9-я Северная линия"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659620",
-                                        "tzOffset": 10800,
-                                        "text": "21:47"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568659898",
-                                        "tzOffset": 10800,
-                                        "text": "21:51"
-                                    },
-                                    "vehicleId": "codd%5Fnew|147522%5F31184"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660760",
-                                        "tzOffset": 10800,
-                                        "text": "22:06"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568661900",
-                                        "tzOffset": 10800,
-                                        "text": "22:25"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:47"
-                        }
-                    },
-                    {
-                        "lineId": "213_82_bus_mosgortrans",
-                        "name": "82",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "2036925244",
-                                "EssentialStops": [
-                                    {
-                                        "id": "2310890052",
-                                        "name": "Метро Верхние Лихоборы"
-                                    },
-                                    {
-                                        "id": "2310890052",
-                                        "name": "Метро Верхние Лихоборы"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659680",
-                                                "tzOffset": 10800,
-                                                "text": "21:48"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568661780",
-                                                "tzOffset": 10800,
-                                                "text": "22:23"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568663760",
-                                                "tzOffset": 10800,
-                                                "text": "22:56"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:48"
-                                }
-                            }
-                        ],
-                        "threadId": "2036925244",
-                        "EssentialStops": [
-                            {
-                                "id": "2310890052",
-                                "name": "Метро Верхние Лихоборы"
-                            },
-                            {
-                                "id": "2310890052",
-                                "name": "Метро Верхние Лихоборы"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659680",
-                                        "tzOffset": 10800,
-                                        "text": "21:48"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568661780",
-                                        "tzOffset": 10800,
-                                        "text": "22:23"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568663760",
-                                        "tzOffset": 10800,
-                                        "text": "22:56"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:48"
-                        }
-                    },
-                    {
-                        "lineId": "2465131598",
-                        "name": "179к",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "2465131758",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9640244",
-                                        "name": "Платформа Лианозово"
-                                    },
-                                    {
-                                        "id": "stop__9639480",
-                                        "name": "Платформа Лианозово"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659500",
-                                                "tzOffset": 10800,
-                                                "text": "21:45"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659980",
-                                                "tzOffset": 10800,
-                                                "text": "21:53"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568660880",
-                                                "tzOffset": 10800,
-                                                "text": "22:08"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:45"
-                                }
-                            }
-                        ],
-                        "threadId": "2465131758",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9640244",
-                                "name": "Платформа Лианозово"
-                            },
-                            {
-                                "id": "stop__9639480",
-                                "name": "Платформа Лианозово"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659500",
-                                        "tzOffset": 10800,
-                                        "text": "21:45"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659980",
-                                        "tzOffset": 10800,
-                                        "text": "21:53"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568660880",
-                                        "tzOffset": 10800,
-                                        "text": "22:08"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:45"
-                        }
-                    },
-                    {
-                        "lineId": "466_bus_default",
-                        "name": "466",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "466B_bus_default",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9640546",
-                                        "name": "Станция Бескудниково"
-                                    },
-                                    {
-                                        "id": "stop__9640545",
-                                        "name": "Станция Бескудниково"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [],
-                                    "Frequency": {
-                                        "text": "22 мин",
-                                        "value": 1320,
-                                        "begin": {
-                                            "value": "1568604647",
-                                            "tzOffset": 10800,
-                                            "text": "6:30"
-                                        },
-                                        "end": {
-                                            "value": "1568675447",
-                                            "tzOffset": 10800,
-                                            "text": "2:10"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "466B_bus_default",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9640546",
-                                "name": "Станция Бескудниково"
-                            },
-                            {
-                                "id": "stop__9640545",
-                                "name": "Станция Бескудниково"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [],
-                            "Frequency": {
-                                "text": "22 мин",
-                                "value": 1320,
-                                "begin": {
-                                    "value": "1568604647",
-                                    "tzOffset": 10800,
-                                    "text": "6:30"
-                                },
-                                "end": {
-                                    "value": "1568675447",
-                                    "tzOffset": 10800,
-                                    "text": "2:10"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "lineId": "677k_bus_default",
-                        "name": "677к",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "677kA_bus_default",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9640244",
-                                        "name": "Платформа Лианозово"
-                                    },
-                                    {
-                                        "id": "stop__9639480",
-                                        "name": "Платформа Лианозово"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568659920",
-                                                "tzOffset": 10800,
-                                                "text": "21:52"
-                                            },
-                                            "Estimated": {
-                                                "value": "1568660003",
-                                                "tzOffset": 10800,
-                                                "text": "21:53"
-                                            },
-                                            "vehicleId": "codd%5Fnew|130308%5F31319"
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568661240",
-                                                "tzOffset": 10800,
-                                                "text": "22:14"
-                                            }
-                                        },
-                                        {
-                                            "Scheduled": {
-                                                "value": "1568662500",
-                                                "tzOffset": 10800,
-                                                "text": "22:35"
-                                            }
-                                        }
-                                    ],
-                                    "departureTime": "21:52"
-                                }
-                            }
-                        ],
-                        "threadId": "677kA_bus_default",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9640244",
-                                "name": "Платформа Лианозово"
-                            },
-                            {
-                                "id": "stop__9639480",
-                                "name": "Платформа Лианозово"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Scheduled": {
-                                        "value": "1568659920",
-                                        "tzOffset": 10800,
-                                        "text": "21:52"
-                                    },
-                                    "Estimated": {
-                                        "value": "1568660003",
-                                        "tzOffset": 10800,
-                                        "text": "21:53"
-                                    },
-                                    "vehicleId": "codd%5Fnew|130308%5F31319"
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568661240",
-                                        "tzOffset": 10800,
-                                        "text": "22:14"
-                                    }
-                                },
-                                {
-                                    "Scheduled": {
-                                        "value": "1568662500",
-                                        "tzOffset": 10800,
-                                        "text": "22:35"
-                                    }
-                                }
-                            ],
-                            "departureTime": "21:52"
-                        }
-                    },
-                    {
-                        "lineId": "m10_bus_default",
-                        "name": "м10",
-                        "Types": [
-                            "bus"
-                        ],
-                        "type": "bus",
-                        "threads": [
-                            {
-                                "threadId": "2036926048",
-                                "EssentialStops": [
-                                    {
-                                        "id": "stop__9640554",
-                                        "name": "Лобненская улица"
-                                    },
-                                    {
-                                        "id": "stop__9640553",
-                                        "name": "Лобненская улица"
-                                    }
-                                ],
-                                "BriefSchedule": {
-                                    "Events": [
-                                        {
-                                            "Estimated": {
-                                                "value": "1568659718",
-                                                "tzOffset": 10800,
-                                                "text": "21:48"
-                                            },
-                                            "vehicleId": "codd%5Fnew|146260%5F31212"
-                                        },
-                                        {
-                                            "Estimated": {
-                                                "value": "1568660422",
-                                                "tzOffset": 10800,
-                                                "text": "22:00"
-                                            },
-                                            "vehicleId": "codd%5Fnew|13997%5F31247"
-                                        }
-                                    ],
-                                    "Frequency": {
-                                        "text": "15 мин",
-                                        "value": 900,
-                                        "begin": {
-                                            "value": "1568606903",
-                                            "tzOffset": 10800,
-                                            "text": "7:08"
-                                        },
-                                        "end": {
-                                            "value": "1568675183",
-                                            "tzOffset": 10800,
-                                            "text": "2:06"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "threadId": "2036926048",
-                        "EssentialStops": [
-                            {
-                                "id": "stop__9640554",
-                                "name": "Лобненская улица"
-                            },
-                            {
-                                "id": "stop__9640553",
-                                "name": "Лобненская улица"
-                            }
-                        ],
-                        "BriefSchedule": {
-                            "Events": [
-                                {
-                                    "Estimated": {
-                                        "value": "1568659718",
-                                        "tzOffset": 10800,
-                                        "text": "21:48"
-                                    },
-                                    "vehicleId": "codd%5Fnew|146260%5F31212"
-                                },
-                                {
-                                    "Estimated": {
-                                        "value": "1568660422",
-                                        "tzOffset": 10800,
-                                        "text": "22:00"
-                                    },
-                                    "vehicleId": "codd%5Fnew|13997%5F31247"
-                                }
-                            ],
-                            "Frequency": {
-                                "text": "15 мин",
-                                "value": 900,
-                                "begin": {
-                                    "value": "1568606903",
-                                    "tzOffset": 10800,
-                                    "text": "7:08"
-                                },
-                                "end": {
-                                    "value": "1568675183",
-                                    "tzOffset": 10800,
-                                    "text": "2:06"
-                                }
-                            }
-                        }
-                    }
+          ],
+          "names": {
+            "ablative": "",
+            "accusative": "Москву",
+            "dative": "Москве",
+            "directional": "",
+            "genitive": "Москвы",
+            "instrumental": "Москвой",
+            "locative": "",
+            "nominative": "Москва",
+            "preposition": "в",
+            "prepositional": "Москве"
+          },
+          "parent": {
+            "id": 1,
+            "type": 5,
+            "parent_id": 3,
+            "capital_id": 213,
+            "geo_parent_id": 0,
+            "city_id": 213,
+            "name": "moscow-and-moscow-oblast",
+            "native_name": "",
+            "iso_name": "RU-MOS",
+            "is_main": true,
+            "en_name": "Moscow and Moscow Oblast",
+            "short_en_name": "RU-MOS",
+            "phone_code": "495 496 498 499",
+            "phone_code_old": "",
+            "zip_code": "",
+            "population": 7503385,
+            "synonyms": "Московская область, Подмосковье, Podmoskovye",
+            "latitude": 55.815792,
+            "longitude": 37.380031,
+            "latitude_size": 2.705659,
+            "longitude_size": 5.060749,
+            "zoom": 8,
+            "tzname": "Europe/Moscow",
+            "official_languages": "ru",
+            "widespread_languages": "ru",
+            "suggest_list": [
+              213,
+              10716,
+              10747,
+              10758,
+              20728,
+              10740,
+              10738,
+              20523,
+              10735,
+              10734,
+              10743,
+              21622
+            ],
+            "is_eu": false,
+            "services_names": [
+              "bs",
+              "yaca",
+              "ad"
+            ],
+            "ename": "moscow-and-moscow-oblast",
+            "bounds": [
+              [
+                34.8496565,
+                54.439456064325434
+              ],
+              [
+                39.9104055,
+                57.14511506432543
+              ]
+            ],
+            "names": {
+              "ablative": "",
+              "accusative": "Москву и Московскую область",
+              "dative": "Москве и Московской области",
+              "directional": "",
+              "genitive": "Москвы и Московской области",
+              "instrumental": "Москвой и Московской областью",
+              "locative": "",
+              "nominative": "Москва и Московская область",
+              "preposition": "в",
+              "prepositional": "Москве и Московской области"
+            },
+            "parent": {
+              "id": 225,
+              "type": 3,
+              "parent_id": 10001,
+              "capital_id": 213,
+              "geo_parent_id": 0,
+              "city_id": 213,
+              "name": "russia",
+              "native_name": "",
+              "iso_name": "RU",
+              "is_main": false,
+              "en_name": "Russia",
+              "short_en_name": "RU",
+              "phone_code": "7",
+              "phone_code_old": "",
+              "zip_code": "",
+              "population": 146880432,
+              "synonyms": "Russian Federation,Российская Федерация",
+              "latitude": 61.698653,
+              "longitude": 99.505405,
+              "latitude_size": 40.700127,
+              "longitude_size": 171.643239,
+              "zoom": 3,
+              "tzname": "",
+              "official_languages": "ru",
+              "widespread_languages": "ru",
+              "suggest_list": [
+                213,
+                2,
+                65,
+                54,
+                47,
+                43,
+                66,
+                51,
+                56,
+                172,
+                39,
+                62
+              ],
+              "is_eu": false,
+              "services_names": [
+                "bs",
+                "yaca",
+                "ad"
+              ],
+              "ename": "russia",
+              "bounds": [
+                [
+                  13.683785499999999,
+                  35.290400699917846
+                ],
+                [
+                  -174.6729755,
+                  75.99052769991785
                 ]
+              ],
+              "names": {
+                "ablative": "",
+                "accusative": "Россию",
+                "dative": "России",
+                "directional": "",
+                "genitive": "России",
+                "instrumental": "Россией",
+                "locative": "",
+                "nominative": "Россия",
+                "preposition": "в",
+                "prepositional": "России"
+              }
             }
+          }
         },
-        "toponymSeoname": "dmitrovskoye_shosse"
-    }
+        "Transport": [
+          {
+            "lineId": "2036924720",
+            "name": "692",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "2036928706",
+                "EssentialStops": [
+                  {
+                    "id": "3163417967",
+                    "name": "Платформа Дегунино"
+                  },
+                  {
+                    "id": "3163417967",
+                    "name": "Платформа Дегунино"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570973441",
+                        "tzOffset": 10800,
+                        "text": "16:30"
+                      },
+                      "vehicleId": "codd%5Fnew|144020%5F31402"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "1 ч",
+                    "value": 3600,
+                    "begin": {
+                      "value": "1570938428",
+                      "tzOffset": 10800,
+                      "text": "6:47"
+                    },
+                    "end": {
+                      "value": "1570990628",
+                      "tzOffset": 10800,
+                      "text": "21:17"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2036924720&ll=37.577436%2C55.828981&name=692&r=4037&type=bus",
+            "seoname": "692"
+          },
+          {
+            "lineId": "2036924968",
+            "name": "82",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "2036925244",
+                "EssentialStops": [
+                  {
+                    "id": "2310890052",
+                    "name": "Метро Верхние Лихоборы"
+                  },
+                  {
+                    "id": "2310890052",
+                    "name": "Метро Верхние Лихоборы"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [],
+                  "Frequency": {
+                    "text": "34 мин",
+                    "value": 2040,
+                    "begin": {
+                      "value": "1570944072",
+                      "tzOffset": 10800,
+                      "text": "8:21"
+                    },
+                    "end": {
+                      "value": "1570997592",
+                      "tzOffset": 10800,
+                      "text": "23:13"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2036924968&ll=37.571504%2C55.816622&name=82&r=4164&type=bus",
+            "seoname": "82"
+          },
+          {
+            "lineId": "2036925416",
+            "name": "194",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "2036927196",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9711780",
+                    "name": "Метро Петровско-Разумовская"
+                  },
+                  {
+                    "id": "stop__9648742",
+                    "name": "Коровино"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [],
+                  "Frequency": {
+                    "text": "12 мин",
+                    "value": 720,
+                    "begin": {
+                      "value": "1570933976",
+                      "tzOffset": 10800,
+                      "text": "5:32"
+                    },
+                    "end": {
+                      "value": "1571004356",
+                      "tzOffset": 10800,
+                      "text": "1:05"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2036925416&ll=37.544800%2C55.865286&name=194&r=3667&type=bus",
+            "seoname": "194"
+          },
+          {
+            "lineId": "2036925728",
+            "name": "282",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_282_bus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9641102",
+                    "name": "Улица Корнейчука"
+                  },
+                  {
+                    "id": "2532226085",
+                    "name": "Метро Войковская"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570971861",
+                        "tzOffset": 10800,
+                        "text": "16:04"
+                      },
+                      "vehicleId": "codd%5Fnew|34854%5F9345401"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570973231",
+                        "tzOffset": 10800,
+                        "text": "16:27"
+                      },
+                      "vehicleId": "codd%5Fnew|37913%5F9225419"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "22 мин",
+                    "value": 1320,
+                    "begin": {
+                      "value": "1570934963",
+                      "tzOffset": 10800,
+                      "text": "5:49"
+                    },
+                    "end": {
+                      "value": "1571005163",
+                      "tzOffset": 10800,
+                      "text": "1:19"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2036925728&ll=37.553526%2C55.860385&name=282&r=5779&type=bus",
+            "seoname": "282"
+          },
+          {
+            "lineId": "2036926781",
+            "name": "154",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213B_154_bus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9642548",
+                    "name": "ВДНХ (южная)"
+                  },
+                  {
+                    "id": "stop__9711744",
+                    "name": "Станция Ховрино"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570972424",
+                        "tzOffset": 10800,
+                        "text": "16:13"
+                      },
+                      "vehicleId": "codd%5Fnew|1161539%5F191543"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570973620",
+                        "tzOffset": 10800,
+                        "text": "16:33"
+                      },
+                      "vehicleId": "codd%5Fnew|58773%5F190599"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "20 мин",
+                    "value": 1200,
+                    "begin": {
+                      "value": "1570938166",
+                      "tzOffset": 10800,
+                      "text": "6:42"
+                    },
+                    "end": {
+                      "value": "1571006446",
+                      "tzOffset": 10800,
+                      "text": "1:40"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2036926781&ll=37.576158%2C55.846301&name=154&r=4917&type=bus",
+            "seoname": "154"
+          },
+          {
+            "lineId": "2036926818",
+            "name": "994",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_294m_minibus_default",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9640756",
+                    "name": "Метро Петровско-Разумовская"
+                  },
+                  {
+                    "id": "stop__9649459",
+                    "name": "Метро Алтуфьево"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [],
+                  "Frequency": {
+                    "text": "30 мин",
+                    "value": 1800,
+                    "begin": {
+                      "value": "1570934327",
+                      "tzOffset": 10800,
+                      "text": "5:38"
+                    },
+                    "end": {
+                      "value": "1571004527",
+                      "tzOffset": 10800,
+                      "text": "1:08"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2036926818&ll=37.560060%2C55.868431&name=994&r=3637&type=bus",
+            "seoname": "994"
+          },
+          {
+            "lineId": "2036926890",
+            "name": "466",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "466B_bus_default",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9640546",
+                    "name": "Станция Бескудниково"
+                  },
+                  {
+                    "id": "stop__9640545",
+                    "name": "Станция Бескудниково"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [],
+                  "Frequency": {
+                    "text": "22 мин",
+                    "value": 1320,
+                    "begin": {
+                      "value": "1570937447",
+                      "tzOffset": 10800,
+                      "text": "6:30"
+                    },
+                    "end": {
+                      "value": "1571008247",
+                      "tzOffset": 10800,
+                      "text": "2:10"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2036926890&ll=37.564238%2C55.845050&name=466&r=4163&type=bus",
+            "seoname": "466"
+          },
+          {
+            "lineId": "213_114_bus_mosgortrans",
+            "name": "114",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213B_114_bus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9647199",
+                    "name": "Метро Войковская"
+                  },
+                  {
+                    "id": "stop__9639588",
+                    "name": "Коровинское шоссе"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570972913",
+                        "tzOffset": 10800,
+                        "text": "16:21"
+                      },
+                      "vehicleId": "codd%5Fnew|1092230%5F191422"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "15 мин",
+                    "value": 900,
+                    "begin": {
+                      "value": "1570936205",
+                      "tzOffset": 10800,
+                      "text": "6:10"
+                    },
+                    "end": {
+                      "value": "1571004965",
+                      "tzOffset": 10800,
+                      "text": "1:16"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_114_bus_mosgortrans&ll=37.508487%2C55.852137&name=114&r=3544&type=bus",
+            "seoname": "114"
+          },
+          {
+            "lineId": "213_179_bus_mosgortrans",
+            "name": "179",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213B_179_bus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9647199",
+                    "name": "Метро Войковская"
+                  },
+                  {
+                    "id": "stop__9639480",
+                    "name": "Платформа Лианозово"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570971963",
+                        "tzOffset": 10800,
+                        "text": "16:06"
+                      },
+                      "vehicleId": "codd%5Fnew|194519%5F31367"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570973105",
+                        "tzOffset": 10800,
+                        "text": "16:25"
+                      },
+                      "vehicleId": "codd%5Fnew|56358%5F31365"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "15 мин",
+                    "value": 900,
+                    "begin": {
+                      "value": "1570936823",
+                      "tzOffset": 10800,
+                      "text": "6:20"
+                    },
+                    "end": {
+                      "value": "1571005583",
+                      "tzOffset": 10800,
+                      "text": "1:26"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_179_bus_mosgortrans&ll=37.526151%2C55.858031&name=179&r=4634&type=bus",
+            "seoname": "179"
+          },
+          {
+            "lineId": "213_191m_minibus_default",
+            "name": "591",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_191m_minibus_default",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9647199",
+                    "name": "Метро Войковская"
+                  },
+                  {
+                    "id": "stop__9711744",
+                    "name": "Станция Ховрино"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570972150",
+                        "tzOffset": 10800,
+                        "text": "16:09"
+                      },
+                      "vehicleId": "codd%5Fnew|35595%5F9345307"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "22 мин",
+                    "value": 1320,
+                    "begin": {
+                      "value": "1570934833",
+                      "tzOffset": 10800,
+                      "text": "5:47"
+                    },
+                    "end": {
+                      "value": "1571005033",
+                      "tzOffset": 10800,
+                      "text": "1:17"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_191m_minibus_default&ll=37.510906%2C55.848214&name=591&r=3384&type=bus",
+            "seoname": "591"
+          },
+          {
+            "lineId": "213_206m_minibus_default",
+            "name": "206к",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_206m_minibus_default",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9640756",
+                    "name": "Метро Петровско-Разумовская"
+                  },
+                  {
+                    "id": "stop__9640553",
+                    "name": "Лобненская улица"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [],
+                  "Frequency": {
+                    "text": "22 мин",
+                    "value": 1320,
+                    "begin": {
+                      "value": "1570934039",
+                      "tzOffset": 10800,
+                      "text": "5:33"
+                    },
+                    "end": {
+                      "value": "1571004239",
+                      "tzOffset": 10800,
+                      "text": "1:03"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_206m_minibus_default&ll=37.548997%2C55.864997&name=206%D0%BA&r=3515&type=bus",
+            "seoname": "206k"
+          },
+          {
+            "lineId": "213_215_bus_mosgortrans",
+            "name": "215",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213B_215_bus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9711780",
+                    "name": "Метро Петровско-Разумовская"
+                  },
+                  {
+                    "id": "stop__9711744",
+                    "name": "Станция Ховрино"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [],
+                  "Frequency": {
+                    "text": "27 мин",
+                    "value": 1620,
+                    "begin": {
+                      "value": "1570934076",
+                      "tzOffset": 10800,
+                      "text": "5:34"
+                    },
+                    "end": {
+                      "value": "1571004276",
+                      "tzOffset": 10800,
+                      "text": "1:04"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_215_bus_mosgortrans&ll=37.543701%2C55.854527&name=215&r=2763&type=bus",
+            "seoname": "215"
+          },
+          {
+            "lineId": "213_36_trolleybus_mosgortrans",
+            "name": "т36",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_36_trolleybus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9642550",
+                    "name": "ВДНХ (южная)"
+                  },
+                  {
+                    "id": "stop__9640641",
+                    "name": "Дмитровское шоссе, 155"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570972236",
+                        "tzOffset": 10800,
+                        "text": "16:10"
+                      },
+                      "vehicleId": "codd%5Fnew|1084830%5F430261"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570972641",
+                        "tzOffset": 10800,
+                        "text": "16:17"
+                      },
+                      "vehicleId": "codd%5Fnew|1084829%5F430260"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570973178",
+                        "tzOffset": 10800,
+                        "text": "16:26"
+                      },
+                      "vehicleId": "codd%5Fnew|1084827%5F430255"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "12 мин",
+                    "value": 720,
+                    "begin": {
+                      "value": "1570932741",
+                      "tzOffset": 10800,
+                      "text": "5:12"
+                    },
+                    "end": {
+                      "value": "1571003121",
+                      "tzOffset": 10800,
+                      "text": "0:45"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_36_trolleybus_mosgortrans&ll=37.588604%2C55.859705&name=%D1%8236&r=5104&type=bus",
+            "seoname": "t36"
+          },
+          {
+            "lineId": "213_47_trolleybus_mosgortrans",
+            "name": "т47",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213B_47_trolleybus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9639568",
+                    "name": "Бескудниковский переулок"
+                  },
+                  {
+                    "id": "stop__9641903",
+                    "name": "Бескудниковский переулок"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Scheduled": {
+                        "value": "1570972080",
+                        "tzOffset": 10800,
+                        "text": "16:08"
+                      },
+                      "Estimated": {
+                        "value": "1570972183",
+                        "tzOffset": 10800,
+                        "text": "16:09"
+                      },
+                      "vehicleId": "codd%5Fnew|1132404%5F430361"
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570972980",
+                        "tzOffset": 10800,
+                        "text": "16:23"
+                      },
+                      "Estimated": {
+                        "value": "1570972219",
+                        "tzOffset": 10800,
+                        "text": "16:10"
+                      },
+                      "vehicleId": "codd%5Fnew|1136132%5F430358"
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570973940",
+                        "tzOffset": 10800,
+                        "text": "16:39"
+                      }
+                    }
+                  ],
+                  "departureTime": "16:08"
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_47_trolleybus_mosgortrans&ll=37.588308%2C55.818685&name=%D1%8247&r=5359&type=bus",
+            "seoname": "t47"
+          },
+          {
+            "lineId": "213_56_trolleybus_mosgortrans",
+            "name": "т56",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_56_trolleybus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9639561",
+                    "name": "Коровинское шоссе"
+                  },
+                  {
+                    "id": "stop__9639588",
+                    "name": "Коровинское шоссе"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Scheduled": {
+                        "value": "1570971900",
+                        "tzOffset": 10800,
+                        "text": "16:05"
+                      },
+                      "Estimated": {
+                        "value": "1570972560",
+                        "tzOffset": 10800,
+                        "text": "16:16"
+                      },
+                      "vehicleId": "codd%5Fnew|1117148%5F430351"
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570972680",
+                        "tzOffset": 10800,
+                        "text": "16:18"
+                      },
+                      "Estimated": {
+                        "value": "1570973442",
+                        "tzOffset": 10800,
+                        "text": "16:30"
+                      },
+                      "vehicleId": "codd%5Fnew|1080552%5F430302"
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570973400",
+                        "tzOffset": 10800,
+                        "text": "16:30"
+                      }
+                    }
+                  ],
+                  "departureTime": "16:05"
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_56_trolleybus_mosgortrans&ll=37.551454%2C55.830147&name=%D1%8256&r=6304&type=bus",
+            "seoname": "t56"
+          },
+          {
+            "lineId": "213_63_bus_mosgortrans",
+            "name": "63",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_63_bus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9640554",
+                    "name": "Лобненская улица"
+                  },
+                  {
+                    "id": "stop__9640553",
+                    "name": "Лобненская улица"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570972434",
+                        "tzOffset": 10800,
+                        "text": "16:13"
+                      },
+                      "vehicleId": "codd%5Fnew|38700%5F9215301"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "17 мин",
+                    "value": 1020,
+                    "begin": {
+                      "value": "1570934207",
+                      "tzOffset": 10800,
+                      "text": "5:36"
+                    },
+                    "end": {
+                      "value": "1571003507",
+                      "tzOffset": 10800,
+                      "text": "0:51"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_63_bus_mosgortrans&ll=37.550792%2C55.872690&name=63&r=3057&type=bus",
+            "seoname": "63"
+          },
+          {
+            "lineId": "213_677_bus_mosgortrans",
+            "name": "677",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213B_677_bus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9639495",
+                    "name": "Метро Петровско-Разумовская"
+                  },
+                  {
+                    "id": "stop__9639480",
+                    "name": "Платформа Лианозово"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Scheduled": {
+                        "value": "1570972200",
+                        "tzOffset": 10800,
+                        "text": "16:10"
+                      },
+                      "Estimated": {
+                        "value": "1570971838",
+                        "tzOffset": 10800,
+                        "text": "16:03"
+                      },
+                      "vehicleId": "codd%5Fnew|58581%5F31321"
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570972560",
+                        "tzOffset": 10800,
+                        "text": "16:16"
+                      }
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570972920",
+                        "tzOffset": 10800,
+                        "text": "16:22"
+                      }
+                    }
+                  ],
+                  "departureTime": "16:10"
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_677_bus_mosgortrans&ll=37.564191%2C55.866620&name=677&r=3386&type=bus",
+            "seoname": "677"
+          },
+          {
+            "lineId": "213_78_trolleybus_mosgortrans",
+            "name": "т78",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "213A_78_trolleybus_mosgortrans",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9887464",
+                    "name": "9-я Северная линия"
+                  },
+                  {
+                    "id": "stop__9887464",
+                    "name": "9-я Северная линия"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570971984",
+                        "tzOffset": 10800,
+                        "text": "16:06"
+                      },
+                      "vehicleId": "codd%5Fnew|59694%5F31155"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570972003",
+                        "tzOffset": 10800,
+                        "text": "16:06"
+                      },
+                      "vehicleId": "codd%5Fnew|55041%5F31116"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570972550",
+                        "tzOffset": 10800,
+                        "text": "16:15"
+                      },
+                      "vehicleId": "codd%5Fnew|62710%5F31142"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570973307",
+                        "tzOffset": 10800,
+                        "text": "16:28"
+                      },
+                      "vehicleId": "codd%5Fnew|1037437%5F31144"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570973456",
+                        "tzOffset": 10800,
+                        "text": "16:30"
+                      },
+                      "vehicleId": "codd%5Fnew|318517%5F31136"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "11 мин",
+                    "value": 660,
+                    "begin": {
+                      "value": "1570937045",
+                      "tzOffset": 10800,
+                      "text": "6:24"
+                    },
+                    "end": {
+                      "value": "1571002385",
+                      "tzOffset": 10800,
+                      "text": "0:33"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=213_78_trolleybus_mosgortrans&ll=37.569453%2C55.855402&name=%D1%8278&r=8810&type=bus",
+            "seoname": "t78"
+          },
+          {
+            "lineId": "2465131598",
+            "name": "179к",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "2465131758",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9640244",
+                    "name": "Платформа Лианозово"
+                  },
+                  {
+                    "id": "stop__9639480",
+                    "name": "Платформа Лианозово"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [],
+                  "Frequency": {
+                    "text": "15 мин",
+                    "value": 900,
+                    "begin": {
+                      "value": "1570935230",
+                      "tzOffset": 10800,
+                      "text": "5:53"
+                    },
+                    "end": {
+                      "value": "1571003030",
+                      "tzOffset": 10800,
+                      "text": "0:43"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=2465131598&ll=37.561423%2C55.871807&name=179%D0%BA&r=2787&type=bus",
+            "seoname": "179k"
+          },
+          {
+            "lineId": "677k_bus_default",
+            "name": "677к",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "677kA_bus_default",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9640244",
+                    "name": "Платформа Лианозово"
+                  },
+                  {
+                    "id": "stop__9639480",
+                    "name": "Платформа Лианозово"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Scheduled": {
+                        "value": "1570972560",
+                        "tzOffset": 10800,
+                        "text": "16:16"
+                      },
+                      "Estimated": {
+                        "value": "1570971986",
+                        "tzOffset": 10800,
+                        "text": "16:06"
+                      },
+                      "vehicleId": "codd%5Fnew|1038096%5F31398"
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570973280",
+                        "tzOffset": 10800,
+                        "text": "16:28"
+                      },
+                      "Estimated": {
+                        "value": "1570972342",
+                        "tzOffset": 10800,
+                        "text": "16:12"
+                      },
+                      "vehicleId": "codd%5Fnew|58590%5F31348"
+                    },
+                    {
+                      "Scheduled": {
+                        "value": "1570974000",
+                        "tzOffset": 10800,
+                        "text": "16:40"
+                      },
+                      "Estimated": {
+                        "value": "1570973387",
+                        "tzOffset": 10800,
+                        "text": "16:29"
+                      },
+                      "vehicleId": "codd%5Fnew|58902%5F31316"
+                    }
+                  ],
+                  "departureTime": "16:16"
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=677k_bus_default&ll=37.565257%2C55.870397&name=677%D0%BA&r=2987&type=bus",
+            "seoname": "677k"
+          },
+          {
+            "lineId": "m10_bus_default",
+            "name": "м10",
+            "Types": [
+              "bus"
+            ],
+            "type": "bus",
+            "threads": [
+              {
+                "threadId": "2036926048",
+                "EssentialStops": [
+                  {
+                    "id": "stop__9640554",
+                    "name": "Лобненская улица"
+                  },
+                  {
+                    "id": "stop__9640553",
+                    "name": "Лобненская улица"
+                  }
+                ],
+                "BriefSchedule": {
+                  "Events": [
+                    {
+                      "Estimated": {
+                        "value": "1570972343",
+                        "tzOffset": 10800,
+                        "text": "16:12"
+                      },
+                      "vehicleId": "codd%5Fnew|62922%5F31434"
+                    },
+                    {
+                      "Estimated": {
+                        "value": "1570972813",
+                        "tzOffset": 10800,
+                        "text": "16:20"
+                      },
+                      "vehicleId": "codd%5Fnew|57281%5F31242"
+                    }
+                  ],
+                  "Frequency": {
+                    "text": "15 мин",
+                    "value": 900,
+                    "begin": {
+                      "value": "1570939772",
+                      "tzOffset": 10800,
+                      "text": "7:09"
+                    },
+                    "end": {
+                      "value": "1571008052",
+                      "tzOffset": 10800,
+                      "text": "2:07"
+                    }
+                  }
+                }
+              }
+            ],
+            "uri": "ymapsbm1://transit/line?id=m10_bus_default&ll=37.579221%2C55.823763&name=%D0%BC10&r=8474&type=bus",
+            "seoname": "m10"
+          }
+        ]
+      }
+    },
+    "searchResult": {
+      "requestId": "1570971868582853-530182592-man1-6817",
+      "title": "7-й автобусный парк",
+      "description": "Россия, Москва, Дмитровское шоссе",
+      "address": "Россия, Москва, Дмитровское шоссе",
+      "coordinates": [
+        37.56528,
+        55.85196
+      ],
+      "bounds": [
+        [
+          37.543123,
+          55.77889866
+        ],
+        [
+          37.587437,
+          55.92488366
+        ]
+      ],
+      "displayCoordinates": [
+        37.56528,
+        55.85196
+      ],
+      "metro": [
+        {
+          "id": "2244536395",
+          "name": "Верхние Лихоборы",
+          "distance": "510 м",
+          "distanceValue": 509.265,
+          "coordinates": [
+            37.56121218,
+            55.854501501
+          ],
+          "type": "metro",
+          "color": "#99cc33"
+        },
+        {
+          "id": "1727539211",
+          "name": "Окружная",
+          "distance": "640 м",
+          "distanceValue": 641.333,
+          "coordinates": [
+            37.572849014,
+            55.848814359
+          ],
+          "type": "metro",
+          "color": "#ffa8af"
+        },
+        {
+          "id": "2244535785",
+          "name": "Окружная",
+          "distance": "1,3 км",
+          "distanceValue": 1263.44,
+          "coordinates": [
+            37.575977155,
+            55.844377845
+          ],
+          "type": "metro",
+          "color": "#99cc33"
+        }
+      ],
+      "stops": [
+        {
+          "id": "stop__9639579",
+          "name": "7-й автобусный парк",
+          "distance": "0 м",
+          "distanceValue": 0.0383997,
+          "coordinates": [
+            37.565280044,
+            55.851959656
+          ],
+          "type": "common"
+        },
+        {
+          "id": "2310890052",
+          "name": "Метро Верхние Лихоборы",
+          "distance": "420 м",
+          "distanceValue": 424.274,
+          "coordinates": [
+            37.563047501,
+            55.853727589
+          ],
+          "type": "common"
+        },
+        {
+          "id": "stop__9639678",
+          "name": "Метро Верхние Лихоборы (северный вестибюль)",
+          "distance": "630 м",
+          "distanceValue": 629.689,
+          "coordinates": [
+            37.562346735,
+            55.857147019
+          ],
+          "type": "common"
+        },
+        {
+          "id": "station__lh_9601830",
+          "name": "Окружная",
+          "distance": "860 м",
+          "distanceValue": 857.487,
+          "coordinates": [
+            37.574303,
+            55.847684
+          ],
+          "type": "common"
+        },
+        {
+          "id": "stop__9639906",
+          "name": "Платформа Окружная",
+          "distance": "930 м",
+          "distanceValue": 926.144,
+          "coordinates": [
+            37.576123886,
+            55.847913668
+          ],
+          "type": "common"
+        }
+      ],
+      "logId": "dHlwZT1iaXpmaW5kZXI7aWQ9MjM5MzY2OTUwNjU4",
+      "type": "business",
+      "id": "239366950658",
+      "shortTitle": "7-й автобусный парк",
+      "additionalAddress": "",
+      "fullAddress": "Россия, Москва, Дмитровское шоссе",
+      "postalCode": "",
+      "addressDetails": {
+        "locality": "Москва",
+        "street": "Дмитровское шоссе"
+      },
+      "categories": [
+        {
+          "name": "Остановка общественного транспорта",
+          "class": "bus stop",
+          "seoname": "public_transport_stop",
+          "pluralName": "Остановки общественного транспорта",
+          "id": "223677355200"
+        }
+      ],
+      "status": "open",
+      "businessLinks": [],
+      "businessProperties": {
+        "geoproduct_poi_color": "#ABAEB3",
+        "snippet_show_title": "short_title",
+        "snippet_show_rating": "five_star_rating",
+        "snippet_show_photo": "single_photo",
+        "snippet_show_eta": "show_eta",
+        "snippet_show_category": "single_category",
+        "snippet_show_subline": [
+          "no_subline"
+        ],
+        "snippet_show_geoproduct_offer": "show_geoproduct_offer",
+        "snippet_show_bookmark": "show_bookmark",
+        "detailview_show_claim_organization": "not_show_claim_organization",
+        "detailview_show_reviews": "show_reviews",
+        "detailview_show_add_photo_button": "show_add_photo_button",
+        "detailview_show_taxi_button": "show_taxi_button",
+        "sensitive": "1"
+      },
+      "seoname": "7_y_avtobusny_park",
+      "geoId": 117015,
+      "uri": "ymapsbm1://org?oid=239366950658",
+      "uriList": [
+        "ymapsbm1://org?oid=239366950658",
+        "ymapsbm1://transit/stop?id=stop__9639579"
+      ],
+      "references": [
+        {
+          "id": "2036929560",
+          "scope": "nyak"
+        }
+      ],
+      "ratingData": {
+        "ratingCount": 0,
+        "ratingValue": 0,
+        "reviewCount": 0
+      },
+      "sources": [
+        {
+          "id": "yandex",
+          "name": "Яндекс",
+          "href": "https://www.yandex.ru"
+        }
+      ],
+      "analyticsId": "1"
+    },
+    "toponymSeoname": "dmitrovskoye_shosse"
+  }
 }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Yandex changed api to get info about buses.
 "Transport": [{"bus_info", "threads":[ROUTES_HERE_NOW]...}

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
