### PR TITLE
Fix missing strings in soma config flow

### DIFF
--- a/homeassistant/components/soma/.translations/en.json
+++ b/homeassistant/components/soma/.translations/en.json
@@ -8,6 +8,16 @@
         "create_entry": {
             "default": "Successfully authenticated with Soma."
         },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "description": "Please enter connection settings of your SOMA Connect.",
+                "title": "SOMA Connect"
+            }
+        },
         "title": "Soma"
     }
 }

--- a/homeassistant/components/soma/strings.json
+++ b/homeassistant/components/soma/strings.json
@@ -8,6 +8,16 @@
         "create_entry": {
             "default": "Successfully authenticated with Soma."
         },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "description": "Please enter connection settings of your SOMA Connect.",
+                "title": "SOMA Connect"
+            }
+        },
         "title": "Soma"
     }
 }


### PR DESCRIPTION
## Description:

The strings.py file and translations were missing texts for config flow labels.

**Related issue (if applicable):** fixes one part of #27434

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
