### PR TITLE
Add Sector Alarm integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -608,6 +608,7 @@ omit =
     homeassistant/components/scrape/sensor.py
     homeassistant/components/scsgate/*
     homeassistant/components/scsgate/cover.py
+    homeassistant/components/sector_alarm/*
     homeassistant/components/sendgrid/notify.py
     homeassistant/components/sense/*
     homeassistant/components/sensehat/light.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -285,6 +285,7 @@ homeassistant/components/scene/* @home-assistant/core
 homeassistant/components/scrape/* @fabaff
 homeassistant/components/script/* @home-assistant/core
 homeassistant/components/search/* @home-assistant/core
+homeassistant/components/sector_alarm/* @peroyvind
 homeassistant/components/sense/* @kbickar
 homeassistant/components/sensibo/* @andrey-git
 homeassistant/components/sentry/* @dcramer

--- a/homeassistant/components/sector_alarm/__init__.py
+++ b/homeassistant/components/sector_alarm/__init__.py
@@ -1,3 +1,4 @@
+"""The Sector Alarm Integration."""
 import logging
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/sector_alarm/__init__.py
+++ b/homeassistant/components/sector_alarm/__init__.py
@@ -1,0 +1,58 @@
+import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_CODE, CONF_EMAIL
+from homeassistant.helpers import discovery
+
+DOMAIN = "sector_alarm"
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ALARM_ID = "alarm_id"
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_EMAIL): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+                vol.Required(CONF_ALARM_ID): cv.string,
+                vol.Required(CONF_CODE): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """Initialitation for Sector Alarm."""
+    try:
+        import sectoralarmlib.sector as sectorlib
+
+        alarm = sectorlib.SectorAlarm(
+            config[DOMAIN][CONF_EMAIL],
+            config[DOMAIN][CONF_PASSWORD],
+            config[DOMAIN][CONF_ALARM_ID],
+            config[DOMAIN][CONF_CODE],
+        )
+    except RuntimeError:
+        _LOGGER.error("Could not login. Wrong username or password?")
+        return
+
+    hass.data[DOMAIN] = alarm
+
+    discovery.load_platform(hass, "sensor", DOMAIN, {CONF_NAME: DOMAIN}, config)
+
+    discovery.load_platform(
+        hass,
+        "alarm_control_panel",
+        DOMAIN,
+        {
+            CONF_CODE: config[DOMAIN][CONF_CODE],
+            CONF_ALARM_ID: config[DOMAIN][CONF_ALARM_ID],
+        },
+        config,
+    )
+
+    return True

--- a/homeassistant/components/sector_alarm/__init__.py
+++ b/homeassistant/components/sector_alarm/__init__.py
@@ -2,7 +2,6 @@
 import logging
 
 import sectoralarmlib.sector as sectorlib
-
 import voluptuous as vol
 
 from homeassistant.const import CONF_CODE, CONF_EMAIL, CONF_NAME, CONF_PASSWORD
@@ -13,7 +12,7 @@ DOMAIN = "sector_alarm"
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ALARM_ID = "alarm_id"
+CONF_ID = "alarm_id"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -21,7 +20,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_EMAIL): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
-                vol.Required(CONF_ALARM_ID): cv.string,
+                vol.Required(CONF_ID): cv.string,
                 vol.Required(CONF_CODE): cv.string,
             }
         )
@@ -36,7 +35,7 @@ async def async_setup(hass, config):
         alarm = sectorlib.SectorAlarm(
             config[DOMAIN][CONF_EMAIL],
             config[DOMAIN][CONF_PASSWORD],
-            config[DOMAIN][CONF_ALARM_ID],
+            config[DOMAIN][CONF_ID],
             config[DOMAIN][CONF_CODE],
         )
     except RuntimeError:
@@ -51,10 +50,7 @@ async def async_setup(hass, config):
         hass,
         "alarm_control_panel",
         DOMAIN,
-        {
-            CONF_CODE: config[DOMAIN][CONF_CODE],
-            CONF_ALARM_ID: config[DOMAIN][CONF_ALARM_ID],
-        },
+        {CONF_CODE: config[DOMAIN][CONF_CODE], CONF_ID: config[DOMAIN][CONF_ID]},
         config,
     )
 

--- a/homeassistant/components/sector_alarm/__init__.py
+++ b/homeassistant/components/sector_alarm/__init__.py
@@ -1,9 +1,13 @@
 """The Sector Alarm Integration."""
 import logging
+
+import sectoralarmlib.sector as sectorlib
+
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_CODE, CONF_EMAIL
+
+from homeassistant.const import CONF_CODE, CONF_EMAIL, CONF_NAME, CONF_PASSWORD
 from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "sector_alarm"
 
@@ -29,8 +33,6 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass, config):
     """Initialitation for Sector Alarm."""
     try:
-        import sectoralarmlib.sector as sectorlib
-
         alarm = sectorlib.SectorAlarm(
             config[DOMAIN][CONF_EMAIL],
             config[DOMAIN][CONF_PASSWORD],

--- a/homeassistant/components/sector_alarm/__init__.py
+++ b/homeassistant/components/sector_alarm/__init__.py
@@ -1,18 +1,16 @@
 """The Sector Alarm Integration."""
 import logging
 
-import sectoralarmlib.sector as sectorlib
+from sectoralarmlib.sector import SectorAlarm
 import voluptuous as vol
 
-from homeassistant.const import CONF_CODE, CONF_EMAIL, CONF_NAME, CONF_PASSWORD
+from homeassistant.const import CONF_CODE, CONF_EMAIL, CONF_ID, CONF_NAME, CONF_PASSWORD
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "sector_alarm"
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_ID = "alarm_id"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -32,7 +30,7 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass, config):
     """Initialitation for Sector Alarm."""
     try:
-        alarm = sectorlib.SectorAlarm(
+        alarm = SectorAlarm(
             config[DOMAIN][CONF_EMAIL],
             config[DOMAIN][CONF_PASSWORD],
             config[DOMAIN][CONF_ID],

--- a/homeassistant/components/sector_alarm/alarm_control_panel.py
+++ b/homeassistant/components/sector_alarm/alarm_control_panel.py
@@ -1,13 +1,16 @@
 """The Sector Alarm Integration."""
 import logging
 
-import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
     SUPPORT_ALARM_ARM_HOME,
 )
-import homeassistant.components.sector_alarm as sector_alarm
-from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN
+from homeassistant.components.sector_alarm import (
+    CONF_CODE,
+    CONF_ID,
+    DOMAIN as SECTOR_DOMAIN,
+)
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
@@ -22,13 +25,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Initialition of the platform."""
     sector_connection = hass.data.get(SECTOR_DOMAIN)
 
-    code = discovery_info[sector_alarm.CONF_CODE]
-    panel_id = discovery_info[sector_alarm.CONF_ID]
+    code = discovery_info[CONF_CODE]
+    panel_id = discovery_info[CONF_ID]
 
     async_add_entities([SectorAlarmPanel(sector_connection, panel_id, code)])
 
 
-class SectorAlarmPanel(alarm.AlarmControlPanel):
+class SectorAlarmPanel(AlarmControlPanel):
     """Get the alarm status, and arm/disarm alarm."""
 
     def __init__(self, sector_connect, alarm_id, code):

--- a/homeassistant/components/sector_alarm/alarm_control_panel.py
+++ b/homeassistant/components/sector_alarm/alarm_control_panel.py
@@ -54,17 +54,16 @@ class SectorAlarmPanel(alarm.AlarmControlPanel):
         if self._state == "ON":
             return STATE_ALARM_ARMED_AWAY
 
-        elif self._state == "PARTIAL":
+        if self._state == "PARTIAL":
             return STATE_ALARM_ARMED_HOME
 
-        elif self._state == "OFF":
+        if self._state == "OFF":
             return STATE_ALARM_DISARMED
 
-        elif self._state == "pending":
+        if self._state == "pending":
             return STATE_ALARM_PENDING
 
-        else:
-            return None
+        return None
 
     async def async_alarm_disarm(self, code=None):
         """Turn off the alarm."""

--- a/homeassistant/components/sector_alarm/alarm_control_panel.py
+++ b/homeassistant/components/sector_alarm/alarm_control_panel.py
@@ -1,15 +1,15 @@
 """The Sector Alarm Integration."""
 import logging
-from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN
+
 import homeassistant.components.alarm_control_panel as alarm
+import homeassistant.components.sector_alarm as sector_alarm
+from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN
 from homeassistant.const import (
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
 )
-
-import homeassistant.components.sector_alarm as sector_alarm
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,10 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Initialition of the platform."""
     sector_connection = hass.data.get(SECTOR_DOMAIN)
-
-    if sector_connection is None:
-        _LOGGER.error("SECTOR_DOMAIN is empty")
-        return
 
     code = discovery_info[sector_alarm.CONF_CODE]
     panel_id = discovery_info[sector_alarm.CONF_ALARM_ID]
@@ -36,12 +32,12 @@ class SectorAlarmPanel(alarm.AlarmControlPanel):
         self._alarmid = alarmId
         self._code = code
         self._sectorconnect = sectorConnect
-        self._state = ""
+        self._state = None
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Sector Alarm {}".format(self._alarmid)
+        return f"Sector Alarm {self._alarmid}"
 
     @property
     def state(self):
@@ -58,7 +54,7 @@ class SectorAlarmPanel(alarm.AlarmControlPanel):
         if self._state == "pending":
             return STATE_ALARM_PENDING
 
-        return "unknown"
+        return None
 
     async def async_alarm_disarm(self, code=None):
         """Turn off the alarm."""

--- a/homeassistant/components/sector_alarm/alarm_control_panel.py
+++ b/homeassistant/components/sector_alarm/alarm_control_panel.py
@@ -1,0 +1,84 @@
+import logging
+from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN
+import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.const import (
+    STATE_ALARM_DISARMED,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_PENDING,
+)
+
+import homeassistant.components.sector_alarm as sector_alarm
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Initialition of the platform."""
+    sector_connection = hass.data.get(SECTOR_DOMAIN)
+
+    if sector_connection is None:
+        _LOGGER.error("SECTOR_DOMAIN is empty")
+        return
+
+    code = discovery_info[sector_alarm.CONF_CODE]
+    panel_id = discovery_info[sector_alarm.CONF_ALARM_ID]
+
+    async_add_entities([SectorAlarmPanel(sector_connection, panel_id, code)])
+
+
+class SectorAlarmPanel(alarm.AlarmControlPanel):
+    """Get the alarm status, and arm/disarm alarm."""
+
+    def __init__(self, sectorConnect, alarmId, code):
+        self._alarmid = alarmId
+        self._code = code
+        self._sectorconnect = sectorConnect
+        self._state = ""
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "Sector Alarm {}".format(self._alarmid)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        if self._state == "ON":
+            return STATE_ALARM_ARMED_AWAY
+
+        if self._state == "PARTIAL":
+            return STATE_ALARM_ARMED_HOME
+
+        if self._state == "OFF":
+            return STATE_ALARM_DISARMED
+
+        if self._state == "pending":
+            return STATE_ALARM_PENDING
+
+        return "unknown"
+
+    async def async_alarm_disarm(self, code=None):
+        """Turn off the alarm."""
+        _LOGGER.debug("Trying to disarm Sector Alarm")
+        status = self._sectorconnect.Disarm()
+        if status:
+            _LOGGER.debug("Disarmed Sector Alarm")
+
+    async def async_alarm_arm_home(self, code=None):
+        """Partial turn on the alarm."""
+        _LOGGER.debug("Trying to partial arm Sector Alarm")
+        status = self._sectorconnect.ArmPartial()
+        if status:
+            _LOGGER.debug("Sector Alarm partial armed")
+
+    async def async_alarm_arm_away(self, code=None):
+        """Fully turn on the alarm."""
+        _LOGGER.debug("Trying to arm Sector Alarm")
+        status = self._sectorconnect.Arm()
+        if status:
+            _LOGGER.debug("Sector Alarm armed")
+
+    async def async_update(self):
+        """Update function for alarm status."""
+        self._state = self._sectorconnect.AlarmStatus()

--- a/homeassistant/components/sector_alarm/alarm_control_panel.py
+++ b/homeassistant/components/sector_alarm/alarm_control_panel.py
@@ -1,3 +1,4 @@
+"""The Sector Alarm Integration."""
 import logging
 from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN
 import homeassistant.components.alarm_control_panel as alarm
@@ -31,6 +32,7 @@ class SectorAlarmPanel(alarm.AlarmControlPanel):
     """Get the alarm status, and arm/disarm alarm."""
 
     def __init__(self, sectorConnect, alarmId, code):
+        """Initialize the service."""
         self._alarmid = alarmId
         self._code = code
         self._sectorconnect = sectorConnect

--- a/homeassistant/components/sector_alarm/manifest.json
+++ b/homeassistant/components/sector_alarm/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sector_alarm",
   "name": "Sector Alarm",
-  "documentation": "https://www.home-assistant.io/components/sector_alarm",
+  "documentation": "https://www.home-assistant.io/integrations/sector_alarm",
   "dependencies": [],
   "codeowners": ["@peroyvind"],
   "requirements": ["sectoralarmlib==0.8"]

--- a/homeassistant/components/sector_alarm/manifest.json
+++ b/homeassistant/components/sector_alarm/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "sector_alarm",
+  "name": "Sector Alarm",
+  "documentation": "https://www.home-assistant.io/components/sector_alarm",
+  "dependencies": [],
+  "codeowners": ["@peroyvind"],
+  "requirements": ["sectoralarmlib==0.8"]
+}

--- a/homeassistant/components/sector_alarm/sensor.py
+++ b/homeassistant/components/sector_alarm/sensor.py
@@ -1,0 +1,60 @@
+import logging
+from datetime import timedelta
+from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+from homeassistant.const import TEMP_CELSIUS
+
+UPDATE_INTERVAL = timedelta(minutes=5)
+
+DEPENDENCIES = ["sector_alarm"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Initialition of the platform."""
+    sector_connection = hass.data.get(SECTOR_DOMAIN)
+
+    temps = sector_connection.GetTemps()
+
+    dev = []
+
+    for temp in temps:
+        dev.append(SectorTempSensor(temp, sector_connection))
+
+    async_add_entities(dev)
+
+
+class SectorTempSensor(Entity):
+    """Secotor Alarm temperature class."""
+
+    def __init__(self, temp, sectorconnection):
+        """Initialize the sensor."""
+        self._sector = sectorconnection
+        self._state = None
+        self._name = temp[0]
+        self._state = temp[1]
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @Throttle(UPDATE_INTERVAL)
+    def update(self):
+        """Update function for the temp sensor."""
+        temps = self._sector.GetTemps()
+        for name, temp in temps:
+            if name == self._name:
+                self._state = temp

--- a/homeassistant/components/sector_alarm/sensor.py
+++ b/homeassistant/components/sector_alarm/sensor.py
@@ -1,10 +1,11 @@
 """The Sector Alarm Integration."""
-import logging
 from datetime import timedelta
+import logging
+
 from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN
+from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-from homeassistant.const import TEMP_CELSIUS
 
 UPDATE_INTERVAL = timedelta(minutes=5)
 

--- a/homeassistant/components/sector_alarm/sensor.py
+++ b/homeassistant/components/sector_alarm/sensor.py
@@ -1,3 +1,4 @@
+"""The Sector Alarm Integration."""
 import logging
 from datetime import timedelta
 from homeassistant.components.sector_alarm import DOMAIN as SECTOR_DOMAIN

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1794,6 +1794,9 @@ schiene==0.23
 # homeassistant.components.scsgate
 scsgate==0.1.0
 
+# homeassistant.components.sector_alarm
+sectoralarmlib==0.8
+
 # homeassistant.components.sendgrid
 sendgrid==6.1.0
 


### PR DESCRIPTION
## Description: 
New integration for Sector Alarm

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10769

## Example entry for `configuration.yaml` (if applicable):
```yaml
sector_alarm:
  email: EMAIL_ADDRESS
  password: PASSWORD
  id: ALARM_ID
  code: ALARM_CODE
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
