### PR TITLE
Add battery status in owntracks

### DIFF
--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -80,7 +80,7 @@ def _parse_see_args(message, subscribe_topic):
     if "cog" in message:
         kwargs["attributes"]["course"] = message["cog"]
     if "bs" in message:
-        kwargs["attributes"]["battery_status"] = message["bs"]     
+        kwargs["attributes"]["battery_status"] = message["bs"]
     if "t" in message:
         if message["t"] in ("c", "u"):
             kwargs["source_type"] = SOURCE_TYPE_GPS

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -79,6 +79,8 @@ def _parse_see_args(message, subscribe_topic):
         kwargs["attributes"]["address"] = message["addr"]
     if "cog" in message:
         kwargs["attributes"]["course"] = message["cog"]
+    if "bs" in message:
+        kwargs["attributes"]["battery_status"] = message["bs"]     
     if "t" in message:
         if message["t"] in ("c", "u"):
             kwargs["source_type"] = SOURCE_TYPE_GPS


### PR DESCRIPTION
## Description:

Add battery status as attribute from owntracks messages.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
