### PR TITLE
add content for services.yaml in component media_extractor

### DIFF
--- a/homeassistant/components/media_extractor/services.yaml
+++ b/homeassistant/components/media_extractor/services.yaml
@@ -10,3 +10,4 @@ play_media:
     media_content_type:
       description: The type of the content to play. Must be one of MUSIC, TVSHOW, VIDEO, EPISODE, CHANNEL or PLAYLIST MUSIC.
       example: 'music'
+      

--- a/homeassistant/components/media_extractor/services.yaml
+++ b/homeassistant/components/media_extractor/services.yaml
@@ -2,7 +2,7 @@ play_media:
   description: Downloads file from given url.
   fields:
     entity_id: 
-      description: Name(s) of entities to seek media on. Defaults to all.
+      description: Name(s) of entities to play media on.
       example: 'media_player.living_room_chromecast'
     media_content_id:
       description: The ID of the content to play. Platform dependent.

--- a/homeassistant/components/media_extractor/services.yaml
+++ b/homeassistant/components/media_extractor/services.yaml
@@ -1,0 +1,18 @@
+turn_on:
+  description: Turn a light on.
+  fields:
+    entity_id:
+      description: Name(s) of entities to turn on
+      example: "light.kitchen"
+play_media:
+  description: Downloads file from given url.
+  fields:
+    entity_id: 
+      description: Name(s) of entities to seek media on. Defaults to all.
+      example: 'media_player.living_room_chromecast'
+    media_content_id:
+      description: The ID of the content to play. Platform dependent.
+      example: 'https://soundcloud.com/bruttoband/brutto-11'
+    media_content_type:
+      description: The type of the content to play. Must be one of MUSIC, TVSHOW, VIDEO, EPISODE, CHANNEL or PLAYLIST MUSIC.
+      example: 'music'

--- a/homeassistant/components/media_extractor/services.yaml
+++ b/homeassistant/components/media_extractor/services.yaml
@@ -1,9 +1,3 @@
-turn_on:
-  description: Turn a light on.
-  fields:
-    entity_id:
-      description: Name(s) of entities to turn on
-      example: "light.kitchen"
 play_media:
   description: Downloads file from given url.
   fields:


### PR DESCRIPTION
## Description:
Adds entries for the service.yaml of media_extractor component.

**Related issue (if applicable):** adresses #27289 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
