### PR TITLE
Fix test coverage, reverting top level import ptvsd

### DIFF
--- a/homeassistant/components/ptvsd/__init__.py
+++ b/homeassistant/components/ptvsd/__init__.py
@@ -8,7 +8,6 @@ from asyncio import Event
 import logging
 from threading import Thread
 
-import ptvsd
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -37,6 +36,12 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType):
     """Set up ptvsd debugger."""
+
+    # This is a local import, since importing this at the top, will cause
+    # ptvsd to hook into `sys.settrace`. So does `coverage` to generate
+    # coverage, resulting in a battle and incomplete code test coverage.
+    import ptvsd  # pylint: disable=import-outside-toplevel
+
     conf = config[DOMAIN]
     host = conf[CONF_HOST]
     port = conf[CONF_PORT]


### PR DESCRIPTION
## Description:

PR #28087 Moved the imports for the `ptvsd` integration to the top, which is the process we are in right now (see #27284). However, `ptvsd` will immediately start hooking into `sys.settrace`.

This causes a problem on multiple levels, especially in our test, since `coverage` uses the same technique to get test coverage during running our tests (e.g. in Azure Pipelines).

In the end, sometimes `ptvsd`, sometimes `coverage` wins the battle. Causing incomplete coverage results. (As we are experiencing right now).

This PR addressed this by reverting #28087. I've added an additional note to the local import to prevent it from happening/being moved in the future again.

![image](https://user-images.githubusercontent.com/195327/67339223-0b178380-f52b-11e9-9e6e-3cf06504d8be.png)

🎉 

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
