### PR TITLE
Counter configure with value

### DIFF
--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -16,6 +16,7 @@ ATTR_INITIAL = "initial"
 ATTR_STEP = "step"
 ATTR_MINIMUM = "minimum"
 ATTR_MAXIMUM = "maximum"
+VALUE = "value"
 
 CONF_INITIAL = "initial"
 CONF_RESTORE = "restore"
@@ -37,6 +38,8 @@ SERVICE_SCHEMA_CONFIGURE = ENTITY_SERVICE_SCHEMA.extend(
         vol.Optional(ATTR_MINIMUM): vol.Any(None, vol.Coerce(int)),
         vol.Optional(ATTR_MAXIMUM): vol.Any(None, vol.Coerce(int)),
         vol.Optional(ATTR_STEP): cv.positive_int,
+        vol.Optional(ATTR_INITIAL): cv.positive_int,
+        vol.Optional(VALUE): cv.positive_int,
     }
 )
 
@@ -171,6 +174,10 @@ class Counter(RestoreEntity):
             state = await self.async_get_last_state()
             if state is not None:
                 self._state = self.compute_next_state(int(state.state))
+                self._initial = state.attributes.get(ATTR_INITIAL)
+                self._max = state.attributes.get(ATTR_MAXIMUM)
+                self._min = state.attributes.get(ATTR_MINIMUM)
+                self._step = state.attributes.get(ATTR_STEP)
 
     async def async_decrement(self):
         """Decrement the counter."""
@@ -195,6 +202,10 @@ class Counter(RestoreEntity):
             self._max = kwargs[CONF_MAXIMUM]
         if CONF_STEP in kwargs:
             self._step = kwargs[CONF_STEP]
+        if CONF_INITIAL in kwargs:
+            self._initial = kwargs[CONF_INITIAL]
+        if VALUE in kwargs:
+            self._state = kwargs[VALUE]
 
         self._state = self.compute_next_state(self._state)
         await self.async_update_ha_state()

--- a/homeassistant/components/counter/services.yaml
+++ b/homeassistant/components/counter/services.yaml
@@ -33,3 +33,9 @@ configure:
     step:
       description: New value for step
       example: 2
+    initial:
+      description: New value for initial
+      example: 6
+    value:
+      description: New state value
+      example: 3


### PR DESCRIPTION
## Breaking Change:

Nothing breaks.

## Description:
This extends the service `counter.configure` by the fields `initial` and `value`. This makes it easier to reproduce the state (#26965).

While working on this PR, I noticed that the state attributes are not restored at startup. I also added this. I will remove these changes again if this is unwanted.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10924

## Example entry for `configuration.yaml` (if applicable):
```yaml
counter:
  my_custom_counter:
    restore: True
    minimum: 10
    maximum: 20
    initial: 12
    step: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
