### PR TITLE
Bump keyring to 19.2.0

### DIFF
--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -8,7 +8,7 @@ from homeassistant.util.yaml import _SECRET_NAMESPACE
 
 # mypy: allow-untyped-defs
 
-REQUIREMENTS = ["keyring==17.1.1", "keyrings.alt==3.1.1"]
+REQUIREMENTS = ["keyring==19.2.0", "keyrings.alt==3.1.1"]
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -721,7 +721,7 @@ kaiterra-async-client==0.0.2
 keba-kecontact==0.2.0
 
 # homeassistant.scripts.keyring
-keyring==17.1.1
+keyring==19.2.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==3.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -267,7 +267,7 @@ influxdb==5.2.3
 jsonpath==0.75
 
 # homeassistant.scripts.keyring
-keyring==17.1.1
+keyring==19.2.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==3.1.1


### PR DESCRIPTION
## Description:

Bump keyring to 19.2.0

<details>
<summary>Changelog</summary>

*Sourced from [keyring's changelog](https://github.com/jaraco/keyring/blob/master/CHANGES.rst).*

> 19.2.0
> ======
> 
> -   Add support for get\_credential() with the SecretService backend.
> 
> 19.1.0
> ======
> 
> -   [#369](https://github-redirect.dependabot.com/jaraco/keyring/issues/369): macOS Keyring now honors a `KEYCHAIN_PATH` environment variable. If set, Keyring will use that keychain instead of the default.
> 
> 19.0.2
> ======
> 
> -   Refresh package skeleton.
> -   Adopt [black](https://pypi.org/project/black) code style.
> 
> 19.0.1
> ======
> 
> -   Merge with 18.0.1.
> 
> 18.0.1
> ======
> 
> -   [#386](https://github-redirect.dependabot.com/jaraco/keyring/issues/386): ExceptionInfo no longer retains a reference to the traceback.
> 
> 19.0.0
> ======
> 
> -   [#383](https://github-redirect.dependabot.com/jaraco/keyring/issues/383): Drop support for EOL Python 2.7 - 3.4.
> 
> 18.0.0
> ======
> 
> -   [#375](https://github-redirect.dependabot.com/jaraco/keyring/issues/375): On macOS, the backend now raises a `KeyringLocked` when access to the keyring is denied (on get or set) instead of `PasswordSetError` or `KeyringError`. Any API users may need to account for this change, probably by catching the parent `KeyringError`. Additionally, the error message from the underying error is now included in any errors that occur.
</details>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
