### PR TITLE
Update WazeRouteCalculator, add config options, fix subscription

### DIFF
--- a/homeassistant/components/waze_travel_time/manifest.json
+++ b/homeassistant/components/waze_travel_time/manifest.json
@@ -3,7 +3,7 @@
   "name": "Waze travel time",
   "documentation": "https://www.home-assistant.io/integrations/waze_travel_time",
   "requirements": [
-    "WazeRouteCalculator==0.10"
+    "WazeRouteCalculator==0.11"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/waze_travel_time/manifest.json
+++ b/homeassistant/components/waze_travel_time/manifest.json
@@ -3,7 +3,7 @@
   "name": "Waze travel time",
   "documentation": "https://www.home-assistant.io/integrations/waze_travel_time",
   "requirements": [
-    "WazeRouteCalculator==0.11"
+    "WazeRouteCalculator==0.12"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -38,10 +38,16 @@ CONF_EXCL_FILTER = "excl_filter"
 CONF_REALTIME = "realtime"
 CONF_UNITS = "units"
 CONF_VEHICLE_TYPE = "vehicle_type"
+CONF_AVOID_FERRIES = "avoid_ferries"
+CONF_AVOID_SUBSCRIPTION_ROADS = "avoid_subscription_roads"
+CONF_AVOID_TOLL_ROADS = "avoid_toll_roads"
 
 DEFAULT_NAME = "Waze Travel Time"
 DEFAULT_REALTIME = True
 DEFAULT_VEHICLE_TYPE = "car"
+DEFAULT_AVOID_FERRIES = False
+DEFAULT_AVOID_SUBSCRIPTION_ROADS = False
+DEFAULT_AVOID_TOLL_ROADS = False
 
 ICON = "mdi:car"
 
@@ -65,6 +71,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             VEHICLE_TYPES
         ),
         vol.Optional(CONF_UNITS): vol.In(UNITS),
+        vol.Optional(CONF_AVOID_FERRIES, default=DEFAUL_AVOID_FERRIES): cv.boolean,
+        vol.Optional(CONF_AVOID_SUBSCRIPTION_ROADS, 
+                     default=DEFAUL_AVOID_SUBSCRIPTION_ROADS): cv.boolean,          
+        vol.Optional(CONF_AVOID_TOLL_ROADS, default=DEFAUL_AVOID_TOLL_ROADS): cv.boolean,
     }
 )
 
@@ -79,10 +89,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     excl_filter = config.get(CONF_EXCL_FILTER)
     realtime = config.get(CONF_REALTIME)
     vehicle_type = config.get(CONF_VEHICLE_TYPE)
+    avoid_ferries = config.get(CONF_AVOID_FERRIES)
+    avoid_subscription_roads = config.get(CONF_AVOID_SUBSCRIPTION_ROADS)
+    avoid_toll_roads = config.get(CONF_AVOID_TOLL_ROADS)
     units = config.get(CONF_UNITS, hass.config.units.name)
 
     data = WazeTravelTimeData(
-        None, None, region, incl_filter, excl_filter, realtime, units, vehicle_type
+        None, None, region, incl_filter, excl_filter, realtime, units, vehicle_type,
+        avoid_ferries, avoid_subscription_roads, avoid_toll_roads
     )
 
     sensor = WazeTravelTime(name, origin, destination, data)
@@ -236,6 +250,9 @@ class WazeTravelTimeData:
         realtime,
         units,
         vehicle_type,
+        avoid_ferries,
+        avoid_subscription_roads,
+        avoid_toll_roads,
     ):
         """Set up WazeRouteCalculator."""
 
@@ -251,6 +268,9 @@ class WazeTravelTimeData:
         self.duration = None
         self.distance = None
         self.route = None
+        self.avoid_ferries = avoid_ferries
+        self.avoid_subscription_roads = avoid_subscription_roads
+        self.avoid_toll_roads = avoid_toll_roads
 
         # Currently WazeRouteCalc only supports PRIVATE, TAXI, MOTORCYCLE.
         if vehicle_type.upper() == "CAR":
@@ -268,7 +288,9 @@ class WazeTravelTimeData:
                     self.destination,
                     self.region,
                     self.vehicle_type,
-                    log_lvl=logging.DEBUG,
+                    self.avoid_ferries,
+                    self.avoid_subscription_roads,
+                    self.avoid_toll_roads,
                 )
                 routes = params.calc_all_routes_info(real_time=self.realtime)
 

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -38,16 +38,16 @@ CONF_EXCL_FILTER = "excl_filter"
 CONF_REALTIME = "realtime"
 CONF_UNITS = "units"
 CONF_VEHICLE_TYPE = "vehicle_type"
-CONF_AVOID_FERRIES = "avoid_ferries"
-CONF_AVOID_SUBSCRIPTION_ROADS = "avoid_subscription_roads"
 CONF_AVOID_TOLL_ROADS = "avoid_toll_roads"
+CONF_AVOID_SUBSCRIPTION_ROADS = "avoid_subscription_roads"
+CONF_AVOID_FERRIES = "avoid_ferries"
 
 DEFAULT_NAME = "Waze Travel Time"
 DEFAULT_REALTIME = True
 DEFAULT_VEHICLE_TYPE = "car"
-DEFAULT_AVOID_FERRIES = False
-DEFAULT_AVOID_SUBSCRIPTION_ROADS = False
 DEFAULT_AVOID_TOLL_ROADS = False
+DEFAULT_AVOID_SUBSCRIPTION_ROADS = False
+DEFAULT_AVOID_FERRIES = False
 
 ICON = "mdi:car"
 
@@ -71,10 +71,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             VEHICLE_TYPES
         ),
         vol.Optional(CONF_UNITS): vol.In(UNITS),
-        vol.Optional(CONF_AVOID_FERRIES, default=DEFAUL_AVOID_FERRIES): cv.boolean,
-        vol.Optional(CONF_AVOID_SUBSCRIPTION_ROADS, 
-                     default=DEFAUL_AVOID_SUBSCRIPTION_ROADS): cv.boolean,          
-        vol.Optional(CONF_AVOID_TOLL_ROADS, default=DEFAUL_AVOID_TOLL_ROADS): cv.boolean,
+        vol.Optional(
+            CONF_AVOID_TOLL_ROADS, default=DEFAULT_AVOID_TOLL_ROADS
+        ): cv.boolean,
+        vol.Optional(
+            CONF_AVOID_SUBSCRIPTION_ROADS, default=DEFAULT_AVOID_SUBSCRIPTION_ROADS
+        ): cv.boolean,
+        vol.Optional(CONF_AVOID_FERRIES, default=DEFAULT_AVOID_FERRIES): cv.boolean,
     }
 )
 
@@ -89,14 +92,23 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     excl_filter = config.get(CONF_EXCL_FILTER)
     realtime = config.get(CONF_REALTIME)
     vehicle_type = config.get(CONF_VEHICLE_TYPE)
-    avoid_ferries = config.get(CONF_AVOID_FERRIES)
-    avoid_subscription_roads = config.get(CONF_AVOID_SUBSCRIPTION_ROADS)
     avoid_toll_roads = config.get(CONF_AVOID_TOLL_ROADS)
+    avoid_subscription_roads = config.get(CONF_AVOID_SUBSCRIPTION_ROADS)
+    avoid_ferries = config.get(CONF_AVOID_FERRIES)
     units = config.get(CONF_UNITS, hass.config.units.name)
 
     data = WazeTravelTimeData(
-        None, None, region, incl_filter, excl_filter, realtime, units, vehicle_type,
-        avoid_ferries, avoid_subscription_roads, avoid_toll_roads
+        None,
+        None,
+        region,
+        incl_filter,
+        excl_filter,
+        realtime,
+        units,
+        vehicle_type,
+        avoid_toll_roads,
+        avoid_subscription_roads,
+        avoid_ferries,
     )
 
     sensor = WazeTravelTime(name, origin, destination, data)
@@ -250,9 +262,9 @@ class WazeTravelTimeData:
         realtime,
         units,
         vehicle_type,
-        avoid_ferries,
-        avoid_subscription_roads,
         avoid_toll_roads,
+        avoid_subscription_roads,
+        avoid_ferries,
     ):
         """Set up WazeRouteCalculator."""
 
@@ -268,9 +280,9 @@ class WazeTravelTimeData:
         self.duration = None
         self.distance = None
         self.route = None
-        self.avoid_ferries = avoid_ferries
-        self.avoid_subscription_roads = avoid_subscription_roads
         self.avoid_toll_roads = avoid_toll_roads
+        self.avoid_subscription_roads = avoid_subscription_roads
+        self.avoid_ferries = avoid_ferries
 
         # Currently WazeRouteCalc only supports PRIVATE, TAXI, MOTORCYCLE.
         if vehicle_type.upper() == "CAR":
@@ -288,9 +300,9 @@ class WazeTravelTimeData:
                     self.destination,
                     self.region,
                     self.vehicle_type,
-                    self.avoid_ferries,
-                    self.avoid_subscription_roads,
                     self.avoid_toll_roads,
+                    self.avoid_subscription_roads,
+                    self.avoid_ferries,
                 )
                 routes = params.calc_all_routes_info(real_time=self.realtime)
 
@@ -308,7 +320,7 @@ class WazeTravelTimeData:
                         if self.exclude.lower() not in k.lower()
                     }
 
-                route = sorted(routes, key=(lambda key: routes[key][0]))[0]
+                route = list(routes)[0]
 
                 self.duration, distance = routes[route]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -100,7 +100,7 @@ TwitterAPI==2.5.9
 # VL53L1X2==0.1.5
 
 # homeassistant.components.waze_travel_time
-WazeRouteCalculator==0.11
+WazeRouteCalculator==0.12
 
 # homeassistant.components.yessssms
 YesssSMS==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -100,7 +100,7 @@ TwitterAPI==2.5.9
 # VL53L1X2==0.1.5
 
 # homeassistant.components.waze_travel_time
-WazeRouteCalculator==0.10
+WazeRouteCalculator==0.11
 
 # homeassistant.components.yessssms
 YesssSMS==0.4.1


### PR DESCRIPTION
## Description:
The current version of waze_travel_time doesn't allow for the use of toll roads in European countries that use the vignette system (like Switzerland, Austria...) so even if avoid_toll_roads is false, no toll roads will be used for routing on those countries. This PR fixes add, and adds possibilities to avoid Ferries, Toll roads and previous mentioned vignette/subscription roads.

~~**DO NOT MERGE UNTIL UNDERLYING WazeRouteCalculator 0.12 PACKAGE HAS BEEN RELEASED** (I will remove [WIP] tags). This is waiting for https://github.com/kovacsbalu/WazeRouteCalculator/pull/52 to be merged.~~

Updates package released - ready to go.

**Related issue (if applicable):** Fixes #27400 and fixes #25964.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10902

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: waze_travel_time
    name: Westerscheldetunnel (normal)
    origin: 51.330436, 3.802043
    destination: 51.445677, 3.749929
    region: 'EU'
    avoid_toll_roads: false
    avoid_subscription_roads: false

  - platform: waze_travel_time
    name: Westerscheldetunnel (avoiding toll, subscription)
    origin: 51.330436, 3.802043
    destination: 51.445677, 3.749929
    region: 'EU'
    avoid_toll_roads: true
    avoid_subscription_roads: true

  - platform: waze_travel_time
    name: Avoid Ferry Alem-Maren Kessel (NLD)
    origin: 51.787593, 5.346249
    destination: 51.790886, 5.377690
    region: 'EU'
    avoid_ferries: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
