### PR TITLE
Support custom source type for MQTT device tracker

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -130,6 +130,7 @@ ABBREVIATIONS = {
     "spd_stat_t": "speed_state_topic",
     "spd_val_tpl": "speed_value_template",
     "spds": "speeds",
+    "src_type": "source_type",
     "stat_clsd": "state_closed",
     "stat_off": "state_off",
     "stat_on": "state_on",

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import mqtt
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SOURCE_TYPES
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_DEVICES, STATE_NOT_HOME, STATE_HOME
@@ -15,12 +15,14 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_PAYLOAD_HOME = "payload_home"
 CONF_PAYLOAD_NOT_HOME = "payload_not_home"
+CONF_SOURCE_TYPE = "source_type"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(mqtt.SCHEMA_BASE).extend(
     {
         vol.Required(CONF_DEVICES): {cv.string: mqtt.valid_subscribe_topic},
         vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.string,
         vol.Optional(CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME): cv.string,
+        vol.Optional(CONF_SOURCE_TYPE): vol.In(SOURCE_TYPES),
     }
 )
 
@@ -31,6 +33,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     qos = config[CONF_QOS]
     payload_home = config[CONF_PAYLOAD_HOME]
     payload_not_home = config[CONF_PAYLOAD_NOT_HOME]
+    source_type = config.get[CONF_SOURCE_TYPE]
 
     for dev_id, topic in devices.items():
 
@@ -44,9 +47,11 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
             else:
                 location_name = msg.payload
 
-            hass.async_create_task(
-                async_see(dev_id=dev_id, location_name=location_name)
-            )
+            see_args = {"dev_id": dev_id, "location_name": location_name}
+            if source_type:
+                see_args["source_type"] = source_type
+
+            hass.async_create_task(async_see(**see_args))
 
         await mqtt.async_subscribe(hass, topic, async_message_received, qos)
 

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -33,7 +33,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     qos = config[CONF_QOS]
     payload_home = config[CONF_PAYLOAD_HOME]
     payload_not_home = config[CONF_PAYLOAD_NOT_HOME]
-    source_type = config.get[CONF_SOURCE_TYPE]
+    source_type = config.get(CONF_SOURCE_TYPE)
 
     for dev_id, topic in devices.items():
 


### PR DESCRIPTION
## Description:
Add optional configuration option for MQTT device tracker to set a source type. This allows the device tracker to be used to control a person component's state differently depending on whether it's a stationary device or GPS based device.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10910

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: mqtt
    devices:
      paulus_oneplus: 'location/paulus'
      annetherese_n4: 'location/annetherese'
    source_type: bluetooth
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
