### PR TITLE
Fire an event when nzbget download completes

### DIFF
--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -81,6 +81,7 @@ def setup(hass, config):
     _LOGGER.debug("Successfully validated NZBGet API connection")
 
     nzbget_data = hass.data[DATA_NZBGET] = NZBGetData(hass, nzbget_api)
+    nzbget_data.init_download_list()
     nzbget_data.update()
 
     def service_handler(service):
@@ -127,17 +128,49 @@ class NZBGetData:
         self.status = None
         self.available = True
         self._api = api
+        self.downloads = None
+        self.completed_downloads = []
 
     def update(self):
         """Get the latest data from NZBGet instance."""
 
         try:
             self.status = self._api.status()
+            self.downloads = self._api.history()
+
+            self.check_completed_downloads()
+
             self.available = True
             dispatcher_send(self.hass, DATA_UPDATED)
         except pynzbgetapi.NZBGetAPIException as err:
             self.available = False
             _LOGGER.error("Unable to refresh NZBGet data: %s", err)
+
+    def init_download_list(self):
+        """Initialize download list."""
+        self.downloads = self._api.history()
+        self.completed_downloads = [
+            (x["Name"], x["Category"], x["Status"]) for x in self.downloads
+        ]
+
+    def check_completed_downloads(self):
+        """Check that downloads have completed."""
+
+        actual_completed_downloads = [
+            (x["Name"], x["Category"], x["Status"]) for x in self.downloads
+        ]
+
+        tmp_completed_downloads = list(
+            set(actual_completed_downloads).difference(self.completed_downloads)
+        )
+
+        for download in tmp_completed_downloads:
+            self.hass.bus.fire(
+                "nzbget_downloaded_nzb",
+                {"name": download[0], "category": download[1], "status": download[2]},
+            )
+
+        self.completed_downloads = actual_completed_downloads
 
     def pause_download(self):
         """Pause download queue."""

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -129,7 +129,7 @@ class NZBGetData:
         self.available = True
         self._api = api
         self.downloads = None
-        self.completed_downloads = []
+        self.completed_downloads = set()
 
     def update(self):
         """Get the latest data from NZBGet instance."""
@@ -149,16 +149,16 @@ class NZBGetData:
     def init_download_list(self):
         """Initialize download list."""
         self.downloads = self._api.history()
-        self.completed_downloads = set(
-            [(x["Name"], x["Category"], x["Status"]) for x in self.downloads]
-        )
+        self.completed_downloads = {
+            (x["Name"], x["Category"], x["Status"]) for x in self.downloads
+        }
 
     def check_completed_downloads(self):
         """Check that downloads have completed."""
 
-        actual_completed_downloads = set(
-            [(x["Name"], x["Category"], x["Status"]) for x in self.downloads]
-        )
+        actual_completed_downloads = {
+            (x["Name"], x["Category"], x["Status"]) for x in self.downloads
+        }
 
         tmp_completed_downloads = list(
             actual_completed_downloads.difference(self.completed_downloads)

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -154,7 +154,7 @@ class NZBGetData:
         }
 
     def check_completed_downloads(self):
-        """Check that downloads have completed."""
+        """Check history for newly completed downloads."""
 
         actual_completed_downloads = {
             (x["Name"], x["Category"], x["Status"]) for x in self.downloads

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -149,24 +149,24 @@ class NZBGetData:
     def init_download_list(self):
         """Initialize download list."""
         self.downloads = self._api.history()
-        self.completed_downloads = [
-            (x["Name"], x["Category"], x["Status"]) for x in self.downloads
-        ]
+        self.completed_downloads = set(
+            [(x["Name"], x["Category"], x["Status"]) for x in self.downloads]
+        )
 
     def check_completed_downloads(self):
         """Check that downloads have completed."""
 
-        actual_completed_downloads = [
-            (x["Name"], x["Category"], x["Status"]) for x in self.downloads
-        ]
+        actual_completed_downloads = set(
+            [(x["Name"], x["Category"], x["Status"]) for x in self.downloads]
+        )
 
         tmp_completed_downloads = list(
-            set(actual_completed_downloads).difference(self.completed_downloads)
+            actual_completed_downloads.difference(self.completed_downloads)
         )
 
         for download in tmp_completed_downloads:
             self.hass.bus.fire(
-                "nzbget_downloaded_nzb",
+                "nzbget_download_complete",
                 {"name": download[0], "category": download[1], "status": download[2]},
             )
 


### PR DESCRIPTION
## Description:

Raise the nzbget_downloaded_nzb event when a download completes. Event includes nzb name, category, and status.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10838

## Example automation:
```yaml
- id: '1571277970615'
  alias: Toggle when TV download completes
  description: ''
  trigger:
  - event_data:
      category: tv
    event_type: nzbget_downloaded_nzb
    platform: event
  condition: []
  action:
  - data:
      entity_id: input_boolean.nzbget_test
    service: input_boolean.toggle
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [No Change ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [No Change] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [No Change] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.