### PR TITLE
Add ATEN PE component for ATEN eco PDUs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -62,6 +62,7 @@ omit =
     homeassistant/components/asterisk_cdr/mailbox.py
     homeassistant/components/asterisk_mbox/*
     homeassistant/components/asuswrt/device_tracker.py
+    homeassistant/components/aten_pe/*
     homeassistant/components/atome/*
     homeassistant/components/august/*
     homeassistant/components/aurora_abb_powerone/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,6 +32,7 @@ homeassistant/components/arcam_fmj/* @elupus
 homeassistant/components/arduino/* @fabaff
 homeassistant/components/arest/* @fabaff
 homeassistant/components/asuswrt/* @kennedyshead
+homeassistant/components/aten_pe/* @mtdcr
 homeassistant/components/atome/* @baqs
 homeassistant/components/aurora_abb_powerone/* @davet2001
 homeassistant/components/auth/* @home-assistant/core

--- a/homeassistant/components/aten_pe/__init__.py
+++ b/homeassistant/components/aten_pe/__init__.py
@@ -1,0 +1,1 @@
+"""The ATEN PE component."""

--- a/homeassistant/components/aten_pe/manifest.json
+++ b/homeassistant/components/aten_pe/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "aten_pe",
+  "name": "ATEN eco PDUs",
+  "documentation": "https://www.home-assistant.io/components/aten_pe",
+  "requirements": [
+    "atenpdu==0.1.2"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@mtdcr"
+  ]
+}

--- a/homeassistant/components/aten_pe/manifest.json
+++ b/homeassistant/components/aten_pe/manifest.json
@@ -3,7 +3,7 @@
   "name": "ATEN eco PDUs",
   "documentation": "https://www.home-assistant.io/integrations/aten_pe",
   "requirements": [
-    "atenpdu==0.2.0"
+    "atenpdu==0.3.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/aten_pe/manifest.json
+++ b/homeassistant/components/aten_pe/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "aten_pe",
   "name": "ATEN eco PDUs",
-  "documentation": "https://www.home-assistant.io/components/aten_pe",
+  "documentation": "https://www.home-assistant.io/integrations/aten_pe",
   "requirements": [
     "atenpdu==0.1.2"
   ],

--- a/homeassistant/components/aten_pe/manifest.json
+++ b/homeassistant/components/aten_pe/manifest.json
@@ -3,7 +3,7 @@
   "name": "ATEN eco PDUs",
   "documentation": "https://www.home-assistant.io/integrations/aten_pe",
   "requirements": [
-    "atenpdu==0.1.2"
+    "atenpdu==0.2.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -5,12 +5,6 @@ import logging
 from atenpdu import AtenPE
 import voluptuous as vol
 
-from homeassistant.components.snmp.const import (
-    CONF_AUTH_KEY,
-    CONF_COMMUNITY,
-    CONF_PRIV_KEY,
-    DEFAULT_PORT,
-)
 from homeassistant.components.switch import (
     DEVICE_CLASS_OUTLET,
     PLATFORM_SCHEMA,
@@ -21,7 +15,11 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_AUTH_KEY = "auth_key"
+CONF_COMMUNITY = "community"
+CONF_PRIV_KEY = "priv_key"
 DEFAULT_COMMUNITY = "private"
+DEFAULT_PORT = "161"
 DEFAULT_USERNAME = "administrator"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.switch import (
     SwitchDevice,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_USERNAME
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,13 +46,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         privkey=config.get(CONF_PRIV_KEY),
     )
 
-    await hass.async_add_executor_job(dev.loadMibs)
+    try:
+        await hass.async_add_executor_job(dev.loadMibs)
 
-    mac = await dev.deviceMAC()
+        mac = await dev.deviceMAC()
 
-    switches = []
-    async for outlet in dev.outlets():
-        switches.append(AtenSwitch(dev, mac, outlet.id, outlet.name))
+        switches = []
+        async for outlet in dev.outlets():
+            switches.append(AtenSwitch(dev, mac, outlet.id, outlet.name))
+    except Exception:  # pylint: disable=broad-except
+        raise PlatformNotReady
 
     async_add_entities(switches)
 

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -38,9 +38,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the ATEN PE switch."""
     dev = AtenPE(
         node=config[CONF_HOST],
-        serv=config.get(CONF_PORT),
-        community=config.get(CONF_COMMUNITY),
-        username=config.get(CONF_USERNAME),
+        serv=config[CONF_PORT],
+        community=config[CONF_COMMUNITY],
+        username=config[CONF_USERNAME],
         authkey=config.get(CONF_AUTH_KEY),
         privkey=config.get(CONF_PRIV_KEY),
     )

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -50,7 +50,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         switches.append(AtenSwitch(dev, outlet.id, outlet.name))
 
     async_add_entities(switches)
-    return True
 
 
 class AtenSwitch(SwitchDevice):

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -9,7 +9,6 @@ from homeassistant.components.snmp.const import (
     CONF_AUTH_KEY,
     CONF_COMMUNITY,
     CONF_PRIV_KEY,
-    DEFAULT_HOST,
     DEFAULT_PORT,
 )
 from homeassistant.components.switch import (
@@ -27,7 +26,7 @@ DEFAULT_USERNAME = "administrator"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
         vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
@@ -40,7 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the ATEN PE switch."""
     dev = AtenPE(
-        node=config.get(CONF_HOST),
+        node=config[CONF_HOST],
         serv=config.get(CONF_PORT),
         community=config.get(CONF_COMMUNITY),
         username=config.get(CONF_USERNAME),

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -1,0 +1,114 @@
+"""The ATEN PE switch component."""
+
+import logging
+
+from atenpdu import AtenPE
+import voluptuous as vol
+
+from homeassistant.components.snmp.const import (
+    CONF_AUTH_KEY,
+    CONF_COMMUNITY,
+    CONF_PRIV_KEY,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+)
+from homeassistant.components.switch import (
+    DEVICE_CLASS_OUTLET,
+    PLATFORM_SCHEMA,
+    SwitchDevice,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_COMMUNITY = "private"
+DEFAULT_USERNAME = "administrator"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
+        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Optional(CONF_AUTH_KEY): cv.string,
+        vol.Optional(CONF_PRIV_KEY): cv.string,
+    }
+)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the ATEN PE switch."""
+    dev = AtenPE(
+        node=config.get(CONF_HOST),
+        serv=config.get(CONF_PORT),
+        community=config.get(CONF_COMMUNITY),
+        username=config.get(CONF_USERNAME),
+        authkey=config.get(CONF_AUTH_KEY),
+        privkey=config.get(CONF_PRIV_KEY),
+    )
+
+    switches = []
+    for outlet in dev.outlets:
+        if outlet.name:
+            switches.append(AtenSwitch(dev, outlet.id, outlet.name))
+
+    async_add_entities(switches)
+    return True
+
+
+class AtenSwitch(SwitchDevice):
+    """Represents an ATEN PE switch."""
+
+    def __init__(self, device, outlet, name):
+        """Initialize an ATEN PE switch."""
+        self._device = device
+        self._outlet = outlet
+        self._name = name
+        self._enabled = False
+        self._outlet_power = 0.0
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"{self._device.deviceMAC}-{self._outlet}"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def device_class(self) -> str:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_OUTLET
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self._enabled
+
+    @property
+    def current_power_w(self) -> float:
+        """Return the current power usage in W."""
+        return self._outlet_power
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self._device.setOutletStatus(self._outlet, "on")
+        self._enabled = True
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        self._device.setOutletStatus(self._outlet, "off")
+        self._enabled = False
+
+    def update(self):
+        """Process update from entity."""
+        status = self._device.displayOutletStatus(self._outlet)
+        if status == "on":
+            self._enabled = True
+            self._outlet_power = self._device.outletPower(self._outlet)
+        elif status == "off":
+            self._enabled = False
+            self._outlet_power = 0.0

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -47,8 +47,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     switches = []
     for outlet in dev.outlets:
-        if outlet.name:
-            switches.append(AtenSwitch(dev, outlet.id, outlet.name))
+        switches.append(AtenSwitch(dev, outlet.id, outlet.name))
 
     async_add_entities(switches)
     return True
@@ -61,7 +60,7 @@ class AtenSwitch(SwitchDevice):
         """Initialize an ATEN PE switch."""
         self._device = device
         self._outlet = outlet
-        self._name = name
+        self._name = name or f"Outlet {outlet}"
         self._enabled = False
         self._outlet_power = 0.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -240,7 +240,7 @@ asterisk_mbox==0.5.0
 async-upnp-client==0.14.11
 
 # homeassistant.components.aten_pe
-atenpdu==0.1.2
+atenpdu==0.2.0
 
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -240,7 +240,7 @@ asterisk_mbox==0.5.0
 async-upnp-client==0.14.11
 
 # homeassistant.components.aten_pe
-atenpdu==0.2.0
+atenpdu==0.3.0
 
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -239,6 +239,9 @@ asterisk_mbox==0.5.0
 # homeassistant.components.upnp
 async-upnp-client==0.14.11
 
+# homeassistant.components.aten_pe
+atenpdu==0.1.2
+
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.6
 


### PR DESCRIPTION
## Description:

This component integrates ATEN power distribution units. A [PE8324](https://www.aten.com/eu/en/products/energy-intelligence-pduupsracks/rack-pdu/pe8324/) was used for development. It fetches configured names from the PDU and creates a switch for each outlet. Communication is done via SNMP.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11301

## Example entry for `configuration.yaml`, using SNMPv3:
```yaml
switch:
  - platform: aten_pe
    host: mypdu.lan.
    auth_key: !secret mypdu_authkey
    priv_key: !secret mypdu_privkey
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
