### PR TITLE
Move imports in panasonic_viera component

### DIFF
--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -1,9 +1,11 @@
 """Support for interface with a Panasonic Viera TV."""
 import logging
 
+from panasonic_viera import RemoteControl
 import voluptuous as vol
+import wakeonlan
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_URL,
     SUPPORT_NEXT_TRACK,
@@ -62,8 +64,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Panasonic Viera TV platform."""
-    from panasonic_viera import RemoteControl
-
     mac = config.get(CONF_MAC)
     name = config.get(CONF_NAME)
     port = config.get(CONF_PORT)
@@ -95,8 +95,6 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
 
     def __init__(self, mac, name, remote, host, app_power, uuid=None):
         """Initialize the Panasonic device."""
-        import wakeonlan
-
         # Save a reference to the imported class
         self._wol = wakeonlan
         self._mac = mac


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Moved import from function to top-level as requested in #27284
**Related issue (if applicable):** fixes 27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
