### PR TITLE
Bump pyatmo version to 2.3.2

### DIFF
--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/integrations/netatmo",
   "requirements": [
-    "pyatmo==2.2.1"
+    "pyatmo==2.3.2"
   ],
   "dependencies": [
     "webhook"

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -80,6 +80,7 @@ SENSOR_TYPES = {
     "gustangle": ["Gust Angle", "", "mdi:compass", None],
     "gustangle_value": ["Gust Angle Value", "º", "mdi:compass", None],
     "guststrength": ["Gust Strength", "km/h", "mdi:weather-windy", None],
+    "reachable": ["Reachability", "", "mdi:signal", None],
     "rf_status": ["Radio", "", "mdi:signal", None],
     "rf_status_lvl": ["Radio_lvl", "", "mdi:signal", None],
     "wifi_status": ["Wifi", "", "mdi:wifi", None],

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -376,6 +376,8 @@ class NetatmoSensor(Entity):
                     self._state = "N (%d\xb0)" % data["GustAngle"]
             elif self.type == "guststrength":
                 self._state = data["GustStrength"]
+            elif self.type == "reachable":
+                self._state = data["reachable"]
             elif self.type == "rf_status_lvl":
                 self._state = data["rf_status"]
             elif self.type == "rf_status":

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1084,7 +1084,7 @@ pyalarmdotcom==0.3.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==2.2.1
+pyatmo==2.3.2
 
 # homeassistant.components.atome
 pyatome==0.1.1


### PR DESCRIPTION
## Description:
Bump pyatmo version to 2.3.2 and add reachability attribute for Netatmo Weatherstations and Home Coach devices.

* Add support for reachable status
* Fix missing dependencies
* Fix camera detection

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
