### PR TITLE
Send zha_event when "model" attribute is reported

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -98,6 +98,25 @@ class BasicChannel(ZigbeeChannel):
         )
         await super().async_initialize(from_cache)
 
+    @callback
+    def attribute_updated(self, attrid, value):
+        """Handle an attribute updated on this cluster."""
+        if attrid == 0x0005:
+            """0x0005 = model attribute.
+            Some devices, like xiaomi sensors, send the model attribute when their reset
+            button is pressed quickly."""
+            self.zha_send_event(
+                self._cluster,
+                SIGNAL_ATTR_UPDATED,
+                {
+                    "attribute_id": attrid,
+                    "attribute_name": self._cluster.attributes.get(attrid, ["Unknown"])[
+                        0
+                    ],
+                    "value": value,
+                },
+            )
+
     def get_power_source(self):
         """Get the power source."""
         return self._power_source


### PR DESCRIPTION
## Description:
Some devices, like xiaomi sensors, send the model attribute when their reset button is pressed quickly.
Having this report propagated to HA as an event allows having a sound or light blink when a sensor button is pressed, which is useful to make sure the sensor is working. This behavior is similar to the one provided by the Xiaomi Hub (that talks).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
