### PR TITLE
[WIP] [PATCH2] Workaround ebusd throttling

### DIFF
--- a/homeassistant/components/ebusd/__init__.py
+++ b/homeassistant/components/ebusd/__init__.py
@@ -1,5 +1,4 @@
 """Support for Ebusd daemon for communication with eBUS heating systems."""
-from datetime import timedelta
 import logging
 import socket
 
@@ -15,9 +14,8 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
-from homeassistant.util import Throttle
 
-from .const import DOMAIN, SENSOR_TYPES
+from .const import DOMAIN, SENSOR_TYPES, MIN_TIME_BETWEEN_UPDATES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,8 +26,6 @@ CONF_CIRCUIT = "circuit"
 CONF_CACHE_TTL = "cache_ttl"
 DEFAULT_CACHE_TTL = 900
 SERVICE_EBUSD_WRITE = "ebusd_write"
-
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
 
 
 def verify_ebusd_circuit_config(config):
@@ -125,7 +121,6 @@ class EbusdData:
         self._cache_ttl = cache_ttl
         self.value = {}
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, circuit, name, stype):
         """Call the Ebusd API to update the data."""
         try:

--- a/homeassistant/components/ebusd/__init__.py
+++ b/homeassistant/components/ebusd/__init__.py
@@ -6,6 +6,7 @@ import socket
 import ebusdpy
 import voluptuous as vol
 
+
 from homeassistant.const import (
     CONF_HOST,
     CONF_MONITORED_CONDITIONS,
@@ -22,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "ebusd"
 DEFAULT_PORT = 8888
+CONF_CIRCUITS = "circuits"
 CONF_CIRCUIT = "circuit"
 CONF_CACHE_TTL = "cache_ttl"
 DEFAULT_CACHE_TTL = 900
@@ -30,12 +32,17 @@ SERVICE_EBUSD_WRITE = "ebusd_write"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
 
 
-def verify_ebusd_config(config):
-    """Verify eBusd config."""
+def verify_ebusd_circuit_config(config):
+    """Verify eBusd circuit config."""
     circuit = config[CONF_CIRCUIT]
     for condition in config[CONF_MONITORED_CONDITIONS]:
         if condition not in SENSOR_TYPES[circuit]:
             raise vol.Invalid("Condition '" + condition + "' not in '" + circuit + "'.")
+    return config
+
+
+def verify_ebusd_config(config):
+    """Verify eBusd config."""
     cache_ttl = config[CONF_CACHE_TTL]
     if cache_ttl < MIN_TIME_BETWEEN_UPDATES.seconds:
         raise vol.Invalid(
@@ -45,22 +52,32 @@ def verify_ebusd_config(config):
             + str(MIN_TIME_BETWEEN_UPDATES.seconds)
             + " seconds."
         )
+    for circuit in config[CONF_CIRCUITS]:
+        verify_ebusd_circuit_config(circuit)
     return config
 
+
+CONFIG_CIRCUIT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CIRCUIT): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_MONITORED_CONDITIONS, default=[]): cv.ensure_list,
+    }
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             vol.All(
                 {
-                    vol.Required(CONF_CIRCUIT): cv.string,
                     vol.Required(CONF_HOST): cv.string,
                     vol.Optional(
                         CONF_CACHE_TTL, default=DEFAULT_CACHE_TTL
                     ): cv.positive_int,
                     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                    vol.Optional(CONF_MONITORED_CONDITIONS, default=[]): cv.ensure_list,
+                    vol.Required(CONF_CIRCUITS, default=[]): vol.All(
+                        cv.ensure_list, [CONFIG_CIRCUIT_SCHEMA]
+                    ),
                 },
                 verify_ebusd_config,
             )
@@ -73,24 +90,23 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the eBusd component."""
     conf = config[DOMAIN]
-    name = conf[CONF_NAME]
-    circuit = conf[CONF_CIRCUIT]
     cache_ttl = conf[CONF_CACHE_TTL]
-    monitored_conditions = conf.get(CONF_MONITORED_CONDITIONS)
     server_address = (conf.get(CONF_HOST), conf.get(CONF_PORT))
 
     try:
         _LOGGER.debug("Ebusd integration setup started")
 
         ebusdpy.init(server_address)
-        hass.data[DOMAIN] = EbusdData(server_address, circuit, cache_ttl)
+        hass.data[DOMAIN] = EbusdData(server_address, cache_ttl)
 
-        sensor_config = {
-            CONF_MONITORED_CONDITIONS: monitored_conditions,
-            "client_name": name,
-            "sensor_types": SENSOR_TYPES[circuit],
-        }
-        load_platform(hass, "sensor", DOMAIN, sensor_config, config)
+        for circuit_cfg in conf[CONF_CIRCUITS]:
+            sensor_config = {
+                "circuit": circuit_cfg["circuit"],
+                CONF_MONITORED_CONDITIONS: circuit_cfg["monitored_conditions"],
+                "client_name": circuit_cfg["name"],
+                "sensor_types": SENSOR_TYPES[circuit_cfg["circuit"]],
+            }
+            load_platform(hass, "sensor", DOMAIN, sensor_config, config)
 
         hass.services.register(DOMAIN, SERVICE_EBUSD_WRITE, hass.data[DOMAIN].write)
 
@@ -103,20 +119,19 @@ def setup(hass, config):
 class EbusdData:
     """Get the latest data from Ebusd."""
 
-    def __init__(self, address, circuit, cache_ttl):
+    def __init__(self, address, cache_ttl):
         """Initialize the data object."""
-        self._circuit = circuit
         self._address = address
         self._cache_ttl = cache_ttl
         self.value = {}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self, name, stype):
+    def update(self, circuit, name, stype):
         """Call the Ebusd API to update the data."""
         try:
             _LOGGER.debug("Opening socket to ebusd %s", name)
             command_result = ebusdpy.read(
-                self._address, self._circuit, name, stype, self._cache_ttl
+                self._address, circuit, name, stype, self._cache_ttl
             )
             if command_result is not None:
                 if "ERR:" in command_result:
@@ -129,12 +144,13 @@ class EbusdData:
 
     def write(self, call):
         """Call write methon on ebusd."""
+        circuit = call.data.get("circuit")
         name = call.data.get("name")
         value = call.data.get("value")
 
         try:
             _LOGGER.debug("Opening socket to ebusd %s", name)
-            command_result = ebusdpy.write(self._address, self._circuit, name, value)
+            command_result = ebusdpy.write(self._address, circuit, name, value)
             if command_result is not None:
                 if "done" not in command_result:
                     _LOGGER.warning("Write command failed: %s", name)

--- a/homeassistant/components/ebusd/const.py
+++ b/homeassistant/components/ebusd/const.py
@@ -1,8 +1,12 @@
 """Constants for ebus component."""
+from datetime import timedelta
 from homeassistant.const import ENERGY_KILO_WATT_HOUR, PRESSURE_BAR, TEMP_CELSIUS
+
 
 DOMAIN = "ebusd"
 TIME_SECONDS = "seconds"
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
 
 #  SensorTypes from ebusdpy module :
 #  0='decimal', 1='time-schedule', 2='switch', 3='string', 4='value;status'

--- a/homeassistant/components/ebusd/sensor.py
+++ b/homeassistant/components/ebusd/sensor.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 
+
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
@@ -20,13 +21,16 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Ebus sensor."""
     ebusd_api = hass.data[DOMAIN]
+    circuit = discovery_info["circuit"]
     monitored_conditions = discovery_info["monitored_conditions"]
     name = discovery_info["client_name"]
 
     dev = []
     for condition in monitored_conditions:
         dev.append(
-            EbusdSensor(ebusd_api, discovery_info["sensor_types"][condition], name)
+            EbusdSensor(
+                ebusd_api, circuit, discovery_info["sensor_types"][condition], name
+            )
         )
 
     add_entities(dev, True)
@@ -35,9 +39,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class EbusdSensor(Entity):
     """Ebusd component sensor methods definition."""
 
-    def __init__(self, data, sensor, name):
+    def __init__(self, data, circuit, sensor, name):
         """Initialize the sensor."""
         self._state = None
+        self._circuit = circuit
         self._client_name = name
         self._name, self._unit_of_measurement, self._icon, self._type = sensor
         self.data = data
@@ -88,7 +93,7 @@ class EbusdSensor(Entity):
     def update(self):
         """Fetch new state data for the sensor."""
         try:
-            self.data.update(self._name, self._type)
+            self.data.update(self._circuit, self._name, self._type)
             if self._name not in self.data.value:
                 return
 

--- a/homeassistant/components/ebusd/sensor.py
+++ b/homeassistant/components/ebusd/sensor.py
@@ -2,11 +2,11 @@
 import datetime
 import logging
 
-
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
+from homeassistant.util import Throttle
 
-from .const import DOMAIN
+from .const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
 
 TIME_FRAME1_BEGIN = "time_frame1_begin"
 TIME_FRAME1_END = "time_frame1_end"
@@ -90,6 +90,7 @@ class EbusdSensor(Entity):
         """Return the unit of measurement."""
         return self._unit_of_measurement
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Fetch new state data for the sensor."""
         try:

--- a/homeassistant/components/ebusd/services.yaml
+++ b/homeassistant/components/ebusd/services.yaml
@@ -2,5 +2,5 @@ write:
   description: Call ebusd write command.
   fields:
     call:
-      description: Property name and value to set
-      example: '{"name": "Hc1MaxFlowTempDesired", "value": 21}'
+      description: Circuit, property name and value to set
+      example: '{"circuit": "700", "name": "Hc1MaxFlowTempDesired", "value": 21}'


### PR DESCRIPTION
## Description:
The way ebusd component is implemented it makes it impossible
    to guarantee that update of individual sensors won't be rejected.
    This happens because EbusdData class handles all read requests from
    all sensors and is decorated with @Throttle. Thus, it is possible
    that sequential read requests from sensors will not be handled and
    make sort of race condition making sensor's update not deterministic.
    
    Workaround this by moving @Throttle to EbusdSensor class' update
    method. This way we protect individual sensor from being queried
    too frequently and give equal opportunities to all entities.
**Related issue (if applicable):** depends on #27863

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
