### PR TITLE
Save client identifier from Plex auth for future use

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -51,7 +51,7 @@ def configured_servers(hass):
 class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Plex config flow."""
 
-    VERSION = 2
+    VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     @staticmethod

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.util.json import load_json
 from .const import (  # pylint: disable=unused-import
     AUTH_CALLBACK_NAME,
     AUTH_CALLBACK_PATH,
+    CONF_CLIENT_IDENTIFIER,
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
     CONF_USE_EPISODE_ART,
@@ -50,7 +51,7 @@ def configured_servers(hass):
 class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Plex config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     @staticmethod
@@ -65,6 +66,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.available_servers = None
         self.plexauth = None
         self.token = None
+        self.client_id = None
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -116,6 +118,8 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         token = server_config.get(CONF_TOKEN)
 
         entry_config = {CONF_URL: url}
+        if self.client_id:
+            entry_config[CONF_CLIENT_IDENTIFIER] = self.client_id
         if token:
             entry_config[CONF_TOKEN] = token
         if url.startswith("https"):
@@ -216,6 +220,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_external_step_done(next_step_id="timed_out")
 
         self.token = token
+        self.client_id = self.plexauth.client_identifier
         return self.async_external_step_done(next_step_id="use_external_token")
 
     async def async_step_timed_out(self, user_input=None):

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -21,6 +21,7 @@ PLEX_NEW_MP_SIGNAL = "plex_new_mp_signal"
 PLEX_UPDATE_MEDIA_PLAYER_SIGNAL = "plex_update_mp_signal.{}"
 PLEX_UPDATE_SENSOR_SIGNAL = "plex_update_sensor_signal"
 
+CONF_CLIENT_IDENTIFIER = "client_id"
 CONF_SERVER = "server"
 CONF_SERVER_IDENTIFIER = "server_id"
 CONF_USE_EPISODE_ART = "use_episode_art"

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/plex",
   "requirements": [
     "plexapi==3.0.6",
-    "plexauth==0.0.4"
+    "plexauth==0.0.5"
   ],
   "dependencies": [
     "http"

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import (
+    CONF_CLIENT_IDENTIFIER,
     CONF_SERVER,
     CONF_SHOW_ALL_CONTROLS,
     CONF_USE_EPISODE_ART,
@@ -33,8 +34,6 @@ plexapi.X_PLEX_DEVICE_NAME = X_PLEX_DEVICE_NAME
 plexapi.X_PLEX_PLATFORM = X_PLEX_PLATFORM
 plexapi.X_PLEX_PRODUCT = X_PLEX_PRODUCT
 plexapi.X_PLEX_VERSION = X_PLEX_VERSION
-plexapi.myplex.BASE_HEADERS = plexapi.reset_base_headers()
-plexapi.server.BASE_HEADERS = plexapi.reset_base_headers()
 
 
 class PlexServer:
@@ -51,6 +50,12 @@ class PlexServer:
         self._verify_ssl = server_config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
         self.options = options
         self.server_choice = None
+
+        # Header conditionally added as it is not available in config entry v1
+        if CONF_CLIENT_IDENTIFIER in server_config:
+            plexapi.X_PLEX_IDENTIFIER = server_config[CONF_CLIENT_IDENTIFIER]
+        plexapi.myplex.BASE_HEADERS = plexapi.reset_base_headers()
+        plexapi.server.BASE_HEADERS = plexapi.reset_base_headers()
 
     def connect(self):
         """Connect to a Plex server directly, obtaining direct URL if necessary."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -971,7 +971,7 @@ pizzapi==0.0.3
 plexapi==3.0.6
 
 # homeassistant.components.plex
-plexauth==0.0.4
+plexauth==0.0.5
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -340,7 +340,7 @@ pillow==6.2.0
 plexapi==3.0.6
 
 # homeassistant.components.plex
-plexauth==0.0.4
+plexauth==0.0.5
 
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm


### PR DESCRIPTION
## Description:
The client identifier generated during the Plex OAuth-like authentication may be needed in the future to utilize the returned token. The client ID was originally discarded, but this saves it to the config entry in case we need it eventually. No current functionality will break if this requirement is added by Plex, but future component features may need it to be available.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html