### PR TITLE
Fix "home" zone to work with zone triggers

### DIFF
--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
 )
 from homeassistant.helpers.event import async_track_state_change
-from homeassistant.helpers import condition, config_validation as cv, location
+from homeassistant.helpers import condition, config_validation as cv
 
 
 # mypy: allow-untyped-defs, no-check-untyped-defs

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -40,13 +40,6 @@ async def async_attach_trigger(hass, config, action, automation_info):
     @callback
     def zone_automation_listener(entity, from_s, to_s):
         """Listen for state changes and calls action."""
-        if (
-            from_s
-            and not location.has_location(from_s)
-            or not location.has_location(to_s)
-        ):
-            return
-
         zone_state = hass.states.get(zone_entity_id)
         if from_s:
             from_match = condition.zone(hass, zone_state, from_s)

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     CONF_VALUE_TEMPLATE,
     CONF_WEEKDAY,
     CONF_ZONE,
+    STATE_HOME,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     SUN_EVENT_SUNRISE,

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -467,6 +467,9 @@ def zone(
     if entity is None:
         return False
 
+    if zone_ent.entity_id == zone_cmp.ENTITY_ID_HOME and entity.state == STATE_HOME:
+        return True
+
     latitude = entity.attributes.get(ATTR_LATITUDE)
     longitude = entity.attributes.get(ATTR_LONGITUDE)
 


### PR DESCRIPTION
The special case "home" zone, and the person states of "home" and
"not_home" should work nicely with Zone automation triggers. Configuring
automations to work on entering the Home zone using presence detection
but without a GPS tracker is a normal first use case of HA. But
following the intuitive steps of making the Zone trigger will result in
an automation that counterintuitively never fires.

This change allows Zone triggers to work with entering/exiting the Home
zone. This includes the case of no GPS trackers and only using presence
detection.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
