### PR TITLE
Issue #27288 Moving imports to top for tesla component

### DIFF
--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 import logging
 
 import voluptuous as vol
+from teslajsonpy import Controller as teslaAPI, TeslaException
+
 
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
@@ -52,8 +54,6 @@ TESLA_COMPONENTS = [
 
 def setup(hass, base_config):
     """Set up of Tesla component."""
-    from teslajsonpy import Controller as teslaAPI, TeslaException
-
     config = base_config.get(DOMAIN)
 
     email = config.get(CONF_USERNAME)


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #27288 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
