### PR TITLE
Fix whois error, check expiration_date for list and pick first

### DIFF
--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -119,7 +119,10 @@ class WhoisSensor(Entity):
             attrs = {}
 
             expiration_date = response["expiration_date"]
-            attrs[ATTR_EXPIRES] = expiration_date.isoformat()
+            if isinstance(expiration_date, list):
+                attrs[ATTR_EXPIRES] = expiration_date[0].isoformat()
+            else:
+                attrs[ATTR_EXPIRES] = expiration_date.isoformat()
 
             if "nameservers" in response:
                 attrs[ATTR_NAME_SERVERS] = " ".join(response["nameservers"])


### PR DESCRIPTION
## Description:
Issue #22007 also affects the expiration date for the domain. This patch applies the same fix used in #22008 to the expiration date.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
No configuration chagnes

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
