### PR TITLE
New platform for Microsoft Teams

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -418,6 +418,7 @@ omit =
     homeassistant/components/mpchc/media_player.py
     homeassistant/components/mpd/media_player.py
     homeassistant/components/mqtt_room/sensor.py
+    homeassistant/components/msteams/notify.py
     homeassistant/components/mvglive/sensor.py
     homeassistant/components/mychevy/*
     homeassistant/components/mycroft/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -190,6 +190,7 @@ homeassistant/components/monoprice/* @etsinko
 homeassistant/components/moon/* @fabaff
 homeassistant/components/mpd/* @fabaff
 homeassistant/components/mqtt/* @home-assistant/core
+homeassistant/components/msteams/* @peroyvind
 homeassistant/components/mysensors/* @MartinHjelmare
 homeassistant/components/mystrom/* @fabaff
 homeassistant/components/neato/* @dshokouhi @Santobert

--- a/homeassistant/components/msteams/__init__.py
+++ b/homeassistant/components/msteams/__init__.py
@@ -1,0 +1,1 @@
+"""The Microsoft Teams component."""

--- a/homeassistant/components/msteams/manifest.json
+++ b/homeassistant/components/msteams/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "msteams",
+  "name": "Microsoft Teams",
+  "documentation": "https://www.home-assistant.io/integrations/msteams",
+  "requirements": ["pymsteams==0.1.12"],
+  "dependencies": [],
+  "codeowners": ["@peroyvind"]
+}

--- a/homeassistant/components/msteams/notify.py
+++ b/homeassistant/components/msteams/notify.py
@@ -43,27 +43,25 @@ class MSTeamsNotificationService(BaseNotificationService):
 
     def send_message(self, message=None, **kwargs):
         """Send a message to the webhook."""
+        title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+        data = kwargs.get(ATTR_DATA)
+
+        self.teams_message.title(title)
+
+        self.teams_message.text(message)
+
+        if data is not None:
+            file_url = data.get(ATTR_FILE_URL)
+
+            if file_url is not None:
+                if not file_url.startswith("http"):
+                    _LOGGER.error("URL should start with http or https")
+                    return
+
+                message_section = pymsteams.cardsection()
+                message_section.addImage(file_url)
+                self.teams_message.addSection(message_section)
         try:
-            title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-            data = kwargs.get(ATTR_DATA)
-
-            self.teams_message.title(title)
-
-            self.teams_message.text(message)
-
-            if data is not None:
-                file_url = data.get(ATTR_FILE_URL)
-
-                if file_url is not None:
-                    if not file_url.startswith("http"):
-                        _LOGGER.error("URL should start with http or https")
-                        return
-
-                    message_section = pymsteams.cardsection()
-                    message_section.addImage(file_url)
-                    self.teams_message.addSection(message_section)
-
             self.teams_message.send()
-
         except RuntimeError as err:
             _LOGGER.error("Could not send notification. Error: %s", err)

--- a/homeassistant/components/msteams/notify.py
+++ b/homeassistant/components/msteams/notify.py
@@ -1,0 +1,69 @@
+"""Microsoft Teams platform for notify component."""
+import logging
+
+import pymsteams
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
+from homeassistant.const import CONF_WEBHOOK_ID
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_FILE_URL = "image_url"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_WEBHOOK_ID): cv.string})
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Microsoft Teams notification service."""
+    webhook_url = config.get(CONF_WEBHOOK_ID)
+
+    try:
+        return MSTeamsNotificationService(webhook_url)
+
+    except RuntimeError as err:
+        _LOGGER.exception("Error in creating a new Microsoft Teams message: %s", err)
+        return None
+
+
+class MSTeamsNotificationService(BaseNotificationService):
+    """Implement the notification service for Microsoft Teams."""
+
+    def __init__(self, webhook_url):
+        """Initialize the service."""
+        self._webhook_url = webhook_url
+        self.teams_message = pymsteams.connectorcard(self._webhook_url)
+
+    def send_message(self, message=None, **kwargs):
+        """Send a message to the webhook."""
+        try:
+            title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+            data = kwargs.get(ATTR_DATA)
+
+            self.teams_message.title(title)
+
+            self.teams_message.text(message)
+
+            if data is not None:
+                file_url = data.get(ATTR_FILE_URL)
+
+                if file_url is not None:
+                    if not file_url.startswith("http"):
+                        _LOGGER.error("URL should start with http or https")
+                        return
+
+                    message_section = pymsteams.cardsection()
+                    message_section.addImage(file_url)
+                    self.teams_message.addSection(message_section)
+
+            self.teams_message.send()
+
+        except RuntimeError as err:
+            _LOGGER.error("Could not send notification. Error: %s", err)

--- a/homeassistant/components/msteams/notify.py
+++ b/homeassistant/components/msteams/notify.py
@@ -11,19 +11,19 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
-from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.const import CONF_URL
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_FILE_URL = "image_url"
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_WEBHOOK_ID): cv.string})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_URL): cv.url})
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the Microsoft Teams notification service."""
-    webhook_url = config.get(CONF_WEBHOOK_ID)
+    webhook_url = config.get(CONF_URL)
 
     try:
         return MSTeamsNotificationService(webhook_url)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1318,6 +1318,9 @@ pymodbus==1.5.2
 # homeassistant.components.monoprice
 pymonoprice==0.3
 
+# homeassistant.components.msteams
+pymsteams==0.1.12
+
 # homeassistant.components.yamaha_musiccast
 pymusiccast==0.1.6
 


### PR DESCRIPTION
## Description:
New notification platform for Microsoft Teams.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10911

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: msteams
    name: myteam
    webhook_id: https://outlook.office.com/webhook/<ID>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
