### PR TITLE
Guard cloud check

### DIFF
--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -78,7 +78,10 @@ class OwnTracksFlow(config_entries.ConfigFlow):
     async def _get_webhook_id(self):
         """Generate webhook ID."""
         webhook_id = self.hass.components.webhook.async_generate_id()
-        if self.hass.components.cloud.async_active_subscription():
+        if (
+            "cloud" in self.hass.config.components
+            and self.hass.components.cloud.async_active_subscription()
+        ):
             webhook_url = await self.hass.components.cloud.async_create_cloudhook(
                 webhook_id
             )

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -22,7 +22,7 @@ from pysmartthings import (
     SubscriptionEntity,
 )
 
-from homeassistant.components import cloud, webhook
+from homeassistant.components import webhook
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
@@ -88,7 +88,10 @@ async def validate_installed_app(api, installed_app_id: str):
 
 def validate_webhook_requirements(hass: HomeAssistantType) -> bool:
     """Ensure HASS is setup properly to receive webhooks."""
-    if cloud.async_active_subscription(hass):
+    if (
+        "cloud" in hass.config.components
+        and hass.components.cloud.async_active_subscription(hass)
+    ):
         return True
     if hass.data[DOMAIN][CONF_CLOUDHOOK_URL] is not None:
         return True
@@ -102,7 +105,11 @@ def get_webhook_url(hass: HomeAssistantType) -> str:
     Return the cloudhook if available, otherwise local webhook.
     """
     cloudhook_url = hass.data[DOMAIN][CONF_CLOUDHOOK_URL]
-    if cloud.async_active_subscription(hass) and cloudhook_url is not None:
+    if (
+        "cloud" in hass.config.components
+        and hass.components.cloud.async_active_subscription(hass)
+        and cloudhook_url is not None
+    ):
         return cloudhook_url
     return webhook.async_generate_url(hass, hass.data[DOMAIN][CONF_WEBHOOK_ID])
 
@@ -222,10 +229,11 @@ async def setup_smartapp_endpoint(hass: HomeAssistantType):
     cloudhook_url = config.get(CONF_CLOUDHOOK_URL)
     if (
         cloudhook_url is None
-        and cloud.async_active_subscription(hass)
+        and "cloud" in hass.config.components
+        and hass.components.cloud.async_active_subscription(hass)
         and not hass.config_entries.async_entries(DOMAIN)
     ):
-        cloudhook_url = await cloud.async_create_cloudhook(
+        cloudhook_url = await hass.components.cloud.async_create_cloudhook(
             hass, config[CONF_WEBHOOK_ID]
         )
         config[CONF_CLOUDHOOK_URL] = cloudhook_url
@@ -273,8 +281,14 @@ async def unload_smartapp_endpoint(hass: HomeAssistantType):
         return
     # Remove the cloudhook if it was created
     cloudhook_url = hass.data[DOMAIN][CONF_CLOUDHOOK_URL]
-    if cloudhook_url and cloud.async_is_logged_in(hass):
-        await cloud.async_delete_cloudhook(hass, hass.data[DOMAIN][CONF_WEBHOOK_ID])
+    if (
+        cloudhook_url
+        and "cloud" in hass.config.components
+        and hass.components.cloud.async_is_logged_in(hass)
+    ):
+        await hass.components.cloud.async_delete_cloudhook(
+            hass, hass.data[DOMAIN][CONF_WEBHOOK_ID]
+        )
         # Remove cloudhook from storage
         store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
         await store.async_save(

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -90,7 +90,7 @@ def validate_webhook_requirements(hass: HomeAssistantType) -> bool:
     """Ensure HASS is setup properly to receive webhooks."""
     if (
         "cloud" in hass.config.components
-        and hass.components.cloud.async_active_subscription(hass)
+        and hass.components.cloud.async_active_subscription()
     ):
         return True
     if hass.data[DOMAIN][CONF_CLOUDHOOK_URL] is not None:
@@ -107,7 +107,7 @@ def get_webhook_url(hass: HomeAssistantType) -> str:
     cloudhook_url = hass.data[DOMAIN][CONF_CLOUDHOOK_URL]
     if (
         "cloud" in hass.config.components
-        and hass.components.cloud.async_active_subscription(hass)
+        and hass.components.cloud.async_active_subscription()
         and cloudhook_url is not None
     ):
         return cloudhook_url
@@ -230,7 +230,7 @@ async def setup_smartapp_endpoint(hass: HomeAssistantType):
     if (
         cloudhook_url is None
         and "cloud" in hass.config.components
-        and hass.components.cloud.async_active_subscription(hass)
+        and hass.components.cloud.async_active_subscription()
         and not hass.config_entries.async_entries(DOMAIN)
     ):
         cloudhook_url = await hass.components.cloud.async_create_cloudhook(
@@ -284,7 +284,7 @@ async def unload_smartapp_endpoint(hass: HomeAssistantType):
     if (
         cloudhook_url
         and "cloud" in hass.config.components
-        and hass.components.cloud.async_is_logged_in(hass)
+        and hass.components.cloud.async_is_logged_in()
     ):
         await hass.components.cloud.async_delete_cloudhook(
             hass, hass.data[DOMAIN][CONF_WEBHOOK_ID]

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -124,7 +124,10 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
 
         webhook_id = self.hass.components.webhook.async_generate_id()
 
-        if self.hass.components.cloud.async_active_subscription():
+        if (
+            "cloud" in self.hass.config.components
+            and self.hass.components.cloud.async_active_subscription()
+        ):
             webhook_url = await self.hass.components.cloud.async_create_cloudhook(
                 webhook_id
             )

--- a/tests/components/owntracks/test_config_flow.py
+++ b/tests/components/owntracks/test_config_flow.py
@@ -43,6 +43,7 @@ async def test_config_flow_unload(hass):
 
 async def test_with_cloud_sub(hass):
     """Test creating a config flow while subscribed."""
+    hass.config.components.add("cloud")
     with patch(
         "homeassistant.components.cloud.async_active_subscription", return_value=True
     ), patch(

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -205,6 +205,8 @@ async def test_cloudhook_app_created_then_show_wait_form(
     hass, app, app_oauth_client, smartthings_mock
 ):
     """Test SmartApp is created with a cloudhoko and shows wait form."""
+    hass.config.components.add("cloud")
+
     # Unload the endpoint so we can reload it under the cloud.
     await smartapp.unload_smartapp_endpoint(hass)
 

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -268,6 +268,7 @@ async def test_remove_entry(hass, config_entry, smartthings_mock):
 
 async def test_remove_entry_cloudhook(hass, config_entry, smartthings_mock):
     """Test that the installed app, app, and cloudhook are removed up."""
+    hass.config.components.add("cloud")
     # Arrange
     config_entry.add_to_hass(hass)
     hass.data[DOMAIN][CONF_CLOUDHOOK_URL] = "https://test.cloud"


### PR DESCRIPTION
## Description:
Guard the cloud check to avoid errors about missing `hass_nabucasa`.

Side effect from moving imports to the top. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
