### PR TITLE
Update Unlock directive for Alexa LockController

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -412,7 +412,6 @@ async def async_api_lock(hass, config, directive, context):
     return response
 
 
-# Not supported by Alexa yet
 @HANDLERS.register(("Alexa.LockController", "Unlock"))
 async def async_api_unlock(hass, config, directive, context):
     """Process an unlock request."""
@@ -425,7 +424,12 @@ async def async_api_unlock(hass, config, directive, context):
         context=context,
     )
 
-    return directive.response()
+    response = directive.response()
+    response.add_context_property(
+        {"namespace": "Alexa.LockController", "name": "lockState", "value": "UNLOCKED"}
+    )
+
+    return response
 
 
 @HANDLERS.register(("Alexa.Speaker", "SetVolume"))

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -403,11 +403,19 @@ async def test_lock(hass):
         "Alexa.LockController", "Lock", "lock#test", "lock.lock", hass
     )
 
-    # always return LOCKED for now
     properties = msg["context"]["properties"][0]
     assert properties["name"] == "lockState"
     assert properties["namespace"] == "Alexa.LockController"
     assert properties["value"] == "LOCKED"
+
+    _, msg = await assert_request_calls_service(
+        "Alexa.LockController", "Unlock", "lock#test", "lock.unlock", hass
+    )
+
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "lockState"
+    assert properties["namespace"] == "Alexa.LockController"
+    assert properties["value"] == "UNLOCKED"
 
 
 async def test_media_player(hass):


### PR DESCRIPTION
## Description:
Based on the comment in the code the Unlock directive may not have been (fully) supported when the original Unlock handler was written. That is no longer the case and it is now supported with user opt-in and a voice PIN. 

Updated the `Alexa.LockController` Unlock directive to include the `lockState` property in the context of the response as expected by the Alexa API.  Also added tests for Unlock directive. 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
