### PR TITLE
Refactor entity_ids, tweak names and consolidate classes

### DIFF
--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -3,8 +3,8 @@ import logging
 from typing import Optional
 
 from aiohttp import ClientResponseError
-import voluptuous as vol
 from incomfortclient import Gateway as InComfortGateway
+import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -1,5 +1,6 @@
 """Support for an Intergas boiler via an InComfort/Intouch Lan2RF gateway."""
 import logging
+from typing import Optional
 
 from aiohttp import ClientResponseError
 import voluptuous as vol
@@ -8,7 +9,9 @@ from incomfortclient import Gateway as InComfortGateway
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.core import callback
 from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,3 +56,44 @@ async def async_setup(hass, hass_config):
         )
 
     return True
+
+
+class IncomfortEntity:
+    """Base class for all InComfort entities."""
+
+    def __init__(self) -> None:
+        """Initialize the class."""
+        self._unique_id = self._name = None
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the sensor."""
+        return self._name
+
+
+class IncomfortChild(IncomfortEntity):
+    """Base class for all InComfort entities (excluding the boiler)."""
+
+    def __init__(self) -> None:
+        """Initialize the class."""
+        super().__init__()
+
+    async def async_added_to_hass(self) -> None:
+        """Set up a listener when this entity is added to HA."""
+        # pylint: disable=no-member
+        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
+
+    @callback
+    def _refresh(self) -> None:
+        # pylint: disable=no-member
+        self.async_schedule_update_ha_state(force_refresh=True)
+
+    @property
+    def should_poll(self) -> bool:
+        """Return False as this device should never be polled."""
+        return False

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -86,7 +86,6 @@ class IncomfortChild(IncomfortEntity):
 
     @callback
     def _refresh(self) -> None:
-        # pylint: disable=no-member
         self.async_schedule_update_ha_state(force_refresh=True)
 
     @property

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -7,11 +7,12 @@ import voluptuous as vol
 from incomfortclient import Gateway as InComfortGateway
 
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.core import callback
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ async def async_setup(hass, hass_config):
     return True
 
 
-class IncomfortEntity:
+class IncomfortEntity(Entity):
     """Base class for all InComfort entities."""
 
     def __init__(self) -> None:
@@ -81,7 +82,6 @@ class IncomfortChild(IncomfortEntity):
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
-        # pylint: disable=no-member
         async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
 
     @callback

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -79,10 +79,6 @@ class IncomfortEntity:
 class IncomfortChild(IncomfortEntity):
     """Base class for all InComfort entities (excluding the boiler)."""
 
-    def __init__(self) -> None:
-        """Initialize the class."""
-        super().__init__()
-
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
         # pylint: disable=no-member

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -25,7 +25,7 @@ class IncomfortFailed(IncomfortChild, BinarySensorDevice):
 
         self._unique_id = f"{heater.serial_no}_failed"
         self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN}_failed")
-        self._name = "InComfort Fault state"
+        self._name = "Boiler Fault"
 
         self._client = client
         self._heater = heater

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -1,11 +1,9 @@
 """Support for an Intergas heater via an InComfort/InTouch Lan2RF gateway."""
 from typing import Any, Dict, Optional
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.components.binary_sensor import BinarySensorDevice, ENTITY_ID_FORMAT
 
-from . import DOMAIN
+from . import DOMAIN, IncomfortChild
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -18,33 +16,19 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
 
 
-class IncomfortFailed(BinarySensorDevice):
+class IncomfortFailed(IncomfortChild, BinarySensorDevice):
     """Representation of an InComfort Failed sensor."""
 
     def __init__(self, client, heater) -> None:
         """Initialize the binary sensor."""
+        super().__init__()
+
         self._unique_id = f"{heater.serial_no}_failed"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN}_failed")
+        self._name = "InComfort Fault state"
 
         self._client = client
         self._heater = heater
-
-    async def async_added_to_hass(self) -> None:
-        """Set up a listener when this entity is added to HA."""
-        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
-
-    @callback
-    def _refresh(self) -> None:
-        self.async_schedule_update_ha_state(force_refresh=True)
-
-    @property
-    def unique_id(self) -> Optional[str]:
-        """Return a unique ID."""
-        return self._unique_id
-
-    @property
-    def name(self) -> Optional[str]:
-        """Return the name of the sensor."""
-        return "Fault state"
 
     @property
     def is_on(self) -> bool:
@@ -55,8 +39,3 @@ class IncomfortFailed(BinarySensorDevice):
     def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return the device state attributes."""
         return {"fault_code": self._heater.status["fault_code"]}
-
-    @property
-    def should_poll(self) -> bool:
-        """Return False as this device should never be polled."""
-        return False

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for an Intergas heater via an InComfort/InTouch Lan2RF gateway."""
 from typing import Any, Dict, Optional
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, ENTITY_ID_FORMAT
+from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorDevice
 
 from . import DOMAIN, IncomfortChild
 

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -1,16 +1,14 @@
 """Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
 from typing import Any, Dict, List, Optional
 
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import ClimateDevice, ENTITY_ID_FORMAT
 from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT,
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import DOMAIN
+from . import DOMAIN, IncomfortChild
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -24,39 +22,19 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([InComfortClimate(client, heater, r) for r in heater.rooms])
 
 
-class InComfortClimate(ClimateDevice):
+class InComfortClimate(IncomfortChild, ClimateDevice):
     """Representation of an InComfort/InTouch climate device."""
 
     def __init__(self, client, heater, room) -> None:
         """Initialize the climate device."""
+        super().__init__()
+
         self._unique_id = f"{heater.serial_no}_{room.room_no}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN}_{room.room_no}")
+        self._name = f"Thermostat {room.room_no}"
 
         self._client = client
         self._room = room
-        self._name = f"Room {room.room_no}"
-
-    async def async_added_to_hass(self) -> None:
-        """Set up a listener when this entity is added to HA."""
-        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
-
-    @callback
-    def _refresh(self) -> None:
-        self.async_schedule_update_ha_state(force_refresh=True)
-
-    @property
-    def should_poll(self) -> bool:
-        """Return False as this device should never be polled."""
-        return False
-
-    @property
-    def unique_id(self) -> Optional[str]:
-        """Return a unique ID."""
-        return self._unique_id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the climate device."""
-        return self._name
 
     @property
     def device_state_attributes(self) -> Dict[str, Any]:

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -1,7 +1,7 @@
 """Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
 from typing import Any, Dict, List, Optional
 
-from homeassistant.components.climate import ClimateDevice, ENTITY_ID_FORMAT
+from homeassistant.components.climate import ENTITY_ID_FORMAT, ClimateDevice
 from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT,
     SUPPORT_TARGET_TEMPERATURE,

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -8,7 +8,6 @@ from homeassistant.const import (
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
 )
-from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
 from . import DOMAIN, IncomfortChild
@@ -41,7 +40,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
 
 
-class IncomfortSensor(IncomfortChild, Entity):
+class IncomfortSensor(IncomfortChild):
     """Representation of an InComfort/InTouch sensor device."""
 
     def __init__(self, client, heater, name) -> None:

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -53,15 +53,16 @@ class IncomfortSensor(IncomfortChild, Entity):
 
         self._unique_id = f"{heater.serial_no}_{slugify(name)}"
         self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN}_{slugify(name)}")
-        self._name = name
+        self._name = f"Boiler {name}"
 
         self._device_class = None
+        self._state_attr = INCOMFORT_MAP_ATTRS[name][0]
         self._unit_of_measurement = None
 
     @property
     def state(self) -> Optional[str]:
         """Return the state of the sensor."""
-        return self._heater.status[INCOMFORT_MAP_ATTRS[self._name][0]]
+        return self._heater.status[self._state_attr]
 
     @property
     def device_class(self) -> Optional[str]:
@@ -92,11 +93,11 @@ class IncomfortTemperature(IncomfortSensor):
         """Initialize the signal strength sensor."""
         super().__init__(client, heater, name)
 
+        self._attr = INCOMFORT_MAP_ATTRS[name][1]
         self._device_class = DEVICE_CLASS_TEMPERATURE
         self._unit_of_measurement = TEMP_CELSIUS
 
     @property
     def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return the device state attributes."""
-        key = INCOMFORT_MAP_ATTRS[self._name][1]
-        return {key: self._heater.status[key]}
+        return {self._attr: self._heater.status[self._attr]}

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, Optional
 
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.const import (
-    PRESSURE_BAR,
-    TEMP_CELSIUS,
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
+    PRESSURE_BAR,
+    TEMP_CELSIUS,
 )
 from homeassistant.util import slugify
 

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -35,7 +35,7 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterDevice):
 
         self._unique_id = f"{heater.serial_no}"
         self.entity_id = ENTITY_ID_FORMAT.format(DOMAIN)
-        self._name = "Boiler State"
+        self._name = "Boiler"
 
         self._client = client
         self._heater = heater

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict
 
 from aiohttp import ClientResponseError
+
 from homeassistant.components.water_heater import ENTITY_ID_FORMAT, WaterHeaterDevice
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.dispatcher import async_dispatcher_send

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -35,7 +35,7 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterDevice):
 
         self._unique_id = f"{heater.serial_no}"
         self.entity_id = ENTITY_ID_FORMAT.format(DOMAIN)
-        self._name = "Intergas Boiler"
+        self._name = "Boiler State"
 
         self._client = client
         self._heater = heater

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -1,14 +1,14 @@
 """Support for an Intergas boiler via an InComfort/Intouch Lan2RF gateway."""
 import asyncio
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from aiohttp import ClientResponseError
-from homeassistant.components.water_heater import WaterHeaterDevice
+from homeassistant.components.water_heater import ENTITY_ID_FORMAT, WaterHeaterDevice
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from . import DOMAIN
+from . import DOMAIN, IncomfortEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,25 +26,19 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([IncomfortWaterHeater(client, heater)])
 
 
-class IncomfortWaterHeater(WaterHeaterDevice):
+class IncomfortWaterHeater(IncomfortEntity, WaterHeaterDevice):
     """Representation of an InComfort/Intouch water_heater device."""
 
     def __init__(self, client, heater) -> None:
         """Initialize the water_heater device."""
+        super().__init__()
+
         self._unique_id = f"{heater.serial_no}"
+        self.entity_id = ENTITY_ID_FORMAT.format(DOMAIN)
+        self._name = "Intergas Boiler"
 
         self._client = client
         self._heater = heater
-
-    @property
-    def unique_id(self) -> Optional[str]:
-        """Return a unique ID."""
-        return self._unique_id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the water_heater device."""
-        return "Boiler"
 
     @property
     def icon(self) -> str:


### PR DESCRIPTION
## Breaking Change:
None known.

For previously registered entities, if its `unique_id` is unchanged, then its `entity_id` as registered in the entity registry will also stay the same. So there will not be a breaking change for existing entities.

## Description:
The PR changes the `entity_id` of all **incomfort** entities.

The entity_ids for **incomfort** devices have much potential to collide with other integrations, which would cause confusion, or worse.  For example:
 - `climate.room_1`, which is now `climate.incomfort_1`, and
 - `sensor.failed`, which is now`sensor.infomfort_failed` 

The `name`s of entities have also been updated, for example:
 - "Room 1" is now "Thermostat 1"
 - "Fault state" is now "Boiler Fault"
 - "CV Temp" is now "Boiler CV Temp"

Finally, duplicated code has been consolidated in base classes.

**Related issue (if applicable):** fixes N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

**Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
