### PR TITLE
If emulated hue entity is a lock, convert service to lock/unlock

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -23,6 +23,15 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
     SUPPORT_SET_POSITION,
 )
+from homeassistant.components.lock import (
+    ATTR_CODE,
+    ATTR_CODE_FORMAT,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+    SERVICE_LOCK,
+    SERVICE_UNLOCK,
+    SERVICE_OPEN,
+)
 from homeassistant.components.fan import (
     ATTR_SPEED,
     SPEED_HIGH,
@@ -334,6 +343,14 @@ class HueOneLightChangeView(HomeAssistantView):
                     service = SERVICE_VOLUME_SET
                     # Convert 0-100 to 0.0-1.0
                     data[ATTR_MEDIA_VOLUME_LEVEL] = parsed[STATE_BRIGHTNESS] / 100.0
+
+        # If the requested entity is a lock, convert to lock/unlock
+        elif entity.domain == lock.DOMAIN:
+            domain = entity.domain
+            if service == SERVICE_TURN_ON:
+                service = SERVICE_UNLOCK
+            else:
+                service = SERVICE_LOCK
 
         # If the requested entity is a cover, convert to open_cover/close_cover
         elif entity.domain == cover.DOMAIN:

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -9,6 +9,7 @@ from homeassistant.components import (
     cover,
     fan,
     light,
+    lock,
     media_player,
     scene,
     script,
@@ -24,13 +25,8 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION,
 )
 from homeassistant.components.lock import (
-    ATTR_CODE,
-    ATTR_CODE_FORMAT,
-    STATE_LOCKED,
-    STATE_UNLOCKED,
     SERVICE_LOCK,
     SERVICE_UNLOCK,
-    SERVICE_OPEN,
 )
 from homeassistant.components.fan import (
     ATTR_SPEED,


### PR DESCRIPTION
## Description:

Items in the `lock` domain can already be exposed by adding `emulated_hue_hidden: false`, but HA does not know how to handle the request when it comes in.

Most of the other domains are already present in `components/emulated_hue/hue_api.py` but this one was not.