### PR TITLE
Move imports for crimereports

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -9,6 +9,8 @@ from aiohttp.client_exceptions import ClientError
 from aiohttp.hdrs import CONNECTION, KEEP_ALIVE
 import async_timeout
 import voluptuous as vol
+import xmltodict
+from urllib import parse
 
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
@@ -329,7 +331,6 @@ class BluesoundPlayer(MediaPlayerDevice):
         self, method, raise_timeout=False, allow_offline=False
     ):
         """Send command to the player."""
-        import xmltodict
 
         if not self._is_online and not allow_offline:
             return
@@ -370,7 +371,6 @@ class BluesoundPlayer(MediaPlayerDevice):
 
     async def async_update_status(self):
         """Use the poll session to always get the status of the player."""
-        import xmltodict
 
         response = None
 
@@ -690,7 +690,6 @@ class BluesoundPlayer(MediaPlayerDevice):
     @property
     def source(self):
         """Name of the current input source."""
-        from urllib import parse
 
         if self._status is None or (self.is_grouped and not self.is_master):
             return None

--- a/homeassistant/components/bme280/sensor.py
+++ b/homeassistant/components/bme280/sensor.py
@@ -3,6 +3,9 @@ from datetime import timedelta
 from functools import partial
 import logging
 
+import smbus  # pylint: disable=import-error
+from i2csense.bme280 import BME280  # pylint: disable=import-error
+
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -76,8 +79,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the BME280 sensor."""
-    import smbus  # pylint: disable=import-error
-    from i2csense.bme280 import BME280  # pylint: disable=import-error
 
     SENSOR_TYPES[SENSOR_TEMP][1] = hass.config.units.temperature_unit
     name = config.get(CONF_NAME)

--- a/homeassistant/components/bme680/sensor.py
+++ b/homeassistant/components/bme680/sensor.py
@@ -5,6 +5,10 @@ import logging
 from time import time, sleep
 
 import voluptuous as vol
+import threading
+
+from smbus import SMBus  # pylint: disable=import-error
+
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
@@ -121,7 +125,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 def _setup_bme680(config):
     """Set up and configure the BME680 sensor."""
-    from smbus import SMBus  # pylint: disable=import-error
 
     bme680 = importlib.import_module("bme680")
 
@@ -224,8 +227,6 @@ class BME680Handler:
         self._gas_baseline = None
 
         if gas_measurement:
-            import threading
-
             threading.Thread(
                 target=self._run_gas_sensor,
                 kwargs={"burn_in_time": burn_in_time},

--- a/homeassistant/components/bt_smarthub/device_tracker.py
+++ b/homeassistant/components/bt_smarthub/device_tracker.py
@@ -2,6 +2,7 @@
 import logging
 
 import voluptuous as vol
+import btsmarthub_devicelist
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
@@ -74,7 +75,6 @@ class BTSmartHubScanner(DeviceScanner):
 
     def get_bt_smarthub_data(self):
         """Retrieve data from BT Smart Hub and return parsed result."""
-        import btsmarthub_devicelist
 
         # Request data from bt smarthub into a list of dicts.
         data = btsmarthub_devicelist.get_devicelist(

--- a/homeassistant/components/cisco_ios/device_tracker.py
+++ b/homeassistant/components/cisco_ios/device_tracker.py
@@ -2,6 +2,8 @@
 import logging
 
 import voluptuous as vol
+from pexpect import pxssh
+import re
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
@@ -100,8 +102,6 @@ class CiscoDeviceScanner(DeviceScanner):
 
     def _get_arp_data(self):
         """Open connection to the router and get arp entries."""
-        from pexpect import pxssh
-        import re
 
         try:
             cisco_ssh = pxssh.pxssh()

--- a/homeassistant/components/co2signal/sensor.py
+++ b/homeassistant/components/co2signal/sensor.py
@@ -2,6 +2,7 @@
 import logging
 
 import voluptuous as vol
+import CO2Signal
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
@@ -97,7 +98,6 @@ class CO2Sensor(Entity):
 
     def update(self):
         """Get the latest data and updates the states."""
-        import CO2Signal
 
         _LOGGER.debug("Update data for %s", self._friendly_name)
 

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -1,6 +1,7 @@
 """Http views to control the config manager."""
 import aiohttp.web_exceptions
 import voluptuous as vol
+import voluptuous_serialize
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.auth.permissions.const import CAT_CONFIG_ENTRIES
@@ -40,8 +41,6 @@ def _prepare_json(result):
     """Convert result for JSON."""
     if result["type"] != data_entry_flow.RESULT_TYPE_FORM:
         return result
-
-    import voluptuous_serialize
 
     data = result.copy()
 

--- a/homeassistant/components/crimereports/sensor.py
+++ b/homeassistant/components/crimereports/sensor.py
@@ -5,6 +5,7 @@ import logging
 
 import voluptuous as vol
 
+import crimereports
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_INCLUDE,
@@ -24,8 +25,6 @@ from homeassistant.util import slugify
 from homeassistant.util.distance import convert
 from homeassistant.util.dt import now
 import homeassistant.helpers.config_validation as cv
-
-import crimereports
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/crimereports/sensor.py
+++ b/homeassistant/components/crimereports/sensor.py
@@ -5,6 +5,7 @@ import logging
 
 import voluptuous as vol
 
+import crimereports
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_INCLUDE,
@@ -65,7 +66,6 @@ class CrimeReportsSensor(Entity):
 
     def __init__(self, hass, name, latitude, longitude, radius, include, exclude):
         """Initialize the Crime Reports sensor."""
-        import crimereports
 
         self._hass = hass
         self._name = name
@@ -113,7 +113,6 @@ class CrimeReportsSensor(Entity):
 
     def update(self):
         """Update device state."""
-        import crimereports
 
         incident_counts = defaultdict(int)
         incidents = self._crimereports.get_incidents(

--- a/homeassistant/components/crimereports/sensor.py
+++ b/homeassistant/components/crimereports/sensor.py
@@ -25,6 +25,8 @@ from homeassistant.util.distance import convert
 from homeassistant.util.dt import now
 import homeassistant.helpers.config_validation as cv
 
+import crimereports
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "crimereports"
@@ -65,7 +67,6 @@ class CrimeReportsSensor(Entity):
 
     def __init__(self, hass, name, latitude, longitude, radius, include, exclude):
         """Initialize the Crime Reports sensor."""
-        import crimereports
 
         self._hass = hass
         self._name = name
@@ -113,7 +114,6 @@ class CrimeReportsSensor(Entity):
 
     def update(self):
         """Update device state."""
-        import crimereports
 
         incident_counts = defaultdict(int)
         incidents = self._crimereports.get_incidents(

--- a/homeassistant/components/darksky/sensor.py
+++ b/homeassistant/components/darksky/sensor.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 import voluptuous as vol
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
+import forecastio
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -797,7 +798,6 @@ class DarkSkyData:
 
     def _update(self):
         """Get the latest data from Dark Sky."""
-        import forecastio
 
         try:
             self.data = forecastio.load_forecast(

--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -4,6 +4,7 @@ import logging
 
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 import voluptuous as vol
+import forecastio
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
@@ -244,7 +245,6 @@ class DarkSkyData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from Dark Sky."""
-        import forecastio
 
         try:
             self.data = forecastio.load_forecast(

--- a/homeassistant/components/decora/light.py
+++ b/homeassistant/components/decora/light.py
@@ -5,6 +5,8 @@ from functools import wraps
 import time
 
 import voluptuous as vol
+import decora
+import bluepy
 
 from homeassistant.const import CONF_API_KEY, CONF_DEVICES, CONF_NAME
 from homeassistant.components.light import (
@@ -35,8 +37,6 @@ def retry(method):
     def wrapper_retry(device, *args, **kwargs):
         """Try send command and retry on error."""
         # pylint: disable=import-error, no-member
-        import decora
-        import bluepy
 
         initial = time.monotonic()
         while True:


### PR DESCRIPTION
## Breaking Change:

Moving imports from functions to top level

## Description:


**Related issue (if applicable):** fixes #27284 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
