### PR TITLE
Fix Emulated Hue not working with switches

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -571,7 +571,7 @@ def get_entity_state(config, entity):
 def entity_to_json(config, entity, state):
     """Convert an entity to its Hue bridge JSON representation."""
     entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-    if (entity_features & SUPPORT_BRIGHTNESS) or (entity.domain == climate.DOMAIN or entity.domain == fan.DOMAIN or entity.domain == media_player.DOMAIN or entity.domain == cover.DOMAIN):
+    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain in [climate.DOMAIN, fan.DOMAIN, media_player.DOMAIN, cover.DOMAIN]:
         return {
             "state": {
                 HUE_API_STATE_ON: state[STATE_ON],

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -571,7 +571,7 @@ def get_entity_state(config, entity):
 def entity_to_json(config, entity, state):
     """Convert an entity to its Hue bridge JSON representation."""
     entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain != light.DOMAIN:
+    if (entity_features & SUPPORT_BRIGHTNESS) or (entity.domain == climate.DOMAIN or entity.domain == fan.DOMAIN or entity.domain == media_player.DOMAIN or entity.domain == cover.DOMAIN):
         return {
             "state": {
                 HUE_API_STATE_ON: state[STATE_ON],

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -571,7 +571,12 @@ def get_entity_state(config, entity):
 def entity_to_json(config, entity, state):
     """Convert an entity to its Hue bridge JSON representation."""
     entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain in [climate.DOMAIN, fan.DOMAIN, media_player.DOMAIN, cover.DOMAIN]:
+    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain in [
+        climate.DOMAIN,
+        fan.DOMAIN,
+        media_player.DOMAIN,
+        cover.DOMAIN,
+    ]:
         return {
             "state": {
                 HUE_API_STATE_ON: state[STATE_ON],


### PR DESCRIPTION
Switches getting recognized as dimmable lights, read here #26860. Credits to schiegg for the suggested change...

## Breaking Change:

Switches will work again with the Emulated Hue Component.

## Description:

Alexa/Echo will recognize switches as "On/off light" and therefore can control them again.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
