### PR TITLE
Add unique_id to yeelight light

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -411,7 +411,7 @@ class YeelightGenericLight(Light):
         """Initialize the Yeelight light."""
         self.config = device.config
         self._device = device
-        self._unique_id = self._device.mac
+        self._unique_id = device.mac
 
         self._brightness = None
         self._color_temp = None

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -411,6 +411,7 @@ class YeelightGenericLight(Light):
         """Initialize the Yeelight light."""
         self.config = device.config
         self._device = device
+        self._unique_id = self._device.mac
 
         self._brightness = None
         self._color_temp = None
@@ -471,6 +472,11 @@ class YeelightGenericLight(Light):
     def name(self) -> str:
         """Return the name of the device if any."""
         return self.device.name
+
+    @property
+    def unique_id(self):
+        """Return Unique ID for entity."""
+        return self._unique_id
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -3,7 +3,8 @@
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
   "requirements": [
-    "yeelight==0.5.0"
+    "yeelight==0.5.0",
+    "getmac==0.8.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -556,6 +556,7 @@ georss_qld_bushfire_alert_client==0.3
 # homeassistant.components.braviatv
 # homeassistant.components.huawei_lte
 # homeassistant.components.nmap_tracker
+# homeassistant.components.yeelight
 getmac==0.8.1
 
 # homeassistant.components.gitter

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -206,6 +206,7 @@ georss_qld_bushfire_alert_client==0.3
 # homeassistant.components.braviatv
 # homeassistant.components.huawei_lte
 # homeassistant.components.nmap_tracker
+# homeassistant.components.yeelight
 getmac==0.8.1
 
 # homeassistant.components.glances


### PR DESCRIPTION
## Breaking Change:
None

## Description:
This PR adds `unique_id` property to yeelight light entities. MAC address of the device is used. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
