### PR TITLE
Migrate Z-Wave unique_id in preparation for OZW1.6

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -1077,6 +1077,21 @@ class ZWaveDeviceEntityValues:
             _LOGGER.debug("Using %s instead of %s", workaround_component, component)
             component = workaround_component
 
+        # Start Unique ID migration in preparation for OZW 1.6
+        # This migration will be removed when the component moves to OZW 1.6
+        old_unique_id = f"{self._node.node_id}-{self.primary.object_id}"
+        new_unique_id = compute_value_unique_id(self._node, self.primary)
+        entity_id = self._registry.async_get_entity_id(component, DOMAIN, old_unique_id)
+        if entity_id is not None:
+            _LOGGER.info(
+                "Migrating unique_id for %s :: %s -> %s",
+                entity_id,
+                old_unique_id,
+                new_unique_id,
+            )
+            self._registry.async_update_entity(entity_id, new_unique_id=new_unique_id)
+        # End Unique ID migration
+
         entity_id = self._registry.async_get_entity_id(
             component, DOMAIN, compute_value_unique_id(self._node, self.primary)
         )
@@ -1315,4 +1330,4 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
 
 def compute_value_unique_id(node, value):
     """Compute unique_id a value would get if it were to get one."""
-    return f"{node.node_id}-{value.object_id}"
+    return f"{node.node_id}-{value.instance}-{value.index}-{value.command_class}"

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -607,7 +607,7 @@ async def async_setup_entry(hass, config_entry):
             "Renamed Z-Wave value (Node %d Value %d) to %s", node_id, value_id, name
         )
         update_ids = service.data.get(const.ATTR_UPDATE_IDS)
-        value_key = f"{node_id}-{value_id}"
+        value_key = compute_value_unique_id(node, value)
         entity = hass.data[DATA_DEVICES][value_key]
         await entity.value_renamed(update_ids)
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -567,6 +567,8 @@ async def test_value_entities(hass, mock_openzwave):
     )
 
 
+# Test Unique ID migration in preparation for OZW 1.6
+# This migration and test will be removed when the component moves to OZW 1.6
 async def test_unique_id_migration(hass, mock_openzwave):
     """Test unique id migration on a node value."""
     mock_receivers = {}


### PR DESCRIPTION
## Description:
The `object_id` used for Z-Wave unique ids is different in OZW/pyozw 1.6. This migrates the unique_id for Z-Wave entities to use a combination of node id, value instance, value index, and command class, which will remain the same in OZW1.6.

This migration will be removed (as it will no longer work) when the component moves to OZW 1.6.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
