### PR TITLE
Move imports in hue component

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -8,11 +8,11 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
-from .const import DOMAIN
 from .bridge import HueBridge
-
-# Loading the config flow file will register the flow
-from .config_flow import configured_hosts
+from .config_flow import (
+    configured_hosts,
+)  # Loading the config flow file will register the flow
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/binary_sensor.py
+++ b/homeassistant/components/hue/binary_sensor.py
@@ -1,19 +1,31 @@
 """Hue binary sensor entities."""
+
+from aiohue.sensors import TYPE_ZLL_PRESENCE
+
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice,
     DEVICE_CLASS_MOTION,
+    BinarySensorDevice,
 )
 from homeassistant.components.hue.sensor_base import (
     GenericZLLSensor,
+    SensorManager,
     async_setup_entry as shared_async_setup_entry,
 )
-
 
 PRESENCE_NAME_FORMAT = "{} motion"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Defer binary sensor setup to the shared sensor module."""
+    SensorManager.sensor_config_map.update(
+        {
+            TYPE_ZLL_PRESENCE: {
+                "binary": True,
+                "name_format": PRESENCE_NAME_FORMAT,
+                "class": HuePresence,
+            }
+        }
+    )
     await shared_async_setup_entry(hass, config_entry, async_add_entities, binary=True)
 
 

--- a/homeassistant/components/hue/helpers.py
+++ b/homeassistant/components/hue/helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for Philips Hue."""
-from homeassistant.helpers.entity_registry import async_get_registry as get_ent_reg
 from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
+from homeassistant.helpers.entity_registry import async_get_registry as get_ent_reg
 
 from .const import DOMAIN
 

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -2,8 +2,8 @@
 import asyncio
 from datetime import timedelta
 import logging
-from time import monotonic
 import random
+from time import monotonic
 
 import aiohue
 import async_timeout
@@ -14,21 +14,22 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_FLASH,
-    ATTR_TRANSITION,
     ATTR_HS_COLOR,
+    ATTR_TRANSITION,
     EFFECT_COLORLOOP,
     EFFECT_RANDOM,
     FLASH_LONG,
     FLASH_SHORT,
     SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT,
     SUPPORT_FLASH,
-    SUPPORT_COLOR,
     SUPPORT_TRANSITION,
     Light,
 )
 from homeassistant.util import color
+
 from .helpers import remove_devices
 
 SCAN_INTERVAL = timedelta(seconds=5)

--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -1,15 +1,17 @@
 """Hue sensor entities."""
+from aiohue.sensors import TYPE_ZLL_LIGHTLEVEL, TYPE_ZLL_TEMPERATURE
+
+from homeassistant.components.hue.sensor_base import (
+    GenericZLLSensor,
+    SensorManager,
+    async_setup_entry as shared_async_setup_entry,
+)
 from homeassistant.const import (
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_TEMPERATURE,
     TEMP_CELSIUS,
 )
 from homeassistant.helpers.entity import Entity
-from homeassistant.components.hue.sensor_base import (
-    GenericZLLSensor,
-    async_setup_entry as shared_async_setup_entry,
-)
-
 
 LIGHT_LEVEL_NAME_FORMAT = "{} light level"
 TEMPERATURE_NAME_FORMAT = "{} temperature"
@@ -17,6 +19,20 @@ TEMPERATURE_NAME_FORMAT = "{} temperature"
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Defer sensor setup to the shared sensor module."""
+    SensorManager.sensor_config_map.update(
+        {
+            TYPE_ZLL_LIGHTLEVEL: {
+                "binary": False,
+                "name_format": LIGHT_LEVEL_NAME_FORMAT,
+                "class": HueLightLevel,
+            },
+            TYPE_ZLL_TEMPERATURE: {
+                "binary": False,
+                "name_format": TEMPERATURE_NAME_FORMAT,
+                "class": HueTemperature,
+            },
+        }
+    )
     await shared_async_setup_entry(hass, config_entry, async_add_entities, binary=False)
 
 


### PR DESCRIPTION
## Breaking Change:

Maybe?
This PR includes a small refactoring to avoid a circular dependence on classes.
Although the tests do not complain, it is not a trivial modification and I do not have the devices to validate it.

## Description:

Moved import from function to top-level as requested in #27284

**Related issue (if applicable):** fixes 27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
