### PR TITLE
Add Gardena component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -250,6 +250,7 @@ omit =
     homeassistant/components/frontier_silicon/media_player.py
     homeassistant/components/futurenow/light.py
     homeassistant/components/garadget/cover.py
+    homeassistant/components/gardena/*
     homeassistant/components/gc100/*
     homeassistant/components/geniushub/*
     homeassistant/components/gearbest/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -107,6 +107,7 @@ homeassistant/components/foursquare/* @robbiet480
 homeassistant/components/freebox/* @snoof85
 homeassistant/components/fronius/* @nielstron
 homeassistant/components/frontend/* @home-assistant/frontend
+homeassistant/components/gardena/* @grm
 homeassistant/components/gearbest/* @HerrHofrat
 homeassistant/components/geniushub/* @zxdavb
 homeassistant/components/geo_rss_events/* @exxamalte

--- a/homeassistant/components/gardena/__init__.py
+++ b/homeassistant/components/gardena/__init__.py
@@ -1,0 +1,99 @@
+"""Support for Gardena Smart system devices."""
+import logging
+
+from gardena.smart_system import SmartSystem
+from oauthlib.oauth2.rfc6749.errors import (
+    AccessDeniedError,
+    InvalidClientError,
+    MissingTokenError,
+)
+import voluptuous as vol
+
+from homeassistant.const import CONF_PASSWORD, CONF_EMAIL
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import async_load_platform
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "gardena"
+GARDENA_SYSTEM = "gardena_system"
+GARDENA_LOCATION = "gardena_location"
+GARDENA_CONFIG = "gardena_config"
+CONF_CLIENT_ID = "client_id"
+CONF_LOCATION_ID = "location_id"
+CONF_MOWER_DURATION = "mower_duration"
+CONF_SMART_IRRIGATION_DURATION = "smart_irrigation_control_duration"
+CONF_SMART_WATERING = "smart_watering_duration"
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_EMAIL): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+                vol.Required(CONF_CLIENT_ID): cv.string,
+                vol.Required(CONF_LOCATION_ID): cv.string,
+                vol.Optional(CONF_MOWER_DURATION, default="60"): cv.string,
+                vol.Optional(CONF_SMART_IRRIGATION_DURATION, default="60"): cv.string,
+                vol.Optional(CONF_SMART_WATERING, default="60"): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+ATTR_NAME = "name"
+ATTR_ACTIVITY = "activity"
+ATTR_BATTERY_STATE = "battery_state"
+ATTR_RF_LINK_LEVEL = "rf_link_level"
+ATTR_RF_LINK_STATE = "rf_link_state"
+ATTR_SERIAL = "serial"
+ATTR_OPERATING_HOURS = "operating_hours"
+ATTR_LAST_ERRORS = "last_error"
+
+
+async def async_setup(hass, config):
+    """Set up the Gardena integation."""
+    _LOGGER.debug("Initialising Gardena")
+
+    try:
+        hass.data[GARDENA_SYSTEM] = GardenaSmartSystem(
+            hass, config[DOMAIN], SmartSystem
+        )
+        hass.data[GARDENA_CONFIG] = config[DOMAIN]
+        _LOGGER.debug("Gardena component initialised")
+        for component in ("vacuum", "sensor", "switch"):
+            hass.async_create_task(
+                async_load_platform(hass, component, DOMAIN, {}, config)
+            )
+
+        return True
+    except (AccessDeniedError, InvalidClientError, MissingTokenError) as exception:
+        _LOGGER.error("Gardena component could not be initialised")
+        print(exception)
+        return False
+
+
+class GardenaSmartSystem:
+    """A Gardena Smart System wrapper class."""
+
+    def __init__(self, hass, domain_config, smart_system):
+        """Initialize the Gardena Smart System."""
+        self.config = domain_config
+        self._hass = hass
+
+        self.smart_system = smart_system(
+            domain_config[CONF_EMAIL],
+            domain_config[CONF_PASSWORD],
+            domain_config[CONF_CLIENT_ID],
+        )
+        self.smart_system.authenticate()
+        self.smart_system.update_locations()
+        self.smart_system.update_devices(
+            self.smart_system.locations[domain_config[CONF_LOCATION_ID]]
+        )
+        self._hass.data[GARDENA_LOCATION] = self.smart_system.locations[
+            domain_config[CONF_LOCATION_ID]
+        ]
+        self.smart_system.start_ws(self._hass.data[GARDENA_LOCATION])

--- a/homeassistant/components/gardena/manifest.json
+++ b/homeassistant/components/gardena/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "gardena",
+  "name": "Gardena Smart System",
+  "documentation": "https://www.home-assistant.io/integration/gardena",
+  "dependencies": [],
+  "codeowners": ["@grm"],
+  "requirements": ["py-smart-gardena==0.6.16"]
+}

--- a/homeassistant/components/gardena/sensor.py
+++ b/homeassistant/components/gardena/sensor.py
@@ -1,0 +1,108 @@
+"""Support for Gardena sensors."""
+import logging
+
+from homeassistant.const import (
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_TEMPERATURE,
+    TEMP_CELSIUS,
+)
+from homeassistant.helpers.entity import Entity
+from homeassistant.core import callback
+from homeassistant.const import ATTR_BATTERY_LEVEL
+
+from . import (
+    ATTR_BATTERY_STATE,
+    ATTR_RF_LINK_LEVEL,
+    ATTR_RF_LINK_STATE,
+    ATTR_SERIAL,
+    GARDENA_LOCATION,
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSOR_TYPES = {
+    "ambient_temperature": [TEMP_CELSIUS, "mdi:thermometer", DEVICE_CLASS_TEMPERATURE],
+    "soil_temperature": [TEMP_CELSIUS, "mdi:thermometer", DEVICE_CLASS_TEMPERATURE],
+    "soil_humidity": ["%", "mdi:water-percent", DEVICE_CLASS_HUMIDITY],
+    "light_intensity": ["lx", None, DEVICE_CLASS_ILLUMINANCE],
+}
+
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Perform the setup for Gardena sensor devices."""
+    dev = []
+    for sensor in hass.data[GARDENA_LOCATION].find_device_by_type("SENSOR"):
+        for sensor_type in SENSOR_TYPES:
+            dev.append(GardenaSensor(sensor, sensor_type))
+    _LOGGER.debug("Adding sensor as sensor %s", dev)
+    add_entities(dev, True)
+
+
+class GardenaSensor(Entity):
+    """Representation of a Gardena Sensor."""
+
+    def __init__(self, device, data_key):
+        """Initialize the Gardena Sensor."""
+        self._data_key = data_key
+        self._name = f"Gardena {data_key.replace('_', ' ')} {device.name}"
+        self._unique_id = f"{device.serial}-{device.id}-{data_key}"
+        self._device = device
+
+    async def async_added_to_hass(self):
+        """Subscribe to sensor events."""
+        self._device.add_callback(self.async_update_callback)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed for a sensor."""
+        return False
+
+    @callback
+    def async_update_callback(self, device):
+        """Call update for Home Assistant when the device is updated."""
+        self.schedule_update_ha_state(True)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return SENSOR_TYPES.get(self._data_key)[1]
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return SENSOR_TYPES.get(self._data_key)[0]
+
+    @property
+    def device_class(self):
+        """Return the device class of this entity."""
+        if self._data_key in SENSOR_TYPES:
+            return SENSOR_TYPES.get(self._data_key)[2]
+        return None
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return getattr(self._device, self._data_key)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return {
+            ATTR_BATTERY_LEVEL: self._device.battery_level,
+            ATTR_BATTERY_STATE: self._device.battery_state,
+            ATTR_RF_LINK_LEVEL: self._device.rf_link_level,
+            ATTR_RF_LINK_STATE: self._device.rf_link_state,
+            ATTR_SERIAL: self._device.serial,
+        }

--- a/homeassistant/components/gardena/switch.py
+++ b/homeassistant/components/gardena/switch.py
@@ -1,0 +1,315 @@
+"""Support for Gardena switch (Power control, water control, smart irrigation control)."""
+
+import logging
+
+from homeassistant.core import callback
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.const import ATTR_BATTERY_LEVEL
+
+from . import (
+    GARDENA_LOCATION,
+    GARDENA_CONFIG,
+    CONF_SMART_IRRIGATION_DURATION,
+    CONF_SMART_WATERING,
+    ATTR_LAST_ERRORS,
+    ATTR_ACTIVITY,
+    ATTR_BATTERY_STATE,
+    ATTR_RF_LINK_LEVEL,
+    ATTR_RF_LINK_STATE,
+    ATTR_SERIAL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the switches plateform."""
+    dev = []
+
+    for water_control in hass.data[GARDENA_LOCATION].find_device_by_type(
+        "WATER_CONTROL"
+    ):
+        dev.append(GardenaSmartWaterControl(water_control, hass.data[GARDENA_CONFIG]))
+    for power_switch in hass.data[GARDENA_LOCATION].find_device_by_type("POWER_SOCKET"):
+        dev.append(GardenaPowerSocket(power_switch, hass.data[GARDENA_CONFIG]))
+    for smart_irrigation in hass.data[GARDENA_LOCATION].find_device_by_type(
+        "SMART_IRRIGATION_CONTROL"
+    ):
+        for valve in smart_irrigation.valves.values():
+            dev.append(
+                GardenaSmartIrrigationControl(
+                    smart_irrigation, valve, hass.data[GARDENA_CONFIG]
+                )
+            )
+    _LOGGER.debug(
+        "Adding water control, power socket and smart irrigation control as switch %s",
+        dev,
+    )
+    add_entities(dev, True)
+
+
+class GardenaSmartWaterControl(SwitchDevice):
+    """Representation of a Gardena Smart Water Control."""
+
+    def __init__(self, wc, config):
+        """Initialize the Gardena Smart Water Control."""
+        self._device = wc
+        self._config = config
+        self._name = f"{self._device.name}"
+        self._state = None
+        self._error_message = ""
+
+    async def async_added_to_hass(self):
+        """Subscribe to events."""
+        self._device.add_callback(self.async_update_callback)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed for a water valve."""
+        return False
+
+    @callback
+    def async_update_callback(self, device):
+        """Call update for Home Assistant when the device is updated."""
+        self.schedule_update_ha_state(True)
+
+    async def async_update(self):
+        """Update the states of Gardena devices."""
+        _LOGGER.debug("Running Gardena update")
+        # Managing state
+        state = self._device.valve_state
+        _LOGGER.debug("Water control has state %s", state)
+        if state in ["WARNING", "ERROR", "UNAVAILABLE"]:
+            _LOGGER.debug("Water control has an error")
+            self._state = False
+            self._error_message = self._device.last_error_code
+        else:
+            _LOGGER.debug("Getting water control state")
+            activity = self._device.valve_activity
+            self._error_message = ""
+            _LOGGER.debug("Water control has activity %s", activity)
+            if activity == "CLOSED":
+                self._state = False
+            elif activity in ["MANUAL_WATERING", "SCHEDULED_WATERING"]:
+                self._state = True
+            else:
+                _LOGGER.debug("Water control has none activity")
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if it is on."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return True if the device is available."""
+        return self._device.valve_state != "UNAVAILABLE"
+
+    def error(self):
+        """Return the error message."""
+        return self._error_message
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the water valve."""
+        return {
+            ATTR_ACTIVITY: self._device.valve_activity,
+            ATTR_BATTERY_LEVEL: self._device.battery_level,
+            ATTR_BATTERY_STATE: self._device.battery_state,
+            ATTR_RF_LINK_LEVEL: self._device.rf_link_level,
+            ATTR_RF_LINK_STATE: self._device.rf_link_state,
+            ATTR_SERIAL: self._device.serial,
+            ATTR_LAST_ERRORS: self._error_message,
+        }
+
+    def turn_on(self, **kwargs):
+        """Start watering."""
+        duration = 3600
+        if self._config[CONF_SMART_WATERING]:
+            duration = str(int(self._config[CONF_SMART_WATERING]) * 60)
+        self._device.start_seconds_to_override(duration)
+
+    def turn_off(self, **kwargs):
+        """Stop watering."""
+        self._device.stop_until_next_task()
+
+
+class GardenaPowerSocket(SwitchDevice):
+    """Representation of a Gardena Power Socket."""
+
+    def __init__(self, ps, config):
+        """Initialize the Gardena Power Socket."""
+        self._device = ps
+        self._config = config
+        self._name = f"{self._device.name}"
+        self._state = None
+        self._error_message = ""
+
+    async def async_added_to_hass(self):
+        """Subscribe to events."""
+        self._device.add_callback(self.async_update_callback)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed for a power socket."""
+        return False
+
+    @callback
+    def async_update_callback(self, device):
+        """Call update for Home Assistant when the device is updated."""
+        self.schedule_update_ha_state(True)
+
+    async def async_update(self):
+        """Update the states of Gardena devices."""
+        _LOGGER.debug("Running Gardena update")
+        # Managing state
+        state = self._device.state
+        _LOGGER.debug("Power socket has state %s", state)
+        if state in ["WARNING", "ERROR", "UNAVAILABLE"]:
+            _LOGGER.debug("Power socket has an error")
+            self._state = False
+            self._error_message = self._device.last_error_code
+        else:
+            _LOGGER.debug("Getting Power socket state")
+            activity = self._device.activity
+            self._error_message = ""
+            _LOGGER.debug("Power socket has activity %s", activity)
+            if activity == "OFF":
+                self._state = False
+            elif activity in ["FOREVER_ON", "TIME_LIMITED_ON", "SCHEDULED_ON"]:
+                self._state = True
+            else:
+                _LOGGER.debug("Power socket has none activity")
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if it is on."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return True if the device is available."""
+        return self._device.state != "UNAVAILABLE"
+
+    def error(self):
+        """Return the error message."""
+        return self._error_message
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the power switch."""
+        return {
+            ATTR_ACTIVITY: self._device.activity,
+            ATTR_RF_LINK_LEVEL: self._device.rf_link_level,
+            ATTR_RF_LINK_STATE: self._device.rf_link_state,
+            ATTR_SERIAL: self._device.serial,
+            ATTR_LAST_ERRORS: self._error_message,
+        }
+
+    def turn_on(self, **kwargs):
+        """Start watering."""
+        self._device.start_override()
+
+    def turn_off(self, **kwargs):
+        """Stop watering."""
+        self._device.stop_until_next_task()
+
+
+class GardenaSmartIrrigationControl(SwitchDevice):
+    """Representation of a Gardena Smart Irrigation Control."""
+
+    def __init__(self, sic, valve, config):
+        """Initialize the Gardena Smart Irrigation Control."""
+        self._device = valve
+        self._sic = sic
+        self._config = config
+        self._name = f'{self._sic.name} - {self._device["name"]}'
+        self._state = None
+        self._error_message = ""
+
+    async def async_added_to_hass(self):
+        """Subscribe to events."""
+        self._sic.add_callback(self.async_update_callback)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed for a smart irrigation control."""
+        return False
+
+    @callback
+    def async_update_callback(self, device):
+        """Call update for Home Assistant when the device is updated."""
+        self.schedule_update_ha_state(True)
+
+    async def async_update(self):
+        """Update the states of Gardena devices."""
+        _LOGGER.debug("Running Gardena update")
+        # Managing state
+        state = self._device["state"]
+        _LOGGER.debug("Valve has state %s", state)
+        if state in ["WARNING", "ERROR", "UNAVAILABLE"]:
+            _LOGGER.debug("Valve has an error")
+            self._state = False
+            self._error_message = self._device["last_error_code"]
+        else:
+            _LOGGER.debug("Getting Valve state")
+            activity = self._device["activity"]
+            self._error_message = ""
+            _LOGGER.debug("Valve has activity %s", activity)
+            if activity == "OFF":
+                self._state = False
+            elif activity in ["FOREVER_ON", "TIME_LIMITED_ON", "SCHEDULED_ON"]:
+                self._state = True
+            else:
+                _LOGGER.debug("Valve has none activity")
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if it is on."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return True if the device is available."""
+        return self._device["state"] != "UNAVAILABLE"
+
+    def error(self):
+        """Return the error message."""
+        return self._error_message
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the smart irrigation control."""
+        return {
+            ATTR_ACTIVITY: self._device["activity"],
+            ATTR_RF_LINK_LEVEL: self._sic.rf_link_level,
+            ATTR_RF_LINK_STATE: self._sic.rf_link_state,
+            ATTR_SERIAL: self._sic.serial,
+            ATTR_LAST_ERRORS: self._error_message,
+        }
+
+    def turn_on(self, **kwargs):
+        """Start watering."""
+        duration = 3600
+        if self._config[CONF_SMART_IRRIGATION_DURATION]:
+            duration = str(int(self._config[CONF_SMART_IRRIGATION_DURATION]) * 60)
+        self._device.start_seconds_to_override(duration, self._device["id"])
+
+    def turn_off(self, **kwargs):
+        """Stop watering."""
+        self._device.stop_until_next_task(self._device["id"])

--- a/homeassistant/components/gardena/vacuum.py
+++ b/homeassistant/components/gardena/vacuum.py
@@ -1,0 +1,178 @@
+"""Support for Gardena mower."""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.core import callback
+from homeassistant.components.vacuum import (
+    StateVacuumDevice,
+    SUPPORT_BATTERY,
+    SUPPORT_RETURN_HOME,
+    SUPPORT_STATE,
+    SUPPORT_STOP,
+    SUPPORT_START,
+    STATE_PAUSED,
+    STATE_CLEANING,
+    STATE_DOCKED,
+    STATE_RETURNING,
+    STATE_ERROR,
+    ATTR_BATTERY_LEVEL,
+)
+
+from . import (
+    GARDENA_LOCATION,
+    GARDENA_CONFIG,
+    CONF_MOWER_DURATION,
+    ATTR_NAME,
+    ATTR_ACTIVITY,
+    ATTR_BATTERY_STATE,
+    ATTR_RF_LINK_LEVEL,
+    ATTR_RF_LINK_STATE,
+    ATTR_SERIAL,
+    ATTR_OPERATING_HOURS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(minutes=1)
+
+SUPPORT_GARDENA = (
+    SUPPORT_BATTERY | SUPPORT_RETURN_HOME | SUPPORT_STOP | SUPPORT_START | SUPPORT_STATE
+)
+
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Gardena smart mower system."""
+    dev = []
+
+    for mower in hass.data[GARDENA_LOCATION].find_device_by_type("MOWER"):
+        dev.append(GardenaSmartMower(hass, mower, hass.data[GARDENA_CONFIG]))
+    _LOGGER.debug("Adding mower as vacuums %s", dev)
+    add_entities(dev, True)
+
+
+class GardenaSmartMower(StateVacuumDevice):
+    """Representation of a Gardena Connected Mower."""
+
+    def __init__(self, hass, mower, config):
+        """Initialize the Gardena Connected Mower."""
+        self._device = mower
+        self._config = config
+        self._name = "{}".format(self._device.name)
+        self._state = None
+        self._error_message = ""
+
+    async def async_added_to_hass(self):
+        """Subscribe to events."""
+        self._device.add_callback(self.async_update_callback)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed for a vacuum."""
+        return False
+
+    @callback
+    def async_update_callback(self, device):
+        """Call update for Home Assistant when the device is updated."""
+        self.schedule_update_ha_state(True)
+
+    async def async_update(self):
+        """Update the states of Gardena devices."""
+        _LOGGER.debug("Running Gardena update")
+        # Managing state
+        state = self._device.state
+        _LOGGER.debug("Mower has state %s", state)
+        if state in ["WARNING", "ERROR", "UNAVAILABLE"]:
+            _LOGGER.debug("Mower has an error")
+            self._state = STATE_ERROR
+            self._error_message = self._device.last_error_code
+        else:
+            _LOGGER.debug("Getting mower state")
+            activity = self._device.activity
+            _LOGGER.debug("Mower has activity %s", activity)
+            if activity == "PAUSED":
+                self._state = STATE_PAUSED
+            elif activity in [
+                "OK_CUTTING",
+                "OK_CUTTING_TIMER_OVERRIDDEN",
+                "OK_LEAVING",
+            ]:
+                self._state = STATE_CLEANING
+            elif activity == "OK_SEARCHING":
+                self._state = STATE_RETURNING
+            elif activity in [
+                "OK_CHARGING",
+                "PARKED_TIMER",
+                "PARKED_PARK_SELECTED",
+                "PARKED_AUTOTIMER",
+            ]:
+                self._state = STATE_DOCKED
+            elif activity == "NONE":
+                self._state = None
+                _LOGGER.debug("Mower has no activity")
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._device.name
+
+    @property
+    def supported_features(self):
+        """Flag lawn mower robot features that are supported."""
+        return SUPPORT_GARDENA
+
+    @property
+    def battery_level(self):
+        """Return the battery level of the lawn mower."""
+        return self._device.battery_level
+
+    @property
+    def state(self):
+        """Return the status of the lawn mower."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return True if the device is available."""
+        return self._device.state != "UNAVAILABLE"
+
+    def error(self):
+        """Return the error message."""
+        if self._state == STATE_ERROR:
+            return self._error_message
+        return ""
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the lawn mower."""
+        return {
+            ATTR_NAME: self._name,
+            ATTR_ACTIVITY: self._device.activity,
+            ATTR_BATTERY_LEVEL: self._device.battery_level,
+            ATTR_BATTERY_STATE: self._device.battery_state,
+            ATTR_RF_LINK_LEVEL: self._device.rf_link_level,
+            ATTR_RF_LINK_STATE: self._device.rf_link_state,
+            ATTR_SERIAL: self._device.serial,
+            ATTR_OPERATING_HOURS: self._device.operating_hours,
+        }
+
+    def start(self):
+        """Start the mower."""
+        self.turn_on()
+
+    def turn_on(self):
+        """Start cleaning or resume mowing."""
+        duration = str(int(self._config[CONF_MOWER_DURATION]) * 60)
+        self._device.start_seconds_to_override(duration)
+
+    def turn_off(self):
+        """Stop mowing."""
+        self._device.park_until_next_task()
+
+    def return_to_base(self, **kwargs):
+        """Set the lawn mower to return to the dock."""
+        self.turn_off()
+
+    def stop(self, **kwargs):
+        """Stop the lawn mower."""
+        self.turn_off()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1049,6 +1049,9 @@ py-cpuinfo==5.0.0
 # homeassistant.components.melissa
 py-melissa-climate==2.0.0
 
+# homeassistant.components.gardena
+py-smart-gardena==0.6.16
+
 # homeassistant.components.synology
 py-synology==0.2.0
 


### PR DESCRIPTION
## Description:

Add the support for the gardena component.
For now the plugin only manages :
* Smart mower as vacuum
* Power switch
* Water control
* Smart irrigation control
* Smart sensor

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10793

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
gardena:
  email: your_email@provider.com
  password: your_secret_gardena_password
  client_id: your_client_id_from_the_gardena_site
  location_id: your_location_id
  default_mower_duration_in_minutes: 300
  default_smart_irrigation_control_duration_in_minutes: 60
  default_smart_watering_duration_in_minutes: 60
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
