### PR TITLE
Remove helper imports relying on installed requirements

### DIFF
--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -11,11 +11,9 @@ from homeassistant.loader import bind_hass, async_get_integration, IntegrationNo
 import homeassistant.util.dt as dt_util
 from homeassistant.components.notify import ATTR_MESSAGE, SERVICE_NOTIFY
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
-from homeassistant.components.mysensors.switch import ATTR_IR_CODE, SERVICE_SEND_IR_CODE
 from homeassistant.components.cover import ATTR_POSITION, ATTR_TILT_POSITION
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_OPTION,
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_DISARM,
@@ -41,7 +39,6 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_UNKNOWN,
     STATE_UNLOCKED,
-    SERVICE_SELECT_OPTION,
 )
 from homeassistant.core import Context, State, DOMAIN as HASS_DOMAIN
 from .typing import HomeAssistantType
@@ -54,8 +51,6 @@ GROUP_DOMAIN = "group"
 # Each item is a service with a list of required attributes.
 SERVICE_ATTRIBUTES = {
     SERVICE_NOTIFY: [ATTR_MESSAGE],
-    SERVICE_SEND_IR_CODE: [ATTR_IR_CODE],
-    SERVICE_SELECT_OPTION: [ATTR_OPTION],
     SERVICE_SET_COVER_POSITION: [ATTR_POSITION],
     SERVICE_SET_COVER_TILT_POSITION: [ATTR_TILT_POSITION],
 }


### PR DESCRIPTION
## Breaking Change:

Scene support for sending IR codes to MySensors devices has been removed.

## Description:
Because we're putting all the imports at the top, we ended up importing from integrations who'se requirements are not installed. 

This surfaced in this example by the state helper importing from mysensors, which then imported from MQTT, blowing up dev. This fixes it by removing MySensors.

I don't think that the MySensors state support here was actually a correct state to reproduce, as it seems like it's about sending an IR code.

Also removed the set option as input_select has `reproduce_state` support :) 

**Related issue (if applicable):** fixes #27858


