### PR TITLE
Add climate profiles to Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -219,11 +219,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def _set_active_climate_profile(service):
         """Service to set the active climate profile."""
-        entity_id_list = service.data.get(ATTR_ENTITY_ID)
-        climate_profile_index = service.data.get(ATTR_CLIMATE_PROFILE_INDEX) - 1
+        entity_id_list = service.data[ATTR_ENTITY_ID]
+        climate_profile_index = service.data[ATTR_CLIMATE_PROFILE_INDEX] - 1
 
         for hap in hass.data[DOMAIN].values():
-            if entity_id_list and entity_id_list != "all":
+            if entity_id_list != "all":
                 for entity_id in entity_id_list:
                     group = hap.hmip_device_by_entity_id.get(entity_id)
                     if group:

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -92,7 +92,7 @@ SCHEMA_DEACTIVATE_VACATION = vol.Schema(
 
 SCHEMA_SET_ACTIVE_CLIMATE_PROFILE = vol.Schema(
     {
-        vol.Optional(ATTR_ENTITY_ID): comp_entity_ids,
+        vol.Required(ATTR_ENTITY_ID): comp_entity_ids,
         vol.Required(ATTR_CLIMATE_PROFILE_INDEX): cv.positive_int,
     }
 )
@@ -128,9 +128,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if home:
                 await home.activate_absence_with_duration(duration)
         else:
-            for hapid in hass.data[DOMAIN]:
-                home = hass.data[DOMAIN][hapid].home
-                await home.activate_absence_with_duration(duration)
+            for hap in hass.data[DOMAIN].values():
+                await hap.home.activate_absence_with_duration(duration)
 
     hass.services.async_register(
         DOMAIN,
@@ -149,9 +148,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if home:
                 await home.activate_absence_with_period(endtime)
         else:
-            for hapid in hass.data[DOMAIN]:
-                home = hass.data[DOMAIN][hapid].home
-                await home.activate_absence_with_period(endtime)
+            for hap in hass.data[DOMAIN].values():
+                await hap.home.activate_absence_with_period(endtime)
 
     hass.services.async_register(
         DOMAIN,
@@ -171,9 +169,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if home:
                 await home.activate_vacation(endtime, temperature)
         else:
-            for hapid in hass.data[DOMAIN]:
-                home = hass.data[DOMAIN][hapid].home
-                await home.activate_vacation(endtime, temperature)
+            for hap in hass.data[DOMAIN].values():
+                await hap.home.activate_vacation(endtime, temperature)
 
     hass.services.async_register(
         DOMAIN,
@@ -191,9 +188,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if home:
                 await home.deactivate_absence()
         else:
-            for hapid in hass.data[DOMAIN]:
-                home = hass.data[DOMAIN][hapid].home
-                await home.deactivate_absence()
+            for hap in hass.data[DOMAIN].values():
+                await hap.home.deactivate_absence()
 
     hass.services.async_register(
         DOMAIN,
@@ -211,9 +207,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if home:
                 await home.deactivate_vacation()
         else:
-            for hapid in hass.data[DOMAIN]:
-                home = hass.data[DOMAIN][hapid].home
-                await home.deactivate_vacation()
+            for hap in hass.data[DOMAIN].values():
+                await hap.home.deactivate_vacation()
 
     hass.services.async_register(
         DOMAIN,
@@ -227,17 +222,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         entity_id_list = service.data.get(ATTR_ENTITY_ID)
         climate_profile_index = service.data.get(ATTR_CLIMATE_PROFILE_INDEX) - 1
 
-        for hapid in hass.data[DOMAIN]:
-            hap = hass.data[DOMAIN][hapid]
-            home = hap.home
-
-            if entity_id_list:
+        for hap in hass.data[DOMAIN].values():
+            if entity_id_list and entity_id_list != "all":
                 for entity_id in entity_id_list:
                     group = hap.hmip_device_by_entity_id.get(entity_id)
                     if group:
                         await group.set_active_profile(climate_profile_index)
             else:
-                for group in home.groups:
+                for group in hap.home.groups:
                     if isinstance(group, AsyncHeatingGroup):
                         await group.set_active_profile(climate_profile_index)
 

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -187,7 +187,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
             for profile in self._device.profiles
             if profile.visible
             and profile.name != ""
-            and profile.index in self._relevant_profile_group.keys()
+            and profile.index in self._relevant_profile_group
         ]
 
     @property

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -140,10 +140,8 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
     @property
     def preset_modes(self):
         """Return a list of available preset modes incl profiles."""
-        presets = self._device_profile_names
-        if not presets:
-            presets.append(PRESET_NONE)
-        presets.append(PRESET_BOOST)
+        presets = [PRESET_NONE, PRESET_BOOST]
+        presets.extend(self._device_profile_names)
         return presets
 
     @property

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -198,7 +198,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         return [profile.name for profile in self._device_profiles]
 
     def _get_profile_idx_by_name(self, profile_name):
-        """Return an profile index by name."""
+        """Return a profile index by name."""
         relevant_index = self._relevant_profile_group
         index_name = [
             profile.index
@@ -210,7 +210,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     @property
     def _relevant_profile_group(self):
-        """Return the relevant profile group."""
+        """Return the relevant profile groups."""
         return (
             HEATING_PROFILES
             if self._device.groupType == GroupType.HEATING
@@ -223,3 +223,4 @@ def _get_first_heating_thermostat(heating_group: AsyncHeatingGroup):
     for device in heating_group.devices:
         if isinstance(device, (AsyncHeatingThermostat, AsyncHeatingThermostatCompact)):
             return device
+    return None

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -99,7 +99,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         Need to be one of HVAC_MODE_*.
         """
         if self._device.boostMode:
-            return HVAC_MODE_AUTO
+            return HVAC_MODE_HEAT
         if self._device.controlMode == HMIP_MANUAL_CM:
             return HVAC_MODE_HEAT
 

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -7,7 +7,7 @@ activate_eco_mode_with_duration:
       description: The duration of eco mode in minutes.
       example: 60
     accesspoint_id:
-      description: The ID of the Homematic IP Access Point
+      description: The ID of the Homematic IP Access Point (optional)
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 activate_eco_mode_with_period:
@@ -17,7 +17,7 @@ activate_eco_mode_with_period:
       description: The time when the eco mode should automatically be disabled.
       example: 2019-02-17 14:00
     accesspoint_id:
-      description: The ID of the Homematic IP Access Point
+      description: The ID of the Homematic IP Access Point (optional)
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 activate_vacation:
@@ -30,20 +30,31 @@ activate_vacation:
       description: the set temperature during the vacation mode.
       example: 18.5
     accesspoint_id:
-      description: The ID of the Homematic IP Access Point
+      description: The ID of the Homematic IP Access Point (optional)
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 deactivate_eco_mode:
   description: Deactivates the eco mode immediately.
   fields:
     accesspoint_id:
-      description: The ID of the Homematic IP Access Point
+      description: The ID of the Homematic IP Access Point (optional)
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 deactivate_vacation:
   description: Deactivates the vacation mode immediately.
   fields:
     accesspoint_id:
-      description: The ID of the Homematic IP Access Point
+      description: The ID of the Homematic IP Access Point (optional)
       example: 3014xxxxxxxxxxxxxxxxxxxx
+
+set_active_climate_profile:
+  description: Set the active climate profile index.
+  fields:
+    entity_id:
+      description: The ID of the climte entity (optional)
+      example: climate.livingroom
+    climate_profile_index:
+      description: The index of the climate profile (1 based)
+      example: 1
+
 

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -51,7 +51,7 @@ set_active_climate_profile:
   description: Set the active climate profile index.
   fields:
     entity_id:
-      description: The ID of the climte entity (optional)
+      description: The ID of the climte entity. Use 'all' keyword to switch the profile for all entities.
       example: climate.livingroom
     climate_profile_index:
       description: The index of the climate profile (1 based)

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -49,8 +49,8 @@ async def test_hmip_heating_group(hass, default_mock_hap):
     assert ha_state.attributes["max_temp"] == 30.0
     assert ha_state.attributes["temperature"] == 5.0
     assert ha_state.attributes["current_humidity"] == 47
-    assert ha_state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
-    assert ha_state.attributes[ATTR_PRESET_MODES] == [PRESET_NONE, PRESET_BOOST]
+    assert ha_state.attributes[ATTR_PRESET_MODE] == "STD"
+    assert ha_state.attributes[ATTR_PRESET_MODES] == ["STD", "Winter", PRESET_BOOST]
 
     service_call_counter = len(hmip_device.mock_calls)
 
@@ -117,7 +117,7 @@ async def test_hmip_heating_group(hass, default_mock_hap):
     assert hmip_device.mock_calls[-1][1] == (False,)
     await async_manipulate_test_data(hass, hmip_device, "boostMode", False)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
+    assert ha_state.attributes[ATTR_PRESET_MODE] == "STD"
 
     # Not required for hmip, but a posiblity to send no temperature.
     await hass.services.async_call(
@@ -152,6 +152,18 @@ async def test_hmip_heating_group(hass, default_mock_hap):
     )
     ha_state = hass.states.get(entity_id)
     assert ha_state.attributes[ATTR_PRESET_MODE] == PRESET_ECO
+
+    # Not required for hmip, but a posiblity to send no temperature.
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": entity_id, "preset_mode": "Winter"},
+        blocking=True,
+    )
+
+    assert len(hmip_device.mock_calls) == service_call_counter + 16
+    assert hmip_device.mock_calls[-1][0] == "set_active_profile"
+    assert hmip_device.mock_calls[-1][1] == (1,)
 
 
 async def test_hmip_climate_services(hass, mock_hap_with_service):

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -50,7 +50,12 @@ async def test_hmip_heating_group(hass, default_mock_hap):
     assert ha_state.attributes["temperature"] == 5.0
     assert ha_state.attributes["current_humidity"] == 47
     assert ha_state.attributes[ATTR_PRESET_MODE] == "STD"
-    assert ha_state.attributes[ATTR_PRESET_MODES] == ["STD", "Winter", PRESET_BOOST]
+    assert ha_state.attributes[ATTR_PRESET_MODES] == [
+        PRESET_NONE,
+        PRESET_BOOST,
+        "STD",
+        "Winter",
+    ]
 
     service_call_counter = len(hmip_device.mock_calls)
 

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -264,3 +264,35 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     assert home.mock_calls[-1][1] == ()
     # There is no further call on connection.
     assert len(home._connection.mock_calls) == 10  # pylint: disable=W0212
+
+
+async def test_hmip_heating_group_services(hass, mock_hap_with_service):
+    """Test HomematicipHeatingGroup services."""
+    entity_id = "climate.badezimmer"
+    entity_name = "Badezimmer"
+    device_model = None
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap_with_service, entity_id, entity_name, device_model
+    )
+    assert ha_state
+
+    await hass.services.async_call(
+        "homematicip_cloud",
+        "set_active_climate_profile",
+        {"climate_profile_index": 2, "entity_id": "climate.badezimmer"},
+        blocking=True,
+    )
+    assert hmip_device.mock_calls[-1][0] == "set_active_profile"
+    assert hmip_device.mock_calls[-1][1] == (1,)
+    assert len(hmip_device._connection.mock_calls) == 2  # pylint: disable=W0212
+
+    await hass.services.async_call(
+        "homematicip_cloud",
+        "set_active_climate_profile",
+        {"climate_profile_index": 2},
+        blocking=True,
+    )
+    assert hmip_device.mock_calls[-1][0] == "set_active_profile"
+    assert hmip_device.mock_calls[-1][1] == (1,)
+    assert len(hmip_device._connection.mock_calls) == 12  # pylint: disable=W0212

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -307,7 +307,7 @@ async def test_hmip_heating_group_services(hass, mock_hap_with_service):
     await hass.services.async_call(
         "homematicip_cloud",
         "set_active_climate_profile",
-        {"climate_profile_index": 2},
+        {"climate_profile_index": 2, "entity_id": "all"},
         blocking=True,
     )
     assert hmip_device.mock_calls[-1][0] == "set_active_profile"

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -4638,7 +4638,7 @@
                     "enabled": true,
                     "groupId": "00000000-0000-0000-0000-000000000021",
                     "index": "PROFILE_1",
-                    "name": "",
+                    "name": "STD",
                     "profileId": "00000000-0000-0000-0000-000000000038",
                     "visible": true
                 },
@@ -4646,9 +4646,9 @@
                     "enabled": true,
                     "groupId": "00000000-0000-0000-0000-000000000021",
                     "index": "PROFILE_2",
-                    "name": "",
+                    "name": "Winter",
                     "profileId": "00000000-0000-0000-0000-000000000039",
-                    "visible": false
+                    "visible": true
                 },
                 "PROFILE_3": {
                     "enabled": true,


### PR DESCRIPTION
## Description:
Add climate service to Homematic IP Cloud to select the active profile.
It also adds HomematicIP Profiles as presets.
To be able to use the profiles, the user has to make them visible and give them a name in the Homematic IP App.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):**
https://github.com/home-assistant/home-assistant.io/pull/10842

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
