### PR TITLE
Add device trigger for vacuum

### DIFF
--- a/homeassistant/components/vacuum/device_trigger.py
+++ b/homeassistant/components/vacuum/device_trigger.py
@@ -8,9 +8,11 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_DEVICE_ID,
     CONF_ENTITY_ID,
-    STATE_ON,
-    STATE_OFF,
+    STATE_PAUSED,
 )
+
+from homeassistant.components.vacuum import STATE_CLEANING
+
 from homeassistant.core import HomeAssistant, CALLBACK_TYPE
 from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.helpers.typing import ConfigType
@@ -19,7 +21,7 @@ from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from . import DOMAIN
 
 # TODO specify your supported trigger types.
-TRIGGER_TYPES = {"turned_on", "turned_off"}
+TRIGGER_TYPES = {"cleaning", "docked", "paused", "idle", "returning", "error"}
 
 TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
@@ -34,13 +36,6 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
     registry = await entity_registry.async_get_registry(hass)
     triggers = []
 
-    # TODO Read this comment and remove it.
-    # This example shows how to iterate over the entities of this device
-    # that match this integration. If your triggers instead rely on
-    # events fired by devices without entities, do something like:
-    # zha_device = await _async_get_zha_device(hass, device_id)
-    # return zha_device.device_triggers
-
     # Get all the integrations entities for this device
     for entry in entity_registry.async_entries_for_device(registry, device_id):
         if entry.domain != DOMAIN:
@@ -48,25 +43,16 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
 
         # Add triggers for each entity that belongs to this integration
         # TODO add your own triggers.
-        triggers.append(
-            {
-                CONF_PLATFORM: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "turned_on",
-            }
-        )
-        triggers.append(
-            {
-                CONF_PLATFORM: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "turned_off",
-            }
-        )
-
+        for trigger in TRIGGER_TYPES:
+            triggers.append(
+                {
+                    CONF_PLATFORM: "device",
+                    CONF_DEVICE_ID: device_id,
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_ENTITY_ID: entry.entity_id,
+                    CONF_TYPE: trigger,
+                }
+            )
     return triggers
 
 
@@ -79,16 +65,9 @@ async def async_attach_trigger(
     """Attach a trigger."""
     config = TRIGGER_SCHEMA(config)
 
-    # TODO Implement your own logic to attach triggers.
-    # Generally we suggest to re-use the existing state or event
-    # triggers from the automation integration.
-
-    if config[CONF_TYPE] == "turned_on":
-        from_state = STATE_OFF
-        to_state = STATE_ON
-    else:
-        from_state = STATE_ON
-        to_state = STATE_OFF
+    if config[CONF_TYPE] == "cleaning":
+        from_state = STATE_PAUSED
+        to_state = STATE_CLEANING
 
     state_config = {
         state.CONF_PLATFORM: "state",

--- a/homeassistant/components/vacuum/device_trigger.py
+++ b/homeassistant/components/vacuum/device_trigger.py
@@ -1,0 +1,102 @@
+"""Provides device automations for Vacuum."""
+from typing import List
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_DOMAIN,
+    CONF_TYPE,
+    CONF_PLATFORM,
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+    STATE_ON,
+    STATE_OFF,
+)
+from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.components.automation import state, AutomationActionType
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from . import DOMAIN
+
+# TODO specify your supported trigger types.
+TRIGGER_TYPES = {"turned_on", "turned_off"}
+
+TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device triggers for Vacuum devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    triggers = []
+
+    # TODO Read this comment and remove it.
+    # This example shows how to iterate over the entities of this device
+    # that match this integration. If your triggers instead rely on
+    # events fired by devices without entities, do something like:
+    # zha_device = await _async_get_zha_device(hass, device_id)
+    # return zha_device.device_triggers
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        # Add triggers for each entity that belongs to this integration
+        # TODO add your own triggers.
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "turned_on",
+            }
+        )
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "turned_off",
+            }
+        )
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+
+    # TODO Implement your own logic to attach triggers.
+    # Generally we suggest to re-use the existing state or event
+    # triggers from the automation integration.
+
+    if config[CONF_TYPE] == "turned_on":
+        from_state = STATE_OFF
+        to_state = STATE_ON
+    else:
+        from_state = STATE_ON
+        to_state = STATE_OFF
+
+    state_config = {
+        state.CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        state.CONF_FROM: from_state,
+        state.CONF_TO: to_state,
+    }
+    state_config = state.TRIGGER_SCHEMA(state_config)
+    return await state.async_attach_trigger(
+        hass, state_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -1,0 +1,8 @@
+{
+  "device_automation": {
+    "trigger_type": {
+      "turned_on": "{entity_name} turned on",
+      "turned_off": "{entity_name} turned off"
+    }
+  }
+}

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -1,0 +1,132 @@
+"""The tests for Vacuum device triggers."""
+import pytest
+
+from homeassistant.components.vacuum import DOMAIN
+from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock serivce."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_triggers(hass, device_reg, entity_reg):
+    """Test we get the expected triggers from a vacuum."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "turned_off",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "turned_on",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+    ]
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_if_fires_on_state_change(hass, calls):
+    """Test for turn_on and turn_off triggers firing."""
+    hass.states.async_set("vacuum.entity", STATE_OFF)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "vacuum.entity",
+                        "type": "turned_on",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "turn_on - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "vacuum.entity",
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "turn_off - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is turning on.
+    hass.states.async_set("vacuum.entity", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "turn_on - device - {} - off - on - None".format(
+        "vacuum.entity"
+    )
+
+    # Fake that the entity is turning off.
+    hass.states.async_set("vacuum.entity", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "turn_off - device - {} - on - off - None".format(
+        "vacuum.entity"
+    )


### PR DESCRIPTION
## Description:
Added the device trigger for vacuum per directions in #27022

**Related issue (if applicable):** fixes #27022

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
