### PR TITLE
Add rainforest_eagle support for legacy hardware

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -275,7 +275,7 @@ homeassistant/components/quantum_gateway/* @cisasteelersfan
 homeassistant/components/qwikswitch/* @kellerza
 homeassistant/components/rainbird/* @konikvranik
 homeassistant/components/raincloud/* @vanstinator
-homeassistant/components/rainforest_eagle/* @gtdiehl
+homeassistant/components/rainforest_eagle/* @gtdiehl @jcalbert
 homeassistant/components/rainmachine/* @bachya
 homeassistant/components/random/* @fabaff
 homeassistant/components/repetier/* @MTrab

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -4,8 +4,9 @@
   "documentation": "https://www.home-assistant.io/integrations/rainforest_eagle",
   "requirements": [
     "eagle200_reader==0.2.1",
-    "uEagle"
+    "uEagle==0.0.1"
   ],
   "dependencies": [],
-  "codeowners": ["@gtdiehl"]
+  "codeowners": ["@gtdiehl",
+                 "@jcalbert"]
 }

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -6,7 +6,7 @@
     "eagle200_reader==0.2.1",
     "uEagle==0.0.1"
   ],
-  "dependencies": [],
+  "dependencies": ["zeroconf"],
   "codeowners": ["@gtdiehl",
                  "@jcalbert"]
 }

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -6,7 +6,7 @@
     "eagle200_reader==0.2.1",
     "uEagle==0.0.1"
   ],
-  "dependencies": ["zeroconf"],
+  "dependencies": [],
   "codeowners": ["@gtdiehl",
                  "@jcalbert"]
 }

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -2,7 +2,10 @@
   "domain": "rainforest_eagle",
   "name": "Rainforest Eagle-200",
   "documentation": "https://www.home-assistant.io/integrations/rainforest_eagle",
-  "requirements": ["eagle200_reader==0.2.1"],
+  "requirements": [
+    "eagle200_reader==0.2.1",
+    "uEagle"
+  ],
   "dependencies": [],
   "codeowners": ["@gtdiehl"]
 }

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -64,7 +64,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     cloud_id = config[CONF_CLOUD_ID]
     install_code = config[CONF_INSTALL_CODE]
     if config[CONF_IP_ADDRESS] == "":
-        ip_address = None
+        from zeroconf import Zeroconf
+
+        zc = Zeroconf()
+        info = zc.get_service_info(
+            "_http._tcp.local.", "eagle-{}._http._tcp.local.".format(cloud_id)
+        )
+        ip_address = "{}.{}.{}.{}".format(*info.address)
     else:
         ip_address = config[CONF_IP_ADDRESS]
 

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -43,9 +43,9 @@ SENSORS = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_IP_ADDRESS): cv.string,
         vol.Required(CONF_CLOUD_ID): cv.string,
         vol.Required(CONF_INSTALL_CODE): cv.string,
+        vol.Optional(CONF_IP_ADDRESS, default=""): cv.string,
     }
 )
 
@@ -61,9 +61,12 @@ def hwtest(cloud_id, install_code, ip_address=None):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Create the Eagle-200 sensor."""
-    ip_address = config[CONF_IP_ADDRESS]
     cloud_id = config[CONF_CLOUD_ID]
     install_code = config[CONF_INSTALL_CODE]
+    if config[CONF_IP_ADDRESS] == "":
+        ip_address = None
+    else:
+        ip_address = config[CONF_IP_ADDRESS]
 
     try:
         eagle_reader = hwtest(cloud_id, install_code, ip_address)

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -56,10 +56,10 @@ def hwtest(cloud_id, install_code, ip_address):
     response = reader.post_cmd("device_list")
     if "Error" in response and "Unknown command" in response["Error"]["Text"]:
         return reader  # Probably a Legacy model
-    elif "DeviceList" in response:
+    if "DeviceList" in response:
         return EagleReader(ip_address, cloud_id, install_code)  # Probably Eagle-200
-    else:
-        _LOGGER.error("Couldn't determine device model.")
+
+    _LOGGER.error("Couldn't determine device model.")
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -158,14 +158,14 @@ class LeagleReader(LegacyReader):
 
     def update(self):
         """Fetch and return the four sensor values in a dict."""
-        d = {}
+        out = {}
 
         resp = self.get_instantaneous_demand()["InstantaneousDemand"]
-        d["instantanous_demand"] = resp["Demand"]
+        out["instantanous_demand"] = resp["Demand"]
 
         resp = self.get_current_summation()["CurrentSummation"]
-        d["summation_delivered"] = resp["SummationDelivered"]
-        d["summation_received"] = resp["SummationReceived"]
-        d["summation_total"] = d["summation_delivered"] - d["summation_received"]
+        out["summation_delivered"] = resp["SummationDelivered"]
+        out["summation_received"] = resp["SummationReceived"]
+        out["summation_total"] = out["summation_delivered"] - out["summation_received"]
 
-        return d
+        return out

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -43,14 +43,14 @@ SENSORS = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
+        vol.Required(CONF_IP_ADDRESS): cv.string,
         vol.Required(CONF_CLOUD_ID): cv.string,
         vol.Required(CONF_INSTALL_CODE): cv.string,
-        vol.Optional(CONF_IP_ADDRESS, default=""): cv.string,
     }
 )
 
 
-def hwtest(cloud_id, install_code, ip_address=None):
+def hwtest(cloud_id, install_code, ip_address):
     """Try API call 'device_list' to see if target device is Legacy or Eagle-200."""
     reader = LeagleReader(cloud_id, install_code, ip_address)
     response = reader.post_cmd("device_list")
@@ -61,18 +61,9 @@ def hwtest(cloud_id, install_code, ip_address=None):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Create the Eagle-200 sensor."""
+    ip_address = config[CONF_IP_ADDRESS]
     cloud_id = config[CONF_CLOUD_ID]
     install_code = config[CONF_INSTALL_CODE]
-    if config[CONF_IP_ADDRESS] == "":
-        from zeroconf import Zeroconf
-
-        zc = Zeroconf()
-        info = zc.get_service_info(
-            "_http._tcp.local.", "eagle-{}._http._tcp.local.".format(cloud_id)
-        )
-        ip_address = "{}.{}.{}.{}".format(*info.address)
-    else:
-        ip_address = config[CONF_IP_ADDRESS]
 
     try:
         eagle_reader = hwtest(cloud_id, install_code, ip_address)

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -56,7 +56,7 @@ def hwtest(cloud_id, install_code, ip_address):
     response = reader.post_cmd("device_list")
     if "Error" in response and "Unknown command" in response["Error"]["Text"]:
         return reader  # Probably a Legacy model
-    elif "device_list" in response:
+    elif "DeviceList" in response:
         return EagleReader(ip_address, cloud_id, install_code)  # Probably Eagle-200
     else:
         _LOGGER.error("Couldn't determine device model.")

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -54,9 +54,12 @@ def hwtest(cloud_id, install_code, ip_address):
     """Try API call 'device_list' to see if target device is Legacy or Eagle-200."""
     reader = LeagleReader(cloud_id, install_code, ip_address)
     response = reader.post_cmd("device_list")
-    if "Error" in response and "Unknown Command" in response["Error"]["Text"]:
-        reader = EagleReader(ip_address, cloud_id, install_code)
-    return reader
+    if "Error" in response and "Unknown command" in response["Error"]["Text"]:
+        return reader  # Probably a Legacy model
+    elif "device_list" in response:
+        return EagleReader(ip_address, cloud_id, install_code)  # Probably Eagle-200
+    else:
+        _LOGGER.error("Couldn't determine device model.")
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 import logging
 
 from eagle200_reader import EagleReader
-from uEagle import Eagle as LegacyReader
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
+from uEagle import Eagle as LegacyReader
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1998,6 +1998,9 @@ twentemilieu==0.2.0
 # homeassistant.components.twilio
 twilio==6.32.0
 
+# homeassistant.components.rainforest_eagle
+uEagle==0.0.1
+
 # homeassistant.components.unifiled
 unifiled==0.11
 


### PR DESCRIPTION
## Description:

Adds support for an older model of device, the Rainforest [Legacy Eagle](https://rainforestautomation.com/support/rfa-z109-eagle-support/).  For now, this only matches the functionality of the existing integration.  This only exposes a small subset of the Legacy Eagle's API -- ultimately I'd like to add a second platform to the integration.

N.B. Since I don't have an Eagle-200 to test on, I can't be sure this works for all hardware.  The function `hwtest()` attempts to identify the model by sending a command the old model doesn't know, but there's probably a better way to tell them apart.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10955

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
