### PR TITLE
Add observed entities to bayesian sensor

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -184,9 +184,15 @@ class BayesianBinarySensor(BinarySensorDevice):
             prob_true = entity_observation["prob_given_true"]
             prob_false = entity_observation.get("prob_given_false", 1 - prob_true)
 
+            if "entity_id" in entity_observation:
+                entity_id=entity_observation.get("entity_id")
+            if "value_template" in entity_observation:
+                entity_id=entity_observation.get(CONF_VALUE_TEMPLATE).extract_entities()
+
             self.current_obs[obs_id] = {
                 "prob_true": prob_true,
                 "prob_false": prob_false,
+				"entity_id": entity_id,
             }
 
         else:
@@ -250,7 +256,7 @@ class BayesianBinarySensor(BinarySensorDevice):
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
-            ATTR_OBSERVATIONS: list(self.current_obs.values()),
+            ATTR_OBSERVATIONS: list(self.current_obs[obs]["entity_id"] for obs in self.current_obs),
             ATTR_PROBABILITY: round(self.probability, 2),
             ATTR_PROBABILITY_THRESHOLD: self._probability_threshold,
         }

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change
 
 ATTR_OBSERVATIONS = "observations"
-ATTR_OBSERVED_ENTITIES = "observed_entities"
+ATTR_OCCURRED_OBSERVATION_ENTITIES = "occurred_observation_entities"
 ATTR_PROBABILITY = "probability"
 ATTR_PROBABILITY_THRESHOLD = "probability_threshold"
 
@@ -262,7 +262,7 @@ class BayesianBinarySensor(BinarySensorDevice):
         """Return the state attributes of the sensor."""
         return {
             ATTR_OBSERVATIONS: list(self.current_obs.values()),
-            ATTR_OBSERVED_ENTITIES: list(
+            ATTR_OCCURRED_OBSERVATION_ENTITIES: list(
                 set(
                     chain.from_iterable(
                         self.entity_obs_dict[obs] for obs in self.current_obs.keys()

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -1,5 +1,6 @@
 """Use Bayesian Inference to trigger a binary sensor."""
 from collections import OrderedDict
+from itertools import chain
 
 import voluptuous as vol
 
@@ -131,10 +132,10 @@ class BayesianBinarySensor(BinarySensorDevice):
 
         for obs in self._observations:
             if "entity_id" in obs:
-                self.entity_obs_dict.append(obs.get("entity_id"))
+                self.entity_obs_dict.append([obs.get("entity_id")])
             if "value_template" in obs:
                 self.entity_obs_dict.append(
-                    set(obs.get(CONF_VALUE_TEMPLATE).extract_entities())
+                    list(obs.get(CONF_VALUE_TEMPLATE).extract_entities())
                 )
 
         to_observe = set()
@@ -262,7 +263,11 @@ class BayesianBinarySensor(BinarySensorDevice):
         return {
             ATTR_OBSERVATIONS: list(self.current_obs.values()),
             ATTR_ENTITY_ID: list(
-                self.entity_obs_dict[obs] for obs in self.current_obs.keys()
+                set(
+                    chain.from_iterable(
+                        self.entity_obs_dict[obs] for obs in self.current_obs.keys()
+                    )
+                )
             ),
             ATTR_PROBABILITY: round(self.probability, 2),
             ATTR_PROBABILITY_THRESHOLD: self._probability_threshold,

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -142,7 +142,6 @@ class BayesianBinarySensor(BinarySensorDevice):
             if "value_template" in obs:
                 for ent in obs.get(CONF_VALUE_TEMPLATE).extract_entities():
                     self.entity_obs[ent].append(obs)
-
         self.watchers = {
             "numeric_state": self._process_numeric_state,
             "state": self._process_state,
@@ -157,14 +156,12 @@ class BayesianBinarySensor(BinarySensorDevice):
             """Handle sensor state changes."""
             if new_state.state == STATE_UNKNOWN:
                 return
-
             entity_obs_list = self.entity_obs[entity]
 
             for entity_obs in entity_obs_list:
                 platform = entity_obs["platform"]
 
                 self.watchers[platform](entity_obs)
-
             prior = self.prior
             for obs in self.current_obs.values():
                 prior = update_probability(prior, obs["prob_true"], obs["prob_false"])
@@ -185,16 +182,16 @@ class BayesianBinarySensor(BinarySensorDevice):
             prob_false = entity_observation.get("prob_given_false", 1 - prob_true)
 
             if "entity_id" in entity_observation:
-                entity_id=entity_observation.get("entity_id")
+                entity_id = entity_observation.get("entity_id")
             if "value_template" in entity_observation:
-                entity_id=entity_observation.get(CONF_VALUE_TEMPLATE).extract_entities()
-
+                entity_id = entity_observation.get(
+                    CONF_VALUE_TEMPLATE
+                ).extract_entities()
             self.current_obs[obs_id] = {
                 "prob_true": prob_true,
                 "prob_false": prob_false,
-				"entity_id": entity_id,
+                "entity_id": entity_id,
             }
-
         else:
             self.current_obs.pop(obs_id, None)
 
@@ -256,7 +253,9 @@ class BayesianBinarySensor(BinarySensorDevice):
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
-            ATTR_OBSERVATIONS: list(self.current_obs[obs]["entity_id"] for obs in self.current_obs),
+            ATTR_OBSERVATIONS: list(
+                self.current_obs[obs]["entity_id"] for obs in self.current_obs
+            ),
             ATTR_PROBABILITY: round(self.probability, 2),
             ATTR_PROBABILITY_THRESHOLD: self._probability_threshold,
         }

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change
 
 ATTR_OBSERVATIONS = "observations"
-ATTR_ENTITY_ID = "observed_entities"
+ATTR_OBSERVED_ENTITIES = "observed_entities"
 ATTR_PROBABILITY = "probability"
 ATTR_PROBABILITY_THRESHOLD = "probability_threshold"
 
@@ -262,7 +262,7 @@ class BayesianBinarySensor(BinarySensorDevice):
         """Return the state attributes of the sensor."""
         return {
             ATTR_OBSERVATIONS: list(self.current_obs.values()),
-            ATTR_ENTITY_ID: list(
+            ATTR_OBSERVED_ENTITIES: list(
                 set(
                     chain.from_iterable(
                         self.entity_obs_dict[obs] for obs in self.current_obs.keys()

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -131,7 +131,7 @@ class BayesianBinarySensor(BinarySensorDevice):
 
         for obs in self._observations:
             if "entity_id" in obs:
-                self.entity_obs_dict.append(set(obs.get("entity_id")))
+                self.entity_obs_dict.append(obs.get("entity_id"))
             if "value_template" in obs:
                 self.entity_obs_dict.append(
                     set(obs.get(CONF_VALUE_TEMPLATE).extract_entities())

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -273,7 +273,12 @@ class TestBayesianBinarySensor(unittest.TestCase):
                         "to_state": "off",
                         "prob_given_true": 0.8,
                         "prob_given_false": 0.4,
-                    }
+                    },
+                    {
+                        "platform": "template",
+                        "value_template": "{{is_state('sensor.test_monitored1','on') and is_state('sensor.test_monitored','off')}}",
+                        "prob_given_true": 0.9,
+                    },
                 ],
                 "prior": 0.2,
                 "probability_threshold": 0.32,
@@ -284,6 +289,8 @@ class TestBayesianBinarySensor(unittest.TestCase):
 
         self.hass.states.set("sensor.test_monitored", "on")
         self.hass.block_till_done()
+        self.hass.states.set("sensor.test_monitored1", "off")
+        self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
         assert [] == state.attributes.get("observed_entities")
@@ -293,3 +300,12 @@ class TestBayesianBinarySensor(unittest.TestCase):
 
         state = self.hass.states.get("binary_sensor.test_binary")
         assert ["sensor.test_monitored"] == state.attributes.get("observed_entities")
+
+        self.hass.states.set("sensor.test_monitored1", "on")
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("binary_sensor.test_binary")
+        assert [
+            "sensor.test_monitored",
+            {"sensor.test_monitored1", "sensor.test_monitored"},
+        ] == state.attributes.get("observed_entities")

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -307,5 +307,5 @@ class TestBayesianBinarySensor(unittest.TestCase):
         state = self.hass.states.get("binary_sensor.test_binary")
         assert [
             "sensor.test_monitored",
-            {"sensor.test_monitored1", "sensor.test_monitored"},
+            "sensor.test_monitored1",
         ] == state.attributes.get("observed_entities")

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -293,19 +293,20 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
-        assert [] == state.attributes.get("observed_entities")
+        assert [] == state.attributes.get("occurred_observation_entities")
 
         self.hass.states.set("sensor.test_monitored", "off")
         self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
-        assert ["sensor.test_monitored"] == state.attributes.get("observed_entities")
+        assert ["sensor.test_monitored"] == state.attributes.get(
+            "occurred_observation_entities"
+        )
 
         self.hass.states.set("sensor.test_monitored1", "on")
         self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
-        assert [
-            "sensor.test_monitored",
-            "sensor.test_monitored1",
-        ] == state.attributes.get("observed_entities")
+        assert ["sensor.test_monitored", "sensor.test_monitored1"] == sorted(
+            state.attributes.get("occurred_observation_entities")
+        )

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -67,8 +67,8 @@ class TestBayesianBinarySensor(unittest.TestCase):
 
         state = self.hass.states.get("binary_sensor.test_binary")
         assert [
-            {"prob_false": 0.4, "prob_true": 0.6},
-            {"prob_false": 0.1, "prob_true": 0.9},
+            "sensor.test_monitored",
+            "sensor.test_monitored1",
         ] == state.attributes.get("observations")
         assert round(abs(0.77 - state.attributes.get("probability")), 7) == 0
 
@@ -131,9 +131,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
-        assert [{"prob_true": 0.8, "prob_false": 0.4}] == state.attributes.get(
-            "observations"
-        )
+        assert ["sensor.test_monitored"] == state.attributes.get("observations")
         assert round(abs(0.33 - state.attributes.get("probability")), 7) == 0
 
         assert state.state == "on"
@@ -223,9 +221,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
-        assert [{"prob_true": 0.8, "prob_false": 0.4}] == state.attributes.get(
-            "observations"
-        )
+        assert ["sensor.test_monitored"] == state.attributes.get("observations")
         assert round(abs(0.33 - state.attributes.get("probability")), 7) == 0
 
         assert state.state == "on"

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -1,8 +1,8 @@
 """The test for the bayesian sensor platform."""
 import unittest
 
-from homeassistant.setup import setup_component
 from homeassistant.components.bayesian import binary_sensor as bayesian
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 
@@ -67,8 +67,8 @@ class TestBayesianBinarySensor(unittest.TestCase):
 
         state = self.hass.states.get("binary_sensor.test_binary")
         assert [
-            "sensor.test_monitored",
-            "sensor.test_monitored1",
+            {"prob_false": 0.4, "prob_true": 0.6},
+            {"prob_false": 0.1, "prob_true": 0.9},
         ] == state.attributes.get("observations")
         assert round(abs(0.77 - state.attributes.get("probability")), 7) == 0
 
@@ -131,7 +131,9 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
-        assert ["sensor.test_monitored"] == state.attributes.get("observations")
+        assert [{"prob_true": 0.8, "prob_false": 0.4}] == state.attributes.get(
+            "observations"
+        )
         assert round(abs(0.33 - state.attributes.get("probability")), 7) == 0
 
         assert state.state == "on"
@@ -147,7 +149,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         assert state.state == "off"
 
     def test_threshold(self):
-        """Test sensor on probabilty threshold limits."""
+        """Test sensor on probability threshold limits."""
         config = {
             "binary_sensor": {
                 "name": "Test_Binary",
@@ -221,7 +223,9 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
-        assert ["sensor.test_monitored"] == state.attributes.get("observations")
+        assert [{"prob_true": 0.8, "prob_false": 0.4}] == state.attributes.get(
+            "observations"
+        )
         assert round(abs(0.33 - state.attributes.get("probability")), 7) == 0
 
         assert state.state == "on"
@@ -255,3 +259,37 @@ class TestBayesianBinarySensor(unittest.TestCase):
             prior = bayesian.update_probability(prior, pt, pf)
 
         assert round(abs(0.9130434782608695 - prior), 7) == 0
+
+    def test_observed_entities(self):
+        """Test sensor on observed entities."""
+        config = {
+            "binary_sensor": {
+                "name": "Test_Binary",
+                "platform": "bayesian",
+                "observations": [
+                    {
+                        "platform": "state",
+                        "entity_id": "sensor.test_monitored",
+                        "to_state": "off",
+                        "prob_given_true": 0.8,
+                        "prob_given_false": 0.4,
+                    }
+                ],
+                "prior": 0.2,
+                "probability_threshold": 0.32,
+            }
+        }
+
+        assert setup_component(self.hass, "binary_sensor", config)
+
+        self.hass.states.set("sensor.test_monitored", "on")
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("binary_sensor.test_binary")
+        assert [] == state.attributes.get("observed_entities")
+
+        self.hass.states.set("sensor.test_monitored", "off")
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("binary_sensor.test_binary")
+        assert ["sensor.test_monitored"] == state.attributes.get("observed_entities")


### PR DESCRIPTION
## Description:
The Bayesian binary sensor currently shows only a list of [object Object] under the field observations:
![image](https://user-images.githubusercontent.com/3611177/66870393-a9db3780-efa1-11e9-935c-5b0301ab3158.png)

This change will include the list of entities that have been observed:
![image](https://user-images.githubusercontent.com/3611177/74176249-941c0d00-4c37-11ea-9263-5c83c0159b39.png)

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
