### PR TITLE
Additional SSL validation checks for cert_expiry

### DIFF
--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the Cert Expiry platform."""
 import socket
+import ssl
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -49,6 +50,13 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._errors[CONF_HOST] = "resolve_failed"
         except socket.timeout:
             self._errors[CONF_HOST] = "connection_timeout"
+        except ssl.CertificateError as err:
+            if "doesn't match" in err.args[0]:
+                self._errors[CONF_HOST] = "wrong_host"
+            else:
+                self._errors[CONF_HOST] = "certificate_error"
+        except ssl.SSLError:
+            self._errors[CONF_HOST] = "certificate_error"
         except OSError:
             self._errors[CONF_HOST] = "certificate_fetch_failed"
         return False

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for the Cert Expiry platform."""
+import logging
 import socket
 import ssl
 import voluptuous as vol
@@ -10,6 +11,8 @@ from homeassistant.util import slugify
 
 from .const import DOMAIN, DEFAULT_PORT, DEFAULT_NAME
 from .helper import get_cert
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback
@@ -41,24 +44,28 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _test_connection(self, user_input=None):
         """Test connection to the server and try to get the certtificate."""
+        host = user_input[CONF_HOST]
         try:
             await self.hass.async_add_executor_job(
-                get_cert, user_input[CONF_HOST], user_input.get(CONF_PORT, DEFAULT_PORT)
+                get_cert, host, user_input.get(CONF_PORT, DEFAULT_PORT)
             )
             return True
         except socket.gaierror:
+            _LOGGER.error("Host cannot be resolved: %s", host)
             self._errors[CONF_HOST] = "resolve_failed"
         except socket.timeout:
+            _LOGGER.error("Timed out connecting to %s", host)
             self._errors[CONF_HOST] = "connection_timeout"
         except ssl.CertificateError as err:
             if "doesn't match" in err.args[0]:
+                _LOGGER.error("Certificate does not match host: %s", host)
                 self._errors[CONF_HOST] = "wrong_host"
             else:
+                _LOGGER.error("Certificate could not be validated: %s", host)
                 self._errors[CONF_HOST] = "certificate_error"
         except ssl.SSLError:
+            _LOGGER.error("Certificate could not be validated: %s", host)
             self._errors[CONF_HOST] = "certificate_error"
-        except OSError:
-            self._errors[CONF_HOST] = "certificate_fetch_failed"
         return False
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -127,6 +127,21 @@ class SSLCertificate(Entity):
             _LOGGER.error("Connection timeout with server: %s", self.server_name)
             self._available = False
             return
+        except ssl.CertificateError as err:
+            if "doesn't match" in err.args[0]:
+                _LOGGER.error(
+                    "Certificate does not match hostname: %s", self.server_name
+                )
+            else:
+                _LOGGER.error(
+                    "Certificate could not be validated: %s [%s]", self.server_name, err
+                )
+            return
+        except ssl.SSLError as err:
+            _LOGGER.error(
+                "Certificate could not be validated: %s [%s]", self.server_name, err
+            )
+            return
         except OSError:
             _LOGGER.error(
                 "Cannot fetch certificate from %s", self.server_name, exc_info=1

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -130,23 +130,7 @@ class SSLCertificate(Entity):
             self._available = False
             self._valid = False
             return
-        except ssl.CertificateError as err:
-            if "doesn't match" in err.args[0]:
-                _LOGGER.error(
-                    "Certificate does not match hostname: %s", self.server_name
-                )
-            else:
-                _LOGGER.error(
-                    "Certificate could not be validated: %s [%s]", self.server_name, err
-                )
-            self._available = True
-            self._state = 0
-            self._valid = False
-            return
-        except ssl.SSLError as err:
-            _LOGGER.error(
-                "Certificate could not be validated: %s [%s]", self.server_name, err
-            )
+        except (ssl.CertificateError, ssl.SSLError):
             self._available = True
             self._state = 0
             self._valid = False

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -16,7 +16,6 @@
             "resolve_failed": "This host can not be resolved",
             "connection_timeout": "Timeout when connecting to this host",
             "certificate_error": "Certificate could not be validated",
-            "certificate_fetch_failed": "Can not fetch certificate from this host and port combination",
             "wrong_host": "Certificate does not match hostname"
         },
         "abort": {

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -15,7 +15,9 @@
             "host_port_exists": "This host and port combination is already configured",
             "resolve_failed": "This host can not be resolved",
             "connection_timeout": "Timeout when connecting to this host",
-            "certificate_fetch_failed": "Can not fetch certificate from this host and port combination"
+            "certificate_error": "Certificate could not be validated",
+            "certificate_fetch_failed": "Can not fetch certificate from this host and port combination",
+            "wrong_host": "Certificate does not match hostname"
         },
         "abort": {
             "host_port_exists": "This host and port combination is already configured"


### PR DESCRIPTION
## Description:
Adds more SSL exception checks for common scenarios. Tested against several bad certificates on https://badssl.com.

The SSL library seems _very_ version dependent, so I attempted to check against the lowest common denominator of exceptions available in Python 3.6.

**Related issue (if applicable):** fixes #27832

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html