### PR TITLE
Config entry and device for Coolmaster integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -125,7 +125,9 @@ omit =
     homeassistant/components/comfoconnect/*
     homeassistant/components/concord232/alarm_control_panel.py
     homeassistant/components/concord232/binary_sensor.py
+    homeassistant/components/coolmaster/__init__.py
     homeassistant/components/coolmaster/climate.py
+    homeassistant/components/coolmaster/const.py
     homeassistant/components/cppm_tracker/device_tracker.py
     homeassistant/components/cpuspeed/sensor.py
     homeassistant/components/crimereports/sensor.py

--- a/homeassistant/components/coolmaster/__init__.py
+++ b/homeassistant/components/coolmaster/__init__.py
@@ -1,10 +1,13 @@
 """The Coolmaster integration."""
 
+
 async def async_setup(hass, config):
+    """Set up Coolmaster components."""
     return True
 
 
 async def async_setup_entry(hass, entry):
+    """Set up Coolmaster from a config entry."""
     hass.async_add_job(
         hass.config_entries.async_forward_entry_setup(entry, "climate")
     )
@@ -13,6 +16,7 @@ async def async_setup_entry(hass, entry):
 
 
 async def async_unload_entry(hass, entry):
+    """Unload a Coolmaster config entry."""
     hass.async_add_job(
         hass.config_entries.async_forward_entry_unload(entry, "climate")
     )

--- a/homeassistant/components/coolmaster/__init__.py
+++ b/homeassistant/components/coolmaster/__init__.py
@@ -1,1 +1,20 @@
-"""The coolmaster component."""
+"""The Coolmaster integration."""
+
+async def async_setup(hass, config):
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    hass.async_add_job(
+        hass.config_entries.async_forward_entry_setup(entry, "climate")
+    )
+
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    hass.async_add_job(
+        hass.config_entries.async_forward_entry_unload(entry, "climate")
+    )
+
+    return True

--- a/homeassistant/components/coolmaster/__init__.py
+++ b/homeassistant/components/coolmaster/__init__.py
@@ -15,6 +15,8 @@ async def async_setup_entry(hass, entry):
 
 async def async_unload_entry(hass, entry):
     """Unload a Coolmaster config entry."""
-    hass.async_add_job(hass.config_entries.async_forward_entry_unload(entry, "climate"))
+    await hass.async_add_job(
+        hass.config_entries.async_forward_entry_unload(entry, "climate")
+    )
 
     return True

--- a/homeassistant/components/coolmaster/__init__.py
+++ b/homeassistant/components/coolmaster/__init__.py
@@ -8,17 +8,13 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up Coolmaster from a config entry."""
-    hass.async_add_job(
-        hass.config_entries.async_forward_entry_setup(entry, "climate")
-    )
+    hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, "climate"))
 
     return True
 
 
 async def async_unload_entry(hass, entry):
     """Unload a Coolmaster config entry."""
-    hass.async_add_job(
-        hass.config_entries.async_forward_entry_unload(entry, "climate")
-    )
+    hass.async_add_job(hass.config_entries.async_forward_entry_unload(entry, "climate"))
 
     return True

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -101,8 +101,8 @@ class CoolmasterClimate(ClimateDevice):
         return {
             "identifiers": {(DOMAIN, self.unique_id)},
             "name": self.name,
-            "manufacturer": "CoolAutomation",  # TODO: take from `line`
-            "model": "CoolMasterNet",  # TODO: take from `set`
+            "manufacturer": "CoolAutomation",
+            "model": "CoolMasterNet",
         }
 
     @property

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -4,7 +4,7 @@ import logging
 
 from pycoolmasternet import CoolMasterNet
 
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
+from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
@@ -48,11 +48,12 @@ def _build_entity(device, supported_modes):
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the CoolMasterNet climate platform."""
     return True
+
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the CoolMasterNet climate platform."""
-
     supported_modes = config_entry.data.get(CONF_SUPPORTED_MODES)
     host = config_entry.data[CONF_HOST]
     port = config_entry.data[CONF_PORT]
@@ -101,13 +102,14 @@ class CoolmasterClimate(ClimateDevice):
 
     @property
     def device_info(self):
+        """Return device info for this device."""
         return {
             'identifiers': {
                 (DOMAIN, self.unique_id)
             },
             'name': self.name,
-            'manufacturer': "CoolAutomation", # TODO: take from `line`
-            'model': "CoolMasterNet" # TODO: take from `set`
+            'manufacturer': "CoolAutomation",  # TODO: take from `line`
+            'model': "CoolMasterNet"  # TODO: take from `set`
         }
 
     @property

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -47,11 +47,6 @@ def _build_entity(device, supported_modes):
     return CoolmasterClimate(device, supported_modes)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the CoolMasterNet climate platform."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the CoolMasterNet climate platform."""
     supported_modes = config_entry.data.get(CONF_SUPPORTED_MODES)

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -104,12 +104,10 @@ class CoolmasterClimate(ClimateDevice):
     def device_info(self):
         """Return device info for this device."""
         return {
-            'identifiers': {
-                (DOMAIN, self.unique_id)
-            },
-            'name': self.name,
-            'manufacturer': "CoolAutomation",  # TODO: take from `line`
-            'model': "CoolMasterNet"  # TODO: take from `set`
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "manufacturer": "CoolAutomation",  # TODO: take from `line`
+            "model": "CoolMasterNet",  # TODO: take from `set`
         }
 
     @property

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -3,7 +3,6 @@
 import logging
 
 from pycoolmasternet import CoolMasterNet
-import voluptuous as vol
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
@@ -23,20 +22,10 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
-import homeassistant.helpers.config_validation as cv
+
+from .const import CONF_SUPPORTED_MODES, DOMAIN
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
-
-DEFAULT_PORT = 10102
-
-AVAILABLE_MODES = [
-    HVAC_MODE_OFF,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_FAN_ONLY,
-]
 
 CM_TO_HA_STATE = {
     "heat": HVAC_MODE_HEAT,
@@ -50,17 +39,6 @@ HA_STATE_TO_CM = {value: key for key, value in CM_TO_HA_STATE.items()}
 
 FAN_MODES = ["low", "med", "high", "auto"]
 
-CONF_SUPPORTED_MODES = "supported_modes"
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_SUPPORTED_MODES, default=AVAILABLE_MODES): vol.All(
-            cv.ensure_list, [vol.In(AVAILABLE_MODES)]
-        ),
-    }
-)
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -69,18 +47,21 @@ def _build_entity(device, supported_modes):
     return CoolmasterClimate(device, supported_modes)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    return True
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the CoolMasterNet climate platform."""
 
-    supported_modes = config.get(CONF_SUPPORTED_MODES)
-    host = config[CONF_HOST]
-    port = config[CONF_PORT]
+    supported_modes = config_entry.data.get(CONF_SUPPORTED_MODES)
+    host = config_entry.data[CONF_HOST]
+    port = config_entry.data[CONF_PORT]
     cool = CoolMasterNet(host, port=port)
-    devices = cool.devices()
+    devices = await hass.async_add_executor_job(cool.devices)
 
     all_devices = [_build_entity(device, supported_modes) for device in devices]
 
-    add_entities(all_devices, True)
+    async_add_devices(all_devices, True)
 
 
 class CoolmasterClimate(ClimateDevice):
@@ -117,6 +98,17 @@ class CoolmasterClimate(ClimateDevice):
             self._unit = TEMP_CELSIUS
         else:
             self._unit = TEMP_FAHRENHEIT
+
+    @property
+    def device_info(self):
+        return {
+            'identifiers': {
+                (DOMAIN, self.unique_id)
+            },
+            'name': self.name,
+            'manufacturer': "CoolAutomation", # TODO: take from `line`
+            'model': "CoolMasterNet" # TODO: take from `set`
+        }
 
     @property
     def unique_id(self):

--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 from homeassistant import core, config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
+# pylint: disable=unused-import
 from .const import AVAILABLE_MODES, CONF_SUPPORTED_MODES, DEFAULT_PORT, DOMAIN
 
 MODES_SCHEMA = {vol.Required(mode, default=True): bool for mode in AVAILABLE_MODES}

--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -11,7 +11,7 @@ from .const import AVAILABLE_MODES, CONF_SUPPORTED_MODES, DEFAULT_PORT, DOMAIN
 
 MODES_SCHEMA = {vol.Required(mode, default=True): bool for mode in AVAILABLE_MODES}
 
-DATA_SCHEMA = vol.Schema({**{vol.Required(CONF_HOST): str}, **MODES_SCHEMA})
+DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str, **MODES_SCHEMA})
 
 
 async def validate_connection(hass: core.HomeAssistant, host):

--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -1,33 +1,35 @@
 """Config flow to configure Coolmaster."""
 
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
+import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN, CONF_SUPPORTED_MODES, DEFAULT_PORT, AVAILABLE_MODES
-
+from .const import AVAILABLE_MODES, CONF_SUPPORTED_MODES, DEFAULT_PORT, DOMAIN
 
 MODES_SCHEMA = {vol.Required(mode): bool for mode in AVAILABLE_MODES}
-DATA_SCHEMA = vol.Schema({**{
+HOST_SCHEMA = {
     vol.Required(CONF_HOST): str,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
-    }, **MODES_SCHEMA})
+}
 
-class CoolmasterConfigFlow(config_entries.ConfigFlow, domain = DOMAIN):
+DATA_SCHEMA = vol.Schema({**HOST_SCHEMA, **MODES_SCHEMA})
+
+
+class CoolmasterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Coolmaster config flow."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    def _async_get_entry(self, input):
-        supported_modes = [key for (key, value) in input.items() if key in AVAILABLE_MODES and value]
+    def _async_get_entry(self, data):
+        supported_modes = [key for (key, value) in data.items() if key in AVAILABLE_MODES and value]
         return self.async_create_entry(
-            title = input[CONF_HOST],
-            data = {
-                CONF_HOST: input[CONF_HOST],
-                CONF_PORT: input[CONF_PORT],
+            title=data[CONF_HOST],
+            data={
+                CONF_HOST: data[CONF_HOST],
+                CONF_PORT: data[CONF_PORT],
                 CONF_SUPPORTED_MODES: supported_modes
             },
         )

--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -1,0 +1,40 @@
+"""Config flow to configure Coolmaster."""
+
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from .const import DOMAIN, CONF_SUPPORTED_MODES, DEFAULT_PORT, AVAILABLE_MODES
+
+
+MODES_SCHEMA = {vol.Required(mode): bool for mode in AVAILABLE_MODES}
+DATA_SCHEMA = vol.Schema({**{
+    vol.Required(CONF_HOST): str,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
+    }, **MODES_SCHEMA})
+
+class CoolmasterConfigFlow(config_entries.ConfigFlow, domain = DOMAIN):
+    """Handle a Coolmaster config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def _async_get_entry(self, input):
+        supported_modes = [key for (key, value) in input.items() if key in AVAILABLE_MODES and value]
+        return self.async_create_entry(
+            title = input[CONF_HOST],
+            data = {
+                CONF_HOST: input[CONF_HOST],
+                CONF_PORT: input[CONF_PORT],
+                CONF_SUPPORTED_MODES: supported_modes
+            },
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            return self._async_get_entry(user_input)
+
+        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)

--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -11,7 +11,7 @@ from .const import AVAILABLE_MODES, CONF_SUPPORTED_MODES, DEFAULT_PORT, DOMAIN
 MODES_SCHEMA = {vol.Required(mode): bool for mode in AVAILABLE_MODES}
 HOST_SCHEMA = {
     vol.Required(CONF_HOST): str,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 }
 
 DATA_SCHEMA = vol.Schema({**HOST_SCHEMA, **MODES_SCHEMA})
@@ -24,13 +24,15 @@ class CoolmasterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def _async_get_entry(self, data):
-        supported_modes = [key for (key, value) in data.items() if key in AVAILABLE_MODES and value]
+        supported_modes = [
+            key for (key, value) in data.items() if key in AVAILABLE_MODES and value
+        ]
         return self.async_create_entry(
             title=data[CONF_HOST],
             data={
                 CONF_HOST: data[CONF_HOST],
                 CONF_PORT: data[CONF_PORT],
-                CONF_SUPPORTED_MODES: supported_modes
+                CONF_SUPPORTED_MODES: supported_modes,
             },
         )
 

--- a/homeassistant/components/coolmaster/const.py
+++ b/homeassistant/components/coolmaster/const.py
@@ -1,0 +1,27 @@
+"""Constants for the Coolmaster integration."""
+
+import logging
+
+from homeassistant.components.climate.const import (
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_OFF
+)
+
+DOMAIN = "coolmaster"
+
+DEFAULT_PORT = 10102
+
+CONF_SUPPORTED_MODES = "supported_modes"
+
+AVAILABLE_MODES = [
+    HVAC_MODE_OFF,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_FAN_ONLY,
+]

--- a/homeassistant/components/coolmaster/const.py
+++ b/homeassistant/components/coolmaster/const.py
@@ -1,14 +1,12 @@
 """Constants for the Coolmaster integration."""
 
-import logging
-
 from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
     HVAC_MODE_FAN_ONLY,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_OFF
+    HVAC_MODE_OFF,
 )
 
 DOMAIN = "coolmaster"

--- a/homeassistant/components/coolmaster/manifest.json
+++ b/homeassistant/components/coolmaster/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "coolmaster",
   "name": "Coolmaster",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/coolmaster",
   "requirements": [
     "pycoolmasternet==0.0.4"

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -15,6 +15,10 @@
           "fan_only": "Support fan only mode"
         }
       }
+    },
+    "error": {
+      "connection_error": "Failed to connect to CoolMasterNet instance. Please check your host and port.",
+      "no_units": "Could not find any HVAC units in CoolMasterNet host."
     }
   }
 }

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "title": "CoolMasterNet",
+    "step": {
+      "user": {
+        "title": "Setup your CoolMasterNet connection details.",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "off": "Can be turned off",
+          "heat": "Support heat mode",
+          "cool": "Support cool mode",
+          "heat_cool": "Support automatic heat/cool mode",
+          "dry": "Support dry mode",
+          "fan_only": "Support fan only mode"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -6,7 +6,6 @@
         "title": "Setup your CoolMasterNet connection details.",
         "data": {
           "host": "Host",
-          "port": "Port",
           "off": "Can be turned off",
           "heat": "Support heat mode",
           "cool": "Support cool mode",
@@ -17,7 +16,7 @@
       }
     },
     "error": {
-      "connection_error": "Failed to connect to CoolMasterNet instance. Please check your host and port.",
+      "connection_error": "Failed to connect to CoolMasterNet instance. Please check your host.",
       "no_units": "Could not find any HVAC units in CoolMasterNet host."
     }
   }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -14,6 +14,7 @@ FLOWS = [
     "axis",
     "cast",
     "cert_expiry",
+    "coolmaster",
     "daikin",
     "deconz",
     "dialogflow",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -395,6 +395,9 @@ pybotvac==0.0.16
 # homeassistant.components.cast
 pychromecast==4.0.1
 
+# homeassistant.components.coolmaster
+pycoolmasternet==0.0.4
+
 # homeassistant.components.daikin
 pydaikin==1.6.1
 

--- a/tests/components/coolmaster/__init__.py
+++ b/tests/components/coolmaster/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Coolmaster component."""

--- a/tests/components/coolmaster/test_config_flow.py
+++ b/tests/components/coolmaster/test_config_flow.py
@@ -10,7 +10,7 @@ from tests.common import mock_coro
 
 
 def _flow_data():
-    options = {"host": "1.1.1.1", "port": 10102}
+    options = {"host": "1.1.1.1"}
     for mode in AVAILABLE_MODES:
         options[mode] = True
     return options

--- a/tests/components/coolmaster/test_config_flow.py
+++ b/tests/components/coolmaster/test_config_flow.py
@@ -1,0 +1,104 @@
+"""Test the Coolmaster config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.coolmaster.const import DOMAIN, AVAILABLE_MODES
+
+# from homeassistant.components.coolmaster.config_flow import validate_connection
+
+from tests.common import mock_coro
+
+
+def _flow_data():
+    options = {"host": "1.1.1.1", "port": 10102}
+    for mode in AVAILABLE_MODES:
+        options[mode] = True
+    return options
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.coolmaster.config_flow.validate_connection",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.coolmaster.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, patch(
+        "homeassistant.components.coolmaster.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _flow_data()
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "1.1.1.1"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "port": 10102,
+        "supported_modes": AVAILABLE_MODES,
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_timeout(hass):
+    """Test we handle a connection timeout."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.coolmaster.config_flow.validate_connection",
+        side_effect=TimeoutError(),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _flow_data()
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "connection_error"}
+
+
+async def test_form_connection_refused(hass):
+    """Test we handle a connection error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.coolmaster.config_flow.validate_connection",
+        side_effect=ConnectionRefusedError(),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _flow_data()
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "connection_error"}
+
+
+async def test_form_no_units(hass):
+    """Test we handle no units found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.coolmaster.config_flow.validate_connection",
+        return_value=mock_coro(False),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _flow_data()
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "no_units"}


### PR DESCRIPTION
## Breaking Change:

Coolmaster configuration is now taken from config entry rather than `configuration.yaml`.
If you're using the CoolMasterNet integration, you'll need to remove the configuration from `configuration.yaml`, and add the integration through the Integrations UI. Click on the `+` sign at the bottom right, select 'CoolMasterNet`, and configure your host and supported modes.

## Description:
This PR creates devices for individual Coolmaster units. This allows them, for example, to be placed in areas.
In order to support devices, a config flow is also implemented, and the configuration is in a config entry.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10947

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
