### PR TITLE
Add hvac_action to geniushub

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -226,21 +226,7 @@ class GeniusZone(GeniusEntity):
     def device_state_attributes(self) -> Dict[str, Any]:
         """Return the device state attributes."""
         status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}
-        status.update(self._zone.data["_state"])
         return {"status": status}
-
-    @property
-    def hvac_action(self) -> Optional[str]:
-        """Return the current running hvac operation (off/idle/heating)."""
-        _LOGGER.warn("_state[%s] = %s", self.name, self._zone.data["_state"])
-        _LOGGER.warn(
-            "hvac_action[%s] = %s",
-            self.name,
-            self._zone.data["_state"]["bOutRequestHeat"],
-        )
-        if self._zone.data["_state"]["bOutRequestHeat"]:
-            return "heating"
-        return None
 
     @property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -227,7 +227,21 @@ class GeniusZone(GeniusEntity):
     def device_state_attributes(self) -> Dict[str, Any]:
         """Return the device state attributes."""
         status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}
+        status.update(self._zone.data["_state"])
         return {"status": status}
+
+    @property
+    def hvac_action(self) -> Optional[str]:
+        """Return the current running hvac operation (off/idle/heating)."""
+        _LOGGER.warn("_state[%s] = %s", self.name, self._zone.data["_state"])
+        _LOGGER.warn(
+            "hvac_action[%s] = %s",
+            self.name,
+            self._zone.data["_state"]["bOutRequestHeat"],
+        )
+        if self._zone.data["_state"]["bOutRequestHeat"]:
+            return "heating"
+        return None
 
     @property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/geniushub/climate.py
+++ b/homeassistant/components/geniushub/climate.py
@@ -3,6 +3,9 @@ from typing import List, Optional
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     PRESET_ACTIVITY,
@@ -67,6 +70,17 @@ class GeniusClimateZone(GeniusZone, ClimateDevice):
     def hvac_modes(self) -> List[str]:
         """Return the list of available hvac operation modes."""
         return list(HA_HVAC_TO_GH)
+
+    @property
+    def hvac_action(self) -> Optional[str]:
+        """Return the current running hvac operation if supported."""
+        if "_state" in self._zone.data:  # only for v3 API
+            if not self._zone.data["_state"].get("bIsActive"):
+                return CURRENT_HVAC_OFF
+            if self._zone.data["_state"].get("bOutRequestHeat"):
+                return CURRENT_HVAC_HEAT
+            return CURRENT_HVAC_IDLE
+        return None
 
     @property
     def preset_mode(self) -> Optional[str]:


### PR DESCRIPTION
## Description:
For **geniushub** integrations using the v3 API, it is possible to determine if a zone is calling for heat, or not.  For each `Climate` entity, this PR returns `CURRENT_HVAC_*` accordingly, or `None` if the v1 API is being used.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

**Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
