### PR TITLE
Move imports in dsmr component

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -4,6 +4,9 @@ from datetime import timedelta
 from functools import partial
 import logging
 
+from dsmr_parser import obis_references as obis_ref
+from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
+import serial
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -51,10 +54,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the DSMR sensor."""
     # Suppress logging
     logging.getLogger("dsmr_parser").setLevel(logging.ERROR)
-
-    from dsmr_parser import obis_references as obis_ref
-    from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
-    import serial
 
     dsmr_version = config[CONF_DSMR_VERSION]
 
@@ -212,11 +211,9 @@ class DSMREntity(Entity):
     @property
     def state(self):
         """Return the state of sensor, if available, translate if needed."""
-        from dsmr_parser import obis_references as obis
-
         value = self.get_dsmr_object_attr("value")
 
-        if self._obis == obis.ELECTRICITY_ACTIVE_TARIFF:
+        if self._obis == obis_ref.ELECTRICITY_ACTIVE_TARIFF:
             return self.translate_tariff(value)
 
         try:

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -11,17 +11,23 @@ from decimal import Decimal
 from unittest.mock import Mock
 
 import asynctest
+from dsmr_parser.clients.protocol import DSMRProtocol
+from dsmr_parser.obis_references import (
+    CURRENT_ELECTRICITY_USAGE,
+    ELECTRICITY_ACTIVE_TARIFF,
+)
+from dsmr_parser.objects import CosemObject, MBusObject
+import pytest
+
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.dsmr.sensor import DerivativeDSMREntity
-import pytest
+
 from tests.common import assert_setup_component
 
 
 @pytest.fixture
 def mock_connection_factory(monkeypatch):
     """Mock the create functions for serial and TCP Asyncio connections."""
-    from dsmr_parser.clients.protocol import DSMRProtocol
-
     transport = asynctest.Mock(spec=asyncio.Transport)
     protocol = asynctest.Mock(spec=DSMRProtocol)
 
@@ -47,12 +53,6 @@ def mock_connection_factory(monkeypatch):
 def test_default_setup(hass, mock_connection_factory):
     """Test the default setup."""
     (connection_factory, transport, protocol) = mock_connection_factory
-
-    from dsmr_parser.obis_references import (
-        CURRENT_ELECTRICITY_USAGE,
-        ELECTRICITY_ACTIVE_TARIFF,
-    )
-    from dsmr_parser.objects import CosemObject
 
     config = {"platform": "dsmr"}
 
@@ -93,8 +93,6 @@ def test_default_setup(hass, mock_connection_factory):
 @asyncio.coroutine
 def test_derivative():
     """Test calculation of derivative value."""
-    from dsmr_parser.objects import MBusObject
-
     config = {"platform": "dsmr"}
 
     entity = DerivativeDSMREntity("test", "1.0.0", config)


### PR DESCRIPTION
## Breaking Change:

## Description:
Moved imports from functions to top-level for dsmr as requested in #27284

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
