### PR TITLE
Rewrite Plex tests

### DIFF
--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -1,35 +1,97 @@
 """Mock classes used in tests."""
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.components.plex.const import CONF_SERVER, CONF_SERVER_IDENTIFIER
 
-MOCK_HOST_1 = "1.2.3.4"
-MOCK_PORT_1 = 32400
-MOCK_HOST_2 = "4.3.2.1"
-MOCK_PORT_2 = 32400
+MOCK_SERVERS = [
+    {
+        CONF_HOST: "1.2.3.4",
+        CONF_PORT: 32400,
+        CONF_SERVER: "Plex Server 1",
+        CONF_SERVER_IDENTIFIER: "unique_id_123",
+    },
+    {
+        CONF_HOST: "4.3.2.1",
+        CONF_PORT: 32400,
+        CONF_SERVER: "Plex Server 2",
+        CONF_SERVER_IDENTIFIER: "unique_id_456",
+    },
+]
 
 
-class MockAvailableServer:  # pylint: disable=too-few-public-methods
-    """Mock avilable server objects."""
+class MockResource:
+    """Mock a PlexAccount resource."""
 
-    def __init__(self, name, client_id):
+    def __init__(self, index):
         """Initialize the object."""
-        self.name = name
-        self.clientIdentifier = client_id  # pylint: disable=invalid-name
+        self.name = MOCK_SERVERS[index][CONF_SERVER]
+        self.clientIdentifier = MOCK_SERVERS[index][  # pylint: disable=invalid-name
+            CONF_SERVER_IDENTIFIER
+        ]
         self.provides = ["server"]
+        self._mock_plex_server = MockPlexServer(index)
+        self._connections = []
+        for connection in range(2):
+            self._connections.append(MockConnection(connection))
+
+    @property
+    def connections(self):
+        """Mock the resource connection listing method."""
+        return self._connections
+
+    def connect(self):
+        """Mock the resource connect method."""
+        return self._mock_plex_server
 
 
 class MockConnection:  # pylint: disable=too-few-public-methods
     """Mock a single account resource connection object."""
 
-    def __init__(self, ssl):
+    def __init__(self, index, ssl=True):
         """Initialize the object."""
         prefix = "https" if ssl else "http"
-        self.httpuri = f"{prefix}://{MOCK_HOST_1}:{MOCK_PORT_1}"
-        self.uri = "{prefix}://{MOCK_HOST_2}:{MOCK_PORT_2}"
-        self.local = True
+        self.httpuri = (
+            f"http://{MOCK_SERVERS[index][CONF_HOST]}:{MOCK_SERVERS[index][CONF_PORT]}"
+        )
+        self.uri = f"{prefix}://{MOCK_SERVERS[index][CONF_HOST]}:{MOCK_SERVERS[index][CONF_PORT]}"
+        # Only first server is local
+        self.local = not bool(index)
 
 
-class MockConnections:  # pylint: disable=too-few-public-methods
-    """Mock a list of resource connections."""
+class MockPlexAccount:
+    """Mock a PlexAccount instance."""
 
-    def __init__(self, ssl=False):
+    def __init__(self, servers=1):
         """Initialize the object."""
-        self.connections = [MockConnection(ssl)]
+        self._resources = []
+        for index in range(servers):
+            self._resources.append(MockResource(index))
+
+    def resource(self, name):
+        """Mock the PlexAccount resource lookup method."""
+        return [x for x in self._resources if x.name == name][0]
+
+    def resources(self):
+        """Mock the PlexAccount resources listing method."""
+        return self._resources
+
+
+class MockPlexServer:
+    """Mock a PlexServer instance."""
+
+    def __init__(self, index=0, ssl=True):
+        """Initialize the object."""
+        host = MOCK_SERVERS[index][CONF_HOST]
+        port = MOCK_SERVERS[index][CONF_PORT]
+        self.friendlyName = MOCK_SERVERS[index][  # pylint: disable=invalid-name
+            CONF_SERVER
+        ]
+        self.machineIdentifier = MOCK_SERVERS[index][  # pylint: disable=invalid-name
+            CONF_SERVER_IDENTIFIER
+        ]
+        prefix = "https" if ssl else "http"
+        self._baseurl = f"{prefix}://{host}:{port}"
+
+    @property
+    def url_in_use(self):
+        """Return URL used by PlexServer."""
+        return self._baseurl


### PR DESCRIPTION
## Description:
Now that I'm starting to understand the testing slightly better, I rewrote the Plex tests to implement several changes:

- Put mocked constants into a dictionary array
- Changed mock classes to better reflect actual objects used/returned by `plexapi`
- Set up the number of mocked available servers with a parameter
- Avoid using difficult-to-follow MagicMock and PropertyMock setups
- Moved flow steps that don't need to be mocked outside of patch context

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
