### PR TITLE
Not slugify cert_expiry name

### DIFF
--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PORT, CONF_NAME, CONF_HOST
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.util import slugify
 
 from .const import DOMAIN, DEFAULT_PORT, DEFAULT_NAME
 from .helper import get_cert
@@ -62,11 +61,12 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_HOST] = "host_port_exists"
             else:
                 if await self._test_connection(user_input):
-                    host = user_input[CONF_HOST]
-                    name = slugify(user_input.get(CONF_NAME, DEFAULT_NAME))
-                    prt = user_input.get(CONF_PORT, DEFAULT_PORT)
                     return self.async_create_entry(
-                        title=name, data={CONF_HOST: host, CONF_PORT: prt}
+                        title=user_input.get(CONF_NAME, DEFAULT_NAME),
+                        data={
+                            CONF_HOST: user_input[CONF_HOST],
+                            CONF_PORT: user_input.get(CONF_PORT, DEFAULT_PORT),
+                        },
                     )
         else:
             user_input = {}

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.cert_expiry import config_flow
-from homeassistant.components.cert_expiry.const import DEFAULT_PORT
+from homeassistant.components.cert_expiry.const import DEFAULT_NAME, DEFAULT_PORT
 from homeassistant.const import CONF_PORT, CONF_NAME, CONF_HOST
 
 from tests.common import MockConfigEntry, mock_coro
@@ -45,7 +45,7 @@ async def test_user(hass, test_connect):
         {CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["title"] == NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
 
@@ -57,21 +57,21 @@ async def test_import(hass, test_connect):
     # import with only host
     result = await flow.async_step_import({CONF_HOST: HOST})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "ssl_certificate_expiry"
+    assert result["title"] == DEFAULT_NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == DEFAULT_PORT
 
     # import with host and name
     result = await flow.async_step_import({CONF_HOST: HOST, CONF_NAME: NAME})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["title"] == NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == DEFAULT_PORT
 
     # improt with host and port
     result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "ssl_certificate_expiry"
+    assert result["title"] == DEFAULT_NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
 
@@ -80,7 +80,7 @@ async def test_import(hass, test_connect):
         {CONF_HOST: HOST, CONF_PORT: PORT, CONF_NAME: NAME}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["title"] == NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
 
@@ -112,7 +112,7 @@ async def test_abort_if_already_setup(hass, test_connect):
         {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: 888}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["title"] == NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == 888
 


### PR DESCRIPTION
## Breaking Change:

None (the entity_id is not changing, just the name)

## Description:

Before : 
<img width="374" alt="Capture d’écran 2019-10-21 à 13 24 10" src="https://user-images.githubusercontent.com/14821482/67201291-453b3500-f406-11e9-9bb2-7d7bcc5e4b2e.png">


After : 
<img width="377" alt="Capture d’écran 2019-10-21 à 13 24 19" src="https://user-images.githubusercontent.com/14821482/67201315-4ec49d00-f406-11e9-9e06-538ab4bedaa4.png">

Same entity_id `sensor.ssl_certificate_expiry`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html