### PR TITLE
Deprecate Python 3.6 support, 3.8.0 is out

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -93,6 +93,17 @@ async def async_from_config_dict(
     stop = time()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop - start)
 
+    if sys.version_info[:3] < (3, 7, 0):
+        msg = (
+            "Python 3.6 support is deprecated and will "
+            "be removed in the first release after December 15, 2019. Please "
+            "upgrade Python to 3.7.0 or higher."
+        )
+        _LOGGER.warning(msg)
+        hass.components.persistent_notification.async_create(
+            msg, "Python version", "python_version"
+        )
+
     return hass
 
 


### PR DESCRIPTION

## Description:

Per ADR 0002.  https://www.python.org/downloads/release/python-380/

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
