### PR TITLE
 Add improved scene support to the input_datetime integration

### DIFF
--- a/homeassistant/components/input_datetime/reproduce_state.py
+++ b/homeassistant/components/input_datetime/reproduce_state.py
@@ -84,12 +84,18 @@ async def _async_reproduce_state(
     service = SERVICE_SET_DATETIME
     service_data = {ATTR_ENTITY_ID: state.entity_id}
 
-    if is_valid_datetime(state.state):
+    has_time = cur_state.attributes.get(CONF_HAS_TIME)
+    has_date = cur_state.attributes.get(CONF_HAS_DATE)
+
+    if has_time and has_date:
         service_data[ATTR_DATETIME] = state.state
-    elif is_valid_date(state.state):
-        service_data[ATTR_DATE] = state.state
-    elif is_valid_time(state.state):
+    elif has_time:
         service_data[ATTR_TIME] = state.state
+    elif has_date:
+        service_data[ATTR_DATE] = state.state
+    else:
+        _LOGGER.warning("input_datetime needs either has_date or has_time or both")
+        return
 
     await hass.services.async_call(
         DOMAIN, service, service_data, context=context, blocking=True

--- a/homeassistant/components/input_datetime/reproduce_state.py
+++ b/homeassistant/components/input_datetime/reproduce_state.py
@@ -1,0 +1,105 @@
+"""Reproduce an Input datetime state."""
+import asyncio
+import logging
+from typing import Iterable, Optional
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import Context, State
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.util import dt as dt_util
+
+from . import (
+    ATTR_DATE,
+    ATTR_DATETIME,
+    ATTR_TIME,
+    CONF_HAS_DATE,
+    CONF_HAS_TIME,
+    DOMAIN,
+    SERVICE_SET_DATETIME,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def is_valid_datetime(string: str) -> bool:
+    """Test if string dt is a valid datetime."""
+    try:
+        return dt_util.parse_datetime(string) is not None
+    except ValueError:
+        return False
+
+
+def is_valid_date(string: str) -> bool:
+    """Test if string dt is a valid date."""
+    try:
+        return dt_util.parse_date(string) is not None
+    except ValueError:
+        return False
+
+
+def is_valid_time(string: str) -> bool:
+    """Test if string dt is a valid time."""
+    try:
+        return dt_util.parse_time(string) is not None
+    except ValueError:
+        return False
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistantType, state: State, context: Optional[Context] = None
+) -> None:
+    """Reproduce a single state."""
+    cur_state = hass.states.get(state.entity_id)
+
+    if cur_state is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if not (
+        (
+            is_valid_datetime(state.state)
+            and cur_state.attributes.get(CONF_HAS_DATE)
+            and cur_state.attributes.get(CONF_HAS_TIME)
+        )
+        or (
+            is_valid_date(state.state)
+            and cur_state.attributes.get(CONF_HAS_DATE)
+            and not cur_state.attributes.get(CONF_HAS_TIME)
+        )
+        or (
+            is_valid_time(state.state)
+            and cur_state.attributes.get(CONF_HAS_TIME)
+            and not cur_state.attributes.get(CONF_HAS_DATE)
+        )
+    ):
+        _LOGGER.warning(
+            "Invalid state specified for %s: %s", state.entity_id, state.state
+        )
+        return
+
+    # Return if we are already at the right state.
+    if cur_state.state == state.state:
+        return
+
+    service = SERVICE_SET_DATETIME
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    if is_valid_datetime(state.state):
+        service_data[ATTR_DATETIME] = state.state
+    elif is_valid_date(state.state):
+        service_data[ATTR_DATE] = state.state
+    elif is_valid_time(state.state):
+        service_data[ATTR_TIME] = state.state
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
+) -> None:
+    """Reproduce Input datetime states."""
+    await asyncio.gather(
+        *(_async_reproduce_state(hass, state, context) for state in states)
+    )

--- a/tests/components/input_datetime/test_reproduce_state.py
+++ b/tests/components/input_datetime/test_reproduce_state.py
@@ -1,0 +1,69 @@
+"""Test reproduce state for Input datetime."""
+from homeassistant.core import State
+
+from tests.common import async_mock_service
+
+
+async def test_reproducing_states(hass, caplog):
+    """Test reproducing Input datetime states."""
+    hass.states.async_set(
+        "input_datetime.entity_datetime",
+        "2010-10-10 01:20:00",
+        {"has_date": True, "has_time": True},
+    )
+    hass.states.async_set(
+        "input_datetime.entity_time", "01:20:00", {"has_date": False, "has_time": True}
+    )
+    hass.states.async_set(
+        "input_datetime.entity_date",
+        "2010-10-10",
+        {"has_date": True, "has_time": False},
+    )
+
+    datetime_calls = async_mock_service(hass, "input_datetime", "set_datetime")
+
+    # These calls should do nothing as entities already in desired state
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("input_datetime.entity_datetime", "2010-10-10 01:20:00"),
+            State("input_datetime.entity_time", "01:20:00"),
+            State("input_datetime.entity_date", "2010-10-10"),
+        ],
+        blocking=True,
+    )
+
+    assert len(datetime_calls) == 0
+
+    # Test invalid state is handled
+    await hass.helpers.state.async_reproduce_state(
+        [State("input_datetime.entity_datetime", "not_supported")], blocking=True
+    )
+
+    assert "not_supported" in caplog.text
+    assert len(datetime_calls) == 0
+
+    # Make sure correct services are called
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("input_datetime.entity_datetime", "2011-10-10 02:20:00"),
+            State("input_datetime.entity_time", "02:20:00"),
+            State("input_datetime.entity_date", "2011-10-10"),
+            # Should not raise
+            State("input_datetime.non_existing", "2010-10-10 01:20:00"),
+        ],
+        blocking=True,
+    )
+
+    valid_calls = [
+        {
+            "entity_id": "input_datetime.entity_datetime",
+            "datetime": "2011-10-10 02:20:00",
+        },
+        {"entity_id": "input_datetime.entity_time", "time": "02:20:00"},
+        {"entity_id": "input_datetime.entity_date", "date": "2011-10-10"},
+    ]
+    assert len(datetime_calls) == 3
+    for call in datetime_calls:
+        assert call.domain == "input_datetime"
+        assert call.data in valid_calls
+        valid_calls.remove(call.data)


### PR DESCRIPTION
## Breaking Change:

Nothing breaks

## Description:
 Add improved scene support to the input_datetime integration

**Related issue (if applicable):** fixes #26968

## Example entry for `configuration.yaml` (if applicable):
```yaml
input_datetime:
  both_date_and_time:
    name: Input with both date and time
    has_date: true
    has_time: true
  only_date:
    name: Input with only date
    has_date: true
    has_time: false
  only_time:
    name: Input with only time
    has_date: false
    has_time: true

scene:
  - name: one
    entities:
      input_datetime.both_date_and_time:
        state: "2011-10-11 01:20:00"
      input_datetime.only_time:
        state: "01:20:00"
      input_datetime.only_date:
        state: "2011-10-11"
  - name: two
    entities:
      input_datetime.both_date_and_time:
        state: "2012-10-11 02:20:00"
      input_datetime.only_time:
        state: "02:20:00"
      input_datetime.only_date:
        state: "2012-10-11"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
