### PR TITLE
Azure pytest parallel

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -125,7 +125,7 @@ stages:
         set -e
 
         . venv/bin/activate
-        pytest --timeout=9 --durations=10 -n 2 -qq -o console_output_style=count -p no:sugar tests
+        pytest --timeout=9 --durations=10 -n 2 --dist loadfile -qq -o console_output_style=count -p no:sugar tests
         script/check_dirty
       displayName: 'Run pytest for python $(python.container)'
       condition: and(succeeded(), ne(variables['python.container'], variables['PythonMain']))
@@ -133,7 +133,7 @@ stages:
         set -e
 
         . venv/bin/activate
-        pytest --timeout=9 --durations=10 -n 2 --cov homeassistant --cov-report html -qq -o console_output_style=count -p no:sugar tests
+        pytest --timeout=9 --durations=10 -n 2 --dist loadfile --cov homeassistant --cov-report html -qq -o console_output_style=count -p no:sugar tests
         codecov --token $(codecovToken)
         script/check_dirty
       displayName: 'Run pytest for python $(python.container) / coverage'

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -106,13 +106,13 @@ stages:
     steps:
     - template: templates/azp-step-cache.yaml@azure
       parameters:
-        keyfile: 'requirements_test_all.txt | homeassistant/package_constraints.txt'
+        keyfile: 'requirements_test_all.txt | homeassistant/package_constraints.txt | "v2"'
         build: |
           set -e
           python -m venv venv
 
           . venv/bin/activate
-          pip install -U pip setuptools pytest-azurepipelines -c homeassistant/package_constraints.txt
+          pip install -U pip setuptools pytest-azurepipelines pytest-xdist -c homeassistant/package_constraints.txt
           pip install -r requirements_test_all.txt -c homeassistant/package_constraints.txt
           # This is a TEMP. Eventually we should make sure our 4 dependencies drop typing.
           # Find offending deps with `pipdeptree -r -p typing`
@@ -125,7 +125,7 @@ stages:
         set -e
 
         . venv/bin/activate
-        pytest --timeout=9 --durations=10 -qq -o console_output_style=count -p no:sugar tests
+        pytest --timeout=9 --durations=10 -n 2 -qq -o console_output_style=count -p no:sugar tests
         script/check_dirty
       displayName: 'Run pytest for python $(python.container)'
       condition: and(succeeded(), ne(variables['python.container'], variables['PythonMain']))
@@ -133,7 +133,7 @@ stages:
         set -e
 
         . venv/bin/activate
-        pytest --timeout=9 --durations=10 --cov homeassistant --cov-report html -qq -o console_output_style=count -p no:sugar tests
+        pytest --timeout=9 --durations=10 -n 2 --cov homeassistant --cov-report html -qq -o console_output_style=count -p no:sugar tests
         codecov --token $(codecovToken)
         script/check_dirty
       displayName: 'Run pytest for python $(python.container) / coverage'

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -169,11 +169,6 @@ async def mock_ddp_response(hass, mock_status_data, games=None):
         await hass.async_block_till_done()
 
 
-async def test_async_setup_platform_does_nothing():
-    """Test setup platform does nothing (Uses config entries only)."""
-    await ps4.media_player.async_setup_platform(None, None, None)
-
-
 async def test_media_player_is_setup_correctly_with_entry(hass):
     """Test entity is setup correctly with entry correctly."""
     mock_entity_id = await setup_mock_component(hass)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
