### PR TITLE
Upgrade Mastodon.py to 1.5.0

### DIFF
--- a/homeassistant/components/mastodon/manifest.json
+++ b/homeassistant/components/mastodon/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mastodon",
   "documentation": "https://www.home-assistant.io/integrations/mastodon",
   "requirements": [
-    "Mastodon.py==1.4.6"
+    "Mastodon.py==1.5.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/mastodon/notify.py
+++ b/homeassistant/components/mastodon/notify.py
@@ -1,12 +1,13 @@
 """Mastodon platform for notify component."""
 import logging
 
+from mastodon import Mastodon
+from mastodon.Mastodon import MastodonAPIError, MastodonUnauthorizedError
 import voluptuous as vol
 
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import CONF_ACCESS_TOKEN
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,9 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_service(hass, config, discovery_info=None):
     """Get the Mastodon notification service."""
-    from mastodon import Mastodon
-    from mastodon.Mastodon import MastodonUnauthorizedError
-
     client_id = config.get(CONF_CLIENT_ID)
     client_secret = config.get(CONF_CLIENT_SECRET)
     access_token = config.get(CONF_ACCESS_TOKEN)
@@ -60,8 +58,6 @@ class MastodonNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        from mastodon.Mastodon import MastodonAPIError
-
         try:
             self._api.toot(message)
         except MastodonAPIError:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -38,7 +38,7 @@ Adafruit-SHT31==1.0.2
 HAP-python==2.6.0
 
 # homeassistant.components.mastodon
-Mastodon.py==1.4.6
+Mastodon.py==1.5.0
 
 # homeassistant.components.orangepi_gpio
 OPi.GPIO==0.3.6


### PR DESCRIPTION
## Description:
Changelog: https://github.com/halcy/Mastodon.py/blob/master/CHANGELOG.rst#v150

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: mastodon
    platform: mastodon
    access_token: !secret mastodon_access_token
    client_id: !secret mastodon_client_id
    client_secret: !secret mastodon_client_secret
```

Data for Service call:

```json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}! A Mastodon.py update for #homeassistant"
}
```

Result: https://mastodon.social/@fabaff/102955942389721704

Addresses also #27284.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.