### PR TITLE
Move imports in harmony component

### DIFF
--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -3,6 +3,12 @@ import asyncio
 import json
 import logging
 
+import aioharmony.exceptions as aioexc
+from aioharmony.harmonyapi import (
+    ClientCallbackType,
+    HarmonyAPI as HarmonyClient,
+    SendCommandDevice,
+)
 import voluptuous as vol
 
 from homeassistant.components import remote
@@ -23,8 +29,8 @@ from homeassistant.const import (
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
 )
-import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
@@ -165,8 +171,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     def __init__(self, name, host, port, activity, out_path, delay_secs):
         """Initialize HarmonyRemote class."""
-        from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
-
         self._name = name
         self.host = host
         self.port = port
@@ -180,8 +184,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def async_added_to_hass(self):
         """Complete the initialization."""
-        from aioharmony.harmonyapi import ClientCallbackType
-
         _LOGGER.debug("%s: Harmony Hub added", self._name)
         # Register the callbacks
         self._client.callbacks = ClientCallbackType(
@@ -194,8 +196,6 @@ class HarmonyRemote(remote.RemoteDevice):
         # Store Harmony HUB config, this will also update our current
         # activity
         await self.new_config()
-
-        import aioharmony.exceptions as aioexc
 
         async def shutdown(_):
             """Close connection on shutdown."""
@@ -234,8 +234,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def connect(self):
         """Connect to the Harmony HUB."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Connecting", self._name)
         try:
             if not await self._client.connect():
@@ -284,8 +282,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def async_turn_on(self, **kwargs):
         """Start an activity from the Harmony device."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Turn On", self.name)
 
         activity = kwargs.get(ATTR_ACTIVITY, self._default_activity)
@@ -314,8 +310,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def async_turn_off(self, **kwargs):
         """Start the PowerOff activity."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Turn Off", self.name)
         try:
             await self._client.power_off()
@@ -325,9 +319,6 @@ class HarmonyRemote(remote.RemoteDevice):
     # pylint: disable=arguments-differ
     async def async_send_command(self, command, **kwargs):
         """Send a list of commands to one device."""
-        from aioharmony.harmonyapi import SendCommandDevice
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Send Command", self.name)
         device = kwargs.get(ATTR_DEVICE)
         if device is None:
@@ -390,8 +381,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def change_channel(self, channel):
         """Change the channel using Harmony remote."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Changing channel to %s", self.name, channel)
         try:
             await self._client.change_channel(channel)
@@ -400,8 +389,6 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def sync(self):
         """Sync the Harmony device with the web service."""
-        import aioharmony.exceptions as aioexc
-
         _LOGGER.debug("%s: Syncing hub with Harmony cloud", self.name)
         try:
             await self._client.sync()


### PR DESCRIPTION
## Breaking Change:


## Description:
Move imports in harmony component 

**Related issue (if applicable):** related #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
