### PR TITLE
Add template filters to convert objects to and from JSON strings

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -883,6 +883,7 @@ def ordinal(value):
         else "th"
     )
 
+
 def from_json(value):
     """Convert a string to a JSON object."""
     try:
@@ -891,6 +892,7 @@ def from_json(value):
         # If string can't be converted
         return value
 
+
 def to_json(value):
     """Convert an object to a JSON string."""
     try:
@@ -898,6 +900,7 @@ def to_json(value):
     except (ValueError, TypeError):
         # If object can't be converted
         return value
+
 
 @contextfilter
 def random_every_time(context, values):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -885,7 +885,7 @@ def ordinal(value):
 
 
 def from_json(value):
-    """Convert a string to a JSON object."""
+    """Convert a JSON string to an object."""
     return json.loads(value)
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -886,20 +886,12 @@ def ordinal(value):
 
 def from_json(value):
     """Convert a string to a JSON object."""
-    try:
-        return json.loads(value)
-    except (ValueError, TypeError):
-        # If string can't be converted
-        return value
+    return json.loads(value)
 
 
 def to_json(value):
     """Convert an object to a JSON string."""
-    try:
-        return json.dumps(value)
-    except (ValueError, TypeError):
-        # If object can't be converted
-        return value
+    return json.dumps(value)
 
 
 @contextfilter

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -883,6 +883,21 @@ def ordinal(value):
         else "th"
     )
 
+def from_json(value):
+    """Convert a string to a JSON object."""
+    try:
+        return json.loads(value)
+    except (ValueError, TypeError):
+        # If string can't be converted
+        return value
+
+def to_json(value):
+    """Convert an object to a JSON string."""
+    try:
+        return json.dumps(value)
+    except (ValueError, TypeError):
+        # If object can't be converted
+        return value
 
 @contextfilter
 def random_every_time(context, values):
@@ -916,6 +931,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["timestamp_custom"] = timestamp_custom
         self.filters["timestamp_local"] = timestamp_local
         self.filters["timestamp_utc"] = timestamp_utc
+        self.filters["to_json"] = to_json
+        self.filters["from_json"] = from_json
         self.filters["is_defined"] = fail_when_undefined
         self.filters["max"] = max
         self.filters["min"] = min

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -501,6 +501,30 @@ def test_timestamp_local(hass):
         )
 
 
+def test_to_json(hass):
+    """Test the object to JSON string filter."""
+
+    # Note that we're not testing the actual json.loads and json.dumps methods,
+    # only the filters, so we don't need to be exhaustive with our sample JSON.
+    expected_result = '{"Foo": "Bar"}'
+    actual_result = template.Template(
+        "{{ {'Foo': 'Bar'} | to_json }}", hass
+    ).async_render()
+    assert actual_result == expected_result
+
+
+def test_from_json(hass):
+    """Test the JSON string to object filter."""
+
+    # Note that we're not testing the actual json.loads and json.dumps methods,
+    # only the filters, so we don't need to be exhaustive with our sample JSON.
+    expected_result = "Bar"
+    actual_result = template.Template(
+        '{{ (\'{"Foo": "Bar"}\' | from_json).Foo }}', hass
+    ).async_render()
+    assert actual_result == expected_result
+
+
 def test_min(hass):
     """Test the min filter."""
     assert template.Template("{{ [1, 2, 3] | min }}", hass).async_render() == "1"


### PR DESCRIPTION
## Description:
Use case:
* Receive JSON payload from webhook
* Attempt to pass JSON object to script as a parameter
* JSON comes through as a string, not an object, and not even a string that is valid JSON. You can no longer pick out individual fields

These filters allow you to convert a JSON object into actual valid JSON so that it may be passed around as a string, and then converted back to an object on the other side.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
