### PR TITLE
Add improved scene support for input_select

### DIFF
--- a/homeassistant/components/input_select/reproduce_state.py
+++ b/homeassistant/components/input_select/reproduce_state.py
@@ -1,13 +1,22 @@
-"""Reproduce an Input selec state."""
+"""Reproduce an Input select state."""
 import asyncio
 import logging
+from types import MappingProxyType
 from typing import Iterable, Optional
 
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN, SERVICE_SELECT_OPTION, ATTR_OPTION
+from . import (
+    DOMAIN,
+    SERVICE_SELECT_OPTION,
+    SERVICE_SET_OPTIONS,
+    ATTR_OPTION,
+    ATTR_OPTIONS,
+)
+
+ATTR_GROUP = [ATTR_OPTION, ATTR_OPTIONS]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,12 +33,30 @@ async def _async_reproduce_state(
         return
 
     # Return if we are already at the right state.
-    if cur_state.state == state.state:
+    if cur_state.state == state.state and all(
+        check_attr_equal(cur_state.attributes, state.attributes, attr)
+        for attr in ATTR_GROUP
+    ):
         return
 
-    # Call service
+    # Set service data
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    # If options are specified, call SERVICE_SET_OPTIONS
+    if ATTR_OPTIONS in state.attributes:
+        service = SERVICE_SET_OPTIONS
+        service_data[ATTR_OPTIONS] = state.attributes[ATTR_OPTIONS]
+
+        await hass.services.async_call(
+            DOMAIN, service, service_data, context=context, blocking=True
+        )
+
+        # Remove ATTR_OPTIONS from service_data so we can reuse service_data in next call
+        del service_data[ATTR_OPTIONS]
+
+    # Call SERVICE_SELECT_OPTION
     service = SERVICE_SELECT_OPTION
-    service_data = {ATTR_ENTITY_ID: state.entity_id, ATTR_OPTION: state.state}
+    service_data[ATTR_OPTION] = state.state
 
     await hass.services.async_call(
         DOMAIN, service, service_data, context=context, blocking=True
@@ -39,8 +66,15 @@ async def _async_reproduce_state(
 async def async_reproduce_states(
     hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
 ) -> None:
-    """Reproduce Input selec states."""
+    """Reproduce Input select states."""
     # Reproduce states in parallel.
     await asyncio.gather(
         *(_async_reproduce_state(hass, state, context) for state in states)
     )
+
+
+def check_attr_equal(
+    attr1: MappingProxyType, attr2: MappingProxyType, attr_str: str
+) -> bool:
+    """Return true if the given attributes are equal."""
+    return attr1.get(attr_str) == attr2.get(attr_str)

--- a/homeassistant/components/input_select/reproduce_state.py
+++ b/homeassistant/components/input_select/reproduce_state.py
@@ -1,0 +1,44 @@
+"""Reproduce an Input selec state."""
+import asyncio
+import logging
+from typing import Iterable, Optional
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import Context, State
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import DOMAIN, SERVICE_SELECT_OPTION, ATTR_OPTION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistantType, state: State, context: Optional[Context] = None
+) -> None:
+    """Reproduce a single state."""
+    cur_state = hass.states.get(state.entity_id)
+
+    if cur_state is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    # Return if we are already at the right state.
+    if cur_state.state == state.state:
+        return
+
+    service = SERVICE_SELECT_OPTION
+    service_data = {ATTR_ENTITY_ID: state.entity_id, ATTR_OPTION: state.state}
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
+) -> None:
+    """Reproduce Input selec states."""
+    # Reproduce states in parallel.
+    await asyncio.gather(
+        *(_async_reproduce_state(hass, state, context) for state in states)
+    )

--- a/homeassistant/components/input_select/reproduce_state.py
+++ b/homeassistant/components/input_select/reproduce_state.py
@@ -18,6 +18,7 @@ async def _async_reproduce_state(
     """Reproduce a single state."""
     cur_state = hass.states.get(state.entity_id)
 
+    # Return if we can't find entity
     if cur_state is None:
         _LOGGER.warning("Unable to find entity %s", state.entity_id)
         return
@@ -26,6 +27,7 @@ async def _async_reproduce_state(
     if cur_state.state == state.state:
         return
 
+    # Call service
     service = SERVICE_SELECT_OPTION
     service_data = {ATTR_ENTITY_ID: state.entity_id, ATTR_OPTION: state.state}
 

--- a/tests/components/input_select/test_reproduce_state.py
+++ b/tests/components/input_select/test_reproduce_state.py
@@ -12,6 +12,7 @@ OPTIONS = [VALID_OPTION1, VALID_OPTION2, VALID_OPTION3]
 async def test_reproducing_states(hass, caplog):
     """Test reproducing Input select states."""
 
+    # Setup entity
     assert await async_setup_component(
         hass,
         "input_select",
@@ -32,9 +33,10 @@ async def test_reproducing_states(hass, caplog):
         blocking=True,
     )
 
+    # Test that entity is in desired state
     assert hass.states.get("input_select.test_select").state == VALID_OPTION1
 
-    # Test reproducing with different state
+    # Try reproducing with different state
     await hass.helpers.state.async_reproduce_state(
         [
             State("input_select.test_select", VALID_OPTION3),
@@ -44,6 +46,7 @@ async def test_reproducing_states(hass, caplog):
         blocking=True,
     )
 
+    # Test that we got the desired result
     assert hass.states.get("input_select.test_select").state == VALID_OPTION3
 
     # Test setting state to invalid state

--- a/tests/components/input_select/test_reproduce_state.py
+++ b/tests/components/input_select/test_reproduce_state.py
@@ -1,12 +1,18 @@
 """Test reproduce state for Input select."""
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
+from tests.common import async_mock_service
 
 VALID_OPTION1 = "Option A"
 VALID_OPTION2 = "Option B"
-VALID_OPTION3 = "Option X"
-INVALID_OPTION = "Option Y"
-OPTIONS = [VALID_OPTION1, VALID_OPTION2, VALID_OPTION3]
+VALID_OPTION3 = "Option C"
+VALID_OPTION4 = "Option D"
+VALID_OPTION5 = "Option E"
+VALID_OPTION6 = "Option F"
+INVALID_OPTION = "Option X"
+VALID_OPTION_SET1 = [VALID_OPTION1, VALID_OPTION2, VALID_OPTION3]
+VALID_OPTION_SET2 = [VALID_OPTION4, VALID_OPTION5, VALID_OPTION6]
+ENTITY = "input_select.test_select"
 
 
 async def test_reproducing_states(hass, caplog):
@@ -18,7 +24,7 @@ async def test_reproducing_states(hass, caplog):
         "input_select",
         {
             "input_select": {
-                "test_select": {"options": OPTIONS, "initial": VALID_OPTION1}
+                "test_select": {"options": VALID_OPTION_SET1, "initial": VALID_OPTION1}
             }
         },
     )
@@ -26,7 +32,7 @@ async def test_reproducing_states(hass, caplog):
     # These calls should do nothing as entities already in desired state
     await hass.helpers.state.async_reproduce_state(
         [
-            State("input_select.test_select", VALID_OPTION1),
+            State(ENTITY, VALID_OPTION1),
             # Should not raise
             State("input_select.non_existing", VALID_OPTION1),
         ],
@@ -34,12 +40,12 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # Test that entity is in desired state
-    assert hass.states.get("input_select.test_select").state == VALID_OPTION1
+    assert hass.states.get(ENTITY).state == VALID_OPTION1
 
     # Try reproducing with different state
     await hass.helpers.state.async_reproduce_state(
         [
-            State("input_select.test_select", VALID_OPTION3),
+            State(ENTITY, VALID_OPTION3),
             # Should not raise
             State("input_select.non_existing", VALID_OPTION3),
         ],
@@ -47,12 +53,27 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # Test that we got the desired result
-    assert hass.states.get("input_select.test_select").state == VALID_OPTION3
+    assert hass.states.get(ENTITY).state == VALID_OPTION3
 
     # Test setting state to invalid state
     await hass.helpers.state.async_reproduce_state(
-        [State("input_select.test_select", INVALID_OPTION)], blocking=True
+        [State(ENTITY, INVALID_OPTION)], blocking=True
     )
 
     # The entity state should be unchanged
-    assert hass.states.get("input_select.test_select").state == VALID_OPTION3
+    assert hass.states.get(ENTITY).state == VALID_OPTION3
+
+    # Test setting a different set of options
+    set_options_calls = async_mock_service(hass, "input_select", "set_options")
+    select_option_calls = async_mock_service(hass, "input_select", "select_option")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(ENTITY, VALID_OPTION5, {"options": VALID_OPTION_SET2})], blocking=True
+    )
+
+    # Test that both set_options and select_option were called
+    assert len(select_option_calls) == 1
+    assert select_option_calls[0].data == {"entity_id": ENTITY, "option": VALID_OPTION5}
+
+    assert len(set_options_calls) == 1
+    assert set_options_calls[0].data == {"entity_id": ENTITY, "option": VALID_OPTION5}

--- a/tests/components/input_select/test_reproduce_state.py
+++ b/tests/components/input_select/test_reproduce_state.py
@@ -1,0 +1,55 @@
+"""Test reproduce state for Input select."""
+from homeassistant.core import State
+from homeassistant.setup import async_setup_component
+
+VALID_OPTION1 = "Option A"
+VALID_OPTION2 = "Option B"
+VALID_OPTION3 = "Option X"
+INVALID_OPTION = "Option Y"
+OPTIONS = [VALID_OPTION1, VALID_OPTION2, VALID_OPTION3]
+
+
+async def test_reproducing_states(hass, caplog):
+    """Test reproducing Input select states."""
+
+    assert await async_setup_component(
+        hass,
+        "input_select",
+        {
+            "input_select": {
+                "test_select": {"options": OPTIONS, "initial": VALID_OPTION1}
+            }
+        },
+    )
+
+    # These calls should do nothing as entities already in desired state
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("input_select.test_select", VALID_OPTION1),
+            # Should not raise
+            State("input_select.non_existing", VALID_OPTION1),
+        ],
+        blocking=True,
+    )
+
+    assert hass.states.get("input_select.test_select").state == VALID_OPTION1
+
+    # Test reproducing with different state
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("input_select.test_select", VALID_OPTION3),
+            # Should not raise
+            State("input_select.non_existing", VALID_OPTION3),
+        ],
+        blocking=True,
+    )
+
+    assert hass.states.get("input_select.test_select").state == VALID_OPTION3
+
+    # Test setting state to invalid state
+    await hass.helpers.state.async_reproduce_state(
+        [State("input_select.test_select", INVALID_OPTION)], blocking=True
+    )
+
+    # The entity state should be unchanged
+    assert hass.states.get("input_select.test_select").state == VALID_OPTION3

--- a/tests/components/input_select/test_reproduce_state.py
+++ b/tests/components/input_select/test_reproduce_state.py
@@ -1,7 +1,6 @@
 """Test reproduce state for Input select."""
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
-from tests.common import async_mock_service
 
 VALID_OPTION1 = "Option A"
 VALID_OPTION2 = "Option B"
@@ -63,17 +62,11 @@ async def test_reproducing_states(hass, caplog):
     # The entity state should be unchanged
     assert hass.states.get(ENTITY).state == VALID_OPTION3
 
-    # Test setting a different set of options
-    set_options_calls = async_mock_service(hass, "input_select", "set_options")
-    select_option_calls = async_mock_service(hass, "input_select", "select_option")
-
+    # Test setting a different option set
     await hass.helpers.state.async_reproduce_state(
         [State(ENTITY, VALID_OPTION5, {"options": VALID_OPTION_SET2})], blocking=True
     )
 
-    # Test that both set_options and select_option were called
-    assert len(select_option_calls) == 1
-    assert select_option_calls[0].data == {"entity_id": ENTITY, "option": VALID_OPTION5}
-
-    assert len(set_options_calls) == 1
-    assert set_options_calls[0].data == {"entity_id": ENTITY, "option": VALID_OPTION5}
+    # These should fail if options weren't changed to VALID_OPTION_SET2
+    assert hass.states.get(ENTITY).attributes == {"options": VALID_OPTION_SET2}
+    assert hass.states.get(ENTITY).state == VALID_OPTION5


### PR DESCRIPTION
## Description:
Adds improved scene support for input_select. Both `select_option` and `set_options` are supported. This PR is a little more complex than my previous ones, so all feedback is appreciated.

**Related issue (if applicable):** fixes #26970

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10795

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.