### PR TITLE
Support to use Whatsapp numbers (fixes #28065)

### DIFF
--- a/homeassistant/components/twilio/__init__.py
+++ b/homeassistant/components/twilio/__init__.py
@@ -1,9 +1,12 @@
 """Support for Twilio."""
+from twilio.rest import Client
+from twilio.twiml import TwiML
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.helpers import config_entry_flow
+import homeassistant.helpers.config_validation as cv
+
 from .const import DOMAIN
 
 CONF_ACCOUNT_SID = "account_sid"
@@ -28,8 +31,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the Twilio component."""
-    from twilio.rest import Client
-
     if DOMAIN not in config:
         return True
 
@@ -42,8 +43,6 @@ async def async_setup(hass, config):
 
 async def handle_webhook(hass, webhook_id, request):
     """Handle incoming webhook from Twilio for inbound messages and calls."""
-    from twilio.twiml import TwiML
-
     data = dict(await request.post())
     data["webhook_id"] = webhook_id
     hass.bus.async_fire(RECEIVED_DATA, dict(data))

--- a/homeassistant/components/twilio/config_flow.py
+++ b/homeassistant/components/twilio/config_flow.py
@@ -3,7 +3,6 @@ from homeassistant.helpers import config_entry_flow
 
 from .const import DOMAIN
 
-
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     "Twilio Webhook",

--- a/homeassistant/components/twilio/manifest.json
+++ b/homeassistant/components/twilio/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/twilio",
   "requirements": [
-    "twilio==6.19.1"
+    "twilio==6.32.0"
   ],
   "dependencies": [
     "webhook"

--- a/homeassistant/components/twilio_call/notify.py
+++ b/homeassistant/components/twilio_call/notify.py
@@ -4,14 +4,13 @@ import urllib
 
 import voluptuous as vol
 
-from homeassistant.components.twilio import DATA_TWILIO
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_TARGET,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.components.twilio import DATA_TWILIO
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/twilio_sms/notify.py
+++ b/homeassistant/components/twilio_sms/notify.py
@@ -3,15 +3,14 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.twilio import DATA_TWILIO
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
+    ATTR_DATA,
     ATTR_TARGET,
     PLATFORM_SCHEMA,
     BaseNotificationService,
-    ATTR_DATA,
 )
+from homeassistant.components.twilio import DATA_TWILIO
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 r"^\+?[1-9]\d{1,14}$|"
                 r"^(?=.{1,11}$)[a-zA-Z0-9\s]*"
                 r"[a-zA-Z][a-zA-Z0-9\s]*$"
+                r"^(?:[a-zA-Z]+)\:?\+?[1-9]\d{1,14}$|"
             ),
         )
     }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1909,7 +1909,7 @@ tuyaha==0.0.4
 twentemilieu==0.1.0
 
 # homeassistant.components.twilio
-twilio==6.19.1
+twilio==6.32.0
 
 # homeassistant.components.upcloud
 upcloud-api==0.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -596,7 +596,7 @@ transmissionrpc==0.11
 twentemilieu==0.1.0
 
 # homeassistant.components.twilio
-twilio==6.19.1
+twilio==6.32.0
 
 # homeassistant.components.uvc
 uvcclient==0.11.0


### PR DESCRIPTION
## Description:
- Support for Whatsapp numbers -> "whatsapp:+123456789"
- Upgrade twilio to 6.32.0
- Sorted/grouped imports (related #27284)

**Related issue (if applicable):** fixes #28065

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10936

## Example entry for `configuration.yaml` (if applicable):
```yaml
twilio:
  account_sid: !secret twilio_sid
  auth_token: !secret twilio_token

notify:
  - name: twilio
    platform: twilio_sms
    from_number: "whatsapp:+123456789"
```

@TomaszKorwel, could you please test this? Thanks.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
 