### PR TITLE
Fix ViCare temperature and heating mode

### DIFF
--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 VICARE_MODE_DHW = "dhw"
 VICARE_MODE_DHWANDHEATING = "dhwAndHeating"
+VICARE_MODE_DHWANDHEATINGCOOLING = "dhwAndHeatingCooling"
 VICARE_MODE_FORCEDREDUCED = "forcedReduced"
 VICARE_MODE_FORCEDNORMAL = "forcedNormal"
 VICARE_MODE_OFF = "standby"
@@ -46,6 +47,7 @@ SUPPORT_FLAGS_HEATING = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 VICARE_TO_HA_HVAC_HEATING = {
     VICARE_MODE_DHW: HVAC_MODE_OFF,
     VICARE_MODE_DHWANDHEATING: HVAC_MODE_AUTO,
+    VICARE_MODE_DHWANDHEATINGCOOLING: HVAC_MODE_AUTO,
     VICARE_MODE_FORCEDREDUCED: HVAC_MODE_OFF,
     VICARE_MODE_FORCEDNORMAL: HVAC_MODE_HEAT,
     VICARE_MODE_OFF: HVAC_MODE_OFF,
@@ -200,9 +202,8 @@ class ViCareClimate(ClimateDevice):
         """Set new target temperatures."""
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is not None:
-            self._api.setProgramTemperature(
-                self._current_program, self._target_temperature
-            )
+            self._api.setProgramTemperature(self._current_program, temp)
+            self._target_temperature = temp
 
     @property
     def preset_mode(self):


### PR DESCRIPTION
## Description:

Fixes:
* Missing ViCare-Mode "dhwAndHeatingCooling" for heatings which are capable of cooling
* Set Temperature not using the actual temperature

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
