### PR TITLE
Code cleanup for orangepi_gpio

### DIFF
--- a/homeassistant/components/orangepi_gpio/__init__.py
+++ b/homeassistant/components/orangepi_gpio/__init__.py
@@ -8,6 +8,8 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_S
 
 _LOGGER = logging.getLogger(__name__)
 
+DOMAIN = "orangepi_gpio"
+
 
 async def async_setup(hass, config):
     """Set up the Orange Pi GPIO component."""

--- a/homeassistant/components/orangepi_gpio/__init__.py
+++ b/homeassistant/components/orangepi_gpio/__init__.py
@@ -1,18 +1,16 @@
 """Support for controlling GPIO pins of a Orange Pi."""
+
 import logging
+
+from OPi import GPIO
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_PIN_MODE = "pin_mode"
-DOMAIN = "orangepi_gpio"
-PIN_MODES = ["pc", "zeroplus", "zeroplus2", "deo", "neocore2"]
 
-
-def setup(hass, config):
+async def async_setup(hass, config):
     """Set up the Orange Pi GPIO component."""
-    from OPi import GPIO
 
     def cleanup_gpio(event):
         """Stuff to do before stopping."""
@@ -20,16 +18,16 @@ def setup(hass, config):
 
     def prepare_gpio(event):
         """Stuff to do when home assistant starts."""
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
+
     return True
 
 
 def setup_mode(mode):
     """Set GPIO pin mode."""
-    from OPi import GPIO
-
+    _LOGGER.debug("Setting GPIO pin mode as %s", mode)
     if mode == "pc":
         import orangepi.pc
 
@@ -52,36 +50,19 @@ def setup_mode(mode):
         GPIO.setmode(nanopi.neocore2.BOARD)
 
 
-def setup_output(port):
-    """Set up a GPIO as output."""
-    from OPi import GPIO
-
-    GPIO.setup(port, GPIO.OUT)
-
-
 def setup_input(port):
     """Set up a GPIO as input."""
-    from OPi import GPIO
-
+    _LOGGER.debug("Setting up GPIO pin %i as input", port)
     GPIO.setup(port, GPIO.IN)
-
-
-def write_output(port, value):
-    """Write a value to a GPIO."""
-    from OPi import GPIO
-
-    GPIO.output(port, value)
 
 
 def read_input(port):
     """Read a value from a GPIO."""
-    from OPi import GPIO
-
+    _LOGGER.debug("Reading GPIO pin %i", port)
     return GPIO.input(port)
 
 
 def edge_detect(port, event_callback):
     """Add detection for RISING and FALLING events."""
-    from OPi import GPIO
-
+    _LOGGER.debug("Add callback for GPIO pin %i", port)
     GPIO.add_event_detect(port, GPIO.BOTH, callback=event_callback)

--- a/homeassistant/components/orangepi_gpio/binary_sensor.py
+++ b/homeassistant/components/orangepi_gpio/binary_sensor.py
@@ -1,50 +1,57 @@
 """Support for binary sensor using Orange Pi GPIO."""
-import logging
 
-from homeassistant.components import orangepi_gpio
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
-from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.components.binary_sensor import (
+    ENTITY_ID_FORMAT,
+    PLATFORM_SCHEMA,
+    BinarySensorDevice,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.entity import async_generate_entity_id
 
-from . import CONF_PIN_MODE
-from .const import CONF_INVERT_LOGIC, CONF_PORTS, PORT_SCHEMA
-
-_LOGGER = logging.getLogger(__name__)
+from . import edge_detect, read_input, setup_input, setup_mode
+from .const import CONF_INVERT_LOGIC, CONF_PIN_MODE, CONF_PORTS, PORT_SCHEMA
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(PORT_SCHEMA)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Orange Pi GPIO devices."""
-    pin_mode = config[CONF_PIN_MODE]
-    orangepi_gpio.setup_mode(pin_mode)
-
-    invert_logic = config[CONF_INVERT_LOGIC]
-
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the Orange Pi GPIO platform."""
     binary_sensors = []
+    invert_logic = config[CONF_INVERT_LOGIC]
+    pin_mode = config[CONF_PIN_MODE]
     ports = config[CONF_PORTS]
+
+    setup_mode(pin_mode)
+
     for port_num, port_name in ports.items():
-        binary_sensors.append(OPiGPIOBinarySensor(port_name, port_num, invert_logic))
-    add_entities(binary_sensors, True)
+        binary_sensors.append(
+            OPiGPIOBinarySensor(hass, port_name, port_num, invert_logic)
+        )
+    async_add_entities(binary_sensors)
 
 
 class OPiGPIOBinarySensor(BinarySensorDevice):
     """Represent a binary sensor that uses Orange Pi GPIO."""
 
-    def __init__(self, name, port, invert_logic):
+    def __init__(self, hass, name, port, invert_logic):
         """Initialize the Orange Pi binary sensor."""
-        self._name = name or DEVICE_DEFAULT_NAME
+        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, name, hass=hass)
+        self._name = name
         self._port = port
         self._invert_logic = invert_logic
         self._state = None
 
-        orangepi_gpio.setup_input(self._port)
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
 
-        def read_gpio(port):
-            """Read state from GPIO."""
-            self._state = orangepi_gpio.read_input(self._port)
-            self.schedule_update_ha_state()
+        @callback
+        def gpio_edge_listener(port):
+            """Update GPIO when edge change is detected."""
+            self.async_schedule_update_ha_state(True)
 
-        orangepi_gpio.edge_detect(self._port, read_gpio)
+        setup_input(self._port)
+        edge_detect(self._port, gpio_edge_listener)
+        self.async_schedule_update_ha_state(True)
 
     @property
     def should_poll(self):
@@ -61,6 +68,6 @@ class OPiGPIOBinarySensor(BinarySensorDevice):
         """Return the state of the entity."""
         return self._state != self._invert_logic
 
-    def update(self):
-        """Update the GPIO state."""
-        self._state = orangepi_gpio.read_input(self._port)
+    async def async_update(self):
+        """Update state with new GPIO data."""
+        self._state = read_input(self._port)

--- a/homeassistant/components/orangepi_gpio/binary_sensor.py
+++ b/homeassistant/components/orangepi_gpio/binary_sensor.py
@@ -46,7 +46,7 @@ class OPiGPIOBinarySensor(BinarySensorDevice):
             edge_detect(self._port, gpio_edge_listener)
             self.schedule_update_ha_state(True)
 
-        self.hass.async_add_executor_job(setup_entity)
+        await self.hass.async_add_executor_job(setup_entity)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/orangepi_gpio/const.py
+++ b/homeassistant/components/orangepi_gpio/const.py
@@ -1,14 +1,14 @@
 """Constants for Orange Pi GPIO."""
+
 import voluptuous as vol
 
 from homeassistant.helpers import config_validation as cv
 
-from . import CONF_PIN_MODE, PIN_MODES
-
 CONF_INVERT_LOGIC = "invert_logic"
+CONF_PIN_MODE = "pin_mode"
 CONF_PORTS = "ports"
-
 DEFAULT_INVERT_LOGIC = False
+PIN_MODES = ["pc", "zeroplus", "zeroplus2", "deo", "neocore2"]
 
 _SENSORS_SCHEMA = vol.Schema({cv.positive_int: cv.string})
 


### PR DESCRIPTION
##  Description:
Cleanup code for orangepi_gpio and use async wherever possible:

* Move constants to const.py

* Use async wherever possible

* Remove obsolute functions

* Use relative package integration imports

* Move callbacks to async_added_to_hass

* Avoid side effects in init

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
