### PR TITLE
bump geniushub client to 0.6.28

### DIFF
--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/integrations/geniushub",
   "requirements": [
-    "geniushub-client==0.6.26"
+    "geniushub-client==0.6.28"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -531,7 +531,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.6.26
+geniushub-client==0.6.28
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
Devs: Could this be Cherry-Picked for current RC?

## Description:
Bumps client to v0.6.28:
 - correctly handles zones without `activeTemperatureDevices`
 - new state attrs fro zones (adds **bIsActive** and **bOutRequestHeat** to `zone.data["_state"]`)
 - change some logic to sandbox riskier conversion from those considered essential
 - tweaks to CI

See: https://github.com/zxdavb/geniushub-client/compare/v0.6.26...v0.6.28

**Related issue (if applicable):** fixes #27719

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A
**Example entry for `configuration.yaml` (if applicable): Unchanged

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
