### PR TITLE
Move imports in hangouts component

### DIFF
--- a/homeassistant/components/hangouts/__init__.py
+++ b/homeassistant/components/hangouts/__init__.py
@@ -1,15 +1,16 @@
 """Support for Hangouts."""
 import logging
 
+from hangups.auth import GoogleAuthError
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.conversation import create_matcher
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import dispatcher, intent
 import homeassistant.helpers.config_validation as cv
 
 # We need an import from .config_flow, without it .config_flow is never loaded.
-from .intents import HelpIntent
 from .config_flow import HangoutsFlowHandler  # noqa: F401
 from .const import (
     CONF_BOT,
@@ -31,6 +32,8 @@ from .const import (
     SERVICE_UPDATE,
     TARGETS_SCHEMA,
 )
+from .hangouts_bot import HangoutsBot
+from .intents import HelpIntent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,8 +57,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the Hangouts bot component."""
-    from homeassistant.components.conversation import create_matcher
-
     config = config.get(DOMAIN)
     if config is None:
         hass.data[DOMAIN] = {
@@ -97,11 +98,7 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config):
     """Set up a config entry."""
-    from hangups.auth import GoogleAuthError
-
     try:
-        from .hangouts_bot import HangoutsBot
-
         bot = HangoutsBot(
             hass,
             config.data.get(CONF_REFRESH_TOKEN),

--- a/homeassistant/components/hangouts/config_flow.py
+++ b/homeassistant/components/hangouts/config_flow.py
@@ -1,7 +1,8 @@
 """Config flow to configure Google Hangouts."""
 import functools
-import voluptuous as vol
 
+from hangups import get_auth
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -9,9 +10,15 @@ from homeassistant.core import callback
 
 from .const import (
     CONF_2FA,
-    CONF_REFRESH_TOKEN,
     CONF_AUTH_CODE,
+    CONF_REFRESH_TOKEN,
     DOMAIN as HANGOUTS_DOMAIN,
+)
+from .hangups_utils import (
+    Google2FAError,
+    GoogleAuthError,
+    HangoutsCredentials,
+    HangoutsRefreshToken,
 )
 
 
@@ -44,14 +51,6 @@ class HangoutsFlowHandler(config_entries.ConfigFlow):
             return self.async_abort(reason="already_configured")
 
         if user_input is not None:
-            from hangups import get_auth
-            from .hangups_utils import (
-                HangoutsCredentials,
-                HangoutsRefreshToken,
-                GoogleAuthError,
-                Google2FAError,
-            )
-
             user_email = user_input[CONF_EMAIL]
             user_password = user_input[CONF_PASSWORD]
             user_auth_code = user_input.get(CONF_AUTH_CODE)
@@ -99,9 +98,6 @@ class HangoutsFlowHandler(config_entries.ConfigFlow):
         errors = {}
 
         if user_input is not None:
-            from hangups import get_auth
-            from .hangups_utils import GoogleAuthError
-
             self._credentials.set_verification_code(user_input[CONF_2FA])
             try:
                 await self.hass.async_add_executor_job(

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -4,6 +4,8 @@ import io
 import logging
 
 import aiohttp
+import hangups
+from hangups import ChatMessageEvent, ChatMessageSegment, Client, get_auth, hangouts_pb2
 
 from homeassistant.helpers import dispatcher, intent
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -24,6 +26,7 @@ from .const import (
     EVENT_HANGOUTS_MESSAGE_RECEIVED,
     INTENT_HELP,
 )
+from .hangups_utils import HangoutsCredentials, HangoutsRefreshToken
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -126,8 +129,6 @@ class HangoutsBot:
         )
 
     async def _async_handle_conversation_event(self, event):
-        from hangups import ChatMessageEvent
-
         if isinstance(event, ChatMessageEvent):
             dispatcher.async_dispatcher_send(
                 self.hass,
@@ -196,11 +197,6 @@ class HangoutsBot:
 
     async def async_connect(self):
         """Login to the Google Hangouts."""
-        from .hangups_utils import HangoutsRefreshToken, HangoutsCredentials
-
-        from hangups import Client
-        from hangups import get_auth
-
         session = await self.hass.async_add_executor_job(
             get_auth,
             HangoutsCredentials(None, None, None),
@@ -251,8 +247,6 @@ class HangoutsBot:
 
         if not conversations:
             return False
-
-        from hangups import ChatMessageSegment, hangouts_pb2
 
         messages = []
         for segment in message:
@@ -306,8 +300,6 @@ class HangoutsBot:
             await conv.send_message(messages, image_file)
 
     async def _async_list_conversations(self):
-        import hangups
-
         self._user_list, self._conversation_list = await hangups.build_user_conversation_list(
             self._client
         )

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -3,6 +3,7 @@ import asyncio
 import io
 import logging
 
+# Main imports
 import aiohttp
 import hangups
 from hangups import ChatMessageEvent, ChatMessageSegment, Client, get_auth, hangouts_pb2

--- a/tests/components/hangouts/test_config_flow.py
+++ b/tests/components/hangouts/test_config_flow.py
@@ -4,6 +4,10 @@ from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.hangouts import config_flow
+from homeassistant.components.hangouts.hangups_utils import (
+    Google2FAError,
+    GoogleAuthError,
+)
 
 
 async def test_flow_works(hass, aioclient_mock):
@@ -40,8 +44,6 @@ async def test_flow_works_with_authcode(hass, aioclient_mock):
 
 async def test_flow_works_with_2fa(hass, aioclient_mock):
     """Test config flow with 2fa."""
-    from homeassistant.components.hangouts.hangups_utils import Google2FAError
-
     flow = config_flow.HangoutsFlowHandler()
 
     flow.hass = hass
@@ -61,8 +63,6 @@ async def test_flow_works_with_2fa(hass, aioclient_mock):
 
 async def test_flow_with_unknown_2fa(hass, aioclient_mock):
     """Test config flow with invalid 2fa method."""
-    from homeassistant.components.hangouts.hangups_utils import GoogleAuthError
-
     flow = config_flow.HangoutsFlowHandler()
 
     flow.hass = hass
@@ -80,8 +80,6 @@ async def test_flow_with_unknown_2fa(hass, aioclient_mock):
 
 async def test_flow_invalid_login(hass, aioclient_mock):
     """Test config flow with invalid 2fa method."""
-    from homeassistant.components.hangouts.hangups_utils import GoogleAuthError
-
     flow = config_flow.HangoutsFlowHandler()
 
     flow.hass = hass
@@ -96,8 +94,6 @@ async def test_flow_invalid_login(hass, aioclient_mock):
 
 async def test_flow_invalid_2fa(hass, aioclient_mock):
     """Test config flow with 2fa."""
-    from homeassistant.components.hangouts.hangups_utils import Google2FAError
-
     flow = config_flow.HangoutsFlowHandler()
 
     flow.hass = hass


### PR DESCRIPTION
## Breaking Change:


## Description:
Move imports to top for hangout component.

**Related issue (if applicable):** related #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
