### PR TITLE
Fix ESPHome climate preset mode refactor

### DIFF
--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -17,6 +17,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE_RANGE,
     PRESET_AWAY,
     HVAC_MODE_OFF,
+    PRESET_HOME,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
@@ -96,7 +97,7 @@ class EsphomeClimateDevice(EsphomeEntity, ClimateDevice):
     @property
     def preset_modes(self):
         """Return preset modes."""
-        return [PRESET_AWAY] if self._static_info.supports_away else []
+        return [PRESET_AWAY, PRESET_HOME] if self._static_info.supports_away else []
 
     @property
     def target_temperature_step(self) -> float:


### PR DESCRIPTION
Fixes https://github.com/home-assistant/home-assistant/issues/25613


## Description:

During the climate refactor this issue came up (introduced here: https://github.com/home-assistant/home-assistant/compare/dev...OttoWinter:esphome-fix-climate-migration), fixing it now.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
