### PR TITLE
Make it possible to set system options on entry create

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -599,7 +599,7 @@ class ConfigEntries:
             title=result["title"],
             data=result["data"],
             options={},
-            system_options={},
+            system_options=result.get("system_options") or {},
             source=flow.context["source"],
             connection_class=flow.CONNECTION_CLASS,
         )


### PR DESCRIPTION
## Description:

Make it possible to create config entries with an initial set of options and system options. This is especially useful on config import, and for some integrations it would be desirable to disable new entities by default as discussed in #26675.

This is an alternative, less intrusive approach to #27044.

**Related issue (if applicable):** #26675, #27044

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
