### PR TITLE
Default to gatttoolbackend with bluepybackend backup

### DIFF
--- a/homeassistant/components/miflora/sensor.py
+++ b/homeassistant/components/miflora/sensor.py
@@ -56,14 +56,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     from miflora import miflora_poller
 
     try:
+        from btlewrap import GatttoolBackend
+
+        backend = GatttoolBackend
+
+    except ImportError:
         import bluepy.btle  # noqa: F401 pylint: disable=unused-import
         from btlewrap import BluepyBackend
 
         backend = BluepyBackend
-    except ImportError:
-        from btlewrap import GatttoolBackend
 
-        backend = GatttoolBackend
     _LOGGER.debug("Miflora is using %s backend.", backend.__name__)
 
     cache = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL).total_seconds()


### PR DESCRIPTION
This change corrects an issue with bluepy disconnecting from devices after some time. 
Gatttool is currently unaffected by this issue.

No code change, code has just been rearranged

## Description:

**Related issue (if applicable):** same change has fixed mitemp_bt sensor: #27672

## Checklist:
  - [ No] The code change is tested and works locally.
  - [N/A ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ Yes] There is no commented out code in this PR.
  - [ Yes] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [yes ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
