### PR TITLE
Move imports in harman_kardon_avr component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -272,6 +272,7 @@ homeassistant/components/songpal/* @rytilahti
 homeassistant/components/spaceapi/* @fabaff
 homeassistant/components/spider/* @peternijssen
 homeassistant/components/sql/* @dgomes
+homeassistant/components/srp_energy/* @briglx
 homeassistant/components/statistics/* @fabaff
 homeassistant/components/stiebel_eltron/* @fucm
 homeassistant/components/stream/* @hunterjm

--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -1,18 +1,19 @@
 """Support for interface with an Harman/Kardon or JBL AVR."""
 import logging
 
+import hkavr
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
+    SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_STEP,
-    SUPPORT_TURN_ON,
-    SUPPORT_SELECT_SOURCE,
 )
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_ON
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,8 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discover_info=None):
     """Set up the AVR platform."""
-    import hkavr
-
     name = config[CONF_NAME]
     host = config[CONF_HOST]
     port = config[CONF_PORT]

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -3,6 +3,12 @@ import asyncio
 import json
 import logging
 
+import aioharmony.exceptions as aioexc
+from aioharmony.harmonyapi import (
+    ClientCallbackType,
+    HarmonyAPI as HarmonyClient,
+    SendCommandDevice,
+)
 import voluptuous as vol
 
 from homeassistant.components import remote
@@ -23,8 +29,8 @@ from homeassistant.const import (
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
 )
-import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
@@ -165,8 +171,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     def __init__(self, name, host, port, activity, out_path, delay_secs):
         """Initialize HarmonyRemote class."""
-        from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
-
         self._name = name
         self.host = host
         self.port = port
@@ -180,8 +184,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def async_added_to_hass(self):
         """Complete the initialization."""
-        from aioharmony.harmonyapi import ClientCallbackType
-
         _LOGGER.debug("%s: Harmony Hub added", self._name)
         # Register the callbacks
         self._client.callbacks = ClientCallbackType(
@@ -194,8 +196,6 @@ class HarmonyRemote(remote.RemoteDevice):
         # Store Harmony HUB config, this will also update our current
         # activity
         await self.new_config()
-
-        import aioharmony.exceptions as aioexc
 
         async def shutdown(_):
             """Close connection on shutdown."""
@@ -234,8 +234,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def connect(self):
         """Connect to the Harmony HUB."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Connecting", self._name)
         try:
             if not await self._client.connect():
@@ -284,8 +282,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def async_turn_on(self, **kwargs):
         """Start an activity from the Harmony device."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Turn On", self.name)
 
         activity = kwargs.get(ATTR_ACTIVITY, self._default_activity)
@@ -314,8 +310,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def async_turn_off(self, **kwargs):
         """Start the PowerOff activity."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Turn Off", self.name)
         try:
             await self._client.power_off()
@@ -325,9 +319,6 @@ class HarmonyRemote(remote.RemoteDevice):
     # pylint: disable=arguments-differ
     async def async_send_command(self, command, **kwargs):
         """Send a list of commands to one device."""
-        from aioharmony.harmonyapi import SendCommandDevice
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Send Command", self.name)
         device = kwargs.get(ATTR_DEVICE)
         if device is None:
@@ -390,8 +381,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def change_channel(self, channel):
         """Change the channel using Harmony remote."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Changing channel to %s", self.name, channel)
         try:
             await self._client.change_channel(channel)
@@ -400,8 +389,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def sync(self):
         """Sync the Harmony device with the web service."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Syncing hub with Harmony cloud", self.name)
         try:
             await self._client.sync()

--- a/homeassistant/components/srp_energy/__init__.py
+++ b/homeassistant/components/srp_energy/__init__.py
@@ -1,0 +1,1 @@
+"""The srp_energy component."""

--- a/homeassistant/components/srp_energy/manifest.json
+++ b/homeassistant/components/srp_energy/manifest.json
@@ -1,0 +1,12 @@
+{
+    "domain": "srp_energy",
+    "name": "SRP Energy",
+    "documentation": "https://www.home-assistant.io/components/srp_energy",
+    "dependencies": [],
+    "codeowners": [
+        "@briglx"
+    ],
+    "requirements": [
+        "srpenergy==1.2.1"
+    ]
+  }

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -89,30 +89,6 @@ class SrpEnergy(Entity):
         """Return the unit of measurement of this entity, if any."""
         return ENERGY_KWH
 
-    @property
-    def history(self):
-        """Return the energy usage history of this entity, if any."""
-        if self._usage is None:
-            return None
-
-        history = [
-            {
-                ATTR_READING_TIME: isodate,
-                ATTR_READING_USAGE: kwh,
-                ATTR_READING_COST: cost,
-            }
-            for _, _, isodate, kwh, cost in self._usage
-        ]
-
-        return history
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attributes = {ATTR_USAGE_HISTORY: self.history}
-
-        return attributes
-
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest usage from SRP Energy."""

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.util import Throttle
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 
-# REQUIREMENTS = ['srpenergy==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -1,0 +1,146 @@
+"""Support for retrieving energy data from SRP."""
+from datetime import datetime, timedelta
+import logging
+
+from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
+import voluptuous as vol
+
+from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_USERNAME, CONF_ID
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import Entity
+
+# REQUIREMENTS = ['srpenergy==1.2.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTRIBUTION = "Powered by SRP Energy"
+
+DEFAULT_NAME = "SRP Energy"
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1440)
+ENERGY_KWH = "kWh"
+
+ATTR_READING_COST = "reading_cost"
+ATTR_READING_TIME = "datetime"
+ATTR_READING_USAGE = "reading_usage"
+ATTR_DAILY_USAGE = "daily_usage"
+ATTR_USAGE_HISTORY = "usage_history"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_ID): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the SRP energy."""
+    name = config[CONF_NAME]
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    account_id = config[CONF_ID]
+
+    from srpenergy.client import SrpEnergyClient
+
+    srp_client = SrpEnergyClient(account_id, username, password)
+
+    if not srp_client.validate():
+        _LOGGER.error("Couldn't connect to %s. Check credentials", name)
+        return
+
+    add_entities([SrpEnergy(name, srp_client)], True)
+
+
+class SrpEnergy(Entity):
+    """Representation of an srp usage."""
+
+    def __init__(self, name, client):
+        """Initialize SRP Usage."""
+        self._state = None
+        self._name = name
+        self._client = client
+        self._history = None
+        self._usage = None
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return ATTRIBUTION
+
+    @property
+    def state(self):
+        """Return the current state."""
+        if self._state is None:
+            return None
+
+        return "{0:.2f}".format(self._state)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return ENERGY_KWH
+
+    @property
+    def history(self):
+        """Return the energy usage history of this entity, if any."""
+        if self._usage is None:
+            return None
+
+        history = [
+            {
+                ATTR_READING_TIME: isodate,
+                ATTR_READING_USAGE: kwh,
+                ATTR_READING_COST: cost,
+            }
+            for _, _, isodate, kwh, cost in self._usage
+        ]
+
+        return history
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attributes = {ATTR_USAGE_HISTORY: self.history}
+
+        return attributes
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest usage from SRP Energy."""
+        start_date = datetime.now() + timedelta(days=-1)
+        end_date = datetime.now()
+
+        try:
+
+            usage = self._client.usage(start_date, end_date)
+
+            daily_usage = 0.0
+            for _, _, _, kwh, _ in usage:
+                daily_usage += float(kwh)
+
+            if usage:
+
+                self._state = daily_usage
+                self._usage = usage
+
+            else:
+                _LOGGER.error("Unable to fetch data from SRP. No data")
+
+        except (ConnectError, HTTPError, Timeout) as error:
+            _LOGGER.error("Unable to connect to SRP. %s", error)
+        except ValueError as error:
+            _LOGGER.error("Value error connecting to SRP. %s", error)
+        except TypeError as error:
+            _LOGGER.error(
+                "Type error connecting to SRP. " "Check username and password. %s",
+                error,
+            )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1825,6 +1825,9 @@ spotipy-homeassistant==2.4.4.dev1
 # homeassistant.components.sql
 sqlalchemy==1.3.10
 
+# homeassistant.components.srp_energy
+srpenergy==1.2.1
+
 # homeassistant.components.starlingbank
 starlingbank==3.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -572,6 +572,9 @@ somecomfort==0.5.2
 # homeassistant.components.sql
 sqlalchemy==1.3.10
 
+# homeassistant.components.srp_energy
+srpenergy==1.2.1
+
 # homeassistant.components.statsd
 statsd==3.2.1
 

--- a/tests/components/srp_energy/__init__.py
+++ b/tests/components/srp_energy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the srp_energy component."""

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -1,0 +1,62 @@
+"""The tests for the Srp Energy Platform."""
+from unittest.mock import patch
+import logging
+from homeassistant.setup import async_setup_component
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_CONFIG_MINIMAL = {
+    "sensor": {
+        "platform": "srp_energy",
+        "username": "foo",
+        "password": "bar",
+        "id": 1234,
+    }
+}
+
+PATCH_INIT = "srpenergy.client.SrpEnergyClient.__init__"
+PATCH_VALIDATE = "srpenergy.client.SrpEnergyClient.validate"
+PATCH_USAGE = "srpenergy.client.SrpEnergyClient.usage"
+
+
+def mock_usage(self, startdate, enddate):  # pylint: disable=invalid-name
+    """Mock srpusage usage."""
+    _LOGGER.log(logging.INFO, "Calling mock usage")
+    usage = [
+        ("9/19/2018", "12:00 AM", "2018-09-19T00:00:00-7:00", "1.2", "0.17"),
+        ("9/19/2018", "1:00 AM", "2018-09-19T01:00:00-7:00", "2.1", "0.30"),
+        ("9/19/2018", "2:00 AM", "2018-09-19T02:00:00-7:00", "1.5", "0.23"),
+        ("9/19/2018", "9:00 PM", "2018-09-19T21:00:00-7:00", "1.2", "0.19"),
+        ("9/19/2018", "10:00 PM", "2018-09-19T22:00:00-7:00", "1.1", "0.18"),
+        ("9/19/2018", "11:00 PM", "2018-09-19T23:00:00-7:00", "0.4", "0.09"),
+    ]
+    return usage
+
+
+async def test_setup_with_config(hass):
+    """Test the platform setup with configuration."""
+    with patch(PATCH_INIT, return_value=None), patch(
+        PATCH_VALIDATE, return_value=True
+    ), patch(PATCH_USAGE, new=mock_usage):
+
+        await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
+
+        state = hass.states.get("sensor.srp_energy")
+        assert state is not None
+
+
+async def test_daily_usage(hass):
+    """Test the platform daily usage."""
+    with patch(PATCH_INIT, return_value=None), patch(
+        PATCH_VALIDATE, return_value=True
+    ), patch(PATCH_USAGE, new=mock_usage):
+
+        await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
+
+        state = hass.states.get("sensor.srp_energy")
+
+        assert state
+        assert state.state == "7.50"
+
+        assert state.attributes
+        assert state.attributes.get("unit_of_measurement")


### PR DESCRIPTION
## Breaking Change:


## Description:
Move imports to top for harman_kardon_avr component.

**Related issue (if applicable):** fixes #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
