### PR TITLE
Add support for more Orange Pi devices

### DIFF
--- a/homeassistant/components/orangepi_gpio/__init__.py
+++ b/homeassistant/components/orangepi_gpio/__init__.py
@@ -6,6 +6,8 @@ from OPi import GPIO
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 
+from .const import PIN_MODES
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "orangepi_gpio"
@@ -23,33 +25,13 @@ async def async_setup(hass, config):
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
-
     return True
 
 
 def setup_mode(mode):
     """Set GPIO pin mode."""
-    _LOGGER.debug("Setting GPIO pin mode as %s", mode)
-    if mode == "pc":
-        import orangepi.pc
-
-        GPIO.setmode(orangepi.pc.BOARD)
-    elif mode == "zeroplus":
-        import orangepi.zeroplus
-
-        GPIO.setmode(orangepi.zeroplus.BOARD)
-    elif mode == "zeroplus2":
-        import orangepi.zeroplus
-
-        GPIO.setmode(orangepi.zeroplus2.BOARD)
-    elif mode == "duo":
-        import nanopi.duo
-
-        GPIO.setmode(nanopi.duo.BOARD)
-    elif mode == "neocore2":
-        import nanopi.neocore2
-
-        GPIO.setmode(nanopi.neocore2.BOARD)
+    _LOGGER.debug("Setting GPIO pin mode as %s", PIN_MODES[mode])
+    GPIO.setmode(PIN_MODES[mode])
 
 
 def setup_input(port):

--- a/homeassistant/components/orangepi_gpio/const.py
+++ b/homeassistant/components/orangepi_gpio/const.py
@@ -1,5 +1,23 @@
 """Constants for Orange Pi GPIO."""
 
+from nanopi import duo, neocore2
+from orangepi import (
+    lite,
+    lite2,
+    one,
+    oneplus,
+    pc,
+    pc2,
+    pcplus,
+    pi3,
+    plus2e,
+    prime,
+    r1,
+    winplus,
+    zero,
+    zeroplus,
+    zeroplus2,
+)
 import voluptuous as vol
 
 from homeassistant.helpers import config_validation as cv
@@ -8,12 +26,30 @@ CONF_INVERT_LOGIC = "invert_logic"
 CONF_PIN_MODE = "pin_mode"
 CONF_PORTS = "ports"
 DEFAULT_INVERT_LOGIC = False
-PIN_MODES = ["pc", "zeroplus", "zeroplus2", "deo", "neocore2"]
+PIN_MODES = {
+    "lite": lite.BOARD,
+    "lite2": lite2.BOARD,
+    "one": one.BOARD,
+    "oneplus": oneplus.BOARD,
+    "pc": pc.BOARD,
+    "pc2": pc2.BOARD,
+    "pcplus": pcplus.BOARD,
+    "pi3": pi3.BOARD,
+    "plus2e": plus2e.BOARD,
+    "prime": prime.BOARD,
+    "r1": r1.BOARD,
+    "winplus": winplus.BOARD,
+    "zero": zero.BOARD,
+    "zeroplus": zeroplus.BOARD,
+    "zeroplus2": zeroplus2.BOARD,
+    "duo": duo.BOARD,
+    "neocore2": neocore2.BOARD,
+}
 
 _SENSORS_SCHEMA = vol.Schema({cv.positive_int: cv.string})
 
 PORT_SCHEMA = {
     vol.Required(CONF_PORTS): _SENSORS_SCHEMA,
-    vol.Required(CONF_PIN_MODE): vol.In(PIN_MODES),
+    vol.Required(CONF_PIN_MODE): vol.In(PIN_MODES.keys()),
     vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
 }

--- a/homeassistant/components/orangepi_gpio/manifest.json
+++ b/homeassistant/components/orangepi_gpio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Orangepi GPIO",
   "documentation": "https://www.home-assistant.io/integrations/orangepi_gpio",
   "requirements": [
-    "OPi.GPIO==0.3.6"
+    "OPi.GPIO==0.4.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -41,7 +41,7 @@ HAP-python==2.6.0
 Mastodon.py==1.5.0
 
 # homeassistant.components.orangepi_gpio
-OPi.GPIO==0.3.6
+OPi.GPIO==0.4.0
 
 # homeassistant.components.essent
 PyEssent==0.13


### PR DESCRIPTION
## Description:
Add support for more Orange Pi devices. As these devices were only just added in the latest OPi.GPIO library, bump version of this library as well. Also adds new configuration values for existing devices to future-proof any possible changes per device instead of `device-groups`.

Because the number of devices increased quite a bit, set the modes differently to reduce redundancy. 

As this also moves all imports to top-level, it also fixes #27284

**Related issue (if applicable):** fixes #27966

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10942
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
