### PR TITLE
Move imports in rpi_gpio

### DIFF
--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -4,7 +4,6 @@ import logging
 from RPi import GPIO  # pylint: disable=import-error
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 
-
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "rpi_gpio"

--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -2,6 +2,7 @@
 import logging
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from RPi import GPIO
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -10,7 +11,6 @@ DOMAIN = "rpi_gpio"
 
 def setup(hass, config):
     """Set up the Raspberry PI GPIO component."""
-    from RPi import GPIO  # pylint: disable=import-error
 
     def cleanup_gpio(event):
         """Stuff to do before stopping."""
@@ -27,34 +27,24 @@ def setup(hass, config):
 
 def setup_output(port):
     """Set up a GPIO as output."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.setup(port, GPIO.OUT)
 
 
 def setup_input(port, pull_mode):
     """Set up a GPIO as input."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.setup(port, GPIO.IN, GPIO.PUD_DOWN if pull_mode == "DOWN" else GPIO.PUD_UP)
 
 
 def write_output(port, value):
     """Write a value to a GPIO."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.output(port, value)
 
 
 def read_input(port):
     """Read a value from a GPIO."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     return GPIO.input(port)
 
 
 def edge_detect(port, event_callback, bounce):
     """Add detection for RISING and FALLING events."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.add_event_detect(port, GPIO.BOTH, callback=event_callback, bouncetime=bounce)

--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -1,8 +1,9 @@
 """Support for controlling GPIO pins of a Raspberry Pi."""
 import logging
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from RPi import GPIO
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -1,7 +1,7 @@
 """Support for controlling GPIO pins of a Raspberry Pi."""
 import logging
 
-from RPi import GPIO
+from RPi import GPIO  # pylint: disable=import-error
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 
 

--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -2,6 +2,7 @@
 import logging
 
 from RPi import GPIO  # pylint: disable=import-error
+
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/rpi_gpio/binary_sensor.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import rpi_gpio
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/rpi_gpio/cover.py
+++ b/homeassistant/components/rpi_gpio/cover.py
@@ -4,9 +4,9 @@ from time import sleep
 
 import voluptuous as vol
 
-from homeassistant.components.cover import CoverDevice, PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME
 from homeassistant.components import rpi_gpio
+from homeassistant.components.cover import PLATFORM_SCHEMA, CoverDevice
+from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved imports to top-level as described in #27284

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
