### PR TITLE
Add ecobee4 model to ecobee integration

### DIFF
--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -19,6 +19,7 @@ ECOBEE_MODEL_TO_NAME = {
     "corSmart": "Carrier/Bryant Cor",
     "nikeSmart": "ecobee3 lite Smart",
     "nikeEms": "ecobee3 lite EMS",
+    "apolloSmart": "ecobee4 Smart",
 }
 
 ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]


### PR DESCRIPTION
## Description:

Simple PR to add a new modelNumber for the ecobee integration, ideally should land at the same time as support for the device registry in the ecobee integration.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
