### PR TITLE
Added mdns resolution via zeroconf.

### DIFF
--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "eagle200_reader==0.2.1"
   ],
-  "dependencies": [],
+  "dependencies": ["zeroconf"],
   "codeowners": ["@gtdiehl"]
 }

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -42,18 +42,27 @@ SENSORS = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_IP_ADDRESS): cv.string,
         vol.Required(CONF_CLOUD_ID): cv.string,
         vol.Required(CONF_INSTALL_CODE): cv.string,
+        vol.Optional(CONF_IP_ADDRESS, default=""): cv.string,
     }
 )
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Create the Eagle-200 sensor."""
-    ip_address = config[CONF_IP_ADDRESS]
     cloud_id = config[CONF_CLOUD_ID]
     install_code = config[CONF_INSTALL_CODE]
+    if config[CONF_IP_ADDRESS] == "":
+        from zeroconf import Zeroconf
+
+        zc = Zeroconf()
+        info = zc.get_service_info(
+            "_http._tcp.local.", "eagle-{}._http._tcp.local.".format(cloud_id)
+        )
+        ip_address = "{}.{}.{}.{}".format(*info.address)
+    else:
+        ip_address = config[CONF_IP_ADDRESS]
 
     try:
         eagle_reader = EagleReader(ip_address, cloud_id, install_code)


### PR DESCRIPTION
## Description:

Using the `zeroconf` module, this uses the `.local` address of EAGLE devices to make the IP address field optional.  Using `zeroconf` is necessary for systems that can't resolve mDNS naturally, as in the Docker version of home-assistant. 

N.B. I don't have this hardware.  I'm writing this PR alongside another which adds support for an older version, the Legacy Eagle, so I can't test this against the Eagle-200.


## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rainforest_eagle
    cloud_id: 012abc
    install_code: 01234567890abcde
```
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [*] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [*] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [*] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [*] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
