### PR TITLE
Add new Zehnder ComfoAir 350 integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -124,6 +124,7 @@ omit =
     homeassistant/components/co2signal/*
     homeassistant/components/coinbase/*
     homeassistant/components/comed_hourly_pricing/sensor.py
+    homeassistant/components/comfoair/*
     homeassistant/components/comfoconnect/*
     homeassistant/components/concord232/alarm_control_panel.py
     homeassistant/components/concord232/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -61,6 +61,7 @@ homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/ciscospark/* @fbradyirl
 homeassistant/components/cloud/* @home-assistant/cloud
 homeassistant/components/cloudflare/* @ludeeus
+homeassistant/components/comfoair/* @mtdcr
 homeassistant/components/comfoconnect/* @michaelarnauts
 homeassistant/components/config/* @home-assistant/core
 homeassistant/components/configurator/* @home-assistant/core

--- a/homeassistant/components/comfoair/__init__.py
+++ b/homeassistant/components/comfoair/__init__.py
@@ -1,0 +1,118 @@
+"""Support to control a Zehnder ComfoAir 350 ventilation unit."""
+
+import logging
+import voluptuous as vol
+
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import discovery
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+import homeassistant.helpers.config_validation as cv
+from comfoair.asyncio import ComfoAir
+
+DOMAIN = "comfoair"
+SIGNAL_COMFOAIR_UPDATE_RECEIVED = "comfoair_update_received"
+CONF_SERIAL_PORT = "serial_port"
+DEFAULT_NAME = "ComfoAir"
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_SERIAL_PORT): cv.string,
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+SERVICE_VIRTUALKEY = "virtualkey"
+ATTR_MASK = "mask"
+ATTR_TYPE = "type"
+CA_PRESS_EVENTS = ["PRESS_SHORT", "PRESS_LONG"]
+
+SCHEMA_SERVICE_VIRTUALKEY = vol.Schema(
+    {
+        vol.Required(ATTR_MASK): vol.In(range(1, 64)),
+        vol.Optional(ATTR_TYPE, default=CA_PRESS_EVENTS[0]): vol.In(CA_PRESS_EVENTS),
+    }
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Set up the ComfoAir component."""
+    hass.data[DOMAIN] = ComfoAirModule(hass, config)
+    await hass.data[DOMAIN].connect()
+
+    for com in ["fan", "sensor"]:
+        coro = discovery.async_load_platform(hass, com, DOMAIN, {}, config)
+        hass.async_create_task(coro)
+
+    async def _ca_service_virtualkey(service):
+        ev_mask = service.data.get(ATTR_MASK)
+        ev_type = service.data.get(ATTR_TYPE)
+        await hass.data[DOMAIN].keypress(ev_mask, ev_type)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_VIRTUALKEY,
+        _ca_service_virtualkey,
+        schema=SCHEMA_SERVICE_VIRTUALKEY,
+    )
+
+    return True
+
+
+class ComfoAirModule:
+    """Representation of a ComfoAir component."""
+
+    def __init__(self, hass: HomeAssistantType, config: ConfigType):
+        """Initialize the ComfoAir component."""
+        self._hass = hass
+        self._name = config[DOMAIN].get(CONF_NAME)
+        self._cache = {}
+
+        self._ca = ComfoAir(config[DOMAIN].get(CONF_SERIAL_PORT))
+        self._ca.add_listener(self._event)
+
+    async def _event(self, event):
+        cmd, data = event
+        if self._cache.get(cmd) == data:
+            return
+        self._cache[cmd] = data
+
+        async_dispatcher_send(self._hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, [cmd, data])
+
+    async def connect(self):
+        """Connect to a serial port or socket."""
+        await self._ca.connect(self._hass.loop)
+
+    async def stop(self):
+        """Close resources."""
+        self._ca.remove_listener(self._event)
+        self._ca.shutdown()
+
+    async def set_speed(self, speed: int):
+        """Set the speed of the fans."""
+        await self._ca.set_speed(speed)
+
+    def __getitem__(self, key: int) -> bytes:
+        """Access cached data."""
+        return self._cache.get(key)
+
+    @property
+    def name(self):
+        """Access configured name of ventilation unit."""
+        return self._name
+
+    async def keypress(self, ev_mask: int, ev_type: str):
+        """Simulate a keypress."""
+        if ev_type == "PRESS_LONG":
+            millis = 1000
+        else:
+            millis = 100
+
+        await self._ca.emulate_keypress(ev_mask, millis)

--- a/homeassistant/components/comfoair/fan.py
+++ b/homeassistant/components/comfoair/fan.py
@@ -1,0 +1,116 @@
+"""Platform to control a Zehnder ComfoAir 350 ventilation unit."""
+import logging
+
+from homeassistant.components.fan import (
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SPEED_OFF,
+    SUPPORT_SET_SPEED,
+    FanEntity,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import DOMAIN, SIGNAL_COMFOAIR_UPDATE_RECEIVED, ComfoAirModule
+
+_LOGGER = logging.getLogger(__name__)
+
+SPEED_MAPPING = {1: SPEED_OFF, 2: SPEED_LOW, 3: SPEED_MEDIUM, 4: SPEED_HIGH}
+
+
+async def async_setup_platform(hass, conf, async_add_entities, discovery_info):
+    """Set up the ComfoAir fan platform."""
+    unit = hass.data[DOMAIN]
+
+    async_add_entities([ComfoAirFan(hass, ca=unit)], True)
+
+
+class ComfoAirFan(FanEntity):
+    """Representation of the ComfoAir fan platform."""
+
+    def __init__(self, hass, ca: ComfoAirModule) -> None:
+        """Initialize the ComfoAir fan."""
+        self._ca = ca
+        self._speed = 1
+        self._saved_speed = 2
+        self._sensor_id = 0xCE
+
+        def _update_state(cmd, data):
+            if cmd == self._sensor_id and len(data) >= 9:
+                speed = data[8]
+                if 1 <= speed <= 4:
+                    self._speed = speed
+
+        @callback
+        def async_handle_update(var):
+            cmd, data = var
+            if cmd == self._sensor_id:
+                _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
+                _update_state(cmd, data)
+                self.async_schedule_update_ha_state()
+
+        data = self._ca[self._sensor_id]
+        if data:
+            _update_state(self._sensor_id, data)
+
+        # Register for dispatcher updates
+        async_dispatcher_connect(
+            hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
+        )
+
+    @property
+    def should_poll(self) -> bool:
+        """Do not poll."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the fan."""
+        return self._ca.name
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return "mdi:air-conditioner"
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_SET_SPEED
+
+    @property
+    def speed(self):
+        """Return the current fan mode."""
+        return SPEED_MAPPING[self._speed]
+
+    @property
+    def speed_list(self):
+        """List of available fan modes."""
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+    def async_turn_on(self, speed: str = None, **kwargs):
+        """Turn on the fan."""
+        if speed is None:
+            return self.__ca_set_speed(self._saved_speed)
+
+        return self.async_set_speed(speed)
+
+    def async_turn_off(self, **kwargs):
+        """Turn off the fan (to away)."""
+        if self._speed > 1:
+            self._saved_speed = self._speed
+        return self.__ca_set_speed(1)
+
+    def async_set_speed(self, speed: str):
+        """Set fan speed."""
+        for key, value in SPEED_MAPPING.items():
+            if value == speed:
+                return self.__ca_set_speed(key)
+
+        # shouldn't happen
+        return self.async_turn_off()
+
+    def __ca_set_speed(self, speed):
+        _LOGGER.debug("Changing fan speed to %s", SPEED_MAPPING[speed])
+        return self._ca.set_speed(speed)

--- a/homeassistant/components/comfoair/fan.py
+++ b/homeassistant/components/comfoair/fan.py
@@ -17,46 +17,50 @@ from . import DOMAIN, SIGNAL_COMFOAIR_UPDATE_RECEIVED, ComfoAirModule
 _LOGGER = logging.getLogger(__name__)
 
 SPEED_MAPPING = {1: SPEED_OFF, 2: SPEED_LOW, 3: SPEED_MEDIUM, 4: SPEED_HIGH}
+SPEED_VALUES = list(SPEED_MAPPING.values())
 
 
 async def async_setup_platform(hass, conf, async_add_entities, discovery_info):
     """Set up the ComfoAir fan platform."""
     unit = hass.data[DOMAIN]
 
-    async_add_entities([ComfoAirFan(hass, ca=unit)], True)
+    async_add_entities([ComfoAirFan(ca=unit)], True)
 
 
 class ComfoAirFan(FanEntity):
     """Representation of the ComfoAir fan platform."""
 
-    def __init__(self, hass, ca: ComfoAirModule) -> None:
+    def __init__(self, ca: ComfoAirModule) -> None:
         """Initialize the ComfoAir fan."""
         self._ca = ca
         self._speed = 1
         self._saved_speed = 2
         self._sensor_id = 0xCE
 
-        def _update_state(cmd, data):
-            if cmd == self._sensor_id and len(data) >= 9:
-                speed = data[8]
-                if 1 <= speed <= 4:
-                    self._speed = speed
+        data = self._ca[self._sensor_id]
+        if data:
+            self._update_state(self._sensor_id, data)
+
+    def _update_state(self, cmd, data):
+        if cmd == self._sensor_id and len(data) >= 9:
+            speed = data[8]
+            if 1 <= speed <= 4:
+                self._speed = speed
+
+    async def async_added_to_hass(self):
+        """Register for sensor updates."""
 
         @callback
         def async_handle_update(var):
             cmd, data = var
             if cmd == self._sensor_id:
                 _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
-                _update_state(cmd, data)
+                self._update_state(cmd, data)
                 self.async_schedule_update_ha_state()
-
-        data = self._ca[self._sensor_id]
-        if data:
-            _update_state(self._sensor_id, data)
 
         # Register for dispatcher updates
         async_dispatcher_connect(
-            hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
+            self.hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
         )
 
     @property
@@ -87,12 +91,12 @@ class ComfoAirFan(FanEntity):
     @property
     def speed_list(self):
         """List of available fan modes."""
-        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+        return SPEED_VALUES
 
     def async_turn_on(self, speed: str = None, **kwargs):
         """Turn on the fan."""
         if speed is None:
-            return self.__ca_set_speed(self._saved_speed)
+            return self._ca_set_speed(self._saved_speed)
 
         return self.async_set_speed(speed)
 
@@ -100,17 +104,17 @@ class ComfoAirFan(FanEntity):
         """Turn off the fan (to away)."""
         if self._speed > 1:
             self._saved_speed = self._speed
-        return self.__ca_set_speed(1)
+        return self._ca_set_speed(1)
 
     def async_set_speed(self, speed: str):
         """Set fan speed."""
         for key, value in SPEED_MAPPING.items():
             if value == speed:
-                return self.__ca_set_speed(key)
+                return self._ca_set_speed(key)
 
         # shouldn't happen
         return self.async_turn_off()
 
-    def __ca_set_speed(self, speed):
+    def _ca_set_speed(self, speed):
         _LOGGER.debug("Changing fan speed to %s", SPEED_MAPPING[speed])
         return self._ca.set_speed(speed)

--- a/homeassistant/components/comfoair/manifest.json
+++ b/homeassistant/components/comfoair/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "comfoair",
+  "name": "ComfoAir",
+  "documentation": "https://www.home-assistant.io/components/comfoair",
+  "requirements": [
+    "bitstring==3.1.5",
+    "pycomfoair==0.0.1"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@mtdcr"
+  ]
+}

--- a/homeassistant/components/comfoair/sensor.py
+++ b/homeassistant/components/comfoair/sensor.py
@@ -1,0 +1,157 @@
+"""Platform to control a Zehnder ComfoAir 350 ventilation unit."""
+
+import logging
+
+from homeassistant.const import CONF_RESOURCES, TEMP_CELSIUS
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+from . import DOMAIN, ComfoAirModule, SIGNAL_COMFOAIR_UPDATE_RECEIVED
+from bitstring import BitArray
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_COMFORT_TEMPERATURE = "comfort_temperature"
+ATTR_OUTSIDE_TEMPERATURE = "outside_temperature"
+ATTR_SUPPLY_TEMPERATURE = "supply_temperature"
+ATTR_RETURN_TEMPERATURE = "return_temperature"
+ATTR_EXHAUST_TEMPERATURE = "exhaust_temperature"
+ATTR_AIR_FLOW_SUPPLY = "air_flow_supply"
+ATTR_AIR_FLOW_EXHAUST = "air_flow_exhaust"
+ATTR_FAN_SPEED_MODE = "speed_mode"
+
+SENSOR_TYPES = {
+    ATTR_COMFORT_TEMPERATURE: [
+        "Comfort Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        0 * 8,
+        8,
+    ],
+    ATTR_OUTSIDE_TEMPERATURE: [
+        "Outside Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        1 * 8,
+        8,
+    ],
+    ATTR_SUPPLY_TEMPERATURE: [
+        "Supply Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        2 * 8,
+        8,
+    ],
+    ATTR_RETURN_TEMPERATURE: [
+        "Return Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        3 * 8,
+        8,
+    ],
+    ATTR_EXHAUST_TEMPERATURE: [
+        "Exhaust Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        4 * 8,
+        8,
+    ],
+    ATTR_AIR_FLOW_EXHAUST: ["Exhaust airflow", "%", "mdi:fan", 0xCE, 6 * 8, 8],
+    ATTR_AIR_FLOW_SUPPLY: ["Supply airflow", "%", "mdi:fan", 0xCE, 7 * 8, 8],
+    ATTR_FAN_SPEED_MODE: ["Speed mode", "", "mdi:fan", 0xCE, 8 * 8, 8],
+}
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the ComfoAir sensor platform."""
+    unit = hass.data[DOMAIN]
+
+    sensors = []
+    for resource in config.get(CONF_RESOURCES, []):
+        sensor_type = resource.lower()
+        _LOGGER.debug("Sensor type: %s", sensor_type)
+
+        if sensor_type not in SENSOR_TYPES:
+            _LOGGER.warning("Sensor type: %s is not a valid sensor", sensor_type)
+            continue
+
+        sensors.append(
+            ComfoAirSensor(
+                hass,
+                name="%s %s" % (unit.name, SENSOR_TYPES[sensor_type][0]),
+                ca=unit,
+                sensor_type=sensor_type,
+            )
+        )
+
+    async_add_entities(sensors, True)
+
+
+class ComfoAirSensor(Entity):
+    """Representation of a ComfoAir sensor."""
+
+    def __init__(self, hass, name, ca: ComfoAirModule, sensor_type) -> None:
+        """Initialize the ComfoAir sensor."""
+        self._ca = ca
+        self._sensor_type = sensor_type
+        self._unit = SENSOR_TYPES[self._sensor_type][1]
+        self._icon = SENSOR_TYPES[self._sensor_type][2]
+        self._sensor_id = SENSOR_TYPES[self._sensor_type][3]
+        self._offset = SENSOR_TYPES[self._sensor_type][4]
+        self._size = SENSOR_TYPES[self._sensor_type][5]
+        self._name = name
+        self._data = None
+
+        def _update_state(data):
+            bits = BitArray(data)
+            value = bits[self._offset : self._offset + self._size].uint
+            if self._unit == TEMP_CELSIUS:
+                value = (value / 2) - 20
+            self._data = value
+
+        @callback
+        def async_handle_update(var):
+            cmd, data = var
+            if cmd == self._sensor_id:
+                _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
+                _update_state(data)
+                self.async_schedule_update_ha_state()
+
+        data = self._ca[self._sensor_id]
+        if data:
+            _update_state(data)
+
+        # Register for dispatcher updates
+        async_dispatcher_connect(
+            hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
+        )
+
+    @property
+    def should_poll(self) -> bool:
+        """Do not poll."""
+        return False
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._data
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit

--- a/homeassistant/components/comfoair/services.yaml
+++ b/homeassistant/components/comfoair/services.yaml
@@ -1,0 +1,9 @@
+virtualkey:
+  description: Press a virtual key from CC-Ease.
+  fields:
+    mask:
+      description: Mask of keys to press (1=fan, 2=mode, 4=clock, 8=temp, 16=plus, 32=minus)
+      example: 1
+    type:
+      description: Event to send i.e. PRESS_LONG, PRESS_SHORT.
+      example: PRESS_SHORT

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -293,6 +293,9 @@ bellows-homeassistant==0.11.0
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.6.2
 
+# homeassistant.components.comfoair
+bitstring==3.1.5
+
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1
 
@@ -1152,6 +1155,9 @@ pychromecast==4.0.1
 
 # homeassistant.components.cmus
 pycmus==0.1.1
+
+# homeassistant.components.comfoair
+pycomfoair==0.0.1
 
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.3


### PR DESCRIPTION
## Description:
This integrates support for Zehnder ComfoAir 350 ventilation units and compatibles. This is not to be confused with the comfoconnect component, which integrates the newer Q350 units.

It allows reading temperature sensors and setting fan speeds. Currently it expects a CC Ease controller to be present.

Documentation will be written if feedback indicates a chance to merge.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10964

## Example entry for `configuration.yaml`:
```yaml
comfoair:
  name: ComfoAir
  serial_port: /dev/ttyS0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
