### PR TITLE
Add remove function to hue sensors

### DIFF
--- a/homeassistant/components/hue/helpers.py
+++ b/homeassistant/components/hue/helpers.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.device_registry import async_get_registry as get_dev_
 from .const import DOMAIN
 
 
-async def get_removed_devices(hass, config_entry, api_ids, current):
+async def remove_devices(hass, config_entry, api_ids, current):
     """Get items that are removed from api."""
     removed_items = []
 
@@ -22,10 +22,12 @@ async def get_removed_devices(hass, config_entry, api_ids, current):
             ent_registry.async_remove(entity.entity_id)
         dev_registry = await get_dev_reg(hass)
         device = dev_registry.async_get_device(
-            identifiers={(DOMAIN, entity.unique_id)}, connections=set()
+            identifiers={(DOMAIN, entity.device_id)}, connections=set()
         )
-        dev_registry.async_update_device(
-            device.id, remove_config_entry_id=config_entry.entry_id
-        )
+        if device is not None:
+            dev_registry.async_update_device(
+                device.id, remove_config_entry_id=config_entry.entry_id
+            )
 
-    return removed_items
+    for item_id in removed_items:
+        del current[item_id]

--- a/homeassistant/components/hue/helpers.py
+++ b/homeassistant/components/hue/helpers.py
@@ -1,0 +1,31 @@
+"""Helper functions for Philips Hue."""
+from homeassistant.helpers.entity_registry import async_get_registry as get_ent_reg
+from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
+
+from .const import DOMAIN
+
+
+async def get_removed_devices(hass, config_entry, api_ids, current):
+    """Get items that are removed from api."""
+    removed_items = []
+
+    for item_id in current:
+        if item_id in api_ids:
+            continue
+
+        # Device is removed from Hue, so we remove it from Home Assistant
+        entity = current[item_id]
+        removed_items.append(item_id)
+        await entity.async_remove()
+        ent_registry = await get_ent_reg(hass)
+        if entity.entity_id in ent_registry.entities:
+            ent_registry.async_remove(entity.entity_id)
+        dev_registry = await get_dev_reg(hass)
+        device = dev_registry.async_get_device(
+            identifiers={(DOMAIN, entity.unique_id)}, connections=set()
+        )
+        dev_registry.async_update_device(
+            device.id, remove_config_entry_id=config_entry.entry_id
+        )
+
+    return removed_items

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -29,7 +29,7 @@ from homeassistant.components.light import (
     Light,
 )
 from homeassistant.util import color
-from .helpers import get_removed_devices
+from .helpers import remove_devices
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
@@ -235,13 +235,10 @@ async def async_update_items(
         elif item_id not in progress_waiting:
             current[item_id].async_schedule_update_ha_state()
 
-    removed_items = await get_removed_devices(hass, config_entry, api, current)
+    await remove_devices(hass, config_entry, api, current)
 
     if new_items:
         async_add_entities(new_items)
-
-    for item_id in removed_items:
-        del current[item_id]
 
 
 class HueLight(Light):
@@ -279,7 +276,7 @@ class HueLight(Light):
                     self.gamut = None
 
     @property
-    def unique_id(self):
+    def device_id(self):
         """Return the ID of this Hue light."""
         return self.light.uniqueid
 
@@ -364,7 +361,7 @@ class HueLight(Light):
             return None
 
         return {
-            "identifiers": {(hue.DOMAIN, self.unique_id)},
+            "identifiers": {(hue.DOMAIN, self.device_id)},
             "name": self.name,
             "manufacturer": self.light.manufacturername,
             # productname added in Hue Bridge API 1.24

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -276,9 +276,14 @@ class HueLight(Light):
                     self.gamut = None
 
     @property
+    def unique_id(self):
+        """Return the unique ID of this Hue light."""
+        return self.light.uniqueid
+
+    @property
     def device_id(self):
         """Return the ID of this Hue light."""
-        return self.light.uniqueid
+        return self.unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -8,9 +8,6 @@ import random
 import aiohue
 import async_timeout
 
-from homeassistant.helpers.entity_registry import async_get_registry as get_ent_reg
-from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
-
 from homeassistant.components import hue
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -32,6 +29,7 @@ from homeassistant.components.light import (
     Light,
 )
 from homeassistant.util import color
+from .helpers import get_removed_devices
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
@@ -226,7 +224,6 @@ async def async_update_items(
         bridge.available = True
 
     new_items = []
-    removed_items = []
 
     for item_id in api:
         if item_id not in current:
@@ -238,24 +235,7 @@ async def async_update_items(
         elif item_id not in progress_waiting:
             current[item_id].async_schedule_update_ha_state()
 
-    for item_id in current:
-        if item_id in api:
-            continue
-
-        # Device is removed from Hue, so we remove it from Home Assistant
-        entity = current[item_id]
-        removed_items.append(item_id)
-        await entity.async_remove()
-        ent_registry = await get_ent_reg(hass)
-        if entity.entity_id in ent_registry.entities:
-            ent_registry.async_remove(entity.entity_id)
-        dev_registry = await get_dev_reg(hass)
-        device = dev_registry.async_get_device(
-            identifiers={(hue.DOMAIN, entity.unique_id)}, connections=set()
-        )
-        dev_registry.async_update_device(
-            device.id, remove_config_entry_id=config_entry.entry_id
-        )
+    removed_items = await get_removed_devices(hass, config_entry, api, current)
 
     if new_items:
         async_add_entities(new_items)

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
-from .helpers import get_removed_devices
+from .helpers import remove_devices
 
 CURRENT_SENSORS = "current_sensors"
 SENSOR_MANAGER_FORMAT = "{}_sensor_manager"
@@ -196,7 +196,7 @@ class SensorManager:
             else:
                 new_sensors.append(current[api[item_id].uniqueid])
 
-        removed_items = await get_removed_devices(
+        await remove_devices(
             self.hass,
             self.config_entry,
             [value.uniqueid for value in api.values()],
@@ -209,9 +209,6 @@ class SensorManager:
             async_add_sensor_entities(new_sensors)
         if new_binary_sensors and async_add_binary_entities:
             async_add_binary_entities(new_binary_sensors)
-
-        for item_id in removed_items:
-            del current[item_id]
 
 
 class GenericHueSensor:


### PR DESCRIPTION
## Description:
Add the function for removing devices that are removed from hue to sensors. 

I don't own Hue sensors, so have not tested this myself.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
