### PR TITLE
Improve code coverage for HomematicIP Cloud

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -290,7 +290,6 @@ omit =
     homeassistant/components/homematic/climate.py
     homeassistant/components/homematic/cover.py
     homeassistant/components/homematic/notify.py
-    homeassistant/components/homematicip_cloud/*
     homeassistant/components/homeworks/*
     homeassistant/components/honeywell/climate.py
     homeassistant/components/hook/switch.py

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -213,9 +213,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     def _get_home(hapid: str):
         """Return a HmIP home."""
-        hap = hass.data[DOMAIN][hapid]
+        hap = hass.data[DOMAIN].get(hapid)
         if hap:
             return hap.home
+
+        _LOGGER.info("No matching access point found for access point id %s.", hapid)
         return None
 
     return True

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -217,7 +217,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if hap:
             return hap.home
 
-        _LOGGER.info("No matching access point found for access point id %s.", hapid)
+        _LOGGER.info("No matching access point found for access point id %s", hapid)
         return None
 
     return True

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -55,7 +55,7 @@ class HomematicipAuth:
 
     async def get_auth(self, hass: HomeAssistant, hapid, pin):
         """Create a HomematicIP access point object."""
-        auth = await self._create_auth(hass)
+        auth = AsyncAuth(hass.loop, async_get_clientsession(hass))
         try:
             await auth.init(hapid)
             if pin:
@@ -64,10 +64,6 @@ class HomematicipAuth:
         except HmipConnectionError:
             return False
         return auth
-
-    async def _create_auth(self, hass: HomeAssistant):
-        """Return a AsyncHome instance."""
-        return AsyncAuth(hass.loop, async_get_clientsession(hass))
 
 
 class HomematicipHAP:
@@ -231,7 +227,7 @@ class HomematicipHAP:
         self, hass: HomeAssistant, hapid: str, authtoken: str, name: str
     ) -> AsyncHome:
         """Create a HomematicIP access point object."""
-        home = await self._create_home(hass)
+        home = AsyncHome(hass.loop, async_get_clientsession(hass))
 
         home.name = name
         home.label = "Access Point"
@@ -248,7 +244,3 @@ class HomematicipHAP:
         hass.loop.create_task(self.async_connect())
 
         return home
-
-    async def _create_home(self, hass: HomeAssistant):
-        """Return a AsyncHome instance."""
-        return AsyncHome(hass.loop, async_get_clientsession(hass))

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -53,9 +53,9 @@ class HomematicipAuth:
         except HmipConnectionError:
             return False
 
-    async def get_auth(self, hass, hapid, pin):
+    async def get_auth(self, hass: HomeAssistant, hapid, pin):
         """Create a HomematicIP access point object."""
-        auth = AsyncAuth(hass.loop, async_get_clientsession(hass))
+        auth = await self._create_auth(hass)
         try:
             await auth.init(hapid)
             if pin:
@@ -64,6 +64,10 @@ class HomematicipAuth:
         except HmipConnectionError:
             return False
         return auth
+
+    async def _create_auth(self, hass: HomeAssistant):
+        """Return a AsyncHome instance."""
+        return AsyncAuth(hass.loop, async_get_clientsession(hass))
 
 
 class HomematicipHAP:
@@ -227,7 +231,7 @@ class HomematicipHAP:
         self, hass: HomeAssistant, hapid: str, authtoken: str, name: str
     ) -> AsyncHome:
         """Create a HomematicIP access point object."""
-        home = AsyncHome(hass.loop, async_get_clientsession(hass))
+        home = await self._create_home(hass)
 
         home.name = name
         home.label = "Access Point"
@@ -244,3 +248,7 @@ class HomematicipHAP:
         hass.loop.create_task(self.async_connect())
 
         return home
+
+    async def _create_home(self, hass: HomeAssistant):
+        """Return a AsyncHome instance."""
+        return AsyncHome(hass.loop, async_get_clientsession(hass))

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -119,9 +119,7 @@ class HomematicipDimmer(HomematicipGenericDevice, Light):
     @property
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
-        if self._device.dimLevel:
-            return int(self._device.dimLevel * 255)
-        return 0
+        return int((self._device.dimLevel or 0.0) * 255)
 
     @property
     def supported_features(self) -> int:
@@ -176,9 +174,7 @@ class HomematicipNotificationLight(HomematicipGenericDevice, Light):
     @property
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
-        if self._func_channel.dimLevel:
-            return int(self._func_channel.dimLevel * 255)
-        return 0
+        return int((self._func_channel.dimLevel or 0.0) * 255)
 
     @property
     def hs_color(self) -> tuple:

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -124,7 +124,7 @@ async def mock_hap_with_service_fixture(
 
 
 @pytest.fixture(name="simple_mock_home")
-async def simple_mock_home_fixture():
+def simple_mock_home_fixture():
     """Return a simple AsyncHome Mock."""
     return Mock(
         spec=AsyncHome,
@@ -139,6 +139,6 @@ async def simple_mock_home_fixture():
 
 
 @pytest.fixture(name="simple_mock_auth")
-async def simple_mock_auth_fixture():
+def simple_mock_auth_fixture():
     """Return a simple AsyncAuth Mock."""
     return Mock(spec=AsyncAuth, pin=HAPPIN, create=True)

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -6,14 +6,11 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.homematicip_cloud import (
-    CONF_ACCESSPOINT,
-    CONF_AUTHTOKEN,
     DOMAIN as HMIPC_DOMAIN,
     async_setup as hmip_async_setup,
     const as hmipc,
     hap as hmip_hap,
 )
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 
 from .helper import AUTH_TOKEN, HAPID, HomeTemplate
@@ -31,14 +28,9 @@ def mock_connection_fixture():
 
     connection._restCall.side_effect = _rest_call_side_effect  # pylint: disable=W0212
     connection.api_call.return_value = mock_coro(True)
+    connection.init.side_effect = mock_coro(True)
 
     return connection
-
-
-@pytest.fixture(name="default_mock_home")
-def default_mock_home_fixture(mock_connection):
-    """Create a fake homematic async home."""
-    return HomeTemplate(connection=mock_connection).init_home().get_async_home_mock()
 
 
 @pytest.fixture(name="hmip_config_entry")
@@ -48,6 +40,7 @@ def hmip_config_entry_fixture():
         hmipc.HMIPC_HAPID: HAPID,
         hmipc.HMIPC_AUTHTOKEN: AUTH_TOKEN,
         hmipc.HMIPC_NAME: "",
+        hmipc.HMIPC_PIN: "1234",
     }
     config_entry = MockConfigEntry(
         version=1,
@@ -64,15 +57,26 @@ def hmip_config_entry_fixture():
 
 @pytest.fixture(name="default_mock_hap")
 async def default_mock_hap_fixture(
-    hass: HomeAssistant, default_mock_home, hmip_config_entry
+    hass: HomeAssistant, mock_connection, hmip_config_entry
 ):
-    """Create a fake homematic access point."""
+    """Create a mocked homematic access point."""
+    return await get_mock_hap(hass, mock_connection, hmip_config_entry)
+
+
+async def get_mock_hap(hass: HomeAssistant, mock_connection, hmip_config_entry):
+    """Create a mocked homematic access point."""
     hass.config.components.add(HMIPC_DOMAIN)
     hap = hmip_hap.HomematicipHAP(hass, hmip_config_entry)
-    with patch.object(hap, "get_hap", return_value=mock_coro(default_mock_home)):
+    home_name = hmip_config_entry.data["name"]
+    mock_home = (
+        HomeTemplate(connection=mock_connection, home_name=home_name)
+        .init_home()
+        .get_async_home_mock()
+    )
+    with patch.object(hap, "get_hap", return_value=mock_coro(mock_home)):
         assert await hap.async_setup() is True
-    default_mock_home.on_update(hap.async_update)
-    default_mock_home.on_create(hap.async_create_entity)
+    mock_home.on_update(hap.async_update)
+    mock_home.on_create(hap.async_create_entity)
 
     hass.data[HMIPC_DOMAIN] = {HAPID: hap}
 
@@ -85,18 +89,28 @@ async def default_mock_hap_fixture(
 def hmip_config_fixture():
     """Create a config for homematic ip cloud."""
 
-    entry_data = {CONF_ACCESSPOINT: HAPID, CONF_AUTHTOKEN: AUTH_TOKEN, CONF_NAME: ""}
+    entry_data = {
+        hmipc.HMIPC_HAPID: HAPID,
+        hmipc.HMIPC_AUTHTOKEN: AUTH_TOKEN,
+        hmipc.HMIPC_NAME: "",
+        hmipc.HMIPC_PIN: HAPID,
+    }
 
-    return {hmipc.DOMAIN: [entry_data]}
+    return {HMIPC_DOMAIN: [entry_data]}
+
+
+@pytest.fixture(name="dummy_config")
+def dummy_config_fixture():
+    """Create a dummy config."""
+    return {"blabla": None}
 
 
 @pytest.fixture(name="mock_hap_with_service")
 async def mock_hap_with_service_fixture(
-    hass: HomeAssistant, default_mock_hap, hmip_config
+    hass: HomeAssistant, default_mock_hap, dummy_config
 ):
     """Create a fake homematic access point with hass services."""
-
-    await hmip_async_setup(hass, hmip_config)
+    await hmip_async_setup(hass, dummy_config)
     await hass.async_block_till_done()
     hass.data[HMIPC_DOMAIN] = {HAPID: default_mock_hap}
     return default_mock_hap

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -1,7 +1,7 @@
 """Helper for HomematicIP Cloud Tests."""
 import json
-from asynctest import Mock
 
+from asynctest import Mock
 from homematicip.aio.class_maps import (
     TYPE_CLASS_MAP,
     TYPE_GROUP_MAP,
@@ -20,6 +20,7 @@ from homeassistant.components.homematicip_cloud.device import (
 from tests.common import load_fixture
 
 HAPID = "3014F7110000000000000001"
+HAPPIN = "5678"
 AUTH_TOKEN = "1234"
 HOME_JSON = "homematicip_cloud.json"
 
@@ -81,10 +82,11 @@ class HomeTemplate(Home):
     _typeGroupMap = TYPE_GROUP_MAP
     _typeSecurityEventMap = TYPE_SECURITY_EVENT_MAP
 
-    def __init__(self, connection=None):
+    def __init__(self, connection=None, home_name=""):
         """Init template with connection."""
         super().__init__(connection=connection)
         self.label = "Access Point"
+        self.name = home_name
         self.model_type = "HmIP-HAP"
         self.init_json_state = None
 
@@ -121,13 +123,12 @@ class HomeTemplate(Home):
         Create Mock for Async_Home. based on template to be used for testing.
 
         It adds collections of mocked devices and groups to the home objects,
-        and sets reuired attributes.
+        and sets required attributes.
         """
         mock_home = Mock(
             spec=AsyncHome, wraps=self, label="Access Point", modelType="HmIP-HAP"
         )
         mock_home.__dict__.update(self.__dict__)
-        mock_home.name = ""
 
         return mock_home
 

--- a/tests/components/homematicip_cloud/test_alarm_control_panel.py
+++ b/tests/components/homematicip_cloud/test_alarm_control_panel.py
@@ -2,12 +2,17 @@
 from homematicip.base.enums import WindowState
 from homematicip.group import SecurityZoneGroup
 
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
+from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
 )
+from homeassistant.setup import async_setup_component
 
 from .helper import get_and_check_entity_basics
 
@@ -36,6 +41,19 @@ async def _async_manipulate_security_zones(
     internal_zone.fire_update_event()
 
     await hass.async_block_till_done()
+
+
+async def test_manually_configured_platform(hass):
+    """Test that we do not set up an access point."""
+    assert (
+        await async_setup_component(
+            hass,
+            ALARM_CONTROL_PANEL_DOMAIN,
+            {ALARM_CONTROL_PANEL_DOMAIN: {"platform": HMIPC_DOMAIN}},
+        )
+        is True
+    )
+    assert not hass.data.get(HMIPC_DOMAIN)
 
 
 async def test_hmip_alarm_control_panel(hass, default_mock_hap):

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -1,6 +1,8 @@
 """Tests for HomematicIP Cloud binary sensor."""
 from homematicip.base.enums import SmokeDetectorAlarmType, WindowState
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.components.homematicip_cloud.binary_sensor import (
     ATTR_ACCELERATION_SENSOR_MODE,
     ATTR_ACCELERATION_SENSOR_NEUTRAL_POSITION,
@@ -10,8 +12,22 @@ from homeassistant.components.homematicip_cloud.binary_sensor import (
     ATTR_MOTION_DETECTED,
 )
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
+
+
+async def test_manually_configured_platform(hass):
+    """Test that we do not set up an access point."""
+    assert (
+        await async_setup_component(
+            hass,
+            BINARY_SENSOR_DOMAIN,
+            {BINARY_SENSOR_DOMAIN: {"platform": HMIPC_DOMAIN}},
+        )
+        is True
+    )
+    assert not hass.data.get(HMIPC_DOMAIN)
 
 
 async def test_hmip_acceleration_sensor(hass, default_mock_hap):

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -2,10 +2,24 @@
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
+    DOMAIN as COVER_DOMAIN,
 )
+from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
+from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
+
+
+async def test_manually_configured_platform(hass):
+    """Test that we do not set up an access point."""
+    assert (
+        await async_setup_component(
+            hass, COVER_DOMAIN, {COVER_DOMAIN: {"platform": HMIPC_DOMAIN}}
+        )
+        is True
+    )
+    assert not hass.data.get(HMIPC_DOMAIN)
 
 
 async def test_hmip_cover_shutter(hass, default_mock_hap):

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -2,6 +2,7 @@
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from .conftest import get_mock_hap
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
 
 
@@ -109,3 +110,23 @@ async def test_hap_reconnected(hass, default_mock_hap):
     await hass.async_block_till_done()
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_ON
+
+
+async def test_hap_with_name(hass, mock_connection, hmip_config_entry):
+    """Test hap with name."""
+    home_name = "TestName"
+    entity_id = f"light.{home_name.lower()}_treppe"
+    entity_name = f"{home_name} Treppe"
+    device_model = "HmIP-BSL"
+
+    hmip_config_entry.data["name"] = home_name
+    mock_hap = await get_mock_hap(hass, mock_connection, hmip_config_entry)
+    assert mock_hap
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+
+    assert hmip_device
+    assert ha_state.state == STATE_ON
+    assert ha_state.attributes["friendly_name"] == entity_name

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -155,17 +155,13 @@ async def test_hap_reset_unloads_entry_if_setup():
 async def test_hap_create(hass, hmip_config_entry, simple_mock_home):
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(HMIPC_DOMAIN)
-    # One platform should be enough.
-    const.COMPONENTS = {"binary_sensor"}
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
-    with patch.object(
-        hap, "_create_home", return_value=mock_coro(simple_mock_home)
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncHome",
+        return_value=simple_mock_home,
     ), patch.object(hap, "async_connect", return_value=mock_coro(None)):
         assert await hap.async_setup() is True
-
-    hass.data[HMIPC_DOMAIN] = {HAPID: hap}
-    await hass.async_block_till_done()
 
 
 async def test_hap_create_exception(hass, hmip_config_entry, simple_mock_home):
@@ -180,8 +176,9 @@ async def test_hap_create_exception(hass, hmip_config_entry, simple_mock_home):
         await hap.async_setup()
 
     simple_mock_home.init.side_effect = HmipConnectionError
-    with patch.object(
-        hap, "_create_home", return_value=simple_mock_home
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncHome",
+        return_value=simple_mock_home,
     ), pytest.raises(ConfigEntryNotReady):
         await hap.async_setup()
 
@@ -196,7 +193,10 @@ async def test_auth_create(hass, simple_mock_auth):
     hmip_auth = HomematicipAuth(hass, config)
     assert hmip_auth
 
-    with patch.object(hmip_auth, "_create_auth", return_value=simple_mock_auth):
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncAuth",
+        return_value=simple_mock_auth,
+    ):
         assert await hmip_auth.async_setup() is True
         await hass.async_block_till_done()
         assert hmip_auth.auth.pin == HAPPIN
@@ -212,10 +212,16 @@ async def test_auth_create_exception(hass, simple_mock_auth):
     hmip_auth = HomematicipAuth(hass, config)
     simple_mock_auth.connectionRequest.side_effect = HmipConnectionError
     assert hmip_auth
-    with patch.object(hmip_auth, "_create_auth", return_value=simple_mock_auth):
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncAuth",
+        return_value=simple_mock_auth,
+    ):
         assert await hmip_auth.async_setup() is True
         await hass.async_block_till_done()
         assert hmip_auth.auth is False
 
-    with patch.object(hmip_auth, "_create_auth", return_value=simple_mock_auth):
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncAuth",
+        return_value=simple_mock_auth,
+    ):
         assert await hmip_auth.get_auth(hass, HAPID, HAPPIN) is False

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -181,7 +181,7 @@ async def test_hap_create_exception(hass, hmip_config_entry, simple_mock_home):
 
     simple_mock_home.init.side_effect = HmipConnectionError
     with patch.object(
-        hap, "_create_home", return_value=mock_coro(simple_mock_home)
+        hap, "_create_home", return_value=simple_mock_home
     ), pytest.raises(ConfigEntryNotReady):
         await hap.async_setup()
 
@@ -196,9 +196,7 @@ async def test_auth_create(hass, simple_mock_auth):
     hmip_auth = HomematicipAuth(hass, config)
     assert hmip_auth
 
-    with patch.object(
-        hmip_auth, "_create_auth", return_value=mock_coro(simple_mock_auth)
-    ):
+    with patch.object(hmip_auth, "_create_auth", return_value=simple_mock_auth):
         assert await hmip_auth.async_setup() is True
         await hass.async_block_till_done()
         assert hmip_auth.auth.pin == HAPPIN
@@ -214,14 +212,10 @@ async def test_auth_create_exception(hass, simple_mock_auth):
     hmip_auth = HomematicipAuth(hass, config)
     simple_mock_auth.connectionRequest.side_effect = HmipConnectionError
     assert hmip_auth
-    with patch.object(
-        hmip_auth, "_create_auth", return_value=mock_coro(simple_mock_auth)
-    ):
+    with patch.object(hmip_auth, "_create_auth", return_value=simple_mock_auth):
         assert await hmip_auth.async_setup() is True
         await hass.async_block_till_done()
         assert hmip_auth.auth is False
 
-    with patch.object(
-        hmip_auth, "_create_auth", return_value=mock_coro(simple_mock_auth)
-    ):
+    with patch.object(hmip_auth, "_create_auth", return_value=simple_mock_auth):
         assert await hmip_auth.get_auth(hass, HAPID, HAPPIN) is False

--- a/tests/components/homematicip_cloud/test_switch.py
+++ b/tests/components/homematicip_cloud/test_switch.py
@@ -1,11 +1,28 @@
 """Tests for HomematicIP Cloud switch."""
+from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.components.homematicip_cloud.device import (
     ATTR_GROUP_MEMBER_UNREACHABLE,
 )
-from homeassistant.components.switch import ATTR_CURRENT_POWER_W, ATTR_TODAY_ENERGY_KWH
+from homeassistant.components.switch import (
+    ATTR_CURRENT_POWER_W,
+    ATTR_TODAY_ENERGY_KWH,
+    DOMAIN as SWITCH_DOMAIN,
+)
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
+
+
+async def test_manually_configured_platform(hass):
+    """Test that we do not set up an access point."""
+    assert (
+        await async_setup_component(
+            hass, SWITCH_DOMAIN, {SWITCH_DOMAIN: {"platform": HMIPC_DOMAIN}}
+        )
+        is True
+    )
+    assert not hass.data.get(HMIPC_DOMAIN)
 
 
 async def test_hmip_switch(hass, default_mock_hap):

--- a/tests/components/homematicip_cloud/test_weather.py
+++ b/tests/components/homematicip_cloud/test_weather.py
@@ -1,13 +1,27 @@
 """Tests for HomematicIP Cloud weather."""
+from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.components.weather import (
     ATTR_WEATHER_ATTRIBUTION,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED,
+    DOMAIN as WEATHER_DOMAIN,
 )
+from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
+
+
+async def test_manually_configured_platform(hass):
+    """Test that we do not set up an access point."""
+    assert (
+        await async_setup_component(
+            hass, WEATHER_DOMAIN, {WEATHER_DOMAIN: {"platform": HMIPC_DOMAIN}}
+        )
+        is True
+    )
+    assert not hass.data.get(HMIPC_DOMAIN)
 
 
 async def test_hmip_weather_sensor(hass, default_mock_hap):


### PR DESCRIPTION
## Description:
- remove entry from .coveragerc
- fixes small issues detected while writing tests
- code coverage should by around 97% (hap.py has only 79%)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
