### PR TITLE
Improve Tahoma Velux support

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema(
 TAHOMA_COMPONENTS = ["scene", "sensor", "cover", "switch", "binary_sensor"]
 
 TAHOMA_TYPES = {
+    "io:VerticalInteriorBlindVeluxIOComponent": "cover",
     "io:ExteriorVenetianBlindIOComponent": "cover",
     "io:HorizontalAwningIOComponent": "cover",
     "io:LightIOSystemSensor": "sensor",

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -33,7 +33,6 @@ CONFIG_SCHEMA = vol.Schema(
 TAHOMA_COMPONENTS = ["scene", "sensor", "cover", "switch", "binary_sensor"]
 
 TAHOMA_TYPES = {
-    "io:VerticalInteriorBlindVeluxIOComponent": "cover",
     "io:ExteriorVenetianBlindIOComponent": "cover",
     "io:HorizontalAwningIOComponent": "cover",
     "io:LightIOSystemSensor": "sensor",
@@ -46,6 +45,7 @@ TAHOMA_TYPES = {
     "io:SomfyBasicContactIOSystemSensor": "sensor",
     "io:SomfyContactIOSystemSensor": "sensor",
     "io:VerticalExteriorAwningIOComponent": "cover",
+    "io:VerticalInteriorBlindVeluxIOComponent": "cover",
     "io:WindowOpenerVeluxIOComponent": "cover",
     "io:GarageOpenerIOComponent": "cover",
     "rtds:RTDSContactSensor": "sensor",

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -241,7 +241,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
             "io:RollerShutterGenericIOComponent",
             "io:VerticalExteriorAwningIOComponent",
             "io:VerticalInteriorBlindVeluxIOComponent",
-            "io:WindowOpenerVeluxIOComponent"
+            "io:WindowOpenerVeluxIOComponent",
         ):
             self.apply_action("stop")
         else:

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -28,6 +28,7 @@ ATTR_LOCK_ORIG = "lock_originator"
 HORIZONTAL_AWNING = "io:HorizontalAwningIOComponent"
 
 TAHOMA_DEVICE_CLASSES = {
+    "io:VerticalInteriorBlindVeluxIOComponent": DEVICE_CLASS_BLIND,
     "io:ExteriorVenetianBlindIOComponent": DEVICE_CLASS_BLIND,
     HORIZONTAL_AWNING: DEVICE_CLASS_AWNING,
     "io:RollerShutterGenericIOComponent": DEVICE_CLASS_SHUTTER,
@@ -162,10 +163,15 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        if self.tahoma_device.type == HORIZONTAL_AWNING:
-            self.apply_action("setPosition", kwargs.get(ATTR_POSITION, 0))
+        if self.tahoma_device.type == "io:WindowOpenerVeluxIOComponent":
+          command = "setClosure"
         else:
-            self.apply_action("setPosition", 100 - kwargs.get(ATTR_POSITION, 0))
+          command = "setPosition"
+        
+        if self.tahoma_device.type == HORIZONTAL_AWNING:
+            self.apply_action(command, kwargs.get(ATTR_POSITION, 0))
+        else:
+            self.apply_action(command, 100 - kwargs.get(ATTR_POSITION, 0))
 
     @property
     def is_closed(self):
@@ -234,6 +240,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
             HORIZONTAL_AWNING,
             "io:RollerShutterGenericIOComponent",
             "io:VerticalExteriorAwningIOComponent",
+            "io:VerticalInteriorBlindVeluxIOComponent",
+            "io:WindowOpenerVeluxIOComponent"
         ):
             self.apply_action("stop")
         else:

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -164,10 +164,10 @@ class TahomaCover(TahomaDevice, CoverDevice):
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         if self.tahoma_device.type == "io:WindowOpenerVeluxIOComponent":
-          command = "setClosure"
+            command = "setClosure"
         else:
-          command = "setPosition"
-        
+            command = "setPosition"
+
         if self.tahoma_device.type == HORIZONTAL_AWNING:
             self.apply_action(command, kwargs.get(ATTR_POSITION, 0))
         else:

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -28,7 +28,6 @@ ATTR_LOCK_ORIG = "lock_originator"
 HORIZONTAL_AWNING = "io:HorizontalAwningIOComponent"
 
 TAHOMA_DEVICE_CLASSES = {
-    "io:VerticalInteriorBlindVeluxIOComponent": DEVICE_CLASS_BLIND,
     "io:ExteriorVenetianBlindIOComponent": DEVICE_CLASS_BLIND,
     HORIZONTAL_AWNING: DEVICE_CLASS_AWNING,
     "io:RollerShutterGenericIOComponent": DEVICE_CLASS_SHUTTER,
@@ -36,6 +35,7 @@ TAHOMA_DEVICE_CLASSES = {
     "io:RollerShutterVeluxIOComponent": DEVICE_CLASS_SHUTTER,
     "io:RollerShutterWithLowSpeedManagementIOComponent": DEVICE_CLASS_SHUTTER,
     "io:VerticalExteriorAwningIOComponent": DEVICE_CLASS_AWNING,
+    "io:VerticalInteriorBlindVeluxIOComponent": DEVICE_CLASS_BLIND,
     "io:WindowOpenerVeluxIOComponent": DEVICE_CLASS_WINDOW,
     "io:GarageOpenerIOComponent": DEVICE_CLASS_GARAGE,
     "rts:BlindRTSComponent": DEVICE_CLASS_BLIND,


### PR DESCRIPTION

## Description:
Added Velux Solar Roller Blind. 
Fixed Velux Integra Window stop & position commands.



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
