### PR TITLE
Bump rpi.gpio to 0.7.0

### DIFF
--- a/homeassistant/components/mcp23017/manifest.json
+++ b/homeassistant/components/mcp23017/manifest.json
@@ -3,7 +3,7 @@
   "name": "MCP23017 I/O Expander",
   "documentation": "https://www.home-assistant.io/integrations/mcp23017",
   "requirements": [
-    "RPi.GPIO==0.6.5",
+    "RPi.GPIO==0.7.0",
     "adafruit-blinka==1.2.1",
     "adafruit-circuitpython-mcp230xx==1.1.2"
     ],

--- a/homeassistant/components/rpi_gpio/manifest.json
+++ b/homeassistant/components/rpi_gpio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Rpi gpio",
   "documentation": "https://www.home-assistant.io/integrations/rpi_gpio",
   "requirements": [
-    "RPi.GPIO==0.6.5"
+    "RPi.GPIO==0.7.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -82,7 +82,7 @@ PyXiaomiGateway==0.12.4
 
 # homeassistant.components.mcp23017
 # homeassistant.components.rpi_gpio
-# RPi.GPIO==0.6.5
+# RPi.GPIO==0.7.0
 
 # homeassistant.components.remember_the_milk
 RtmAPI==0.7.2


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
latest version of RPi.GPIO  is 0.7.0 - https://pypi.org/project/RPi.GPIO/

Change Log

- Updated RPI_INFO to include RPi 4B
- Fixed pull up/down for Pi4 (issue 168)
- Fix spelling mistake in docstrings
- Tested and working on Raspbian Buster + Python 3.8.0b2
- Fix board detection for aarch64 (Issues 161 / 165)
- Fix checking mmap return value in c_gpio.c (issue 166)


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
