### PR TITLE
ESPHome Fix intermediary state published

### DIFF
--- a/homeassistant/components/esphome/camera.py
+++ b/homeassistant/components/esphome/camera.py
@@ -47,9 +47,9 @@ class EsphomeCamera(Camera, EsphomeEntity):
     def _state(self) -> Optional[CameraState]:
         return super()._state
 
-    async def _on_update(self) -> None:
+    async def _on_state_update(self) -> None:
         """Notify listeners of new image when update arrives."""
-        await super()._on_update()
+        await super()._on_state_update()
         async with self._image_cond:
             self._image_cond.notify_all()
 


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/426

## Description:

There was an issue with ESPHome entities where they would publish old states when coming back online because of some internal mechanics.

Scenario:

 1. Device powers up, sends state 23.0 to HA - HA creates entity with state `23.0`
 2. Device powers down, HA sees this and sets availability to false. State: `unavailable`.
 3. Device powers up again, HA sees this again and sets availability on all entities to true again. A state update is scheduled and the **old state** of `23.0` is published
 4. A few milliseconds later, the device reports the new state of 18.0. HA state update: `18.0`

This PR basically disables the state update scheduling in step 3. In hindsight, it's an oversight in the communication protocol that the initial state is not sent *together* in the packet with the entity info, but now it can't be changed that easily.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
