### PR TITLE
Translation update

### DIFF
--- a/homeassistant/components/ios/.translations/es.json
+++ b/homeassistant/components/ios/.translations/es.json
@@ -1,7 +1,15 @@
 {
     "config": {
         "abort": {
-            "single_instance_allowed": "Solo se necesita una \u00fanica configuraci\u00f3n de Home Assistant iOS."
+            "single_instance_allowed": "Solo se necesita una \u00fanica configuraci\u00f3n de Home Assistant iOS.",
+            "all_configured": "Todos los puentes Philips Hue han sido configurados",
+            "already_configured": "El puente ya esta configurado",
+            "already_in_progress": "La configuraci\u00f3n del flujo para el puente ya esta en progreso",
+            "cannot_connect": "Imposible conectarse al puente",
+            "discover_timeout": "Imposible encontrar el puente Hue",
+            "no_bridges": "No se descubrieron puentes Philips Hue",
+            "not_hue_bridge": "No es un puente Hue",
+            "unknown": "Ha ocurrido un error desconocido"
         },
         "step": {
             "confirm": {


### PR DESCRIPTION
Added new messages from https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/hue/.translations/en.json

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
