### PR TITLE
Fix Soma integration connection issue

### DIFF
--- a/homeassistant/components/soma/.translations/en.json
+++ b/homeassistant/components/soma/.translations/en.json
@@ -3,7 +3,9 @@
         "abort": {
             "already_setup": "You can only configure one Soma account.",
             "authorize_url_timeout": "Timeout generating authorize url.",
-            "missing_configuration": "The Soma component is not configured. Please follow the documentation."
+            "missing_configuration": "The Soma component is not configured. Please follow the documentation.",
+            "result_error": "SOMA Connect responded with error status.",
+            "connection_error": "Failed to connect to SOMA Connect."
         },
         "create_entry": {
             "default": "Successfully authenticated with Soma."

--- a/homeassistant/components/soma/config_flow.py
+++ b/homeassistant/components/soma/config_flow.py
@@ -48,7 +48,7 @@ class SomaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     data={"host": user_input["host"], "port": user_input["port"]},
                 )
             _LOGGER.error(
-                "Connection to SOMA Connect failed (result:%s)" % (result["result"])
+                "Connection to SOMA Connect failed (result:%s)", result["result"]
             )
             return self.async_abort(reason="result_error")
         except RequestException:

--- a/homeassistant/components/soma/config_flow.py
+++ b/homeassistant/components/soma/config_flow.py
@@ -47,13 +47,15 @@ class SomaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     title="Soma Connect",
                     data={"host": user_input["host"], "port": user_input["port"]},
                 )
-            else:
-                _LOGGER.error(
-                    "Connection to SOMA Connect failed (result:%s)" % (result["result"])
-                )
-                return self.async_abort(reason="result_error")
+            _LOGGER.error(
+                "Connection to SOMA Connect failed (result:%s)" % (result["result"])
+            )
+            return self.async_abort(reason="result_error")
         except RequestException:
-            _LOGGER.error("Connection to SOMA Connect failed")
+            _LOGGER.error("Connection to SOMA Connect failed with RequestException")
+            return self.async_abort(reason="connection_error")
+        except KeyError:
+            _LOGGER.error("Connection to SOMA Connect failed with KeyError")
             return self.async_abort(reason="connection_error")
 
     async def async_step_import(self, user_input=None):

--- a/homeassistant/components/soma/config_flow.py
+++ b/homeassistant/components/soma/config_flow.py
@@ -40,12 +40,18 @@ class SomaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Finish config flow."""
         api = SomaApi(user_input["host"], user_input["port"])
         try:
-            await self.hass.async_add_executor_job(api.list_devices)
+            result = await self.hass.async_add_executor_job(api.list_devices)
             _LOGGER.info("Successfully set up Soma Connect")
-            return self.async_create_entry(
-                title="Soma Connect",
-                data={"host": user_input["host"], "port": user_input["port"]},
-            )
+            if result["result"] == "success":
+                return self.async_create_entry(
+                    title="Soma Connect",
+                    data={"host": user_input["host"], "port": user_input["port"]},
+                )
+            else:
+                _LOGGER.error(
+                    "Connection to SOMA Connect failed (result:%s)" % (result["result"])
+                )
+                return self.async_abort(reason="result_error")
         except RequestException:
             _LOGGER.error("Connection to SOMA Connect failed")
             return self.async_abort(reason="connection_error")

--- a/homeassistant/components/soma/strings.json
+++ b/homeassistant/components/soma/strings.json
@@ -3,7 +3,9 @@
         "abort": {
             "already_setup": "You can only configure one Soma account.",
             "authorize_url_timeout": "Timeout generating authorize url.",
-            "missing_configuration": "The Soma component is not configured. Please follow the documentation."
+            "missing_configuration": "The Soma component is not configured. Please follow the documentation.",
+            "result_error": "SOMA Connect responded with error status.",
+            "connection_error": "Failed to connect to SOMA Connect."
         },
         "create_entry": {
             "default": "Successfully authenticated with Soma."

--- a/tests/components/soma/test_config_flow.py
+++ b/tests/components/soma/test_config_flow.py
@@ -35,9 +35,19 @@ async def test_import_create(hass):
     """Test configuration from YAML."""
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
-    with patch.object(SomaApi, "list_devices", return_value={}):
+    with patch.object(SomaApi, "list_devices", return_value={"result": "success"}):
         result = await flow.async_step_import({"host": MOCK_HOST, "port": MOCK_PORT})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_error_status(hass):
+    """Test Connect successfully returning error status."""
+    flow = config_flow.SomaFlowHandler()
+    flow.hass = hass
+    with patch.object(SomaApi, "list_devices", return_value={"result": "error"}):
+        result = await flow.async_step_import({"host": MOCK_HOST, "port": MOCK_PORT})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "result_error"
 
 
 async def test_exception(hass):
@@ -55,6 +65,6 @@ async def test_full_flow(hass):
     hass.data[DOMAIN] = {}
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
-    with patch.object(SomaApi, "list_devices", return_value={}):
+    with patch.object(SomaApi, "list_devices", return_value={"result": "success"}):
         result = await flow.async_step_user({"host": MOCK_HOST, "port": MOCK_PORT})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/soma/test_config_flow.py
+++ b/tests/components/soma/test_config_flow.py
@@ -50,6 +50,16 @@ async def test_error_status(hass):
     assert result["reason"] == "result_error"
 
 
+async def test_key_error(hass):
+    """Test Connect returning empty string."""
+    flow = config_flow.SomaFlowHandler()
+    flow.hass = hass
+    with patch.object(SomaApi, "list_devices", return_value={}):
+        result = await flow.async_step_import({"host": MOCK_HOST, "port": MOCK_PORT})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "connection_error"
+
+
 async def test_exception(hass):
     """Test if RequestException fires when no connection can be made."""
     flow = config_flow.SomaFlowHandler()


### PR DESCRIPTION
## Description:
Config flow used to return a success status if the connection event didn't cause an exception. I changed it so that it would actually try to parse the returned string and only return success if the response contains a well formed success message.

**Related issue:**  #27434

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
