### PR TITLE
Add homekit sha512 layer to adler32 hash

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -1,6 +1,7 @@
 """Support for Apple HomeKit."""
 import ipaddress
 import logging
+import hashlib
 from zlib import adler32
 
 import voluptuous as vol
@@ -255,7 +256,7 @@ def get_accessory(hass, driver, state, aid, config):
 
 def generate_aid(entity_id):
     """Generate accessory aid with zlib adler32."""
-    aid = adler32(entity_id.encode("utf-8"))
+    aid = adler32(hashlib.sha512(entity_id.encode("utf-8")).digest())
     if aid in (0, 1):
         return None
     return aid

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -176,15 +176,15 @@ async def test_homekit_add_accessory():
 
         mock_get_acc.side_effect = [None, "acc", None]
         homekit.add_bridge_accessory(State("light.demo", "on"))
-        mock_get_acc.assert_called_with("hass", "driver", ANY, 363398124, {})
+        mock_get_acc.assert_called_with("hass", "driver", ANY, 1730485127, {})
         assert not mock_bridge.add_accessory.called
 
         homekit.add_bridge_accessory(State("demo.test", "on"))
-        mock_get_acc.assert_called_with("hass", "driver", ANY, 294192020, {})
+        mock_get_acc.assert_called_with("hass", "driver", ANY, 166142111, {})
         assert mock_bridge.add_accessory.called
 
         homekit.add_bridge_accessory(State("demo.test_2", "on"))
-        mock_get_acc.assert_called_with("hass", "driver", ANY, 429982757, {})
+        mock_get_acc.assert_called_with("hass", "driver", ANY, 732110236, {})
         mock_bridge.add_accessory.assert_called_with("acc")
 
 


### PR DESCRIPTION
## Breaking Change:

This change modifies how AIDs are generated within the homekit component.  I do not know if these IDs are adhoc, or require consistency across HA boot cycles.  If these are adhoc, this should be a silent change.  If consistency is required, however, users will probably need to toss their cached homekit state and rebind their iOS devices.

## Description:

This is a two line change to introduce more entropy to the generation of AIDs within homekit, which, given the nature of entity IDs, are prone to hash collisions.

**Related issue (if applicable):** fixes #27954 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
