### PR TITLE
Fix #28104 - CalDav support for floating datetimes

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -278,6 +278,10 @@ class WebDavCalendarData:
     def to_datetime(obj):
         """Return a datetime."""
         if isinstance(obj, datetime):
+            if obj.tzinfo is None:
+                # floating value, not bound to any time zone in particular
+                # represent same time regardless of which time zone is currently being observed
+                return obj.replace(tzinfo=dt.DEFAULT_TIME_ZONE)
             return obj
         return dt.as_local(dt.dt.datetime.combine(obj, dt.dt.time.min))
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -262,9 +262,12 @@ class WebDavCalendarData:
     @staticmethod
     def is_over(vevent):
         """Return if the event is over."""
-        return dt.now() >= WebDavCalendarData.to_datetime(
-            WebDavCalendarData.get_end_date(vevent)
-        )
+        end_date = WebDavCalendarData.to_datetime(WebDavCalendarData.get_end_date(vevent))
+        if end_date.tzinfo is None:
+            # floating value, not bound to any time zone in particular
+            # represent same time regardless of which time zone is currently being observed
+            end_date = end_date.astimezone(dt.DEFAULT_TIME_ZONE)
+        return dt.now() >= end_date
 
     @staticmethod
     def get_hass_date(obj):

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -262,12 +262,9 @@ class WebDavCalendarData:
     @staticmethod
     def is_over(vevent):
         """Return if the event is over."""
-        end_date = WebDavCalendarData.to_datetime(WebDavCalendarData.get_end_date(vevent))
-        if end_date.tzinfo is None:
-            # floating value, not bound to any time zone in particular
-            # represent same time regardless of which time zone is currently being observed
-            end_date = end_date.astimezone(dt.DEFAULT_TIME_ZONE)
-        return dt.now() >= end_date
+        return dt.now() >= WebDavCalendarData.to_datetime(
+            WebDavCalendarData.get_end_date(vevent)
+        )
 
     @staticmethod
     def get_hass_date(obj):

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -304,6 +304,7 @@ async def test_ongoing_event_different_tz(mock_now, hass, calendar):
         "location": "San Francisco",
     }
 
+
 @patch("homeassistant.util.dt.now", return_value=_local_datetime(19, 10))
 async def test_ongoing_floating_event_returned(mock_now, hass, calendar):
     """Test that floating events without timezones work."""
@@ -325,6 +326,7 @@ async def test_ongoing_floating_event_returned(mock_now, hass, calendar):
         "location": "Hamburg",
         "description": "What a day",
     }
+
 
 @patch("homeassistant.util.dt.now", return_value=_local_datetime(8, 30))
 async def test_ongoing_event_with_offset(mock_now, hass, calendar):

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -112,6 +112,19 @@ DESCRIPTION:Sunny day
 END:VEVENT
 END:VCALENDAR
 """,
+    """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Global Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:8
+DTSTART:20171127T190000
+DTEND:20171127T200000
+SUMMARY:This is a floating Event
+LOCATION:Hamburg
+DESCRIPTION:What a day
+END:VEVENT
+END:VCALENDAR
+""",
 ]
 
 CALDAV_CONFIG = {
@@ -291,6 +304,27 @@ async def test_ongoing_event_different_tz(mock_now, hass, calendar):
         "location": "San Francisco",
     }
 
+@patch("homeassistant.util.dt.now", return_value=_local_datetime(19, 10))
+async def test_ongoing_floating_event_returned(mock_now, hass, calendar):
+    """Test that floating events without timezones work."""
+    assert await async_setup_component(hass, "calendar", {"calendar": CALDAV_CONFIG})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("calendar.private")
+    print(dt.DEFAULT_TIME_ZONE)
+    print(state)
+    assert state.name == calendar.name
+    assert state.state == STATE_ON
+    assert dict(state.attributes) == {
+        "friendly_name": "Private",
+        "message": "This is a floating Event",
+        "all_day": False,
+        "offset_reached": False,
+        "start_time": "2017-11-27 19:00:00",
+        "end_time": "2017-11-27 20:00:00",
+        "location": "Hamburg",
+        "description": "What a day",
+    }
 
 @patch("homeassistant.util.dt.now", return_value=_local_datetime(8, 30))
 async def test_ongoing_event_with_offset(mock_now, hass, calendar):


### PR DESCRIPTION
## Description:

Timzones are optional in CalDav

It is possible that an entry contains neither a TZID, nor is an UTC time.
When this is the case, it should be treated as a floating date-time value,
which represent the same hour, minute, and second value regardless of which
time zone is currently being observed.

For Home-Assistant the correct timezone therefore is whatever is configured
as local time in the settings.

See https://www.kanzaki.com/docs/ical/dateTime.html

After this change, the following entry works as well:

```
BEGIN:VCALENDAR
VERSION:2.0
CALSCALE:GREGORIAN
BEGIN:VEVENT
UID:uid5@example.com
SUMMARY:Test
DTSTART:20191023T003400
DTEND:20191023T110400
STATUS:CONFIRMED
SEQUENCE:3
END:VEVENT
END:VCALENDAR
```

**Related issue (if applicable):** fixes #28104

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
