### PR TITLE
Adds aiohttp_cors to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ PACKAGES = find_packages(exclude=["tests", "tests.*"])
 
 REQUIRES = [
     "aiohttp==3.6.2",
+    "aiohttp_cors==0.7.0",
     "astral==1.10.1",
     "async_timeout==3.0.1",
     "attrs==19.2.0",


### PR DESCRIPTION
## Description:

After https://github.com/home-assistant/home-assistant/pull/27474 startup of a fresh dev installation was broken.

Since `aiohttp_cors` are needed for the initial setup now, this is probably a good place, if not please close down this one.

**Traceback without this change:***

```txt
Traceback (most recent call last):
  File "/usr/local/bin/hass", line 11, in <module>
    load_entry_point('homeassistant', 'console_scripts', 'hass')()
  File "/workspaces/home-assistant-dev/homeassistant/__main__.py", line 399, in main
    exit_code = asyncio_run(setup_and_run_hass(config_dir, args))
  File "/usr/local/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.7/asyncio/base_events.py", line 579, in run_until_complete
    return future.result()
  File "/workspaces/home-assistant-dev/homeassistant/__main__.py", line 293, in setup_and_run_hass
    config_file = await ensure_config_file(hass, config_dir)
  File "/workspaces/home-assistant-dev/homeassistant/__main__.py", line 104, in ensure_config_file
    config_path = await config_util.async_ensure_config_exists(hass, config_dir)
  File "/workspaces/home-assistant-dev/homeassistant/config.py", line 238, in async_ensure_config_exists
    config_path = await async_create_default_config(hass, config_dir)
  File "/workspaces/home-assistant-dev/homeassistant/config.py", line 251, in async_create_default_config
    return await hass.async_add_executor_job(_write_default_config, config_dir)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/workspaces/home-assistant-dev/homeassistant/config.py", line 256, in _write_default_config
    from homeassistant.components.config.group import CONFIG_PATH as GROUP_CONFIG_PATH
  File "/workspaces/home-assistant-dev/homeassistant/components/config/__init__.py", line 8, in <module>
    from homeassistant.components.http import HomeAssistantView
  File "/workspaces/home-assistant-dev/homeassistant/components/http/__init__.py", line 25, in <module>
    from .cors import setup_cors
  File "/workspaces/home-assistant-dev/homeassistant/components/http/cors.py", line 2, in <module>
    import aiohttp_cors
ModuleNotFoundError: No module named 'aiohttp_cors'
```

More details on the issue <https://discordapp.com/channels/330944238910963714/330990195199442944/633343239654473788>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
