### PR TITLE
Move imports in darksky component

### DIFF
--- a/homeassistant/components/darksky/sensor.py
+++ b/homeassistant/components/darksky/sensor.py
@@ -2,6 +2,7 @@
 import logging
 from datetime import timedelta
 
+import forecastio
 import voluptuous as vol
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 
@@ -797,8 +798,6 @@ class DarkSkyData:
 
     def _update(self):
         """Get the latest data from Dark Sky."""
-        import forecastio
-
         try:
             self.data = forecastio.load_forecast(
                 self._api_key,

--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+import forecastio
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 import voluptuous as vol
 
@@ -244,8 +245,6 @@ class DarkSkyData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from Dark Sky."""
-        import forecastio
-
         try:
             self.data = forecastio.load_forecast(
                 self._api_key, self.latitude, self.longitude, units=self.requested_units

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -123,9 +123,7 @@ class TestDarkSkySetup(unittest.TestCase):
         state = self.hass.states.get("sensor.dark_sky_summary")
         assert state is not None
 
-    @MockDependency("forecastio")
-    @patch("forecastio.load_forecast", new=load_forecastMock)
-    def test_setup_with_invalid_config(self, mock_forecastio):
+    def test_setup_with_invalid_config(self):
         """Test the platform setup with invalid configuration."""
         setup_component(self.hass, "sensor", INVALID_CONFIG_MINIMAL)
 
@@ -144,9 +142,7 @@ class TestDarkSkySetup(unittest.TestCase):
         state = self.hass.states.get("sensor.dark_sky_summary")
         assert state is not None
 
-    @MockDependency("forecastio")
-    @patch("forecastio.load_forecast", new=load_forecastMock)
-    def test_setup_with_invalid_language_config(self, mock_forecastio):
+    def test_setup_with_invalid_language_config(self):
         """Test the platform setup with language configuration."""
         setup_component(self.hass, "sensor", INVALID_CONFIG_LANG)
 

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -112,7 +112,10 @@ class TestDarkSkySetup(unittest.TestCase):
         self.hass.stop()
 
     @MockDependency("forecastio")
-    @patch("forecastio.load_forecast", new=load_forecastMock)
+    @patch(
+        "homeassistant.components.darksky.sensor.forecastio.load_forecast",
+        new=load_forecastMock,
+    )
     def test_setup_with_config(self, mock_forecastio):
         """Test the platform setup with configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_MINIMAL)
@@ -130,7 +133,10 @@ class TestDarkSkySetup(unittest.TestCase):
         assert state is None
 
     @MockDependency("forecastio")
-    @patch("forecastio.load_forecast", new=load_forecastMock)
+    @patch(
+        "homeassistant.components.darksky.sensor.forecastio.load_forecast",
+        new=load_forecastMock,
+    )
     def test_setup_with_language_config(self, mock_forecastio):
         """Test the platform setup with language configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_LANG_DE)
@@ -164,7 +170,10 @@ class TestDarkSkySetup(unittest.TestCase):
         assert not response
 
     @MockDependency("forecastio")
-    @patch("forecastio.load_forecast", new=load_forecastMock)
+    @patch(
+        "homeassistant.components.darksky.sensor.forecastio.load_forecast",
+        new=load_forecastMock,
+    )
     def test_setup_with_alerts_config(self, mock_forecastio):
         """Test the platform setup with alert configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_ALERTS)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved imports from functions to top-level as requested in #27284

**Related issue (if applicable):** #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
