### PR TITLE
Resolve geniushub duplicate unique_id and add unique_id for issues

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -214,7 +214,7 @@ class GeniusZone(GeniusEntity):
         super().__init__()
 
         self._zone = zone
-        self._unique_id = f"{broker.hub_uid}_device_{zone.id}"
+        self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
 
         self._max_temp = self._min_temp = self._supported_features = None
 

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -94,6 +94,8 @@ class GeniusIssue(GeniusEntity):
         super().__init__()
 
         self._hub = broker.client
+        self._unique_id = f"{broker.hub_uid}_{GH_LEVEL_MAPPING[level]}"
+
         self._name = f"GeniusHub {GH_LEVEL_MAPPING[level]}"
         self._level = level
         self._issues = []


### PR DESCRIPTION
## Breaking Change:

This PR addresses and issue that requires the `unique_id` of **climate** and **water_heater** entities to be changed. After upgrading HA with this change, users will have stale entities in the entity registry that they may wish to clear out.

## Description:
Due to a typo, **geniushub** zones (implemented as climate, water_heater entities) may share a `unique_id` with devices (sensor, binary_sensor entities) within the integration. 

This PR fixes that (see breaking change above), and also adds a `unique_id` for geniushub issues (errors, warning, information) so that all geniushub entities now have a `unique_id`.

Note that `entity_id`s are not changed.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

**Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
