### PR TITLE
Add edl21 component for SML-based smart meters

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -180,6 +180,7 @@ omit =
     homeassistant/components/ecobee/weather.py
     homeassistant/components/econet/*
     homeassistant/components/ecovacs/*
+    homeassistant/components/edl21/*
     homeassistant/components/eddystone_temperature/sensor.py
     homeassistant/components/edimax/switch.py
     homeassistant/components/egardia/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -81,6 +81,7 @@ homeassistant/components/doorbird/* @oblogic7
 homeassistant/components/dweet/* @fabaff
 homeassistant/components/ecobee/* @marthoc
 homeassistant/components/ecovacs/* @OverloadUT
+homeassistant/components/edl21/* @mtdcr
 homeassistant/components/egardia/* @jeroenterheerdt
 homeassistant/components/eight_sleep/* @mezz64
 homeassistant/components/elv/* @majuss

--- a/homeassistant/components/edl21/__init__.py
+++ b/homeassistant/components/edl21/__init__.py
@@ -1,0 +1,1 @@
+"""The edl21 component."""

--- a/homeassistant/components/edl21/manifest.json
+++ b/homeassistant/components/edl21/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "edl21",
+  "name": "EDL21",
+  "documentation": "https://www.home-assistant.io/components/edl21",
+  "requirements": [
+    "pysml==0.0.2"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@mtdcr"
+  ]
+}

--- a/homeassistant/components/edl21/manifest.json
+++ b/homeassistant/components/edl21/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "edl21",
   "name": "EDL21",
-  "documentation": "https://www.home-assistant.io/components/edl21",
+  "documentation": "https://www.home-assistant.io/integrations/edl21",
   "requirements": [
     "pysml==0.0.2"
   ],

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -1,0 +1,156 @@
+"""Support for EDL21 Smart Meters."""
+
+import logging
+from re import split
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import STATE_UNKNOWN
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import Optional
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "edl21"
+CONF_SERIAL_PORT = "serial_port"
+ICON_POWER = "mdi:flash"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_SERIAL_PORT): cv.string})
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the EDL21 sensor."""
+    hass.data[DOMAIN] = EDL21(hass, config, async_add_entities)
+    await hass.data[DOMAIN].connect()
+
+
+class EDL21:
+    """EDL21 handles telegrams sent by a compatible smart meter."""
+
+    def __init__(self, hass, config, async_add_entities) -> None:
+        """Initialize an EDL21 object."""
+        from sml.asyncio import SmlProtocol
+
+        self._cache = {}
+        self._hass = hass
+        self._async_add_entities = async_add_entities
+        self._proto = SmlProtocol(config[CONF_SERIAL_PORT])
+        self._proto.add_listener(self.event, ["SmlGetListResponse"])
+
+    async def connect(self):
+        """Connect to an EDL21 reader."""
+        await self._proto.connect(self._hass.loop)
+
+    def event(self, message_body) -> None:
+        """Handle events from pysml."""
+        from sml import SmlGetListResponse
+
+        assert isinstance(message_body, SmlGetListResponse)
+
+        new_devices = []
+        for telegram in message_body.get("valList", []):
+            obis = telegram.get("objName")
+            if not obis:
+                continue
+
+            device = self._cache.get(obis)
+            if not device:
+                device = self._cache[obis] = EDL21Entity(obis, telegram)
+                new_devices.append(device)
+            elif device.update_telegram(telegram):
+                self._hass.async_create_task(device.async_update_ha_state())
+
+        if new_devices:
+            self._hass.async_add_job(
+                self._async_add_entities(new_devices, update_before_add=True)
+            )
+
+
+class EDL21Entity(Entity):
+    """Entity reading values from EDL21 telegram."""
+
+    # OBIS format: A-B:C.D.E*F
+    _OBIS_NAMES = {
+        # A=1: Electricity
+        # C=0: General purpose objects
+        "1-0:0.0.9*255": "Electricity ID",
+        # C=1: Active power +
+        # D=8: Time integral 1
+        # E=0: Total
+        "1-0:1.8.0*255": "Positive active energy total",
+        # E=1: Rate 1
+        "1-0:1.8.1*255": "Positive active energy in tariff T1",
+        # E=2: Rate 2
+        "1-0:1.8.2*255": "Positive active energy in tariff T2",
+        # D=17: Time integral 7
+        # E=0: Total
+        "1-0:1.17.0*255": "Last signed positive active energy total",
+        # C=15: Active power absolute
+        # D=7: Instantaneous value
+        # E=0: Total
+        "1-0:15.7.0*255": "Absolute active instantaneous power",
+        # C=16: Active power sum
+        # D=7: Instantaneous value
+        # E=0: Total
+        "1-0:16.7.0*255": "Sum active instantaneous power",
+        # A=129: Manufacturer specific
+        "129-129:199.130.3*255": "Manufacturer",
+        "129-129:199.130.5*255": "Public Key",
+    }
+
+    def __init__(self, obis, telegram):
+        """Initialize an EDL21Entity."""
+        self._obis = obis
+        self._obis_parts = [int(n) for n in split("[^0-9]", obis)]
+        self._telegram = telegram
+
+    @property
+    def should_poll(self) -> bool:
+        """Do not poll."""
+        return False
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._obis
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return a name."""
+        return self._OBIS_NAMES.get(self._obis)
+
+    @property
+    def state(self) -> str:
+        """Return the value of the last received telegram."""
+        value = self._telegram.get("value")
+        if value is None:
+            return STATE_UNKNOWN
+        return value
+
+    @property
+    def device_state_attributes(self):
+        """Enumerate supported attributes."""
+        attr = self._telegram.copy()
+        for key in ("objName", "unit", "value"):
+            if key in attr:
+                del attr[key]
+        return attr
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._telegram.get("unit")
+
+    @property
+    def icon(self):
+        """Return an icon."""
+        return ICON_POWER
+
+    def update_telegram(self, telegram: dict) -> bool:
+        """Update attributes from last received telegram for this object."""
+        if self._telegram == telegram:
+            return False
+        self._telegram = telegram
+        return True

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -1,5 +1,6 @@
 """Support for EDL21 Smart Meters."""
 
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -9,12 +10,14 @@ from homeassistant.const import STATE_UNKNOWN
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import Optional
+from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "edl21"
 CONF_SERIAL_PORT = "serial_port"
 ICON_POWER = "mdi:flash"
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_SERIAL_PORT): cv.string})
 
@@ -146,6 +149,7 @@ class EDL21Entity(Entity):
         """Return an icon."""
         return ICON_POWER
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update_telegram(self, telegram: dict) -> bool:
         """Update attributes from last received telegram for this object."""
         if self._telegram == telegram:

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -1,7 +1,6 @@
 """Support for EDL21 Smart Meters."""
 
 import logging
-from re import split
 
 import voluptuous as vol
 
@@ -103,7 +102,6 @@ class EDL21Entity(Entity):
     def __init__(self, obis, telegram):
         """Initialize an EDL21Entity."""
         self._obis = obis
-        self._obis_parts = [int(n) for n in split("[^0-9]", obis)]
         self._telegram = telegram
 
     @property

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -8,6 +8,7 @@ from sml.asyncio import SmlProtocol
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -130,6 +131,7 @@ class EDL21Entity(Entity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
 
+        @callback
         def handle_telegram(telegram):
             """Update attributes from last received telegram for this object."""
             if self._obis != telegram.get("objName"):

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -119,6 +119,7 @@ class EDL21Entity(Entity):
         self._telegram = telegram
         self._min_time = MIN_TIME_BETWEEN_UPDATES
         self._last_update = utcnow()
+        self._state_attrs = {"status", "valTime", "scaler", "valueSignature"}
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
@@ -163,11 +164,7 @@ class EDL21Entity(Entity):
     @property
     def device_state_attributes(self):
         """Enumerate supported attributes."""
-        attr = self._telegram.copy()
-        for key in ("objName", "unit", "value"):
-            if key in attr:
-                del attr[key]
-        return attr
+        return {k: v for k, v in self._telegram.items() if k in self._state_attrs}
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -120,6 +120,7 @@ class EDL21Entity(Entity):
         self._min_time = MIN_TIME_BETWEEN_UPDATES
         self._last_update = utcnow()
         self._state_attrs = {"status", "valTime", "scaler", "valueSignature"}
+        self._async_remove_dispatcher = None
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
@@ -139,7 +140,14 @@ class EDL21Entity(Entity):
             self._last_update = now
             self.schedule_update_ha_state()
 
-        async_dispatcher_connect(self.hass, SIGNAL_EDL21_TELEGRAM, handle_telegram)
+        self._async_remove_dispatcher = async_dispatcher_connect(
+            self.hass, SIGNAL_EDL21_TELEGRAM, handle_telegram
+        )
+
+    async def async_will_remove_from_hass(self):
+        """Run when entity will be removed from hass."""
+        if self._async_remove_dispatcher:
+            self._async_remove_dispatcher()
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -79,18 +79,18 @@ class EDL21:
         """Handle events from pysml."""
         assert isinstance(message_body, SmlGetListResponse)
 
-        new_devices = []
+        new_entities = []
         for telegram in message_body.get("valList", []):
             obis = telegram.get("objName")
             if not obis:
                 continue
 
-            device = self._cache.get(obis)
-            if not device:
+            entity = self._cache.get(obis)
+            if not entity:
                 name = self._OBIS_NAMES.get(obis)
                 if name:
-                    device = self._cache[obis] = EDL21Entity(obis, name, telegram)
-                    new_devices.append(device)
+                    entity = self._cache[obis] = EDL21Entity(obis, name, telegram)
+                    new_entities.append(entity)
                 elif obis not in self._OBIS_BLACKLIST:
                     _LOGGER.warning(
                         "Unhandled sensor %s detected. Please report at "
@@ -98,12 +98,12 @@ class EDL21:
                         obis,
                     )
                     self._OBIS_BLACKLIST.add(obis)
-            elif device.update_telegram(telegram):
-                self._hass.async_create_task(device.async_update_ha_state())
+            elif entity.update_telegram(telegram):
+                self._hass.async_create_task(entity.async_update_ha_state())
 
-        if new_devices:
+        if new_entities:
             self._hass.async_add_job(
-                self._async_add_entities(new_devices, update_before_add=True)
+                self._async_add_entities(new_entities, update_before_add=True)
             )
 
 

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -94,7 +94,7 @@ class EDL21:
                 elif obis not in self._blacklist:
                     _LOGGER.warning(
                         "Unhandled sensor %s detected. Please report at "
-                        "https://github.com/home-assistant/home-assistant/issues",
+                        'https://github.com/home-assistant/home-assistant/issues?q=is%%3Aissue+label%%3A"integration%%3A+edl21"+',
                         obis,
                     )
                     self._blacklist.add(obis)

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -145,7 +145,7 @@ class EDL21Entity(Entity):
 
             self._telegram = telegram
             self._last_update = now
-            self.schedule_update_ha_state()
+            self.async_write_ha_state()
 
         self._async_remove_dispatcher = async_dispatcher_connect(
             self.hass, SIGNAL_EDL21_TELEGRAM, handle_telegram

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -57,14 +57,14 @@ class EDL21:
         # E=0: Total
         "1-0:16.7.0*255": "Sum active instantaneous power",
     }
+    _OBIS_BLACKLIST = {
+        # A=129: Manufacturer specific
+        "129-129:199.130.3*255",  # Iskraemeco: Manufacturer
+        "129-129:199.130.5*255",  # Iskraemeco: Public Key
+    }
 
     def __init__(self, hass, config, async_add_entities) -> None:
         """Initialize an EDL21 object."""
-        self._blacklist = {
-            # A=129: Manufacturer specific
-            "129-129:199.130.3*255",  # Iskraemeco: Manufacturer
-            "129-129:199.130.5*255",  # Iskraemeco: Public Key
-        }
         self._cache = {}
         self._hass = hass
         self._async_add_entities = async_add_entities
@@ -91,13 +91,13 @@ class EDL21:
                 if name:
                     device = self._cache[obis] = EDL21Entity(obis, name, telegram)
                     new_devices.append(device)
-                elif obis not in self._blacklist:
+                elif obis not in self._OBIS_BLACKLIST:
                     _LOGGER.warning(
                         "Unhandled sensor %s detected. Please report at "
                         'https://github.com/home-assistant/home-assistant/issues?q=is%%3Aissue+label%%3A"integration%%3A+edl21"+',
                         obis,
                     )
-                    self._blacklist.add(obis)
+                    self._OBIS_BLACKLIST.add(obis)
             elif device.update_telegram(telegram):
                 self._hass.async_create_task(device.async_update_ha_state())
 

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -3,6 +3,8 @@
 from datetime import timedelta
 import logging
 
+from sml import SmlGetListResponse
+from sml.asyncio import SmlProtocol
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -33,8 +35,6 @@ class EDL21:
 
     def __init__(self, hass, config, async_add_entities) -> None:
         """Initialize an EDL21 object."""
-        from sml.asyncio import SmlProtocol
-
         self._cache = {}
         self._hass = hass
         self._async_add_entities = async_add_entities
@@ -47,8 +47,6 @@ class EDL21:
 
     def event(self, message_body) -> None:
         """Handle events from pysml."""
-        from sml import SmlGetListResponse
-
         assert isinstance(message_body, SmlGetListResponse)
 
         new_devices = []

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -102,9 +102,7 @@ class EDL21:
                 self._hass.async_create_task(entity.async_update_ha_state())
 
         if new_entities:
-            self._hass.async_add_job(
-                self._async_add_entities(new_entities, update_before_add=True)
-            )
+            self._async_add_entities(new_entities, update_before_add=True)
 
 
 class EDL21Entity(Entity):

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -8,7 +8,6 @@ from sml.asyncio import SmlProtocol
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import STATE_UNKNOWN
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import Optional
@@ -123,10 +122,7 @@ class EDL21Entity(Entity):
     @property
     def state(self) -> str:
         """Return the value of the last received telegram."""
-        value = self._telegram.get("value")
-        if value is None:
-            return STATE_UNKNOWN
-        return value
+        return self._telegram.get("value")
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -119,7 +119,12 @@ class EDL21Entity(Entity):
         self._telegram = telegram
         self._min_time = MIN_TIME_BETWEEN_UPDATES
         self._last_update = utcnow()
-        self._state_attrs = {"status", "valTime", "scaler", "valueSignature"}
+        self._state_attrs = {
+            "status": "status",
+            "valTime": "val_time",
+            "scaler": "scaler",
+            "valueSignature": "value_signature",
+        }
         self._async_remove_dispatcher = None
 
     async def async_added_to_hass(self):
@@ -172,7 +177,11 @@ class EDL21Entity(Entity):
     @property
     def device_state_attributes(self):
         """Enumerate supported attributes."""
-        return {k: v for k, v in self._telegram.items() if k in self._state_attrs}
+        return {
+            self._state_attrs[k]: v
+            for k, v in self._telegram.items()
+            if k in self._state_attrs
+        }
 
     @property
     def unit_of_measurement(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1483,6 +1483,9 @@ pysmartthings==0.6.9
 # homeassistant.components.smarty
 pysmarty==0.8
 
+# homeassistant.components.edl21
+pysml==0.0.2
+
 # homeassistant.components.snmp
 pysnmp==4.4.12
 


### PR DESCRIPTION
## Description:
This PR integrates EDL21 compatible smart meters as used in Germany. These smart meters use SML protocol messages to transmit various „OBIS“ values.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11325

## Example entry for `configuration.yaml`:
```yaml
sensor:
  - platform: edl21
  - serial_port: socket://10.2.3.4:7750
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
