### PR TITLE
Implement Alexa.DoorbellEventSource Interface Controller for alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -92,6 +92,15 @@ class AlexaCapability:
         return None
 
     @staticmethod
+    def capability_proactively_reported():
+        """Return True if the capability is proactively reported.
+
+        Set properties_proactively_reported() for proactively reported properties.
+        Applicable to DoorbellEventSource.
+        """
+        return None
+
+    @staticmethod
     def capability_resources():
         """Applicable to ToggleController, RangeController, and ModeController interfaces."""
         return []
@@ -103,16 +112,20 @@ class AlexaCapability:
 
     def serialize_discovery(self):
         """Serialize according to the Discovery API."""
-        result = {
-            "type": "AlexaInterface",
-            "interface": self.name(),
-            "version": "3",
-            "properties": {
+        result = {"type": "AlexaInterface", "interface": self.name(), "version": "3"}
+
+        properties_supported = self.properties_supported()
+        if properties_supported:
+            result["properties"] = {
                 "supported": self.properties_supported(),
                 "proactivelyReported": self.properties_proactively_reported(),
                 "retrievable": self.properties_retrievable(),
-            },
-        }
+            }
+
+        # pylint: disable=assignment-from-none
+        proactively_reported = self.capability_proactively_reported()
+        if proactively_reported is not None:
+            result["proactivelyReported"] = proactively_reported
 
         # pylint: disable=assignment-from-none
         non_controllable = self.properties_non_controllable()
@@ -1050,3 +1063,18 @@ class AlexaChannelController(AlexaCapability):
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.ChannelController"
+
+
+class AlexaDoorbellEventSource(AlexaCapability):
+    """Implements Alexa.DoorbellEventSource.
+
+    https://developer.amazon.com/docs/device-apis/alexa-doorbelleventsource.html
+    """
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa.DoorbellEventSource"
+
+    def capability_proactively_reported(self):
+        """Return True for proactively reported capability."""
+        return True

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -38,6 +38,7 @@ from .capabilities import (
     AlexaColorController,
     AlexaColorTemperatureController,
     AlexaContactSensor,
+    AlexaDoorbellEventSource,
     AlexaEndpointHealth,
     AlexaInputController,
     AlexaLockController,
@@ -84,7 +85,7 @@ class DisplayCategory:
     DOOR = "DOOR"
 
     # Indicates a doorbell.
-    DOOR_BELL = "DOORBELL"
+    DOORBELL = "DOORBELL"
 
     # Indicates a fan.
     FAN = "FAN"
@@ -499,6 +500,11 @@ class BinarySensorCapabilities(AlexaEntity):
             yield AlexaContactSensor(self.hass, self.entity)
         elif sensor_type is self.TYPE_MOTION:
             yield AlexaMotionSensor(self.hass, self.entity)
+
+        entity_conf = self.config.entity_config.get(self.entity.entity_id, {})
+        if CONF_DISPLAY_CATEGORIES in entity_conf:
+            if entity_conf[CONF_DISPLAY_CATEGORIES] == DisplayCategory.DOORBELL:
+                yield AlexaDoorbellEventSource(self.entity)
 
         yield AlexaEndpointHealth(self.hass, self.entity)
 

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -6,7 +6,8 @@ import logging
 import aiohttp
 import async_timeout
 
-from homeassistant.const import MATCH_ALL
+import homeassistant.util.dt as dt_util
+from homeassistant.const import MATCH_ALL, STATE_ON
 
 from .const import API_CHANGE, Cause
 from .entities import ENTITY_ADAPTERS
@@ -42,6 +43,14 @@ async def async_enable_proactive_mode(hass, smart_home_config):
         for interface in alexa_changed_entity.interfaces():
             if interface.properties_proactively_reported():
                 await async_send_changereport_message(
+                    hass, smart_home_config, alexa_changed_entity
+                )
+                return
+            if (
+                interface.name() == "Alexa.DoorbellEventSource"
+                and new_state.state == STATE_ON
+            ):
+                await async_send_doorbell_event_message(
                     hass, smart_home_config, alexa_changed_entity
                 )
                 return
@@ -183,4 +192,59 @@ async def async_send_delete_message(hass, config, entity_ids):
 
     return await session.post(
         config.endpoint, headers=headers, json=message_serialized, allow_redirects=True
+    )
+
+
+async def async_send_doorbell_event_message(hass, config, alexa_entity):
+    """Send a DoorbellPress event message for an Alexa entity.
+
+    https://developer.amazon.com/docs/smarthome/send-events-to-the-alexa-event-gateway.html
+    """
+    token = await config.async_get_access_token()
+
+    headers = {"Authorization": f"Bearer {token}"}
+
+    endpoint = alexa_entity.alexa_id()
+
+    message = AlexaResponse(
+        name="DoorbellPress",
+        namespace="Alexa.DoorbellEventSource",
+        payload={
+            "cause": {"type": Cause.PHYSICAL_INTERACTION},
+            "timestamp": f"{dt_util.utcnow().replace(tzinfo=None).isoformat()}Z",
+        },
+    )
+
+    message.set_endpoint_full(token, endpoint)
+
+    message_serialized = message.serialize()
+    session = hass.helpers.aiohttp_client.async_get_clientsession()
+
+    try:
+        with async_timeout.timeout(DEFAULT_TIMEOUT):
+            response = await session.post(
+                config.endpoint,
+                headers=headers,
+                json=message_serialized,
+                allow_redirects=True,
+            )
+
+    except (asyncio.TimeoutError, aiohttp.ClientError):
+        _LOGGER.error("Timeout sending report to Alexa.")
+        return
+
+    response_text = await response.text()
+
+    _LOGGER.debug("Sent: %s", json.dumps(message_serialized))
+    _LOGGER.debug("Received (%s): %s", response.status, response_text)
+
+    if response.status == 202:
+        return
+
+    response_json = json.loads(response_text)
+
+    _LOGGER.error(
+        "Error when sending DoorbellPress event to Alexa: %s: %s",
+        response_json["payload"]["code"],
+        response_json["payload"]["description"],
     )

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -13,7 +13,7 @@ TEST_TOKEN_URL = "https://api.amazon.com/auth/o2/token"
 class MockConfig(config.AbstractConfig):
     """Mock Alexa config."""
 
-    entity_config = {}
+    entity_config = {"binary_sensor.test_doorbell": {"display_categories": "DOORBELL"}}
 
     @property
     def supports_auth(self):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1196,6 +1196,28 @@ async def test_motion_sensor(hass):
     properties.assert_equal("Alexa.MotionSensor", "detectionState", "DETECTED")
 
 
+async def test_doorbell_sensor(hass):
+    """Test doorbell sensor discovery."""
+    device = (
+        "binary_sensor.test_doorbell",
+        "off",
+        {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "binary_sensor#test_doorbell"
+    assert appliance["displayCategories"][0] == "DOORBELL"
+    assert appliance["friendlyName"] == "Test Doorbell Sensor"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance, "Alexa.DoorbellEventSource", "Alexa.EndpointHealth"
+    )
+
+    doorbell_capability = get_capability(capabilities, "Alexa.DoorbellEventSource")
+    assert doorbell_capability is not None
+    assert doorbell_capability["proactivelyReported"] is True
+
+
 async def test_unknown_sensor(hass):
     """Test sensors of unknown quantities are not discovered."""
     device = (

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -137,3 +137,34 @@ async def test_send_delete_message(hass, aioclient_mock):
         call_json["event"]["payload"]["endpoints"][0]["endpointId"]
         == "binary_sensor#test_contact"
     )
+
+
+async def test_doorbell_event(hass, aioclient_mock):
+    """Test doorbell press reports."""
+    aioclient_mock.post(TEST_URL, text="", status=202)
+
+    hass.states.async_set(
+        "binary_sensor.test_doorbell",
+        "off",
+        {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+
+    await state_report.async_enable_proactive_mode(hass, DEFAULT_CONFIG)
+
+    hass.states.async_set(
+        "binary_sensor.test_doorbell",
+        "on",
+        {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+
+    # To trigger event listener
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 1
+    call = aioclient_mock.mock_calls
+
+    call_json = call[0][2]
+    assert call_json["event"]["header"]["namespace"] == "Alexa.DoorbellEventSource"
+    assert call_json["event"]["header"]["name"] == "DoorbellPress"
+    assert call_json["event"]["payload"]["cause"]["type"] == "PHYSICAL_INTERACTION"
+    assert call_json["event"]["endpoint"]["endpointId"] == "binary_sensor#test_doorbell"


### PR DESCRIPTION
## Description:
Implements the `Alexa.DoorbellEventSource` Interface controller for the `alexa` integration. 

After discovered, and enabled by the user in the Alexa App. Alexa will announce "Someone is at the {Sensor Name Here}" on all echo devices when the sensor state changes to `on`.

This implementation makes use of any binary_sensor but the user must add `display_categories: DOORBELL` to the `entity_config` section of their alexa config in-order for the `Alexa.DoorbellEventSource` controller to be exposed during discovery for that binary_sensor. 

I attempted to try to expose this without user configuration, but there isn't a `binary_sensor` `DEVICE_CLASS` that fits best without exposing this controller to sensors that don't need it. See [Architecture Proposal 302](https://github.com/home-assistant/architecture/issues/302) for a proposed option. 

Additional Note:
The Alexa API was very picky about how this controller was reported during discovery, and would error if anything else was included in the capability (even if null), hence the changes to `serialize_discovery`. 

**Related issue (if applicable):** another checkbox for #24579 

## Example entry for `configuration.yaml` (if applicable):
```yaml
smart_home:
  endpoint: https://api.amazonalexa.com/v3/events
  client_id: !secret alexa_client_id
  client_secret: !secret alexa_client_secret
  filter:
    include_entities:
      - binary_sensor.alexa_doorbell
  entity_config:
    binary_sensor.alexa_doorbell:
      display_categories: DOORBELL
      name: Front Door
      description: Front Door Bell sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) 
Will add if implementation method is acceptable.
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
