### PR TITLE
Move imports in spotify component

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -3,11 +3,14 @@ from datetime import timedelta
 import logging
 import random
 
+import spotipy
+import spotipy.oauth2
 import voluptuous as vol
 
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
+    ATTR_MEDIA_CONTENT_ID,
     MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_PLAYLIST,
     SUPPORT_NEXT_TRACK,
@@ -18,7 +21,6 @@ from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
     SUPPORT_SHUFFLE_SET,
     SUPPORT_VOLUME_SET,
-    ATTR_MEDIA_CONTENT_ID,
 )
 from homeassistant.const import CONF_NAME, STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import callback
@@ -97,7 +99,6 @@ def request_configuration(hass, config, add_entities, oauth):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Spotify platform."""
-    import spotipy.oauth2
 
     callback_url = f"{hass.config.api.base_url}{AUTH_CALLBACK_PATH}"
     cache = config.get(CONF_CACHE_PATH, hass.config.path(DEFAULT_CACHE_PATH))
@@ -181,7 +182,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
 
     def refresh_spotify_instance(self):
         """Fetch a new spotify instance."""
-        import spotipy
 
         token_refreshed = False
         need_token = self._token_info is None or self._oauth.is_token_expired(


### PR DESCRIPTION
## Breaking Change:
None

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved import to top-level as requested in #27284

Note: imports sorted using [isort](https://pypi.org/project/isort/)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
