### PR TITLE
Better header check for OAuth2 helper

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -392,7 +392,7 @@ async def async_oauth2_request(
         url,
         **kwargs,
         headers={
-            **kwargs.get("headers", {}),
+            **(kwargs.get("headers") or {}),
             "authorization": f"Bearer {token['access_token']}",
         },
     )


### PR DESCRIPTION
## Description:
Passing in `headers=None` would break this code. Not any more.

