### PR TITLE
update fritzconnection requirement to 0.8.4

### DIFF
--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -3,7 +3,7 @@
   "name": "Fritz",
   "documentation": "https://www.home-assistant.io/integrations/fritz",
   "requirements": [
-    "fritzconnection==0.6.5"
+    "fritzconnection==0.8.4"
   ],
   "dependencies": [],
   "codeowners": []


### PR DESCRIPTION
## Breaking Change:
Update of requirements

## Description:
Using different fritzbox components together leads to problems regarding the version of fritzconnection installed in homeassistant. We encountered this problem, when using our custom component:
https://github.com/mammuth/ha-fritzbox-tools/issues/19

See also #27699 and #27698   

**Related issue (if applicable):

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):

## Example entry for `configuration.yaml` (if applicable):

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. (not tested yet)
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
