### PR TITLE
Bump abodepy version

### DIFF
--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/abode",
   "requirements": [
-    "abodepy==0.16.5"
+    "abodepy==0.16.6"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -103,7 +103,7 @@ WazeRouteCalculator==0.10
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.5
+abodepy==0.16.6
 
 # homeassistant.components.mcp23017
 adafruit-blinka==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -46,7 +46,7 @@ RtmAPI==0.7.2
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.5
+abodepy==0.16.6
 
 # homeassistant.components.androidtv
 adb-shell==0.0.7


### PR DESCRIPTION
## Description:

Bump abodepy version to 0.16.6 which includes [some fixes](https://github.com/MisterWil/abodepy/releases/tag/v0.16.6).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.