### PR TITLE
Add p2pcam integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -482,6 +482,7 @@ omit =
     homeassistant/components/osramlightify/light.py
     homeassistant/components/otp/sensor.py
     homeassistant/components/owlet/*
+    homeassistant/components/p2pcam/*
     homeassistant/components/panasonic_bluray/media_player.py
     homeassistant/components/panasonic_viera/media_player.py
     homeassistant/components/pandora/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -214,6 +214,7 @@ homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff
 homeassistant/components/orangepi_gpio/* @pascallj
 homeassistant/components/owlet/* @oblogic7
+homeassistant/components/p2pcam/* @indykoning
 homeassistant/components/panel_custom/* @home-assistant/frontend
 homeassistant/components/panel_iframe/* @home-assistant/frontend
 homeassistant/components/persistent_notification/* @home-assistant/core

--- a/homeassistant/components/p2pcam/__init__.py
+++ b/homeassistant/components/p2pcam/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for p2pcamera integration."""

--- a/homeassistant/components/p2pcam/camera.py
+++ b/homeassistant/components/p2pcam/camera.py
@@ -28,10 +28,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class P2PCam(Camera):
     """P2PCamera entity."""
 
-
     def __init__(self, hass, config):
         """Init of the P2PCamera."""
-        super().__init__();
+        super().__init__()
         import p2pcam as p2pcam_req
 
         if CONF_HOST not in config:

--- a/homeassistant/components/p2pcam/camera.py
+++ b/homeassistant/components/p2pcam/camera.py
@@ -1,11 +1,14 @@
 """P2PCamera integration."""
 import logging
 
+import p2pcam as p2pcam_req
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_IP_ADDRESS
-from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
+from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
+from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS, CONF_NAME
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util as util
+
 from .const import DEFAULT_NAME
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,10 +34,9 @@ class P2PCam(Camera):
     def __init__(self, hass, config):
         """Init of the P2PCamera."""
         super().__init__()
-        import p2pcam as p2pcam_req
 
         if CONF_HOST not in config:
-            config[CONF_HOST] = get_host_ip()
+            config[CONF_HOST] = util.get_local_ip()
 
         self._name = config[CONF_NAME]
         self._host_ip = config[CONF_HOST]
@@ -50,26 +52,3 @@ class P2PCam(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._name
-
-
-def get_host_ip():
-    """Get the host ip."""
-    import socket
-
-    return [
-        l
-        for l in (
-            [
-                ip
-                for ip in socket.gethostbyname_ex(socket.gethostname())[2]
-                if not ip.startswith("127.")
-            ][:1],
-            [
-                [
-                    (s.connect(("8.8.8.8", 53)), s.getsockname()[0], s.close())
-                    for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]
-                ][0][1]
-            ],
-        )
-        if l
-    ][0][0]

--- a/homeassistant/components/p2pcam/camera.py
+++ b/homeassistant/components/p2pcam/camera.py
@@ -1,0 +1,76 @@
+"""P2PCamera integration"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_NAME, CONF_HOST, CONF_IP_ADDRESS
+from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from .const import DEFAULT_NAME
+
+_LOGGER = logging.getLogger(__name__)
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Required(CONF_IP_ADDRESS): cv.string,
+    }
+)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Register camera"""
+    async_add_entities([P2PCam(hass, config)])
+
+
+class P2PCam(Camera):
+    """P2PCamera entity."""
+
+
+    def __init__(self, hass, config):
+        """Init of the P2PCamera."""
+        super().__init__();
+        import p2pcam as p2pcam_req
+
+        if CONF_HOST not in config:
+            config[CONF_HOST] = get_host_ip()
+
+        self._name = config[CONF_NAME]
+        self._host_ip = config[CONF_HOST]
+        self._target_ip = config[CONF_IP_ADDRESS]
+
+        self.camera = p2pcam_req.P2PCam(self._host_ip, self._target_ip)
+
+    async def async_camera_image(self):
+        """Retrieve the camera image."""
+        return self.camera.retrieveImage()
+
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return self._name
+
+
+def get_host_ip():
+    """Get the host ip"""
+    import socket
+
+    return [
+        l
+        for l in (
+            [
+                ip
+                for ip in socket.gethostbyname_ex(socket.gethostname())[2]
+                if not ip.startswith("127.")
+            ][:1],
+            [
+                [
+                    (s.connect(("8.8.8.8", 53)), s.getsockname()[0], s.close())
+                    for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]
+                ][0][1]
+            ],
+        )
+        if l
+    ][0][0]

--- a/homeassistant/components/p2pcam/camera.py
+++ b/homeassistant/components/p2pcam/camera.py
@@ -1,4 +1,4 @@
-"""P2PCamera integration"""
+"""P2PCamera integration."""
 import logging
 
 import voluptuous as vol
@@ -21,7 +21,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Register camera"""
+    """Register camera."""
     async_add_entities([P2PCam(hass, config)])
 
 
@@ -53,7 +53,7 @@ class P2PCam(Camera):
 
 
 def get_host_ip():
-    """Get the host ip"""
+    """Get the host ip."""
     import socket
 
     return [

--- a/homeassistant/components/p2pcam/const.py
+++ b/homeassistant/components/p2pcam/const.py
@@ -1,3 +1,3 @@
 """Constants for the p2pcam component."""
 
-DEFAULT_NAME="p2pcam"
+DEFAULT_NAME = "p2pcam"

--- a/homeassistant/components/p2pcam/const.py
+++ b/homeassistant/components/p2pcam/const.py
@@ -1,0 +1,3 @@
+"""Constants for the p2pcam component."""
+
+DEFAULT_NAME="p2pcam"

--- a/homeassistant/components/p2pcam/manifest.json
+++ b/homeassistant/components/p2pcam/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "p2pcam",
+  "name": "p2pcam",
+  "documentation": "https://www.home-assistant.io/components/p2pcam",
+  "requirements": ["p2pcam==0.0.2"],
+  "dependencies": [],
+  "codeowners": [
+    "@indykoning"
+  ]
+}

--- a/homeassistant/components/p2pcam/manifest.json
+++ b/homeassistant/components/p2pcam/manifest.json
@@ -3,7 +3,7 @@
   "name": "p2pcam",
   "documentation": "https://www.home-assistant.io/components/p2pcam",
   "requirements": [
-    "p2pcam==0.0.2"
+    "p2pcam==0.0.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/p2pcam/manifest.json
+++ b/homeassistant/components/p2pcam/manifest.json
@@ -2,7 +2,9 @@
   "domain": "p2pcam",
   "name": "p2pcam",
   "documentation": "https://www.home-assistant.io/components/p2pcam",
-  "requirements": ["p2pcam==0.0.2"],
+  "requirements": [
+    "p2pcam==0.0.2"
+  ],
   "dependencies": [],
   "codeowners": [
     "@indykoning"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -917,7 +917,7 @@ openwrt-luci-rpc==1.1.1
 orvibo==1.1.1
 
 # homeassistant.components.p2pcam
-p2pcam==0.0.2
+p2pcam==0.0.3
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -916,6 +916,9 @@ openwrt-luci-rpc==1.1.1
 # homeassistant.components.orvibo
 orvibo==1.1.1
 
+# homeassistant.components.p2pcam
+p2pcam==0.0.2
+
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
 paho-mqtt==1.4.0


### PR DESCRIPTION
## Description:

Add support for generic cheap chinese p2pcamers operating locally under a UDP protocol.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10767

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: p2pcam
    ip_address: 192.168.178.9
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
