### PR TITLE
Add support for SAJ inverters connected via WiFi

### DIFF
--- a/homeassistant/components/saj/manifest.json
+++ b/homeassistant/components/saj/manifest.json
@@ -3,7 +3,7 @@
   "name": "SAJ",
   "documentation": "https://www.home-assistant.io/integrations/saj",
   "requirements": [
-    "pysaj==0.0.9"
+    "pysaj==0.0.11"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/saj/manifest.json
+++ b/homeassistant/components/saj/manifest.json
@@ -3,7 +3,7 @@
   "name": "SAJ",
   "documentation": "https://www.home-assistant.io/integrations/saj",
   "requirements": [
-    "pysaj==0.0.11"
+    "pysaj==0.0.12"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1414,7 +1414,7 @@ pyrepetier==3.0.5
 pysabnzbd==1.1.0
 
 # homeassistant.components.saj
-pysaj==0.0.9
+pysaj==0.0.11
 
 # homeassistant.components.sony_projector
 pysdcp==1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1414,7 +1414,7 @@ pyrepetier==3.0.5
 pysabnzbd==1.1.0
 
 # homeassistant.components.saj
-pysaj==0.0.11
+pysaj==0.0.12
 
 # homeassistant.components.sony_projector
 pysdcp==1


### PR DESCRIPTION
## Description:

Currently the SAJ component only works with inverters connected via an ethernet webserver module.
Apparently the WiFi webserver module has another web interface and thus also other URL's to get the data from.
Also the WiFi webserver requires a username and password where the ethernet webserver does not.
This PR adds 3 extra optional configuration parameters:
- type : `ethernet` or `wifi` (default value: `ethernet` so not breaking for existing configurations)
- username (only used when type is `wifi` but can be skipped if the inverter still has the default credentials set: admin/admin)
- password (only used when type is `wifi` but can be skipped if the inverter still has the default credentials set: admin/admin)

**Related issue (if applicable):** fixes #27685

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10819

## Example entry for `configuration.yaml`:
```yaml
sensor:
  - platform: saj
    host: IP_ADDRESS_OF_DEVICE
    type: wifi
    username: USERNAME
    password: PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
