### PR TITLE
add content for services.yaml for component stream

### DIFF
--- a/homeassistant/components/stream/services.yaml
+++ b/homeassistant/components/stream/services.yaml
@@ -1,0 +1,15 @@
+record:
+  description: Make a .mp4 recording from a provided stream.
+  fields:
+    stream_source:
+      description: The input source for the stream.
+      example: "rtsp://my.stream.feed:554"
+    filename:
+      description: The file name string. 
+      example: "/tmp/my_stream.mp4"
+    duration:
+      description: "Target recording length (in seconds). Default: 30"
+      example: 30
+    lookback:
+      description: "Target lookback period (in seconds) to include in addition to duration. Only available if there is currently an active HLS stream for stream_source. Default: 0"
+      example: 5


### PR DESCRIPTION
## Description:
Adds entries for the service.yaml of stream component.

**Related issue (if applicable):** adresses #27289 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
