### PR TITLE
Move imports in pushover component

### DIFF
--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -1,7 +1,9 @@
 """Pushover platform for notify component."""
 import logging
 
+import requests
 import voluptuous as vol
+from pushover import InitError, Client, RequestError
 
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
@@ -28,8 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_service(hass, config, discovery_info=None):
     """Get the Pushover notification service."""
-    from pushover import InitError
-
     try:
         return PushoverNotificationService(
             hass, config[CONF_USER_KEY], config[CONF_API_KEY]
@@ -44,8 +44,6 @@ class PushoverNotificationService(BaseNotificationService):
 
     def __init__(self, hass, user_key, api_token):
         """Initialize the service."""
-        from pushover import Client
-
         self._hass = hass
         self._user_key = user_key
         self._api_token = api_token
@@ -53,8 +51,6 @@ class PushoverNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        from pushover import RequestError
-
         # Make a copy and use empty dict if necessary
         data = dict(kwargs.get(ATTR_DATA) or {})
 
@@ -65,8 +61,6 @@ class PushoverNotificationService(BaseNotificationService):
             # If attachment is a URL, use requests to open it as a stream.
             if data[ATTR_ATTACHMENT].startswith("http"):
                 try:
-                    import requests
-
                     response = requests.get(
                         data[ATTR_ATTACHMENT], stream=True, timeout=5
                     )


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved imports from functions to top-level as requested in #27284

I tested this component manually with a pushover account pushing to macOS and iOS devices because there are unfortunately no unit tests.

**Related issue (if applicable):** #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
