### PR TITLE
Fix config_entries.async_forward_entry_unload calls (step 1)

### DIFF
--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -19,7 +19,4 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    )
-    return True
+    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -55,7 +55,4 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Unload Linky sensors."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    )
-    return True
+    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")

--- a/homeassistant/components/locative/__init__.py
+++ b/homeassistant/components/locative/__init__.py
@@ -127,8 +127,7 @@ async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
     hass.data[DOMAIN]["unsub_device_tracker"].pop(entry.entry_id)()
-    await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
-    return True
+    return await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
 
 
 # pylint: disable=invalid-name

--- a/homeassistant/components/luftdaten/__init__.py
+++ b/homeassistant/components/luftdaten/__init__.py
@@ -172,12 +172,9 @@ async def async_unload_entry(hass, config_entry):
     )
     remove_listener()
 
-    for component in ("sensor",):
-        await hass.config_entries.async_forward_entry_unload(config_entry, component)
-
     hass.data[DOMAIN][DATA_LUFTDATEN_CLIENT].pop(config_entry.entry_id)
 
-    return True
+    return await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
 
 
 class LuftDatenData:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -92,8 +92,4 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Unload Withings config entry."""
-    await hass.async_create_task(
-        hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    )
-
-    return True
+    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Fixing calls of `hass.config_entries.async_forward_entry_unload` that should be awaited.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html