### PR TITLE
New sensor platform integration for PSE&G utility gas meter

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -519,6 +519,7 @@ omit =
     homeassistant/components/prometheus/*
     homeassistant/components/prowl/notify.py
     homeassistant/components/proxy/camera.py
+    homeassistant/components/pseg/*
     homeassistant/components/ptvsd/*
     homeassistant/components/pulseaudio_loopback/switch.py
     homeassistant/components/pushbullet/notify.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -229,6 +229,7 @@ homeassistant/components/plex/* @jjlawren
 homeassistant/components/plugwise/* @laetificat @CoMPaTech
 homeassistant/components/point/* @fredrike
 homeassistant/components/ps4/* @ktnrg45
+homeassistant/components/pseg/* @bvlaicu
 homeassistant/components/ptvsd/* @swamp-ig
 homeassistant/components/push/* @dgomes
 homeassistant/components/pvoutput/* @fabaff

--- a/homeassistant/components/pseg/__init__.py
+++ b/homeassistant/components/pseg/__init__.py
@@ -1,0 +1,1 @@
+"""The PSE&G gas meter integration."""

--- a/homeassistant/components/pseg/manifest.json
+++ b/homeassistant/components/pseg/manifest.json
@@ -1,0 +1,8 @@
+{
+    "domain": "pseg",
+    "name": "PSE&G Gas Meter Sensors",
+    "documentation": "https://www.home-assistant.io/integrations/pseg",
+    "dependencies": [],
+    "codeowners": ["@bvlaicu"],
+    "requirements": ["pseg==0.1.1"]
+}

--- a/homeassistant/components/pseg/sensor.py
+++ b/homeassistant/components/pseg/sensor.py
@@ -19,7 +19,7 @@ CONF_ACCESS_TOKEN = "session_id"
 SCAN_INTERVAL = timedelta(minutes=60)
 
 ENERGY_THERMS = "therms"
-COST_DOLLARS = "dollars"
+COST_DOLLARS = "$"
 
 SENSOR_NAME_GAS_CONSUMPTION = "PSEG Gas Consumption"
 SENSOR_ICON_GAS_CONSUMPTION = "mdi:counter"
@@ -29,7 +29,7 @@ SENSOR_ICON_GAS_COST = "mdi:currency-usd"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_ENERGIZE_ID): cv.string,
-        vol.Optional(CONF_ACCESS_TOKEN): cv.string,
+        vol.Required(CONF_ACCESS_TOKEN): cv.string,
     }
 )
 

--- a/homeassistant/components/pseg/sensor.py
+++ b/homeassistant/components/pseg/sensor.py
@@ -1,0 +1,150 @@
+"""Platform for sensor integration."""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from pseg import Meter
+from pseg import MeterError
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ENERGIZE_ID = "energize_id"
+CONF_ACCESS_TOKEN = "session_id"
+
+SCAN_INTERVAL = timedelta(minutes=60)
+
+ENERGY_THERMS = "therms"
+COST_DOLLARS = "dollars"
+
+SENSOR_NAME_GAS_CONSUMPTION = "PSEG Gas Consumption"
+SENSOR_ICON_GAS_CONSUMPTION = "mdi:counter"
+SENSOR_NAME_GAS_COST = "PSEG Gas Cost"
+SENSOR_ICON_GAS_COST = "mdi:currency-usd"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENERGIZE_ID): cv.string,
+        vol.Optional(CONF_ACCESS_TOKEN): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+
+    energize_id = config[CONF_ENERGIZE_ID]
+    session_id = config[CONF_ACCESS_TOKEN]
+
+    _LOGGER.debug("Pseg energize_id = %s, session_id = %s", energize_id, session_id)
+
+    try:
+        meter = Meter(energize_id, session_id)
+
+    except MeterError:
+        _LOGGER.error("Unable to create Pseg meter")
+        return
+
+    add_entities([GasConsumptionSensor(meter), GasCostSensor(meter)], True)
+
+
+class GasConsumptionSensor(Entity):
+    """Representation of the Gas Consumption sensor."""
+
+    def __init__(self, meter):
+        """Initialize the sensor."""
+        self._state = None
+        self._available = None
+        self.meter = meter
+
+    @property
+    def unique_id(self):
+        """Return a unique, HASS-friendly identifier for this entity."""
+        return self.meter.energize_id + "_consumption"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return SENSOR_NAME_GAS_CONSUMPTION
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return SENSOR_ICON_GAS_CONSUMPTION
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return ENERGY_THERMS
+
+    def update(self):
+        """Fetch new state data for the sensor."""
+        try:
+            self._state = self.meter.last_gas_read_consumption()
+            self._available = True
+
+            _LOGGER.debug(
+                "%s = %s %s", self.name, self._state, self.unit_of_measurement
+            )
+        except MeterError as err:
+            self._available = False
+
+            _LOGGER.error("Unexpected pseg meter error: %s", err)
+
+
+class GasCostSensor(Entity):
+    """Representation of the Gas Cost sensor."""
+
+    def __init__(self, meter):
+        """Initialize the sensor."""
+        self._state = None
+        self._available = None
+        self.meter = meter
+
+    @property
+    def unique_id(self):
+        """Return a unique, HASS-friendly identifier for this entity."""
+        return self.meter.energize_id + "_cost"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return SENSOR_NAME_GAS_COST
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return SENSOR_ICON_GAS_COST
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return COST_DOLLARS
+
+    def update(self):
+        """Fetch new state data for the sensor."""
+        try:
+            self._state = self.meter.last_gas_read_cost()
+            self._available = True
+
+            _LOGGER.debug(
+                "%s = %s %s", self.name, self._state, self.unit_of_measurement
+            )
+        except MeterError as err:
+            self._available = False
+
+            _LOGGER.error("Unexpected pseg meter error: %s", err)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1004,6 +1004,9 @@ prometheus_client==0.7.1
 # homeassistant.components.tensorflow
 protobuf==3.6.1
 
+# homeassistant.components.pseg
+pseg==0.1.1
+
 # homeassistant.components.systemmonitor
 psutil==5.6.3
 


### PR DESCRIPTION


## Description:

New sensor platform integration for PSE&G utility gas meter.
[PSE&G](https://pseg.com) is an energy provider in NY and NJ, USA.
The sensors provide the last gas consumption (therms) and cost (USD) from PSE&G.

## Docs PR:

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10869

## Example entry for `configuration.yaml`:
```yaml
sensor:
  - platform: pseg
    energize_id: YOUR_ENERGIZE_ID
    session_id: YOUR_SESSION_ID
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
