### PR TITLE
Add improved scene support to the timer integration

### DIFF
--- a/homeassistant/components/timer/reproduce_state.py
+++ b/homeassistant/components/timer/reproduce_state.py
@@ -1,0 +1,70 @@
+"""Reproduce an Timer state."""
+import asyncio
+import logging
+from typing import Iterable, Optional
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import Context, State
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import (
+    ATTR_DURATION,
+    DOMAIN,
+    SERVICE_CANCEL,
+    SERVICE_PAUSE,
+    SERVICE_START,
+    STATUS_ACTIVE,
+    STATUS_IDLE,
+    STATUS_PAUSED,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_STATES = {STATUS_IDLE, STATUS_ACTIVE, STATUS_PAUSED}
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistantType, state: State, context: Optional[Context] = None
+) -> None:
+    """Reproduce a single state."""
+    cur_state = hass.states.get(state.entity_id)
+
+    if cur_state is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if state.state not in VALID_STATES:
+        _LOGGER.warning(
+            "Invalid state specified for %s: %s", state.entity_id, state.state
+        )
+        return
+
+    # Return if we are already at the right state.
+    if cur_state.state == state.state and cur_state.attributes.get(
+        ATTR_DURATION
+    ) == state.attributes.get(ATTR_DURATION):
+        return
+
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    if state.state == STATUS_ACTIVE:
+        service = SERVICE_START
+        if ATTR_DURATION in state.attributes:
+            service_data[ATTR_DURATION] = state.attributes[ATTR_DURATION]
+    elif state.state == STATUS_PAUSED:
+        service = SERVICE_PAUSE
+    elif state.state == STATUS_IDLE:
+        service = SERVICE_CANCEL
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
+) -> None:
+    """Reproduce Timer states."""
+    await asyncio.gather(
+        *(_async_reproduce_state(hass, state, context) for state in states)
+    )

--- a/tests/components/timer/test_reproduce_state.py
+++ b/tests/components/timer/test_reproduce_state.py
@@ -1,0 +1,84 @@
+"""Test reproduce state for Timer."""
+from homeassistant.components.timer import (
+    ATTR_DURATION,
+    SERVICE_CANCEL,
+    SERVICE_PAUSE,
+    SERVICE_START,
+    STATUS_ACTIVE,
+    STATUS_IDLE,
+    STATUS_PAUSED,
+)
+from homeassistant.core import State
+from tests.common import async_mock_service
+
+
+async def test_reproducing_states(hass, caplog):
+    """Test reproducing Timer states."""
+    hass.states.async_set("timer.entity_idle", STATUS_IDLE, {})
+    hass.states.async_set("timer.entity_paused", STATUS_PAUSED, {})
+    hass.states.async_set("timer.entity_active", STATUS_ACTIVE, {})
+    hass.states.async_set(
+        "timer.entity_active_attr", STATUS_ACTIVE, {ATTR_DURATION: "00:01:00"}
+    )
+
+    start_calls = async_mock_service(hass, "timer", SERVICE_START)
+    pause_calls = async_mock_service(hass, "timer", SERVICE_PAUSE)
+    cancel_calls = async_mock_service(hass, "timer", SERVICE_CANCEL)
+
+    # These calls should do nothing as entities already in desired state
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("timer.entity_idle", STATUS_IDLE),
+            State("timer.entity_paused", STATUS_PAUSED),
+            State("timer.entity_active", STATUS_ACTIVE),
+            State(
+                "timer.entity_active_attr", STATUS_ACTIVE, {ATTR_DURATION: "00:01:00"}
+            ),
+        ],
+        blocking=True,
+    )
+
+    assert len(start_calls) == 0
+    assert len(pause_calls) == 0
+    assert len(cancel_calls) == 0
+
+    # Test invalid state is handled
+    await hass.helpers.state.async_reproduce_state(
+        [State("timer.entity_idle", "not_supported")], blocking=True
+    )
+
+    assert "not_supported" in caplog.text
+    assert len(start_calls) == 0
+    assert len(pause_calls) == 0
+    assert len(cancel_calls) == 0
+
+    # Make sure correct services are called
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("timer.entity_idle", STATUS_ACTIVE, {ATTR_DURATION: "00:01:00"}),
+            State("timer.entity_paused", STATUS_ACTIVE),
+            State("timer.entity_active", STATUS_IDLE),
+            State("timer.entity_active_attr", STATUS_PAUSED),
+            # Should not raise
+            State("timer.non_existing", "on"),
+        ],
+        blocking=True,
+    )
+
+    valid_start_calls = [
+        {"entity_id": "timer.entity_idle", ATTR_DURATION: "00:01:00"},
+        {"entity_id": "timer.entity_paused"},
+    ]
+    assert len(start_calls) == 2
+    for call in start_calls:
+        assert call.domain == "timer"
+        assert call.data in valid_start_calls
+        valid_start_calls.remove(call.data)
+
+    assert len(pause_calls) == 1
+    assert pause_calls[0].domain == "timer"
+    assert pause_calls[0].data == {"entity_id": "timer.entity_active_attr"}
+
+    assert len(cancel_calls) == 1
+    assert cancel_calls[0].domain == "timer"
+    assert cancel_calls[0].data == {"entity_id": "timer.entity_active"}


### PR DESCRIPTION
## Breaking Change:

Nothing breaks

## Description:
Add improved scene support to the timer integration

**Related issue (if applicable):** fixes #26971

## Example entry for `configuration.yaml` (if applicable):
```yaml
timer:
  test:
    duration: '00:00:30'

scene:
  - name: timer_start
    entities:
      timer.test:
        duration: "00:01:00"
        state: active
  - name: timer_stop
    entities:
      timer.test:
        state: idle
  - name: timer_pause
    entities:
      timer.test:
        state: paused
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
