### PR TITLE
Remove and replace pytest-azurepipelines

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -118,6 +118,8 @@ stages:
                 # This is a TEMP. Eventually we should make sure our 4 dependencies drop typing.
                 # Find offending deps with `pipdeptree -r -p typing`
                 pip uninstall -y typing
+                # This is a temporary workaround to deal with cache
+                pip uninstall -y pytest-azurepipelines
           - script: |
               . venv/bin/activate
               pip install -e .

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -118,8 +118,6 @@ stages:
                 # This is a TEMP. Eventually we should make sure our 4 dependencies drop typing.
                 # Find offending deps with `pipdeptree -r -p typing`
                 pip uninstall -y typing
-                # This is a temporary workaround to deal with cache
-                pip uninstall -y pytest-azurepipelines
           - script: |
               . venv/bin/activate
               pip install -e .
@@ -127,6 +125,8 @@ stages:
           - script: |
               set -e
               . venv/bin/activate
+              # This is a temporary workaround to deal with cache
+              pip uninstall -y pytest-azurepipelines
               pytest --timeout=9 --durations=10 -n 2 --dist loadfile --junitxml=test-results.xml --cov --cov-report=xml -qq -o console_output_style=count -p no:sugar tests
             displayName: "Run pytest for python $(python.container)"
             condition: succeeded()

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -129,6 +129,7 @@ stages:
             displayName: "Run pytest for python $(python.container)"
             condition: succeeded()
           - script: |
+              . venv/bin/activate
               codecov --token $(codecovToken)
             displayName: "Uploading test coverage to Codecov"
             condition: and(succeeded(), eq(variables['python.container'], variables['PythonMain']))

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -4,9 +4,9 @@ trigger:
   batch: true
   branches:
     include:
-    - rc
-    - dev
-    - master
+      - rc
+      - dev
+      - master
 pr:
   - rc
   - dev
@@ -14,176 +14,183 @@ pr:
 
 resources:
   containers:
-  - container: 36
-    image: homeassistant/ci-azure:3.6
-  - container: 37
-    image: homeassistant/ci-azure:3.7
+    - container: 36
+      image: homeassistant/ci-azure:3.6
+    - container: 37
+      image: homeassistant/ci-azure:3.7
   repositories:
     - repository: azure
       type: github
-      name: 'home-assistant/ci-azure'
-      endpoint: 'home-assistant'
+      name: "home-assistant/ci-azure"
+      endpoint: "home-assistant"
 variables:
   - name: PythonMain
-    value: '36'
+    value: "36"
   - group: codecov
 
 stages:
+  - stage: "Overview"
+    jobs:
+      - job: "Lint"
+        pool:
+          vmImage: "ubuntu-latest"
+        container: $[ variables['PythonMain'] ]
+        steps:
+          - template: templates/azp-step-cache.yaml@azure
+            parameters:
+              keyfile: "requirements_test.txt | homeassistant/package_constraints.txt"
+              build: |
+                python -m venv venv
 
-- stage: 'Overview'
-  jobs:
-  - job: 'Lint'
-    pool:
-      vmImage: 'ubuntu-latest'
-    container: $[ variables['PythonMain'] ]
-    steps:
-    - template: templates/azp-step-cache.yaml@azure
-      parameters:
-        keyfile: 'requirements_test.txt | homeassistant/package_constraints.txt'
-        build: |
-          python -m venv venv
+                . venv/bin/activate
+                pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
+                pre-commit install-hooks
+          - script: |
+              . venv/bin/activate
+              pre-commit run flake8 --all-files
+            displayName: "Run flake8"
+      - job: "Validate"
+        pool:
+          vmImage: "ubuntu-latest"
+        container: $[ variables['PythonMain'] ]
+        steps:
+          - template: templates/azp-step-cache.yaml@azure
+            parameters:
+              keyfile: "homeassistant/package_constraints.txt"
+              build: |
+                python -m venv venv
 
-          . venv/bin/activate
-          pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
-          pre-commit install-hooks
-    - script: |
-        . venv/bin/activate
-        pre-commit run flake8 --all-files
-      displayName: 'Run flake8'
-  - job: 'Validate'
-    pool:
-      vmImage: 'ubuntu-latest'
-    container: $[ variables['PythonMain'] ]
-    steps:
-    - template: templates/azp-step-cache.yaml@azure
-      parameters:
-        keyfile: 'homeassistant/package_constraints.txt'
-        build: |
-          python -m venv venv
+                . venv/bin/activate
+                pip install -e .
+          - script: |
+              . venv/bin/activate
+              python -m script.hassfest validate
+            displayName: "Validate manifests"
+          - script: |
+              . venv/bin/activate
+              ./script/gen_requirements_all.py validate
+            displayName: "requirements_all validate"
+      - job: "CheckFormat"
+        pool:
+          vmImage: "ubuntu-latest"
+        container: $[ variables['PythonMain'] ]
+        steps:
+          - template: templates/azp-step-cache.yaml@azure
+            parameters:
+              keyfile: "requirements_test.txt | homeassistant/package_constraints.txt"
+              build: |
+                python -m venv venv
 
-          . venv/bin/activate
-          pip install -e .
-    - script: |
-        . venv/bin/activate
-        python -m script.hassfest validate
-      displayName: 'Validate manifests'
-    - script: |
-        . venv/bin/activate
-        ./script/gen_requirements_all.py validate
-      displayName: 'requirements_all validate'
-  - job: 'CheckFormat'
-    pool:
-      vmImage: 'ubuntu-latest'
-    container: $[ variables['PythonMain'] ]
-    steps:
-    - template: templates/azp-step-cache.yaml@azure
-      parameters:
-        keyfile: 'requirements_test.txt | homeassistant/package_constraints.txt'
-        build: |
-          python -m venv venv
+                . venv/bin/activate
+                pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
+                pre-commit install-hooks
+          - script: |
+              . venv/bin/activate
+              pre-commit run black --all-files
+            displayName: "Check Black formatting"
 
-          . venv/bin/activate
-          pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
-          pre-commit install-hooks
-    - script: |
-        . venv/bin/activate
-        pre-commit run black --all-files
-      displayName: 'Check Black formatting'
+  - stage: "Tests"
+    dependsOn:
+      - "Overview"
+    jobs:
+      - job: "PyTest"
+        pool:
+          vmImage: "ubuntu-latest"
+        strategy:
+          maxParallel: 3
+          matrix:
+            Python36:
+              python.container: "36"
+            Python37:
+              python.container: "37"
+        container: $[ variables['python.container'] ]
+        steps:
+          - template: templates/azp-step-cache.yaml@azure
+            parameters:
+              keyfile: "requirements_test_all.txt | homeassistant/package_constraints.txt"
+              build: |
+                set -e
+                python -m venv venv
 
-- stage: 'Tests'
-  dependsOn:
-    - 'Overview'
-  jobs:
-  - job: 'PyTest'
-    pool:
-      vmImage: 'ubuntu-latest'
-    strategy:
-      maxParallel: 3
-      matrix:
-        Python36:
-          python.container: '36'
-        Python37:
-          python.container: '37'
-    container: $[ variables['python.container'] ]
-    steps:
-    - template: templates/azp-step-cache.yaml@azure
-      parameters:
-        keyfile: 'requirements_test_all.txt | homeassistant/package_constraints.txt'
-        build: |
-          set -e
-          python -m venv venv
+                . venv/bin/activate
+                pip install -U pip setuptools pytest-xdist -c homeassistant/package_constraints.txt
+                pip install -r requirements_test_all.txt -c homeassistant/package_constraints.txt
+                # This is a TEMP. Eventually we should make sure our 4 dependencies drop typing.
+                # Find offending deps with `pipdeptree -r -p typing`
+                pip uninstall -y typing
+          - script: |
+              . venv/bin/activate
+              pip install -e .
+            displayName: "Install Home Assistant"
+          - script: |
+              set -e
+              . venv/bin/activate
+              pytest --timeout=9 --durations=10 -n 2 --dist loadfile --junitxml=test-results.xml --cov --cov-report=xml -qq -o console_output_style=count -p no:sugar tests
+            displayName: "Run pytest for python $(python.container)"
+            condition: succeeded()
+          - script: |
+              codecov --token $(codecovToken)
+            displayName: "Uploading test coverage to Codecov"
+            condition: and(succeeded(), eq(variables['python.container'], variables['PythonMain']))
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFiles: "test-results.xml"
+              testRunTitle: "Publish test results for Python $(python.container)"
+            condition: succeededOrFailed()
+          - task: PublishCodeCoverageResults@1
+            inputs:
+              codeCoverageTool: cobertura
+              summaryFileLocation: coverage.xml
+            displayName: "publish coverage artifact"
+            condition: and(succeeded(), eq(variables['python.container'], variables['PythonMain']))
+          - script: |
+              set -e
+              script/check_dirty
+            displayName: "Run dirty check (Are tests are leaving files behind?)"
 
-          . venv/bin/activate
-          pip install -U pip setuptools pytest-azurepipelines pytest-xdist -c homeassistant/package_constraints.txt
-          pip install -r requirements_test_all.txt -c homeassistant/package_constraints.txt
-          # This is a TEMP. Eventually we should make sure our 4 dependencies drop typing.
-          # Find offending deps with `pipdeptree -r -p typing`
-          pip uninstall -y typing
-    - script: |
-        . venv/bin/activate
-        pip install -e .
-      displayName: 'Install Home Assistant'
-    - script: |
-        set -e
+  - stage: "FullCheck"
+    dependsOn:
+      - "Overview"
+    jobs:
+      - job: "Pylint"
+        pool:
+          vmImage: "ubuntu-latest"
+        container: $[ variables['PythonMain'] ]
+        steps:
+          - template: templates/azp-step-cache.yaml@azure
+            parameters:
+              keyfile: "requirements_all.txt | requirements_test.txt | homeassistant/package_constraints.txt"
+              build: |
+                set -e
+                python -m venv venv
 
-        . venv/bin/activate
-        pytest --timeout=9 --durations=10 -n 2 --dist loadfile -qq -o console_output_style=count -p no:sugar tests
-        script/check_dirty
-      displayName: 'Run pytest for python $(python.container)'
-      condition: and(succeeded(), ne(variables['python.container'], variables['PythonMain']))
-    - script: |
-        set -e
+                . venv/bin/activate
+                pip install -U pip setuptools
+                pip install -r requirements_all.txt -c homeassistant/package_constraints.txt
+                pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
+          - script: |
+              . venv/bin/activate
+              pip install -e .
+            displayName: "Install Home Assistant"
+          - script: |
+              . venv/bin/activate
+              pylint -j 2 homeassistant
+            displayName: "Run pylint"
+      - job: "Mypy"
+        pool:
+          vmImage: "ubuntu-latest"
+        container: $[ variables['PythonMain'] ]
+        steps:
+          - template: templates/azp-step-cache.yaml@azure
+            parameters:
+              keyfile: "requirements_test.txt | setup.py | homeassistant/package_constraints.txt"
+              build: |
+                python -m venv venv
 
-        . venv/bin/activate
-        pytest --timeout=9 --durations=10 -n 2 --dist loadfile --cov homeassistant --cov-report html -qq -o console_output_style=count -p no:sugar tests
-        codecov --token $(codecovToken)
-        script/check_dirty
-      displayName: 'Run pytest for python $(python.container) / coverage'
-      condition: and(succeeded(), eq(variables['python.container'], variables['PythonMain']))
-
-- stage: 'FullCheck'
-  dependsOn:
-    - 'Overview'
-  jobs:
-  - job: 'Pylint'
-    pool:
-      vmImage: 'ubuntu-latest'
-    container: $[ variables['PythonMain'] ]
-    steps:
-    - template: templates/azp-step-cache.yaml@azure
-      parameters:
-        keyfile: 'requirements_all.txt | requirements_test.txt | homeassistant/package_constraints.txt'
-        build: |
-          set -e
-          python -m venv venv
-
-          . venv/bin/activate
-          pip install -U pip setuptools
-          pip install -r requirements_all.txt -c homeassistant/package_constraints.txt
-          pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
-    - script: |
-        . venv/bin/activate
-        pip install -e .
-      displayName: 'Install Home Assistant'
-    - script: |
-        . venv/bin/activate
-        pylint -j 2 homeassistant
-      displayName: 'Run pylint'
-  - job: 'Mypy'
-    pool:
-      vmImage: 'ubuntu-latest'
-    container: $[ variables['PythonMain'] ]
-    steps:
-    - template: templates/azp-step-cache.yaml@azure
-      parameters:
-        keyfile: 'requirements_test.txt | setup.py | homeassistant/package_constraints.txt'
-        build: |
-          python -m venv venv
-
-          . venv/bin/activate
-          pip install -e . -r requirements_test.txt -c homeassistant/package_constraints.txt
-          pre-commit install-hooks
-    - script: |
-        . venv/bin/activate
-        pre-commit run mypy --all-files
-      displayName: 'Run mypy'
+                . venv/bin/activate
+                pip install -e . -r requirements_test.txt -c homeassistant/package_constraints.txt
+                pre-commit install-hooks
+          - script: |
+              . venv/bin/activate
+              pre-commit run mypy --all-files
+            displayName: "Run mypy"

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -137,12 +137,13 @@ stages:
             inputs:
               testResultsFiles: "test-results.xml"
               testRunTitle: "Publish test results for Python $(python.container)"
+            displayName: "Publish test results"
             condition: succeededOrFailed()
           - task: PublishCodeCoverageResults@1
             inputs:
               codeCoverageTool: cobertura
               summaryFileLocation: coverage.xml
-            displayName: "publish coverage artifact"
+            displayName: "Publish coverage artifact"
             condition: and(succeeded(), eq(variables['python.container'], variables['PythonMain']))
           - script: |
               set -e


### PR DESCRIPTION
## Description:

Attempt in removing and replacing the `pytest-azurepipelines` package.
It seems to conflict with `pytest-xdist`. I've replaced the missing functionality by upload test and code coverage to azure manually.

😠 The vscode YAML extension reformatted the file 😠 

Will fix that depending on the test results (or not if this is considered better formatting 😉 )

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
