### PR TITLE
Mypy setup fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,17 @@ repos:
         additional_dependencies:
           - flake8-docstrings==1.3.1
           - pydocstyle==4.0.0
--   repo: https://github.com/pre-commit/mirrors-mypy.git
-    rev: v0.730
+# Using a local "system" mypy instead of the mypy hook, because its
+# results depend on what is installed. And the mypy hook runs in a
+# virtualenv of its own, meaning we'd need to install and maintain
+# another set of our dependencies there... no. Use the "system" one
+# and reuse the environment that is set up anyway already instead.
+-   repo: local
     hooks:
     -   id: mypy
-        args: []
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        require_serial: true
         exclude: ^script/scaffold/templates/

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -174,12 +174,12 @@ stages:
     steps:
     - template: templates/azp-step-cache.yaml@azure
       parameters:
-        keyfile: 'requirements_test.txt | homeassistant/package_constraints.txt'
+        keyfile: 'requirements_test.txt | setup.py | homeassistant/package_constraints.txt'
         build: |
           python -m venv venv
 
           . venv/bin/activate
-          pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
+          pip install -e . -r requirements_test.txt -c homeassistant/package_constraints.txt
     - script: |
         . venv/bin/activate
         mypy homeassistant

--- a/homeassistant/util/ruamel_yaml.py
+++ b/homeassistant/util/ruamel_yaml.py
@@ -90,7 +90,7 @@ def load_yaml(fname: str, round_trip: bool = False) -> JSON_TYPE:
     if round_trip:
         yaml = YAML(typ="rt")
         # type ignore: https://bitbucket.org/ruamel/yaml/pull-requests/42
-        yaml.preserve_quotes = True
+        yaml.preserve_quotes = True  # type: ignore
     else:
         if ExtSafeConstructor.name is None:
             ExtSafeConstructor.name = fname


### PR DESCRIPTION
## Description:

Commit 8a0f26e15547652c1ae7ff4050684a18762d375f removed `pip install -e .` from azure, which results in ruamel.yaml no longer installed, and requires removal of the type ignore. However, this breaks mypy in all other environments where ruamel.yaml **is** installed and which thus require the type ignore, including local dev setups and tox.

So add back the core dep install to azure, and make pre-commit use the mypy that we installed through requirements_test.txt instead of using a separate one installed by pre-commit. This brings the environments in sync, and paves way for using pre-commit also in CI.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
