### PR TITLE
Move imports in slack and socialblade

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -4,11 +4,9 @@ from datetime import timedelta
 import logging
 import socket
 
-from samsungctl import Remote, exceptions
 import voluptuous as vol
-import wakeonlan
 
-from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
+from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,
@@ -113,6 +111,9 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def __init__(self, host, port, name, timeout, mac, uuid):
         """Initialize the Samsung device."""
+        from samsungctl import exceptions
+        from samsungctl import Remote
+        import wakeonlan
 
         # Save a reference to the imported classes
         self._exceptions_class = exceptions

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -4,9 +4,11 @@ from datetime import timedelta
 import logging
 import socket
 
+from samsungctl import Remote, exceptions
 import voluptuous as vol
+import wakeonlan
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,
@@ -111,9 +113,6 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def __init__(self, host, port, name, timeout, mac, uuid):
         """Initialize the Samsung device."""
-        from samsungctl import exceptions
-        from samsungctl import Remote
-        import wakeonlan
 
         # Save a reference to the imported classes
         self._exceptions_class = exceptions

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -3,10 +3,9 @@ import logging
 
 import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+import slacker
+from slacker import Slacker
 import voluptuous as vol
-
-from homeassistant.const import CONF_API_KEY, CONF_ICON, CONF_USERNAME
-import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -15,6 +14,8 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_API_KEY, CONF_ICON, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +46,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_service(hass, config, discovery_info=None):
     """Get the Slack notification service."""
-    import slacker
 
     channel = config.get(CONF_CHANNEL)
     api_key = config.get(CONF_API_KEY)
@@ -67,7 +67,6 @@ class SlackNotificationService(BaseNotificationService):
 
     def __init__(self, default_channel, api_token, username, icon, is_allowed_path):
         """Initialize the service."""
-        from slacker import Slacker
 
         self._default_channel = default_channel
         self._api_token = api_token
@@ -84,7 +83,6 @@ class SlackNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        import slacker
 
         if kwargs.get(ATTR_TARGET) is None:
             targets = [self._default_channel]

--- a/homeassistant/components/socialblade/sensor.py
+++ b/homeassistant/components/socialblade/sensor.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+import socialbladeclient
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -71,7 +72,6 @@ class SocialBladeSensor(Entity):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from Social Blade."""
-        import socialbladeclient
 
         try:
             data = socialbladeclient.get_data(self.channel_id)


### PR DESCRIPTION
## Breaking Change:
None

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved imports to top-level as requested in #27284
Components:
- slack
- socialblade

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
