### PR TITLE
Add override switch for juicenet

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -155,6 +155,7 @@ homeassistant/components/iqvia/* @bachya
 homeassistant/components/irish_rail_transport/* @ttroy50
 homeassistant/components/izone/* @Swamp-Ig
 homeassistant/components/jewish_calendar/* @tsvi
+homeassistant/components/juicenet/* @jesserockz
 homeassistant/components/kaiterra/* @Michsior14
 homeassistant/components/keba/* @dannerph
 homeassistant/components/keenetic_ndms2/* @foxel

--- a/homeassistant/components/juicenet/__init__.py
+++ b/homeassistant/components/juicenet/__init__.py
@@ -17,6 +17,8 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+JUICENET_COMPONENTS = ["sensor", "switch"]
+
 
 def setup(hass, config):
     """Set up the Juicenet component."""
@@ -27,7 +29,9 @@ def setup(hass, config):
     access_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
     hass.data[DOMAIN]["api"] = pyjuicenet.Api(access_token)
 
-    discovery.load_platform(hass, "sensor", DOMAIN, {}, config)
+    for component in JUICENET_COMPONENTS:
+        discovery.load_platform(hass, component, DOMAIN, {}, config)
+
     return True
 
 

--- a/homeassistant/components/juicenet/manifest.json
+++ b/homeassistant/components/juicenet/manifest.json
@@ -3,7 +3,7 @@
   "name": "Juicenet",
   "documentation": "https://www.home-assistant.io/integrations/juicenet",
   "requirements": [
-    "python-juicenet==0.1.4"
+    "python-juicenet==0.1.5"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/juicenet/manifest.json
+++ b/homeassistant/components/juicenet/manifest.json
@@ -3,8 +3,10 @@
   "name": "Juicenet",
   "documentation": "https://www.home-assistant.io/integrations/juicenet",
   "requirements": [
-    "python-juicenet==0.0.5"
+    "python-juicenet==0.1.4"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@jesserockz"
+  ]
 }

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -32,13 +32,6 @@ class JuicenetChargeNowSwitch(JuicenetDevice, SwitchDevice):
         return "{} {}".format(self.device.name(), "Charge Now")
 
     @property
-    def state(self):
-        """Return the state."""
-        if self.device.getOverrideTime() != 0:
-            return "on"
-        return "off"
-
-    @property
     def is_on(self):
         """Return true if switch is on."""
         return self.device.getOverrideTime() != 0

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -36,8 +36,7 @@ class JuicenetChargeNowSwitch(JuicenetDevice, SwitchDevice):
         """Return the state."""
         if self.device.getOverrideTime() != 0:
             return "on"
-        else:
-            return "off"
+        return "off"
 
     @property
     def is_on(self):

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -9,7 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Juicenet sensor."""
+    """Set up the Juicenet switch."""
     api = hass.data[DOMAIN]["api"]
 
     devs = []

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -1,4 +1,4 @@
-"""Support for monitoring juicenet/juicepoint/juicebox based EVSE sensors."""
+"""Support for monitoring juicenet/juicepoint/juicebox based EVSE switches."""
 import logging
 
 from homeassistant.components.switch import SwitchDevice

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -35,9 +35,9 @@ class JuicenetChargeNowSwitch(JuicenetDevice, SwitchDevice):
     def state(self):
         """Return the state."""
         if self.device.getOverrideTime() != 0:
-          return "on"
+            return "on"
         else:
-          return "off"
+            return "off"
 
     @property
     def is_on(self):

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -41,13 +41,13 @@ class JuicenetChargeNowSwitch(JuicenetDevice, SwitchDevice):
 
     @property
     def is_on(self):
-      """Return true if switch is on."""
-      return self.device.getOverrideTime() != 0
+        """Return true if switch is on."""
+        return self.device.getOverrideTime() != 0
 
     def turn_on(self, **kwargs):
-      """Charge now."""
-      self.device.setOverride(True)
+        """Charge now."""
+        self.device.setOverride(True)
 
     def turn_off(self, **kwargs):
-      """Don't charge now."""
-      self.device.setOverride(False)
+        """Don't charge now."""
+        self.device.setOverride(False)

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -1,0 +1,53 @@
+"""Support for monitoring juicenet/juicepoint/juicebox based EVSE sensors."""
+import logging
+
+from homeassistant.components.switch import SwitchDevice
+
+from . import DOMAIN, JuicenetDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Juicenet sensor."""
+    api = hass.data[DOMAIN]["api"]
+
+    devs = []
+    for device in api.get_devices():
+        devs.append(JuicenetChargeNowSwitch(device, hass))
+
+    add_entities(devs)
+
+
+class JuicenetChargeNowSwitch(JuicenetDevice, SwitchDevice):
+    """Implementation of a Juicenet switch."""
+
+    def __init__(self, device, hass):
+        """Initialise the switch."""
+        super().__init__(device, "charge_now", hass)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return "{} {}".format(self.device.name(), "Charge Now")
+
+    @property
+    def state(self):
+        """Return the state."""
+        if self.device.getOverrideTime() != 0:
+          return "on"
+        else:
+          return "off"
+
+    @property
+    def is_on(self):
+      """Return true if switch is on."""
+      return self.device.getOverrideTime() != 0
+
+    def turn_on(self, **kwargs):
+      """Charge now."""
+      self.device.setOverride(True)
+
+    def turn_off(self, **kwargs):
+      """Don't charge now."""
+      self.device.setOverride(False)

--- a/homeassistant/components/juicenet/switch.py
+++ b/homeassistant/components/juicenet/switch.py
@@ -29,7 +29,7 @@ class JuicenetChargeNowSwitch(JuicenetDevice, SwitchDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return "{} {}".format(self.device.name(), "Charge Now")
+        return f"{self.device.name()} Charge Now"
 
     @property
     def is_on(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1525,7 +1525,7 @@ python-izone==1.1.1
 python-join-api==0.0.4
 
 # homeassistant.components.juicenet
-python-juicenet==0.1.4
+python-juicenet==0.1.5
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1525,7 +1525,7 @@ python-izone==1.1.1
 python-join-api==0.0.4
 
 # homeassistant.components.juicenet
-python-juicenet==0.0.5
+python-juicenet==0.1.4
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3


### PR DESCRIPTION
## Description:
Adds a switch to allow overriding car charging schedule

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10917

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
