### PR TITLE
Add device_info to HomematicIP climate and acp

### DIFF
--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -60,6 +60,17 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
                 self._external_alarm_zone = security_zone
 
     @property
+    def device_info(self):
+        """Return device specific attributes."""
+        return {
+            "identifiers": {(HMIPC_DOMAIN, f"ACP {self._home.id}")},
+            "name": self.name,
+            "manufacturer": "eQ-3",
+            "model": CONST_ALARM_CONTROL_PANEL_NAME,
+            "via_device": (HMIPC_DOMAIN, self._home.id),
+        }
+
+    @property
     def state(self) -> str:
         """Return the state of the device."""
         activation_state = self._home.get_security_zones_activation()

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -56,11 +56,22 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize heating group."""
-        device.modelType = "Group-Heating"
+        device.modelType = "HmIP-Heating-Group"
         self._simple_heating = None
         if device.actualTemperature is None:
             self._simple_heating = _get_first_heating_thermostat(device)
         super().__init__(hap, device)
+
+    @property
+    def device_info(self):
+        """Return device specific attributes."""
+        return {
+            "identifiers": {(HMIPC_DOMAIN, self._device.id)},
+            "name": self._device.label,
+            "manufacturer": "eQ-3",
+            "model": self._device.modelType,
+            "via_device": (HMIPC_DOMAIN, self._device.homeId),
+        }
 
     @property
     def temperature_unit(self) -> str:
@@ -176,4 +187,3 @@ def _get_first_heating_thermostat(heating_group: AsyncHeatingGroup):
     for device in heating_group.devices:
         if isinstance(device, (AsyncHeatingThermostat, AsyncHeatingThermostatCompact)):
             return device
-    return None


### PR DESCRIPTION
## Description:
This PR enables device automations for alarm control panel and climate devices

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
