### PR TITLE
Add turn_on/off to tfiac

### DIFF
--- a/homeassistant/components/tfiac/climate.py
+++ b/homeassistant/components/tfiac/climate.py
@@ -189,3 +189,11 @@ class TfiacClimate(ClimateDevice):
     async def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""
         await self._client.set_swing(swing_mode.capitalize())
+        
+    async def async_turn_on(self):
+        """Turn device on."""
+        await self._client.set_state(OPERATION_MODE)
+
+    async def async_turn_off(self):
+        """Turn device off."""
+        await self._client.set_state(ON_MODE, "off")

--- a/homeassistant/components/tfiac/climate.py
+++ b/homeassistant/components/tfiac/climate.py
@@ -189,7 +189,7 @@ class TfiacClimate(ClimateDevice):
     async def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""
         await self._client.set_swing(swing_mode.capitalize())
-        
+
     async def async_turn_on(self):
         """Turn device on."""
         await self._client.set_state(OPERATION_MODE)


### PR DESCRIPTION
## Description:

Adds turn_on/turn_off to tfiac. 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
