### PR TITLE
Default to gatttoolbackend with bluepybackend backup

### DIFF
--- a/homeassistant/components/mitemp_bt/sensor.py
+++ b/homeassistant/components/mitemp_bt/sensor.py
@@ -63,14 +63,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     from mitemp_bt import mitemp_bt_poller
 
     try:
+        from btlewrap import GatttoolBackend
+
+        backend = GatttoolBackend        
+    except ImportError:    
         import bluepy.btle  # noqa: F401 pylint: disable=unused-import
         from btlewrap import BluepyBackend
 
         backend = BluepyBackend
-    except ImportError:
-        from btlewrap import GatttoolBackend
-
-        backend = GatttoolBackend
+        
     _LOGGER.debug("MiTempBt is using %s backend.", backend.__name__)
 
     cache = config.get(CONF_CACHE)


### PR DESCRIPTION
This change corrects an issue with bluepy disconnecting from devices after some time. 
Gatttool is currently unaffected by this issue.

No new code added, just rearranged.

## Description:


**Related issue (if applicable):** fixes #24313

## Checklist:
  - [Yes ] The code change is tested and works locally.
  - [Yes ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ Yes] There is no commented out code in this PR.
  - [ Yes] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ Yes] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
