### PR TITLE
Fix exception after unsuccessful api call in kaiterra component

### DIFF
--- a/homeassistant/components/kaiterra/__init__.py
+++ b/homeassistant/components/kaiterra/__init__.py
@@ -1,34 +1,32 @@
 """Support for Kaiterra devices."""
 import voluptuous as vol
 
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.helpers import config_validation as cv
-
 from homeassistant.const import (
     CONF_API_KEY,
-    CONF_DEVICES,
     CONF_DEVICE_ID,
+    CONF_DEVICES,
+    CONF_NAME,
     CONF_SCAN_INTERVAL,
     CONF_TYPE,
-    CONF_NAME,
 )
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.event import async_track_time_interval
 
+from .api_data import KaiterraApiData
 from .const import (
     AVAILABLE_AQI_STANDARDS,
-    AVAILABLE_UNITS,
     AVAILABLE_DEVICE_TYPES,
+    AVAILABLE_UNITS,
     CONF_AQI_STANDARD,
     CONF_PREFERRED_UNITS,
-    DOMAIN,
     DEFAULT_AQI_STANDARD,
     DEFAULT_PREFERRED_UNIT,
     DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
     KAITERRA_COMPONENTS,
 )
-
-from .api_data import KaiterraApiData
 
 KAITERRA_DEVICE_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/kaiterra/air_quality.py
+++ b/homeassistant/components/kaiterra/air_quality.py
@@ -1,16 +1,14 @@
 """Support for Kaiterra Air Quality Sensors."""
 from homeassistant.components.air_quality import AirQualityEntity
-
+from homeassistant.const import CONF_DEVICE_ID, CONF_NAME
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from homeassistant.const import CONF_DEVICE_ID, CONF_NAME
-
 from .const import (
-    DOMAIN,
-    ATTR_VOC,
     ATTR_AQI_LEVEL,
     ATTR_AQI_POLLUTANT,
+    ATTR_VOC,
     DISPATCHER_KAITERRA,
+    DOMAIN,
 )
 
 

--- a/homeassistant/components/kaiterra/sensor.py
+++ b/homeassistant/components/kaiterra/sensor.py
@@ -1,11 +1,9 @@
 """Support for Kaiterra Temperature ahn Humidity Sensors."""
+from homeassistant.const import CONF_DEVICE_ID, CONF_NAME, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-
-from homeassistant.const import CONF_DEVICE_ID, CONF_NAME, TEMP_CELSIUS, TEMP_FAHRENHEIT
-
-from .const import DOMAIN, DISPATCHER_KAITERRA
+from .const import DISPATCHER_KAITERRA, DOMAIN
 
 SENSORS = [
     {"name": "Temperature", "prop": "rtemp", "device_class": "temperature"},


### PR DESCRIPTION
Description:
Fix an exception during startup of Kaiterra component if API call errored and sort imports.

**Related issue (if applicable):** partially fixes #27599

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
