### PR TITLE
Add  Alexa.ChannelController functions for media players

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1041,7 +1041,7 @@ class AlexaToggleController(AlexaCapability):
         return capability_resources
 
 
-class AlexaChannelController(AlexaCapibility):
+class AlexaChannelController(AlexaCapability):
     """Implements Alexa.ChannelController.
 
     https://developer.amazon.com/docs/device-apis/alexa-channelcontroller.html

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1039,3 +1039,14 @@ class AlexaToggleController(AlexaCapability):
             ]
 
         return capability_resources
+
+
+class AlexaChannelController(AlexaCapibility):
+    """Implements Alexa.ChannelController.
+
+    https://developer.amazon.com/docs/device-apis/alexa-channelcontroller.html
+    """
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa.ChannelController"

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -34,6 +34,7 @@ from homeassistant.components import (
 from .const import CONF_DESCRIPTION, CONF_DISPLAY_CATEGORIES
 from .capabilities import (
     AlexaBrightnessController,
+    AlexaChannelController,
     AlexaColorController,
     AlexaColorTemperatureController,
     AlexaContactSensor,
@@ -419,6 +420,9 @@ class MediaPlayerCapabilities(AlexaEntity):
 
         if supported & media_player.SUPPORT_SELECT_SOURCE:
             yield AlexaInputController(self.entity)
+
+        if supported & media_player.const.SUPPORT_PLAY_MEDIA:
+            yield AlexaChannelController(self.entity)
 
 
 @ENTITY_ADAPTERS.register(scene.DOMAIN)

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1130,9 +1130,6 @@ async def async_api_changechannel(hass, config, directive, context):
     elif "uri" in payload:
         channel = payload["uri"]
         payload_name = "uri"
-    elif "name" in payload:
-        channel = payload["name"]
-        payload_name = "name"
 
     data = {
         ATTR_ENTITY_ID: entity.entity_id,

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1,4 +1,5 @@
 """Alexa message handlers."""
+import asyncio
 import logging
 import math
 
@@ -529,6 +530,7 @@ async def async_api_adjust_volume_step(hass, config, directive, context):
     volume_int = int(directive.payload["volumeSteps"])
     is_default = bool(directive.payload["volumeStepsDefault"])
     default_steps = 1
+    sleep_delay = 0.5
 
     if "volume_steps_default" in entity.attributes:
         try:
@@ -562,6 +564,7 @@ async def async_api_adjust_volume_step(hass, config, directive, context):
                     blocking=False,
                     context=context,
                 )
+            await asyncio.sleep(sleep_delay)
 
     return directive.response()
 
@@ -1163,6 +1166,7 @@ async def async_api_skipchannel(hass, config, directive, context):
     """Process a skipchannel request."""
     channel = int(directive.payload["channelCount"])
     entity = directive.entity
+    sleep_delay = 0.5
 
     data = {ATTR_ENTITY_ID: entity.entity_id}
 
@@ -1175,7 +1179,6 @@ async def async_api_skipchannel(hass, config, directive, context):
                 blocking=False,
                 context=context,
             )
-
         if channel < 0:
             await hass.services.async_call(
                 entity.domain,
@@ -1184,6 +1187,7 @@ async def async_api_skipchannel(hass, config, directive, context):
                 blocking=False,
                 context=context,
             )
+        await asyncio.sleep(sleep_delay)
 
     response = directive.response()
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1160,7 +1160,7 @@ async def async_api_changechannel(hass, config, directive, context):
 
 @HANDLERS.register(("Alexa.ChannelController", "SkipChannels"))
 async def async_api_skipchannel(hass, config, directive, context):
-    """Process a change channel request."""
+    """Process a skipchannel request."""
     channel = int(directive.payload["channelCount"])
     entity = directive.entity
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -929,7 +929,6 @@ async def async_api_disarm(hass, config, directive, context):
     return response
 
 
-<<<<<<< HEAD
 @HANDLERS.register(("Alexa.ModeController", "SetMode"))
 async def async_api_set_mode(hass, config, directive, context):
     """Process a next request."""

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -5,6 +5,7 @@ import math
 from homeassistant import core as ha
 from homeassistant.components import cover, fan, group, light, media_player
 from homeassistant.components.climate import const as climate
+from homeassistant.components.media_player.const import MEDIA_TYPE_CHANNEL
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
@@ -1116,7 +1117,7 @@ async def async_api_changechannel(hass, config, directive, context):
     data = {
         ATTR_ENTITY_ID: entity.entity_id,
         media_player.const.ATTR_MEDIA_CONTENT_ID: channel,
-        media_player.const.ATTR_MEDIA_CONTENT_TYPE: "channel",
+        media_player.const.ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_CHANNEL,
     }
 
     await hass.services.async_call(

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -571,7 +571,6 @@ async def async_api_set_mute(hass, config, directive, context):
     """Process a set mute request."""
     mute = bool(directive.payload["mute"])
     entity = directive.entity
-
     data = {
         ATTR_ENTITY_ID: entity.entity_id,
         media_player.const.ATTR_MEDIA_VOLUME_MUTED: mute,

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -523,8 +523,7 @@ async def async_api_adjust_volume_step(hass, config, directive, context):
     # each component handles it differently e.g. via config.
     # This workaround will simply call the volume up/Volume down the amount of steps asked for
     # When no steps are called in the request, Alexa sends a default of 10 steps which for most
-    # purposes is too high.  A device_state_attribute can be set in the media player to set this to a new default
-    # The default without the attribute is set 1 in this case.
+    # purposes is too high. The default  is set 1 in this case.
     entity = directive.entity
     volume_int = int(directive.payload["volumeSteps"])
     is_default = bool(directive.payload["volumeStepsDefault"])

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -5,7 +5,6 @@ import math
 from homeassistant import core as ha
 from homeassistant.components import cover, fan, group, light, media_player
 from homeassistant.components.climate import const as climate
-from homeassistant.components.media_player.const import MEDIA_TYPE_CHANNEL
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
@@ -1117,7 +1116,7 @@ async def async_api_changechannel(hass, config, directive, context):
     data = {
         ATTR_ENTITY_ID: entity.entity_id,
         media_player.const.ATTR_MEDIA_CONTENT_ID: channel,
-        media_player.const.ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_CHANNEL,
+        media_player.const.ATTR_MEDIA_CONTENT_TYPE: media_player.const.MEDIA_TYPE_CHANNEL,
     }
 
     await hass.services.async_call(

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -535,6 +535,7 @@ async def async_api_adjust_volume_step(hass, config, directive, context):
             default_steps = int(entity.attributes["volume_steps_default"])
         except ValueError:
             default_steps = 1
+
     if is_default:
         if volume_int < 0:
             volume_int = -default_steps

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -524,7 +524,7 @@ async def async_api_adjust_volume_step(hass, config, directive, context):
     # This workaround will simply call the volume up/Volume down the amount of steps asked for
     # When no steps are called in the request, Alexa sends a default of 10 steps which for most
     # purposes is too high.  A device_state_attribute can be set in the media player to set this to a new default
-    # The default without the attribute is lowered to 5 in this case.
+    # The default without the attribute is set 1 in this case.
     entity = directive.entity
     volume_int = int(directive.payload["volumeSteps"])
     is_default = bool(directive.payload["volumeStepsDefault"])

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -90,7 +90,7 @@ async def assert_request_calls_service(
     msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
     await hass.async_block_till_done()
 
-    assert len(calls) > 0
+    assert len(calls) == 1
     call = calls[0]
     assert "event" in msg
     assert call.data["entity_id"] == endpoint.replace("#", ".")

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -90,7 +90,7 @@ async def assert_request_calls_service(
     msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
+    assert len(calls) > 0
     call = calls[0]
     assert "event" in msg
     assert call.data["entity_id"] == endpoint.replace("#", ".")

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -718,7 +718,6 @@ async def test_media_player(hass):
             | SUPPORT_STOP
             | SUPPORT_PLAY,
             "volume_level": 0.75,
-            "volume_steps_default": "INVALID",
         },
     )
     appliance = await discovery_test(device, hass)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -693,7 +693,7 @@ async def test_media_player(hass):
         "off",
         {
             "friendly_name": "Test media player",
-            "supported_features": 0x59BD,
+            "supported_features": 0x59BD | 512,
             "volume_level": 0.75,
         },
     )
@@ -711,6 +711,7 @@ async def test_media_player(hass):
         "Alexa.StepSpeaker",
         "Alexa.PlaybackController",
         "Alexa.EndpointHealth",
+        "Alexa.ChannelController",
     )
 
     await assert_power_controller_works(
@@ -824,7 +825,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_up",
         hass,
-        payload={"volumeSteps": 20},
+        payload={"volumeSteps": 20, "volumeStepsDefault": False},
     )
 
     call, _ = await assert_request_calls_service(
@@ -833,7 +834,24 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_down",
         hass,
-        payload={"volumeSteps": -20},
+        payload={"volumeSteps": -20, "volumeStepsDefault": False},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.StepSpeaker",
+        "AdjustVolume",
+        "media_player#test",
+        "media_player.volume_up",
+        hass,
+        payload={"volumeSteps": 10, "volumeStepsDefault": True},
+    )
+    call, _ = await assert_request_calls_service(
+        "Alexa.ChannelController",
+        "ChangeChannel",
+        "media_player#test",
+        "media_player.play_media",
+        hass,
+        payload={"channel": {"number": 24}},
     )
 
 
@@ -862,6 +880,7 @@ async def test_media_player_power(hass):
         "Alexa.StepSpeaker",
         "Alexa.PlaybackController",
         "Alexa.EndpointHealth",
+        "Alexa.ChannelController",
     )
 
     await assert_request_calls_service(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -693,7 +693,7 @@ async def test_media_player(hass):
         "off",
         {
             "friendly_name": "Test media player",
-            "supported_features": 0x59BD | 512,
+            "supported_features": 0x59BD | 16384 | 4096 | 512 | 32 | 16 | 1,
             "volume_level": 0.75,
         },
     )
@@ -825,7 +825,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_up",
         hass,
-        payload={"volumeSteps": 5, "volumeStepsDefault": True},
+        payload={"volumeSteps": 1, "volumeStepsDefault": False},
     )
 
     call, _ = await assert_request_calls_service(
@@ -834,7 +834,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_down",
         hass,
-        payload={"volumeSteps": -5, "volumeStepsDefault": True},
+        payload={"volumeSteps": -1, "volumeStepsDefault": False},
     )
 
     call, _ = await assert_request_calls_service(
@@ -852,6 +852,33 @@ async def test_media_player(hass):
         "media_player.play_media",
         hass,
         payload={"channel": {"number": 24}},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ChannelController",
+        "ChangeChannel",
+        "media_player#test",
+        "media_player.play_media",
+        hass,
+        payload={"channel": {"callSign": "ABC"}},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ChannelController",
+        "SkipChannels",
+        "media_player#test",
+        "media_player.media_next_track",
+        hass,
+        payload={"channelCount": 1},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ChannelController",
+        "SkipChannels",
+        "media_player#test",
+        "media_player.media_previous_track",
+        hass,
+        payload={"channelCount": -1},
     )
 
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -695,6 +695,7 @@ async def test_media_player(hass):
             "friendly_name": "Test media player",
             "supported_features": 0x59BD | 16384 | 4096 | 512 | 32 | 16 | 1,
             "volume_level": 0.75,
+            "volume_steps_default": "INVALID",
         },
     )
     appliance = await discovery_test(device, hass)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -5,17 +5,17 @@ from homeassistant.core import Context, callback
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.components.alexa import smart_home, messages
 from homeassistant.components.media_player.const import (
-    SUPPORT_PAUSE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_PREVIOUS_TRACK,
     SUPPORT_NEXT_TRACK,
-    SUPPORT_TURN_ON,
-    SUPPORT_TURN_OFF,
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
+    SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
-    SUPPORT_PLAY,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
 )
 from homeassistant.helpers import entityfilter
 
@@ -706,17 +706,17 @@ async def test_media_player(hass):
         "off",
         {
             "friendly_name": "Test media player",
-            "supported_features": SUPPORT_PAUSE
-            | SUPPORT_VOLUME_SET
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_PREVIOUS_TRACK
-            | SUPPORT_NEXT_TRACK
-            | SUPPORT_TURN_ON
-            | SUPPORT_TURN_OFF
+            "supported_features": SUPPORT_NEXT_TRACK
+            | SUPPORT_PAUSE
+            | SUPPORT_PLAY
             | SUPPORT_PLAY_MEDIA
+            | SUPPORT_PREVIOUS_TRACK
             | SUPPORT_SELECT_SOURCE
             | SUPPORT_STOP
-            | SUPPORT_PLAY,
+            | SUPPORT_TURN_OFF
+            | SUPPORT_TURN_ON
+            | SUPPORT_VOLUME_MUTE
+            | SUPPORT_VOLUME_SET,
             "volume_level": 0.75,
         },
     )

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -866,6 +866,24 @@ async def test_media_player(hass):
 
     call, _ = await assert_request_calls_service(
         "Alexa.ChannelController",
+        "ChangeChannel",
+        "media_player#test",
+        "media_player.play_media",
+        hass,
+        payload={"channel": {"affiliateCallSign": "ABC"}},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ChannelController",
+        "ChangeChannel",
+        "media_player#test",
+        "media_player.play_media",
+        hass,
+        payload={"channel": {"uri": "ABC"}},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ChannelController",
         "SkipChannels",
         "media_player#test",
         "media_player.media_next_track",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -825,7 +825,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_up",
         hass,
-        payload={"volumeSteps": 20, "volumeStepsDefault": "True"},
+        payload={"volumeSteps": 5, "volumeStepsDefault": True},
     )
 
     call, _ = await assert_request_calls_service(
@@ -834,7 +834,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_down",
         hass,
-        payload={"volumeSteps": -20, "volumeStepsDefault": "False"},
+        payload={"volumeSteps": -5, "volumeStepsDefault": True},
     )
 
     call, _ = await assert_request_calls_service(
@@ -843,7 +843,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_up",
         hass,
-        payload={"volumeSteps": 10, "volumeStepsDefault": "True"},
+        payload={"volumeSteps": 10, "volumeStepsDefault": True},
     )
     call, _ = await assert_request_calls_service(
         "Alexa.ChannelController",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.core import Context, callback
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.components.alexa import smart_home, messages
-from homeassistant.components.media_player import SUPPORT_PLAY_MEDIA
+from homeassistant.components.media_player.const import SUPPORT_PLAY_MEDIA
 from homeassistant.helpers import entityfilter
 
 from tests.common import async_mock_service

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -825,7 +825,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_up",
         hass,
-        payload={"volumeSteps": 20, "volumeStepsDefault": False},
+        payload={"volumeSteps": 20, "volumeStepsDefault": "True"},
     )
 
     call, _ = await assert_request_calls_service(
@@ -834,7 +834,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_down",
         hass,
-        payload={"volumeSteps": -20, "volumeStepsDefault": False},
+        payload={"volumeSteps": -20, "volumeStepsDefault": "False"},
     )
 
     call, _ = await assert_request_calls_service(
@@ -843,7 +843,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.volume_up",
         hass,
-        payload={"volumeSteps": 10, "volumeStepsDefault": True},
+        payload={"volumeSteps": 10, "volumeStepsDefault": "True"},
     )
     call, _ = await assert_request_calls_service(
         "Alexa.ChannelController",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -4,7 +4,19 @@ import pytest
 from homeassistant.core import Context, callback
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.components.alexa import smart_home, messages
-from homeassistant.components.media_player.const import SUPPORT_PLAY_MEDIA
+from homeassistant.components.media_player.const import (
+    SUPPORT_PAUSE,
+    SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_TURN_ON,
+    SUPPORT_TURN_OFF,
+    SUPPORT_PLAY_MEDIA,
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_STOP,
+    SUPPORT_PLAY,
+)
 from homeassistant.helpers import entityfilter
 
 from tests.common import async_mock_service
@@ -694,7 +706,17 @@ async def test_media_player(hass):
         "off",
         {
             "friendly_name": "Test media player",
-            "supported_features": 0x59BD | SUPPORT_PLAY_MEDIA,
+            "supported_features": SUPPORT_PAUSE
+            | SUPPORT_VOLUME_SET
+            | SUPPORT_VOLUME_MUTE
+            | SUPPORT_PREVIOUS_TRACK
+            | SUPPORT_NEXT_TRACK
+            | SUPPORT_TURN_ON
+            | SUPPORT_TURN_OFF
+            | SUPPORT_PLAY_MEDIA
+            | SUPPORT_SELECT_SOURCE
+            | SUPPORT_STOP
+            | SUPPORT_PLAY,
             "volume_level": 0.75,
             "volume_steps_default": "INVALID",
         },

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -4,6 +4,7 @@ import pytest
 from homeassistant.core import Context, callback
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.components.alexa import smart_home, messages
+from homeassistant.components.media_player import SUPPORT_PLAY_MEDIA
 from homeassistant.helpers import entityfilter
 
 from tests.common import async_mock_service
@@ -693,7 +694,7 @@ async def test_media_player(hass):
         "off",
         {
             "friendly_name": "Test media player",
-            "supported_features": 0x59BD | 16384 | 4096 | 512 | 32 | 16 | 1,
+            "supported_features": 0x59BD | SUPPORT_PLAY_MEDIA,
             "volume_level": 0.75,
             "volume_steps_default": "INVALID",
         },


### PR DESCRIPTION
Added missing Alexa.ChannelController functions. Specifically Change Channel and SkipChannel commands. These functions will call the play_media function in a media_player app if it has the capability published and pass on the  channel# or channel name. The selected media player can then use this to select the channel on the device it is associated to.

Modified the existing Alexa.StepSpeaker Setvolume function to actually do a stepped volume change using the steps sent by Alexa. The Alexa default step of 10 for a simple volume up/down can be changed via an exposed media_player attribute called volume_step_default.  The default is set to 1.
Any other value than default will be sent  as a looped sequence of volume up/down calls to the media_player.

Modifed the test script test_smart_home.py to add the missing payload attribute volumeStepDefault and test for it.  Also added ChannelController tests.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]



If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

Checks the Channel controller box in  #24579