### PR TITLE
Add context based callbacks for Telegram

### DIFF
--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -30,17 +30,17 @@ async def async_setup_platform(hass, config):
     return True
 
 
-def process_error(bot, update, error):
+def process_error(bot, update, context):
     """Telegram bot error handler."""
     from telegram.error import TelegramError, TimedOut, NetworkError, RetryAfter
 
     try:
-        raise error
+        raise context.error
     except (TimedOut, NetworkError, RetryAfter):
         # Long polling timeout or connection problem. Nothing serious.
         pass
     except TelegramError:
-        _LOGGER.error('Update "%s" caused error "%s"', update, error)
+        _LOGGER.error('Update "%s" caused error "%s"', update, context.error)
 
 
 def message_handler(handler):
@@ -76,7 +76,7 @@ class TelegramPoll(BaseTelegramBotEntity):
 
         BaseTelegramBotEntity.__init__(self, hass, allowed_chat_ids)
 
-        self.updater = Updater(bot=bot, workers=4)
+        self.updater = Updater(bot=bot, workers=4, use_context=True)
         self.dispatcher = self.updater.dispatcher
 
         self.dispatcher.add_handler(message_handler(self.process_update))
@@ -90,6 +90,6 @@ class TelegramPoll(BaseTelegramBotEntity):
         """Stop the polling task."""
         self.updater.stop()
 
-    def process_update(self, bot, update):
+    def process_update(self, bot, update, context):
         """Process incoming message."""
         self.process_message(update.to_dict())


### PR DESCRIPTION
Added context-based callbacks as it was stated in the [Transition guide](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Transition-guide-to-Version-12.0#context-based-callbacks) for `telegram-ext` library.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
