### PR TITLE
Make Plex dispatch signals unique per server

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -17,9 +17,9 @@ PLEX_CONFIG_FILE = "plex.conf"
 PLEX_MEDIA_PLAYER_OPTIONS = "plex_mp_options"
 PLEX_SERVER_CONFIG = "server_config"
 
-PLEX_NEW_MP_SIGNAL = "plex_new_mp_signal"
+PLEX_NEW_MP_SIGNAL = "plex_new_mp_signal.{}"
 PLEX_UPDATE_MEDIA_PLAYER_SIGNAL = "plex_update_mp_signal.{}"
-PLEX_UPDATE_SENSOR_SIGNAL = "plex_update_sensor_signal"
+PLEX_UPDATE_SENSOR_SIGNAL = "plex_update_sensor_signal.{}"
 
 CONF_SERVER = "server"
 CONF_SERVER_IDENTIFIER = "server_id"

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -62,7 +62,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             hass, config_entry, async_add_entities, server_id, new_entities
         )
 
-    unsub = async_dispatcher_connect(hass, PLEX_NEW_MP_SIGNAL, async_new_media_players)
+    unsub = async_dispatcher_connect(
+        hass, PLEX_NEW_MP_SIGNAL.format(server_id), async_new_media_players
+    )
     hass.data[PLEX_DOMAIN][DISPATCHERS][server_id].append(unsub)
 
 

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -49,7 +49,9 @@ class PlexSensor(Entity):
         """Run when about to be added to hass."""
         server_id = self._server.machine_identifier
         unsub = async_dispatcher_connect(
-            self.hass, PLEX_UPDATE_SENSOR_SIGNAL, self.async_refresh_sensor
+            self.hass,
+            PLEX_UPDATE_SENSOR_SIGNAL.format(server_id),
+            self.async_refresh_sensor,
         )
         self.hass.data[PLEX_DOMAIN][DISPATCHERS][server_id].append(unsub)
 

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -147,9 +147,17 @@ class PlexServer:
             self.refresh_entity(client_id, None, None)
 
         if new_entity_configs:
-            dispatcher_send(self._hass, PLEX_NEW_MP_SIGNAL, new_entity_configs)
+            dispatcher_send(
+                self._hass,
+                PLEX_NEW_MP_SIGNAL.format(self.machine_identifier),
+                new_entity_configs,
+            )
 
-        dispatcher_send(self._hass, PLEX_UPDATE_SENSOR_SIGNAL, sessions)
+        dispatcher_send(
+            self._hass,
+            PLEX_UPDATE_SENSOR_SIGNAL.format(self.machine_identifier),
+            sessions,
+        )
 
     @property
     def friendly_name(self):


### PR DESCRIPTION
## Description:
After #27764 was merged, I realized that the dispatch signals could get crossed if multiple Plex servers were configured. This makes the signal names unique per Plex server.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
