### PR TITLE
Fix Tesla climate

### DIFF
--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT,
+    HVAC_MODE_AUTO,
     HVAC_MODE_OFF,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -13,7 +13,7 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+SUPPORT_HVAC = [HVAC_MODE_AUTO, HVAC_MODE_OFF]
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -46,7 +46,7 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         Need to be one of HVAC_MODE_*.
         """
         if self.tesla_device.is_hvac_enabled():
-            return HVAC_MODE_HEAT
+            return HVAC_MODE_AUTO
         return HVAC_MODE_OFF
 
     @property
@@ -95,5 +95,5 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         _LOGGER.debug("Setting mode for: %s", self._name)
         if hvac_mode == HVAC_MODE_OFF:
             self.tesla_device.set_status(False)
-        elif hvac_mode == HVAC_MODE_HEAT:
+        elif hvac_mode == HVAC_MODE_AUTO:
             self.tesla_device.set_status(True)

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -13,7 +13,7 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_HVAC = [HVAC_MODE_AUTO, HVAC_MODE_OFF]
+SUPPORT_HVAC = [HVAC_MODE_HEAT_COOL, HVAC_MODE_OFF]
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -46,7 +46,7 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         Need to be one of HVAC_MODE_*.
         """
         if self.tesla_device.is_hvac_enabled():
-            return HVAC_MODE_AUTO
+            return HVAC_MODE_HEAT_COOL
         return HVAC_MODE_OFF
 
     @property
@@ -95,5 +95,5 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         _LOGGER.debug("Setting mode for: %s", self._name)
         if hvac_mode == HVAC_MODE_OFF:
             self.tesla_device.set_status(False)
-        elif hvac_mode == HVAC_MODE_AUTO:
+        elif hvac_mode == HVAC_MODE_HEAT_COOL:
             self.tesla_device.set_status(True)


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Changes the Tesla integration's climate options from `HVAC_MODE_HEAT` to `HVAC_MODE_AUTO` fixing an error that was introduced in the HA climate 1.0 migration.

I've tested this on my Model 3 but obviously haven't tested it on every configuration of Tesla out there.

**Related issue (if applicable):**

The issue was documented in the Polymer repository although the fix was backend related: [Issue Number 2397](https://github.com/home-assistant/home-assistant-polymer/issues/2397)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
