### PR TITLE
Add Sky+HD

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -603,6 +603,7 @@ omit =
     homeassistant/components/simulated/sensor.py
     homeassistant/components/sisyphus/*
     homeassistant/components/sky_hub/device_tracker.py
+    homeassistant/components/sky_plus_hd/media_player.py
     homeassistant/components/skybeacon/sensor.py
     homeassistant/components/skybell/*
     homeassistant/components/slack/notify.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -258,6 +258,7 @@ homeassistant/components/shiftr/* @fabaff
 homeassistant/components/shodan/* @fabaff
 homeassistant/components/simplisafe/* @bachya
 homeassistant/components/sinch/* @bendikrb
+homeassistant/components/sky_plus_hd/* @GreenTurtwig
 homeassistant/components/slide/* @ualex73
 homeassistant/components/sma/* @kellerza
 homeassistant/components/smarthab/* @outadoc

--- a/homeassistant/components/sky_plus_hd/__init__.py
+++ b/homeassistant/components/sky_plus_hd/__init__.py
@@ -1,0 +1,1 @@
+"""The Sky+HD integration."""

--- a/homeassistant/components/sky_plus_hd/manifest.json
+++ b/homeassistant/components/sky_plus_hd/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "sky_plus_hd",
+  "name": "Sky+HD",
+  "documentation": "https://www.home-assistant.io/integrations/sky_plus_hd",
+  "requirements": ["pyskyplushd==0.1.1"],
+  "dependencies": [],
+  "codeowners": ["@GreenTurtwig"]
+}

--- a/homeassistant/components/sky_plus_hd/manifest.json
+++ b/homeassistant/components/sky_plus_hd/manifest.json
@@ -2,7 +2,7 @@
   "domain": "sky_plus_hd",
   "name": "Sky+HD",
   "documentation": "https://www.home-assistant.io/integrations/sky_plus_hd",
-  "requirements": ["pyskyplushd==0.1.1"],
+  "requirements": ["pyskyplushd==0.2.0"],
   "dependencies": [],
   "codeowners": ["@GreenTurtwig"]
 }

--- a/homeassistant/components/sky_plus_hd/media_player.py
+++ b/homeassistant/components/sky_plus_hd/media_player.py
@@ -20,7 +20,6 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Sky+HD"
-ICON = "mdi:set-top-box"
 
 SERVICE_RECORD = ""
 
@@ -69,11 +68,6 @@ class SkyPlusHD(MediaPlayerDevice):
     def name(self):
         """Return the name of the device."""
         return self._name
-
-    @property
-    def icon(self):
-        """Return the icon of the device."""
-        return ICON
 
     @property
     def state(self):

--- a/homeassistant/components/sky_plus_hd/media_player.py
+++ b/homeassistant/components/sky_plus_hd/media_player.py
@@ -1,0 +1,118 @@
+"""Platform for Sky+HD integration."""
+import logging
+
+import PySkyPlusHD
+import voluptuous as vol
+
+from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player.const import (
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_STOP,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+)
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "Sky+HD"
+ICON = "mdi:set-top-box"
+
+SERVICE_RECORD = ""
+
+SUPPORT_SKYPLUSHD = (
+    SUPPORT_NEXT_TRACK
+    | SUPPORT_PAUSE
+    | SUPPORT_PLAY
+    | SUPPORT_PREVIOUS_TRACK
+    | SUPPORT_STOP
+    | SUPPORT_TURN_OFF
+    | SUPPORT_TURN_ON
+)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Sky+HD platform."""
+    host = config.get(CONF_HOST)
+    name = config.get(CONF_NAME)
+
+    sky = PySkyPlusHD.SkyBox(host)
+
+    add_entities([SkyPlusHD(sky, name)])
+
+
+class SkyPlusHD(MediaPlayerDevice):
+    """Representation of a Sky+HD box."""
+
+    def __init__(self, sky, name):
+        """Initialize the Sky+HD box."""
+        self._sky = sky
+        self._name = name
+        self._state = None
+
+    def update(self):
+        """Get the latest details from the device."""
+        self._state = STATE_ON if self._sky.getState() else STATE_OFF
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of the device."""
+        return ICON
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_SKYPLUSHD
+
+    def turn_off(self):
+        """Turn off the media player."""
+        self._sky.sendButton("power")
+
+    def turn_on(self):
+        """Turn on the media player."""
+        self._sky.sendButton("power")
+
+    def media_pause(self):
+        """Send pause command."""
+        self._sky.sendButton("pause")
+
+    def media_play_pause(self):
+        """Simulate play pause media player."""
+        self._sky.sendButton("pause")
+
+    def media_play(self):
+        """Send play command."""
+        self._sky.sendButton("play")
+
+    def media_stop(self):
+        """Send stop command."""
+        self._sky.sendButton("stop")
+
+    def media_next(self):
+        """Send next track command."""
+        self._sky.sendButton("fastforward")
+
+    def media_previous(self):
+        """Send previous track command."""
+        self._sky.sendButton("rewind")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1437,6 +1437,9 @@ pysesame2==1.0.1
 # homeassistant.components.goalfeed
 pysher==1.0.1
 
+# homeassistant.components.sky_plus_hd
+pyskyplushd==0.1.1
+
 # homeassistant.components.sma
 pysma==0.3.4
 


### PR DESCRIPTION
## Description:
Support for Sky+HD.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10935

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: sky_plus_hd
    host: 192.168.0.2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
