### PR TITLE
Allow Unifi device tracker report its position to decide zone of person.

### DIFF
--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -43,7 +43,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
         if (
             from_s
             and not location.has_location(from_s)
-            or not location.has_location(to_s)
+            and not location.has_location(to_s)
         ):
             return
 

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -121,9 +121,30 @@ class ScannerEntity(BaseTrackerEntity):
     """Represent a tracked device that is on a scanned network."""
 
     @property
+    def latitude(self) -> float:
+        """Return latitude value of the device."""
+        return None
+
+    @property
+    def longitude(self) -> float:
+        """Return longitude value of the device."""
+        return None
+
+    @property
     def state(self):
         """Return the state of the device."""
         if self.is_connected:
+            if self.latitude is not None:
+                zone_state = zone.async_active_zone(
+                    self.hass, self.latitude, self.longitude
+                )
+                if zone_state is None:
+                    state = STATE_HOME
+                elif zone_state.entity_id == zone.ENTITY_ID_HOME:
+                    state = STATE_HOME
+                else:
+                    state = zone_state.name
+                return state
             return STATE_HOME
         return STATE_NOT_HOME
 
@@ -131,3 +152,14 @@ class ScannerEntity(BaseTrackerEntity):
     def is_connected(self):
         """Return true if the device is connected to the network."""
         raise NotImplementedError
+
+    @property
+    def state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        attr.update(super().state_attributes)
+        if self.latitude is not None:
+            attr[ATTR_LATITUDE] = self.latitude
+            attr[ATTR_LONGITUDE] = self.longitude
+
+        return attr

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     STATE_UNKNOWN,
     STATE_UNAVAILABLE,
-    STATE_HOME,
     STATE_NOT_HOME,
 )
 from homeassistant.core import callback, Event, State
@@ -400,7 +399,11 @@ class Person(RestoreEntity):
 
             if state.attributes.get(ATTR_SOURCE_TYPE) == SOURCE_TYPE_GPS:
                 latest_gps = _get_latest(latest_gps, state)
-            elif state.state == STATE_HOME:
+            elif (
+                state.state != STATE_NOT_HOME
+                and state.state != STATE_UNKNOWN
+                and state.state != STATE_UNAVAILABLE
+            ):
                 latest_non_gps_home = _get_latest(latest_non_gps_home, state)
             elif state.state == STATE_NOT_HOME:
                 latest_not_home = _get_latest(latest_not_home, state)

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -1,7 +1,7 @@
 """Support for devices connected to UniFi POE."""
 import voluptuous as vol
 
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
@@ -41,6 +41,8 @@ CONTROLLER_SCHEMA = vol.Schema(
         vol.Optional(CONF_DONT_TRACK_WIRED_CLIENTS): cv.boolean,
         vol.Optional(CONF_DETECTION_TIME): cv.positive_int,
         vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_LATITUDE): cv.latitude,
+        vol.Optional(CONF_LONGITUDE): cv.longitude,
     }
 )
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -10,7 +10,7 @@ from aiohttp import CookieJar
 import aiounifi
 
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -80,6 +80,16 @@ class UniFiController:
     def site_role(self):
         """Return the site user role of this controller."""
         return self._site_role
+
+    @property
+    def latitude(self) -> float:
+        """Return latitude value of the device."""
+        return self.config_entry.options.get(CONF_LATITUDE)
+
+    @property
+    def longitude(self) -> float:
+        """Return longitude value of the device."""
+        return self.config_entry.options.get(CONF_LONGITUDE)
 
     @property
     def option_allow_bandwidth_sensors(self):
@@ -279,6 +289,8 @@ class UniFiController:
             (CONF_DONT_TRACK_DEVICES, CONF_TRACK_DEVICES),
             (CONF_DETECTION_TIME, CONF_DETECTION_TIME),
             (CONF_SSID_FILTER, CONF_SSID_FILTER),
+            (CONF_LATITUDE, CONF_LATITUDE),
+            (CONF_LONGITUDE, CONF_LONGITUDE),
         ):
             if config in import_config:
                 print(config)

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -216,6 +216,20 @@ class UniFiClientTracker(ScannerEntity):
 
         return attributes
 
+    @property
+    def latitude(self) -> float:
+        """Return latitude value of the device."""
+        if self.is_connected:
+            return self.controller.latitude
+        return None
+
+    @property
+    def longitude(self) -> float:
+        """Return longitude value of the device."""
+        if self.is_connected:
+            return self.controller.longitude
+        return None
+
 
 class UniFiDeviceTracker(ScannerEntity):
     """Representation of a network infrastructure device."""
@@ -308,3 +322,17 @@ class UniFiDeviceTracker(ScannerEntity):
             attributes["upgradable"] = self.device.upgradable
 
         return attributes
+
+    @property
+    def latitude(self) -> float:
+        """Return latitude value of the device."""
+        if self.is_connected:
+            return self.controller.latitude
+        return None
+
+    @property
+    def longitude(self) -> float:
+        """Return longitude value of the device."""
+        if self.is_connected:
+            return self.controller.longitude
+        return None

--- a/tests/components/device_tracker/test_entities.py
+++ b/tests/components/device_tracker/test_entities.py
@@ -10,7 +10,13 @@ from homeassistant.components.device_tracker.const import (
     ATTR_SOURCE_TYPE,
     DOMAIN,
 )
-from homeassistant.const import STATE_HOME, STATE_NOT_HOME, ATTR_BATTERY_LEVEL
+from homeassistant.const import (
+    STATE_HOME,
+    STATE_NOT_HOME,
+    ATTR_BATTERY_LEVEL,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+)
 from tests.common import MockConfigEntry
 
 
@@ -36,6 +42,12 @@ async def test_scanner_entity_device_tracker(hass):
 
     entity_state = hass.states.get(entity_id)
     assert entity_state.state == STATE_HOME
+    assert entity_state.attributes == {
+        ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER,
+        ATTR_BATTERY_LEVEL: 100,
+        ATTR_LATITUDE: 40,
+        ATTR_LONGITUDE: 50,
+    }
 
 
 def test_scanner_entity():
@@ -47,6 +59,8 @@ def test_scanner_entity():
         assert entity.is_connected is None
     with pytest.raises(NotImplementedError):
         assert entity.state == STATE_NOT_HOME
+    assert entity.latitude is None
+    assert entity.longitude is None
     assert entity.battery_level is None
 
 

--- a/tests/testing_config/custom_components/test/device_tracker.py
+++ b/tests/testing_config/custom_components/test/device_tracker.py
@@ -35,6 +35,20 @@ class MockScannerEntity(ScannerEntity):
         """Return true if the device is connected to the network."""
         return self.connected
 
+    @property
+    def latitude(self) -> float:
+        """Return latitude value of the device."""
+        if self.is_connected:
+            return 40
+        return None
+
+    @property
+    def longitude(self) -> float:
+        """Return longitude value of the device."""
+        if self.is_connected:
+            return 50
+        return None
+
     def set_connected(self):
         """Set connected to True."""
         self.connected = True


### PR DESCRIPTION
## Breaking Change:

Unifi device Tracker may accept latitude and longitude property.

As discussed in this thread: https://community.home-assistant.io/t/presence-detection-zone-assigment/4803, sometimes we may connect the router which is not at home. Assigning latitude and 
longitude to ScannerEntity (Super of UniFiDeviceTracker) can help to decide which zone the tracked devices are in.

To make UniFiDeviceTracker outside home (may be in the zone called office), add latitude and longitude param in configuration.yaml.

## Description:
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10801
## Example entry for `configuration.yaml` (if applicable):
```yaml
unifi:
  controllers:
    - host: "192.168.11.6"
      site: Default
      latitude: 31.317551
      longitude: 121.469879
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
