### PR TITLE
Add available to unifiled lights

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -713,6 +713,7 @@ omit =
     homeassistant/components/uber/sensor.py
     homeassistant/components/ubus/device_tracker.py
     homeassistant/components/ue_smart_radio/media_player.py
+    homeassistant/components/unifiled/*
     homeassistant/components/upcloud/*
     homeassistant/components/upnp/*
     homeassistant/components/upc_connect/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -305,6 +305,7 @@ homeassistant/components/twentemilieu/* @frenck
 homeassistant/components/twilio_call/* @robbiet480
 homeassistant/components/twilio_sms/* @robbiet480
 homeassistant/components/unifi/* @kane610
+homeassistant/components/unifiled/* @florisvdk
 homeassistant/components/upc_connect/* @pvizeli
 homeassistant/components/upcloud/* @scop
 homeassistant/components/updater/* @home-assistant/core

--- a/homeassistant/components/unifiled/__init__.py
+++ b/homeassistant/components/unifiled/__init__.py
@@ -1,0 +1,1 @@
+"""Example Lights integration."""

--- a/homeassistant/components/unifiled/__init__.py
+++ b/homeassistant/components/unifiled/__init__.py
@@ -1,1 +1,1 @@
-"""Example Lights integration."""
+"""Unifi LED Lights integration."""

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -58,6 +58,7 @@ class UnifiLedLight(Light):
         self._name = light["name"]
         self._unique_id = light["id"]
         self._state = light["status"]["output"]
+        self._available = self._api.getlightavailable(self._unique_id)
         self._brightness = self._api.convertfrom100to255(light["status"]["led"])
         self._features = SUPPORT_BRIGHTNESS
 
@@ -67,8 +68,13 @@ class UnifiLedLight(Light):
         return self._name
 
     @property
+    def available(self):
+        """Return the available state of this light."""
+        return self._available
+
+    @property
     def brightness(self):
-        """Return the brightness name of this light."""
+        """Return the brightness of this light."""
         return self._brightness
 
     @property
@@ -104,3 +110,4 @@ class UnifiLedLight(Light):
         self._brightness = self._api.convertfrom100to255(
             self._api.getlightbrightness(self._unique_id)
         )
+        self._available = self._api.getlightavailable(self._unique_id)

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -1,0 +1,119 @@
+"""Support for Unifi Led lights."""
+import logging
+
+import voluptuous as vol
+
+# Import the device class from the component that you want to support
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS,
+    Light,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_ID,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+# Validation of the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_USERNAME, default="ubnt"): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_PORT, default="20443"): cv.string,
+        vol.Optional(CONF_ID): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Unifi LED platform."""
+
+    from unifiled import unifiled
+
+    # Assign configuration variables.
+    # The configuration check takes care they are present.
+    ip = config[CONF_HOST]
+    port = config[CONF_PORT]
+    username = config[CONF_USERNAME]
+    password = config.get(CONF_PASSWORD)
+
+    api = unifiled(ip, port, username=username, password=password)
+
+    # Verify that passed in configuration works
+    if not api.getloginstate():
+        _LOGGER.error("Could not connect to unifiled controller")
+        return
+
+    # Add devices
+    add_entities(
+        unifiledlight(light, ip, port, username, password) for light in api.getlights()
+    )
+
+
+class unifiledlight(Light):
+    """Representation of an unifiled Light."""
+
+    def __init__(self, light, ip, port, username, password):
+        """Init Unifi LED Light."""
+
+        from unifiled import unifiled
+
+        self._api = unifiled(ip, port, username=username, password=password)
+        self._light = light
+        self._name = light["name"]
+        self._unique_id = light["id"]
+        self._state = light["status"]["output"]
+        self._brightness = self._api.convertfrom100to255(light["status"]["led"])
+        self._features = SUPPORT_BRIGHTNESS
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def brightness(self):
+        """Return the brightness name of this light."""
+        return self._brightness
+
+    @property
+    def unique_id(self):
+        """Return the unique id of this light."""
+        return self._unique_id
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Return the supported features of this light."""
+        return self._features
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on."""
+        self._api.setdevicebrightness(
+            self._unique_id,
+            str(self._api.convertfrom255to100(kwargs.get(ATTR_BRIGHTNESS, 255))),
+        )
+        self._api.setdeviceoutput(self._unique_id, 1)
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._api.setdeviceoutput(self._unique_id, 0)
+
+    def update(self):
+        """Update the light states."""
+        self._state = self._api.getlightstate(self._unique_id)
+        self._brightness = self._api.convertfrom100to255(
+            self._api.getlightbrightness(self._unique_id)
+        )

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -40,12 +40,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Assign configuration variables.
     # The configuration check takes care they are present.
-    ip = config[CONF_HOST]
-    port = config[CONF_PORT]
-    username = config[CONF_USERNAME]
-    password = config.get(CONF_PASSWORD)
+    _ip = config[CONF_HOST]
+    _port = config[CONF_PORT]
+    _username = config[CONF_USERNAME]
+    _password = config.get(CONF_PASSWORD)
 
-    api = unifiled(ip, port, username=username, password=password)
+    api = unifiled(_ip, _port, username=_username, password=_password)
 
     # Verify that passed in configuration works
     if not api.getloginstate():
@@ -54,11 +54,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Add devices
     add_entities(
-        unifiledlight(light, ip, port, username, password) for light in api.getlights()
+        UnifiLedLight(light, _ip, _port, _username, _password)
+        for light in api.getlights()
     )
 
 
-class unifiledlight(Light):
+class UnifiLedLight(Light):
     """Representation of an unifiled Light."""
 
     def __init__(self, light, ip, port, username, password):

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 
-# Import the device class from the component that you want to support
+from unifiled import unifiled
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
@@ -12,7 +12,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
-from unifiled import unifiled
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PORT, default="20443"): cv.string,
     }
 )

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -10,13 +10,7 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS,
     Light,
 )
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_ID,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,7 +22,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PORT, default="20443"): cv.string,
-        vol.Optional(CONF_ID): cv.string,
     }
 )
 

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_USERNAME, default="ubnt"): cv.string,
+        vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PORT, default="20443"): cv.string,
         vol.Optional(CONF_ID): cv.string,

--- a/homeassistant/components/unifiled/manifest.json
+++ b/homeassistant/components/unifiled/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "unifiled",
+  "name": "Unifi LED",
+  "documentation": "https://www.home-assistant.io/components/unifiled",
+  "dependencies": [],
+  "codeowners": ['@florisvdk'],
+  "requirements": ["unifiled==0.10"]
+}

--- a/homeassistant/components/unifiled/manifest.json
+++ b/homeassistant/components/unifiled/manifest.json
@@ -3,6 +3,6 @@
   "name": "Unifi LED",
   "documentation": "https://www.home-assistant.io/components/unifiled",
   "dependencies": [],
-  "codeowners": ['@florisvdk'],
+  "codeowners": ["@florisvdk"],
   "requirements": ["unifiled==0.10"]
 }

--- a/homeassistant/components/unifiled/manifest.json
+++ b/homeassistant/components/unifiled/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/components/unifiled",
   "dependencies": [],
   "codeowners": ["@florisvdk"],
-  "requirements": ["unifiled==0.10"]
+  "requirements": ["unifiled==0.11"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1908,6 +1908,9 @@ twentemilieu==0.1.0
 # homeassistant.components.twilio
 twilio==6.19.1
 
+# homeassistant.components.unifiled
+unifiled==0.10
+
 # homeassistant.components.upcloud
 upcloud-api==0.4.3
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1909,7 +1909,7 @@ twentemilieu==0.1.0
 twilio==6.19.1
 
 # homeassistant.components.unifiled
-unifiled==0.10
+unifiled==0.11
 
 # homeassistant.components.upcloud
 upcloud-api==0.4.3


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Added the available state to the Unifi LED lights
Updated pypi library version
This is a continuation on https://github.com/home-assistant/home-assistant/pull/27475

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: unifiled
    host: 192.168.1.20
    port: 20443
    username: ubnt
    password: ubnt
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
