### PR TITLE
Fix attribution for Airly sensors

### DIFF
--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -1,5 +1,6 @@
 """Support for the Airly sensor service."""
 from homeassistant.const import (
+    ATTR_ATTRIBUTION,
     ATTR_DEVICE_CLASS,
     CONF_NAME,
     DEVICE_CLASS_HUMIDITY,
@@ -93,7 +94,7 @@ class AirlySensor(Entity):
         self._state = None
         self._icon = None
         self._unit_of_measurement = None
-        self._attrs = {}
+        self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
 
     @property
     def name(self):
@@ -135,11 +136,6 @@ class AirlySensor(Entity):
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return SENSOR_TYPES[self.kind][ATTR_UNIT]
-
-    @property
-    def attribution(self):
-        """Return the attribution."""
-        return ATTRIBUTION
 
     @property
     def available(self):


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Fixes my stupid copy/paste mistake with sensors' ATTRIBUTION.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
