### PR TITLE
Report state

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_ROOM_HINT,
     CONF_ALLOW_UNLOCK,
     CONF_SECURE_DEVICES_PIN,
+    CONF_SERVICE_ACCOUNT,
 )
 from .const import EVENT_COMMAND_RECEIVED, EVENT_SYNC_RECEIVED  # noqa: F401
 from .const import EVENT_QUERY_RECEIVED  # noqa: F401
@@ -46,6 +47,11 @@ ENTITY_SCHEMA = vol.Schema(
         vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_ROOM_HINT): cv.string,
     }
+)
+
+GOOGLE_SERVICE_ACCOUNT = vol.Schema(
+    {vol.Required("private_key"): cv.string, vol.Required("client_email"): cv.string},
+    extra=vol.ALLOW_EXTRA,
 )
 
 GOOGLE_ASSISTANT_SCHEMA = vol.All(
@@ -65,6 +71,9 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
             # str on purpose, makes sure it is configured correctly.
             vol.Optional(CONF_SECURE_DEVICES_PIN): str,
             vol.Optional(CONF_REPORT_STATE, default=False): cv.boolean,
+            vol.Optional(CONF_SERVICE_ACCOUNT): GOOGLE_SERVICE_ACCOUNT,
+            # temporary measure to get the user_id setup
+            vol.Optional("agent_user_id"): str,
         },
         extra=vol.PREVENT_EXTRA,
     ),

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -59,6 +59,16 @@ GOOGLE_SERVICE_ACCOUNT = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+
+def _check_report_state(data):
+    if data[CONF_REPORT_STATE]:
+        if CONF_SERVICE_ACCOUNT not in data:
+            raise vol.Invalid(
+                "If report state is enabled, a service account must exist"
+            )
+    return data
+
+
 GOOGLE_ASSISTANT_SCHEMA = vol.All(
     cv.deprecated(CONF_ALLOW_UNLOCK, invalidation_version="0.95"),
     vol.Schema(
@@ -80,6 +90,7 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
         },
         extra=vol.PREVENT_EXTRA,
     ),
+    _check_report_state,
 )
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: GOOGLE_ASSISTANT_SCHEMA}, extra=vol.ALLOW_EXTRA)

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_ENTITY_CONFIG,
     CONF_EXPOSE,
     CONF_ALIASES,
+    CONF_REPORT_STATE,
     CONF_ROOM_HINT,
     CONF_ALLOW_UNLOCK,
     CONF_SECURE_DEVICES_PIN,
@@ -63,6 +64,7 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
             vol.Optional(CONF_ALLOW_UNLOCK): cv.boolean,
             # str on purpose, makes sure it is configured correctly.
             vol.Optional(CONF_SECURE_DEVICES_PIN): str,
+            vol.Optional(CONF_REPORT_STATE, default=False): cv.boolean,
         },
         extra=vol.PREVENT_EXTRA,
     ),

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -72,8 +72,6 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
             vol.Optional(CONF_SECURE_DEVICES_PIN): str,
             vol.Optional(CONF_REPORT_STATE, default=False): cv.boolean,
             vol.Optional(CONF_SERVICE_ACCOUNT): GOOGLE_SERVICE_ACCOUNT,
-            # temporary measure to get the user_id setup
-            vol.Optional("agent_user_id"): str,
         },
         extra=vol.PREVENT_EXTRA,
     ),

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -33,6 +33,8 @@ from .const import (
     CONF_ALLOW_UNLOCK,
     CONF_SECURE_DEVICES_PIN,
     CONF_SERVICE_ACCOUNT,
+    CONF_CLIENT_EMAIL,
+    CONF_PRIVATE_KEY,
 )
 from .const import EVENT_COMMAND_RECEIVED, EVENT_SYNC_RECEIVED  # noqa: F401
 from .const import EVENT_QUERY_RECEIVED  # noqa: F401
@@ -50,7 +52,10 @@ ENTITY_SCHEMA = vol.Schema(
 )
 
 GOOGLE_SERVICE_ACCOUNT = vol.Schema(
-    {vol.Required("private_key"): cv.string, vol.Required("client_email"): cv.string},
+    {
+        vol.Required(CONF_PRIVATE_KEY): cv.string,
+        vol.Required(CONF_CLIENT_EMAIL): cv.string,
+    },
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -32,6 +32,7 @@ CONF_API_KEY = "api_key"
 CONF_ROOM_HINT = "room"
 CONF_ALLOW_UNLOCK = "allow_unlock"
 CONF_SECURE_DEVICES_PIN = "secure_devices_pin"
+CONF_REPORT_STATE = "report_state"
 
 DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -77,7 +77,7 @@ TYPE_ALARM = PREFIX_TYPES + "SECURITYSYSTEM"
 SERVICE_REQUEST_SYNC = "request_sync"
 HOMEGRAPH_URL = "https://homegraph.googleapis.com/"
 HOMEGRAPH_SCOPE = "https://www.googleapis.com/auth/homegraph"
-HOMEGRAPH_AUDIENCE = "https://accounts.google.com/o/oauth2/token"
+HOMEGRAPH_TOKEN_URL = "https://accounts.google.com/o/oauth2/token"
 REQUEST_SYNC_BASE_URL = HOMEGRAPH_URL + "v1/devices:requestSync"
 REPORT_STATE_BASE_URL = HOMEGRAPH_URL + "v1/devices:reportStateAndNotification"
 

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -33,6 +33,9 @@ CONF_ROOM_HINT = "room"
 CONF_ALLOW_UNLOCK = "allow_unlock"
 CONF_SECURE_DEVICES_PIN = "secure_devices_pin"
 CONF_REPORT_STATE = "report_state"
+CONF_SERVICE_ACCOUNT = "service_account"
+CONF_CLIENT_EMAIL = "client_email"
+CONF_PRIVATE_KEY = "private_key"
 
 DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
@@ -73,7 +76,10 @@ TYPE_ALARM = PREFIX_TYPES + "SECURITYSYSTEM"
 
 SERVICE_REQUEST_SYNC = "request_sync"
 HOMEGRAPH_URL = "https://homegraph.googleapis.com/"
+HOMEGRAPH_SCOPE = "https://www.googleapis.com/auth/homegraph"
+HOMEGRAPH_AUDIENCE = "https://accounts.google.com/o/oauth2/token"
 REQUEST_SYNC_BASE_URL = HOMEGRAPH_URL + "v1/devices:requestSync"
+REPORT_STATE_BASE_URL = HOMEGRAPH_URL + "v1/devices:reportStateAndNotification"
 
 # Error codes used for SmartHomeError class
 # https://developers.google.com/actions/reference/smarthome/errors-exceptions

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -112,10 +112,7 @@ class GoogleConfig(AbstractConfig):
         """If an entity should have 2FA checked."""
         return True
 
-    async def _async_get_access_token(self):
-        now = dt_util.utcnow()
-        if self._access_token and now < self._access_token_renew:
-            return self._access_token
+    async def _async_get_access_token(self, now):
 
         if CONF_SERVICE_ACCOUNT not in self._config:
             raise Exception(
@@ -148,7 +145,11 @@ class GoogleConfig(AbstractConfig):
 
     async def async_report_state(self, message):
         """Send a state report to Google."""
-        access_token = await self._async_get_access_token()
+        now = dt_util.utcnow()
+        if self._access_token and now < self._access_token_renew:
+            access_token = self._access_token
+        else:
+            access_token = await self._async_get_access_token(now)
 
         headers = {
             "Authorization": "Bearer {}".format(access_token),

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -11,13 +11,14 @@ from aiohttp.web import Request, Response
 
 # Typing imports
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.core import callback
+from homeassistant.core import callback, ServiceCall
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
 
 from .const import (
     GOOGLE_ASSISTANT_API_ENDPOINT,
+    CONF_API_KEY,
     CONF_EXPOSE_BY_DEFAULT,
     CONF_EXPOSED_DOMAINS,
     CONF_ENTITY_CONFIG,
@@ -27,9 +28,12 @@ from .const import (
     CONF_SERVICE_ACCOUNT,
     CONF_CLIENT_EMAIL,
     CONF_PRIVATE_KEY,
+    DOMAIN,
     HOMEGRAPH_TOKEN_URL,
     HOMEGRAPH_SCOPE,
     REPORT_STATE_BASE_URL,
+    REQUEST_SYNC_BASE_URL,
+    SERVICE_REQUEST_SYNC,
 )
 from .smart_home import async_handle_message
 from .helpers import AbstractConfig
@@ -193,6 +197,25 @@ def async_register_http(hass, cfg):
     hass.http.register_view(GoogleAssistantView(config))
     if config.should_report_state:
         config.async_enable_report_state()
+
+    async def request_sync_service_handler(call: ServiceCall):
+        """Handle request sync service calls."""
+        agent_user_id = call.data.get("agent_user_id") or call.context.user_id
+
+        if agent_user_id is None:
+            _LOGGER.warning(
+                "No agent_user_id supplied for request_sync. Call as a user or pass in user id as agent_user_id."
+            )
+            return
+        await config.async_call_homegraph_api(
+            REQUEST_SYNC_BASE_URL, {"agentUserId": agent_user_id}
+        )
+
+    # Register service only if api key is provided
+    if CONF_API_KEY not in cfg and CONF_SERVICE_ACCOUNT in cfg:
+        hass.services.async_register(
+            DOMAIN, SERVICE_REQUEST_SYNC, request_sync_service_handler
+        )
 
 
 class GoogleAssistantView(HomeAssistantView):

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -166,7 +166,8 @@ def async_register_http(hass, cfg):
     """Register HTTP views for Google Assistant."""
     config = GoogleConfig(hass, cfg)
     hass.http.register_view(GoogleAssistantView(config))
-    config.async_enable_report_state()
+    if config.should_report_state:
+        config.async_enable_report_state()
 
 
 class GoogleAssistantView(HomeAssistantView):

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -50,7 +50,7 @@ class GoogleConfig(AbstractConfig):
     @property
     def agent_user_id(self):
         """Return Agent User Id to use for query responses."""
-        return self._config.get("agent_user_id")
+        return None
 
     @property
     def entity_config(self):
@@ -134,7 +134,7 @@ class GoogleConfig(AbstractConfig):
 
         data = {
             "requestId": uuid4().hex,
-            "agentUserId": self.agent_user_id,
+            "agentUserId": (await self.hass.auth.async_get_owner()).id,
             "payload": message,
         }
 

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -153,7 +153,6 @@ class GoogleConfig(AbstractConfig):
 
     async def async_call_homegraph_api(self, url, data):
         """Call a homegraph api with authenticaiton."""
-
         try:
             with async_timeout.timeout(15):
                 await self._async_update_token()

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -151,9 +151,7 @@ class GoogleConfig(AbstractConfig):
                 ),
             )
             self._access_token = token["access_token"]
-            self._access_token_renew = now + timedelta(
-                seconds=token["expires_in"] * 0.8
-            )
+            self._access_token_renew = now + timedelta(seconds=token["expires_in"])
 
     async def async_call_homegraph_api(self, url, data):
         """Call a homegraph api with authenticaiton."""

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -28,12 +28,9 @@ async def test_get_jwt(hass):
     with patch("homeassistant.components.google_assistant.http.dt_util") as mock_dt:
         mock_dt.utcnow.return_value = datetime(2019, 10, 14)
         jwt = config._async_get_jwt()
-        assert jwt == (
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZ"
-            "pY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9"
-            "ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9"
-            "rZW4iLCJpc3QiOjE1NzEwMDQwMDAuMCwiZXhwIjoxNTcxMDA3NjAwLjB9.J64gpWBonUUs9S71ty"
-            "bQ0VlStodPBtiejIKH0LOIjYE"
+        assert (
+            jwt
+            == "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9rZW4iLCJpYXQiOjE1NzEwMDQwMDAsImV4cCI6MTU3MTAwNzYwMH0.V4mXq5_GflIeg176axybOCmbrqMtx37vi4l5asoK35y9cRcDO51y4rRrrVzhmVQTLJk4GgpIfshS5Z0YJO2L8XP9njp2ql9O98bUy3wKQuprVefnXuPmTFlUUCOKsgUNhrr5-TkjCjo9mDJ13wKBpslCtp9w2T0IGsaNdm-dc3g"
         )
 
 
@@ -48,12 +45,17 @@ async def test_get_access_token(hass, aioclient_mock):
         token = "dummyjwt"
         mock_get_token.return_value = token
 
-        aioclient_mock.post(HOMEGRAPH_AUDIENCE, status=200)
+        aioclient_mock.post(
+            HOMEGRAPH_AUDIENCE,
+            status=200,
+            json={"access_token": "1234", "expires_in": 3600},
+        )
 
         await config._async_get_access_token()
         assert aioclient_mock.call_count == 1
         assert aioclient_mock.mock_calls[0][3] == {
-            "Authorization": "Bearer {}".format(token)
+            "Authorization": "Bearer {}".format(token),
+            "Content-Type": "application/x-www-form-urlencoded",
         }
 
 
@@ -70,7 +72,7 @@ async def test_report_state(hass, aioclient_mock, hass_storage):
         owner = User(name="Test User", perm_lookup=None, groups=[], is_owner=True)
         mock_get_owner.return_value = owner
 
-        aioclient_mock.post(REPORT_STATE_BASE_URL, status=200)
+        aioclient_mock.post(REPORT_STATE_BASE_URL, status=200, json={})
 
         await config.async_report_state(message)
 

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -1,5 +1,5 @@
 """Test Google http services."""
-from datetime import datetime
+from datetime import datetime, timezone
 from asynctest import patch, ANY
 
 from homeassistant.components.google_assistant.http import (
@@ -29,9 +29,11 @@ async def test_get_jwt(hass):
     """Test signing of key."""
 
     key = "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\n-----END PRIVATE KEY-----\n"
-    jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9rZW4iLCJpYXQiOjE1NzEwMDQwMDAsImV4cCI6MTU3MTAwNzYwMH0.V4mXq5_GflIeg176axybOCmbrqMtx37vi4l5asoK35y9cRcDO51y4rRrrVzhmVQTLJk4GgpIfshS5Z0YJO2L8XP9njp2ql9O98bUy3wKQuprVefnXuPmTFlUUCOKsgUNhrr5-TkjCjo9mDJ13wKBpslCtp9w2T0IGsaNdm-dc3g"
+    jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9rZW4iLCJpYXQiOjE1NzEwMTEyMDAsImV4cCI6MTU3MTAxNDgwMH0.gG06SmY-zSvFwSrdFfqIdC6AnC22rwz-d2F2UDeWbywjdmFL_1zceL-OOLBwjD8MJr6nR0kmN_Osu7ml9-EzzZjJqsRUxMjGn2G8nSYHbv16R4FYIp62Ibvt6Jj_wdFobEPoy_5OJ28P5Hdu0giGMlFBJMy0Tc6MgEDZA-cwOBw"
     res = _get_homegraph_jwt(
-        datetime(2019, 10, 14), "dummy@dummy.iam.gserviceaccount.com", key
+        datetime(2019, 10, 14, tzinfo=timezone.utc),
+        "dummy@dummy.iam.gserviceaccount.com",
+        key,
     )
     assert res == jwt
 

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -43,11 +43,9 @@ async def test_get_access_token(hass, aioclient_mock):
     config = GoogleConfig(hass, DUMMY_CONFIG)
     with patch(
         "homeassistant.components.google_assistant.http._get_homegraph_jwt"
-    ) as mock_get_token, patch(
-        "homeassistant.components.google_assistant.http.dt_util"
-    ) as mock_dt:
-        mock_dt.utcnow.return_value = datetime(2019, 10, 14)
+    ) as mock_get_token:
 
+        now = datetime(2019, 10, 14)
         token = "dummyjwt"
         mock_get_token.return_value = token
 
@@ -57,7 +55,7 @@ async def test_get_access_token(hass, aioclient_mock):
             json={"access_token": "1234", "expires_in": 3600},
         )
 
-        await config._async_get_access_token()
+        await config._async_get_access_token(now)
         assert aioclient_mock.call_count == 1
         assert aioclient_mock.mock_calls[0][3] == {
             "Authorization": "Bearer {}".format(token),

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -63,7 +63,7 @@ async def test_get_access_token(hass, aioclient_mock):
 
 
 async def test_call_homegraph_api(hass, aioclient_mock, hass_storage):
-    """Test the report state function."""
+    """Test the function to call the homegraph api."""
     config = GoogleConfig(hass, DUMMY_CONFIG)
     with patch(
         "homeassistant.components.google_assistant.http._get_homegraph_token"
@@ -83,7 +83,7 @@ async def test_call_homegraph_api(hass, aioclient_mock, hass_storage):
 
 
 async def test_call_homegraph_api_retry(hass, aioclient_mock, hass_storage):
-    """Test the report state function."""
+    """Test the that the calls get retried with new token on 401."""
     config = GoogleConfig(hass, DUMMY_CONFIG)
     with patch(
         "homeassistant.components.google_assistant.http._get_homegraph_token"

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -2,11 +2,14 @@
 from asynctest import patch, ANY
 from datetime import datetime
 
-from homeassistant.components.google_assistant.http import GoogleConfig
+from homeassistant.components.google_assistant.http import (
+    GoogleConfig,
+    _get_homegraph_jwt,
+)
 from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA
 from homeassistant.components.google_assistant.const import (
     REPORT_STATE_BASE_URL,
-    HOMEGRAPH_AUDIENCE,
+    HOMEGRAPH_TOKEN_URL,
 )
 from homeassistant.auth.models import User
 
@@ -23,15 +26,13 @@ DUMMY_CONFIG = GOOGLE_ASSISTANT_SCHEMA(
 
 async def test_get_jwt(hass):
     """Test signing of key."""
-    config = GoogleConfig(hass, DUMMY_CONFIG)
 
-    with patch("homeassistant.components.google_assistant.http.dt_util") as mock_dt:
-        mock_dt.utcnow.return_value = datetime(2019, 10, 14)
-        jwt = config._async_get_jwt()
-        assert (
-            jwt
-            == "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9rZW4iLCJpYXQiOjE1NzEwMDQwMDAsImV4cCI6MTU3MTAwNzYwMH0.V4mXq5_GflIeg176axybOCmbrqMtx37vi4l5asoK35y9cRcDO51y4rRrrVzhmVQTLJk4GgpIfshS5Z0YJO2L8XP9njp2ql9O98bUy3wKQuprVefnXuPmTFlUUCOKsgUNhrr5-TkjCjo9mDJ13wKBpslCtp9w2T0IGsaNdm-dc3g"
-        )
+    key = "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\n-----END PRIVATE KEY-----\n"
+    jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9rZW4iLCJpYXQiOjE1NzEwMDQwMDAsImV4cCI6MTU3MTAwNzYwMH0.V4mXq5_GflIeg176axybOCmbrqMtx37vi4l5asoK35y9cRcDO51y4rRrrVzhmVQTLJk4GgpIfshS5Z0YJO2L8XP9njp2ql9O98bUy3wKQuprVefnXuPmTFlUUCOKsgUNhrr5-TkjCjo9mDJ13wKBpslCtp9w2T0IGsaNdm-dc3g"
+    res = _get_homegraph_jwt(
+        datetime(2019, 10, 14), "dummy@dummy.iam.gserviceaccount.com", key
+    )
+    assert res == jwt
 
 
 async def test_get_access_token(hass, aioclient_mock):
@@ -40,13 +41,18 @@ async def test_get_access_token(hass, aioclient_mock):
     # TODO this should be cached with expire time remembered
 
     config = GoogleConfig(hass, DUMMY_CONFIG)
-    with patch.object(config, "_async_get_jwt") as mock_get_token:
+    with patch(
+        "homeassistant.components.google_assistant.http._get_homegraph_jwt"
+    ) as mock_get_token, patch(
+        "homeassistant.components.google_assistant.http.dt_util"
+    ) as mock_dt:
+        mock_dt.utcnow.return_value = datetime(2019, 10, 14)
 
         token = "dummyjwt"
         mock_get_token.return_value = token
 
         aioclient_mock.post(
-            HOMEGRAPH_AUDIENCE,
+            HOMEGRAPH_TOKEN_URL,
             status=200,
             json={"access_token": "1234", "expires_in": 3600},
         )

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -37,9 +37,6 @@ async def test_get_jwt(hass):
 
 async def test_get_access_token(hass, aioclient_mock):
     """Test the function to get access token."""
-
-    # TODO this should be cached with expire time remembered
-
     config = GoogleConfig(hass, DUMMY_CONFIG)
     with patch(
         "homeassistant.components.google_assistant.http._get_homegraph_jwt"

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -35,12 +35,11 @@ MOCK_HEADER = {
 async def test_get_jwt(hass):
     """Test signing of key."""
 
-    key = "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\n-----END PRIVATE KEY-----\n"
     jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9rZW4iLCJpYXQiOjE1NzEwMTEyMDAsImV4cCI6MTU3MTAxNDgwMH0.gG06SmY-zSvFwSrdFfqIdC6AnC22rwz-d2F2UDeWbywjdmFL_1zceL-OOLBwjD8MJr6nR0kmN_Osu7ml9-EzzZjJqsRUxMjGn2G8nSYHbv16R4FYIp62Ibvt6Jj_wdFobEPoy_5OJ28P5Hdu0giGMlFBJMy0Tc6MgEDZA-cwOBw"
     res = _get_homegraph_jwt(
         datetime(2019, 10, 14, tzinfo=timezone.utc),
-        "dummy@dummy.iam.gserviceaccount.com",
-        key,
+        DUMMY_CONFIG["service_account"]["client_email"],
+        DUMMY_CONFIG["service_account"]["private_key"],
     )
     assert res == jwt
 

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -8,6 +8,7 @@ from homeassistant.components.google_assistant.const import (
     REPORT_STATE_BASE_URL,
     HOMEGRAPH_AUDIENCE,
 )
+from homeassistant.auth.models import User
 
 DUMMY_CONFIG = GOOGLE_ASSISTANT_SCHEMA(
     {
@@ -16,7 +17,6 @@ DUMMY_CONFIG = GOOGLE_ASSISTANT_SCHEMA(
             "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\n-----END PRIVATE KEY-----\n",
             "client_email": "dummy@dummy.iam.gserviceaccount.com",
         },
-        "agent_user_id": "dummy-user",
     }
 )
 
@@ -57,14 +57,18 @@ async def test_get_access_token(hass, aioclient_mock):
         }
 
 
-async def test_report_state(hass, aioclient_mock):
+async def test_report_state(hass, aioclient_mock, hass_storage):
     """Test the report state function."""
     config = GoogleConfig(hass, DUMMY_CONFIG)
-    with patch.object(config, "_async_get_access_token") as mock_get_token:
+    with patch.object(
+        config, "_async_get_access_token"
+    ) as mock_get_token, patch.object(hass.auth, "async_get_owner") as mock_get_owner:
 
         token = "dummyaccess"
         message = {"devices": {}}
         mock_get_token.return_value = token
+        owner = User(name="Test User", perm_lookup=None, groups=[], is_owner=True)
+        mock_get_owner.return_value = owner
 
         aioclient_mock.post(REPORT_STATE_BASE_URL, status=200)
 
@@ -78,6 +82,6 @@ async def test_report_state(hass, aioclient_mock):
         }
         assert call[2] == {
             "requestId": ANY,
-            "agentUserId": config.agent_user_id,
+            "agentUserId": owner.id,
             "payload": message,
         }

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -1,0 +1,83 @@
+"""Test Google http services."""
+from asynctest import patch, ANY
+from datetime import datetime
+
+from homeassistant.components.google_assistant.http import GoogleConfig
+from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA
+from homeassistant.components.google_assistant.const import (
+    REPORT_STATE_BASE_URL,
+    HOMEGRAPH_AUDIENCE,
+)
+
+DUMMY_CONFIG = GOOGLE_ASSISTANT_SCHEMA(
+    {
+        "project_id": "1234",
+        "service_account": {
+            "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\n-----END PRIVATE KEY-----\n",
+            "client_email": "dummy@dummy.iam.gserviceaccount.com",
+        },
+        "agent_user_id": "dummy-user",
+    }
+)
+
+
+async def test_get_jwt(hass):
+    """Test signing of key."""
+    config = GoogleConfig(hass, DUMMY_CONFIG)
+
+    with patch("homeassistant.components.google_assistant.http.dt_util") as mock_dt:
+        mock_dt.utcnow.return_value = datetime(2019, 10, 14)
+        jwt = config._async_get_jwt()
+        assert jwt == (
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkdW1teUBkdW1teS5pYW0uZ3NlcnZ"
+            "pY2VhY2NvdW50LmNvbSIsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9"
+            "ob21lZ3JhcGgiLCJhdWQiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20vby9vYXV0aDIvdG9"
+            "rZW4iLCJpc3QiOjE1NzEwMDQwMDAuMCwiZXhwIjoxNTcxMDA3NjAwLjB9.J64gpWBonUUs9S71ty"
+            "bQ0VlStodPBtiejIKH0LOIjYE"
+        )
+
+
+async def test_get_access_token(hass, aioclient_mock):
+    """Test the function to get access token."""
+
+    # TODO this should be cached with expire time remembered
+
+    config = GoogleConfig(hass, DUMMY_CONFIG)
+    with patch.object(config, "_async_get_jwt") as mock_get_token:
+
+        token = "dummyjwt"
+        mock_get_token.return_value = token
+
+        aioclient_mock.post(HOMEGRAPH_AUDIENCE, status=200)
+
+        await config._async_get_access_token()
+        assert aioclient_mock.call_count == 1
+        assert aioclient_mock.mock_calls[0][3] == {
+            "Authorization": "Bearer {}".format(token)
+        }
+
+
+async def test_report_state(hass, aioclient_mock):
+    """Test the report state function."""
+    config = GoogleConfig(hass, DUMMY_CONFIG)
+    with patch.object(config, "_async_get_access_token") as mock_get_token:
+
+        token = "dummyaccess"
+        message = {"devices": {}}
+        mock_get_token.return_value = token
+
+        aioclient_mock.post(REPORT_STATE_BASE_URL, status=200)
+
+        await config.async_report_state(message)
+
+        assert aioclient_mock.call_count == 1
+        call = aioclient_mock.mock_calls[0]
+        assert call[3] == {
+            "Authorization": "Bearer {}".format(token),
+            "X-GFE-SSL": "yes",
+        }
+        assert call[2] == {
+            "requestId": ANY,
+            "agentUserId": config.agent_user_id,
+            "payload": message,
+        }


### PR DESCRIPTION
## Description:
Support report state for local google assistant configuration. 

To support this a new service_account need to be created since api_key access is not supported. Luckily this also let the same service key be used for requestSync. So we can do away with the api_key once it's been deprecated a few
releases.

Current logic uses the owner of hass as the reporting user. That mean when you add hass to your google home, you must login using the owner account, otherwise we will report state with the wrong user.

Todo:
  - [ ] Remember synced agentUserId's
  - [ ] Support DISCONNECT intent to remove an agentUserId from previously synced agentUserId's
  - [x] Support a negative response on request if token expired 

**Related issue (if applicable):** #27112

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** 

## Example entry for `configuration.yaml` (if applicable):
```yaml

google_assistant:
  project_id: someid
  report_state: true
  service_account:
    private_key: "-----BEGIN PRIVATE KEY-----asfasfa-----END PRIVATE KEY-----\n"
    client_email: "somename@something.iam.gserviceaccount.com"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
