### PR TITLE
Avoid drawing image_processing font text inside the bow line

### DIFF
--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -85,8 +85,8 @@ def draw_box(
     the bounding box will be `(40, 10)` to `(180, 50)` (in (x,y) coordinates).
     """
 
-    line_width = 5
-    font_height = 7
+    line_width = 3
+    font_height = 8
     y_min, x_min, y_max, x_max = box
     (left, right, top, bottom) = (
         x_min * img_width,

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -86,7 +86,7 @@ def draw_box(
     """
 
     line_width = 5
-    font_height = 10
+    font_height = 7
     y_min, x_min, y_max, x_max = box
     (left, right, top, bottom) = (
         x_min * img_width,

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -86,6 +86,7 @@ def draw_box(
     """
 
     line_width = 5
+    font_height = 10
     y_min, x_min, y_max, x_max = box
     (left, right, top, bottom) = (
         x_min * img_width,
@@ -99,7 +100,9 @@ def draw_box(
         fill=color,
     )
     if text:
-        draw.text((left + line_width, abs(top - line_width)), text, fill=color)
+        draw.text(
+            (left + line_width, abs(top - line_width - font_height)), text, fill=color
+        )
 
 
 async def async_setup(hass, config):


### PR DESCRIPTION
## Description:

The image_processing.draw_box function is drawing the label text inside the line. This adjusts the text offset to account for the font size.

**Related issue:** fixes #27766

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
