### PR TITLE
Update pyhomematic to 0.1.61

### DIFF
--- a/homeassistant/components/homematic/manifest.json
+++ b/homeassistant/components/homematic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Homematic",
   "documentation": "https://www.home-assistant.io/integrations/homematic",
   "requirements": [
-    "pyhomematic==0.1.60"
+    "pyhomematic==0.1.61"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1226,7 +1226,7 @@ pyhik==0.2.4
 pyhiveapi==0.2.19.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.60
+pyhomematic==0.1.61
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -420,7 +420,7 @@ pyhaversion==3.1.0
 pyheos==0.6.0
 
 # homeassistant.components.homematic
-pyhomematic==0.1.60
+pyhomematic==0.1.61
 
 # homeassistant.components.ipma
 pyipma==1.2.1


### PR DESCRIPTION
## Breaking Change:

None as long as #27307 gets merged as well.

## Description:
Update pyhomematic to 0.1.61.
- Minor fixes
- Adds support for HmIP-RCV-50
- Adds light-controls for HmIP-BSL

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
