### PR TITLE
Add config flow for tesla component

### DIFF
--- a/homeassistant/components/tesla/.translations/en.json
+++ b/homeassistant/components/tesla/.translations/en.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "error": {
+      "connection_error": "Error connecting; check network and retry.\n{message}",
+      "identifier_exists": "Email already registered",
+      "invalid_credentials": "Invalid credentials",
+      "unknown_error": "Unknown error, please report log info"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Seconds between scans"
+        },
+        "description": "Please enter your information.",
+        "title": "Tesla - Configuration"
+      }
+    },
+    "title": "Tesla"
+  }
+}

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -15,6 +15,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for device in hass.data[TESLA_DOMAIN]["devices"]["binary_sensor"]
     ]
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["binary_sensor"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaBinarySensor(TeslaDevice, BinarySensorDevice):

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -23,6 +23,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for device in hass.data[TESLA_DOMAIN]["devices"]["climate"]
     ]
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["climate"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaThermostat(TeslaDevice, ClimateDevice):

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -1,0 +1,107 @@
+"""Tesla Config Flow."""
+from collections import OrderedDict, defaultdict
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+
+DOMAIN = "tesla"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def configured_instances(hass):
+    """Return a set of configured Tesla instances."""
+    return set(entry.title for entry in hass.config_entries.async_entries(DOMAIN))
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class TeslaFlowHandler(config_entries.ConfigFlow):
+    """Handle a Tesla config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize the config flow."""
+        self.login = None
+        self.config = OrderedDict()
+        self.data_schema = OrderedDict(
+            [
+                (vol.Required(CONF_USERNAME), str),
+                (vol.Required(CONF_PASSWORD), str),
+                (
+                    vol.Optional(CONF_SCAN_INTERVAL, default=300),
+                    vol.All(cv.positive_int, vol.Clamp(min=300)),
+                ),
+            ]
+        )
+
+    async def _show_form(
+        self, step="user", placeholders=None, errors=None, data_schema=None
+    ) -> None:
+        """Show the form to the user."""
+        _LOGGER.debug("show_form %s %s %s %s", step, placeholders, errors, data_schema)
+        data_schema = data_schema or vol.Schema(self.data_schema)
+        if step == "user":
+            return self.async_show_form(
+                step_id=step,
+                data_schema=data_schema,
+                errors=errors if errors else {},
+                description_placeholders=placeholders if placeholders else {},
+            )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        from teslajsonpy import Controller as teslaAPI, TeslaException
+
+        if not user_input:
+            return await self._show_form(data_schema=vol.Schema(self.data_schema))
+
+        if user_input[CONF_USERNAME] in configured_instances(self.hass):
+            return await self._show_form(errors={CONF_USERNAME: "identifier_exists"})
+
+        self.config[CONF_USERNAME] = user_input[CONF_USERNAME]
+        self.config[CONF_PASSWORD] = user_input[CONF_PASSWORD]
+        from datetime import timedelta
+
+        self.config[CONF_SCAN_INTERVAL] = (
+            user_input[CONF_SCAN_INTERVAL]
+            if not isinstance(user_input[CONF_SCAN_INTERVAL], timedelta)
+            else user_input[CONF_SCAN_INTERVAL].total_seconds()
+        )
+
+        try:
+            controller = teslaAPI(
+                self.config[CONF_USERNAME],
+                self.config[CONF_PASSWORD],
+                self.config[CONF_SCAN_INTERVAL],
+            )
+            self.hass.data[DOMAIN] = {
+                "controller": controller,
+                "devices": defaultdict(list),
+            }
+            _LOGGER.debug("Connected to the Tesla API.")
+            return self.async_create_entry(
+                title=self.config[CONF_USERNAME], data=self.config
+            )
+        except TeslaException as ex:
+            if ex.code == 401:
+                return await self._show_form(errors={"base": "invalid_credentials"})
+            _LOGGER.error("Unable to communicate with Tesla API: %s", ex.message)
+            return await self._show_form(
+                errors={"base": "connection_error"},
+                placeholders={"message": f"\n> {ex.message}"},
+            )
+        except BaseException as ex:
+            _LOGGER.warning("Unknown error: %s", ex)
+            return await self._show_form(errors={"base": "unknown_error"})

--- a/homeassistant/components/tesla/device_tracker.py
+++ b/homeassistant/components/tesla/device_tracker.py
@@ -4,6 +4,8 @@ import logging
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import slugify
 
+from homeassistant.components.device_tracker import see as dev_see
+
 from . import DOMAIN as TESLA_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -11,9 +13,23 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Tesla tracker."""
-    TeslaDeviceTracker(
+    hass.data[TESLA_DOMAIN]["devices"]["device_tracker"] = TeslaDeviceTracker(
         hass, config, see, hass.data[TESLA_DOMAIN]["devices"]["devices_tracker"]
     )
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_scanner, hass, config_entry.data, dev_see, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    _LOGGER.debug("Unloading %s", hass.data[TESLA_DOMAIN]["devices"]["device_tracker"])
+    hass.data[TESLA_DOMAIN]["devices"]["device_tracker"].unload()
     return True
 
 
@@ -27,7 +43,9 @@ class TeslaDeviceTracker:
         self.devices = tesla_devices
         self._update_info()
 
-        track_utc_time_change(self.hass, self._update_info, second=range(0, 60, 30))
+        self._listener = track_utc_time_change(
+            self.hass, self._update_info, second=range(0, 60, 30)
+        )
 
     def _update_info(self, now=None):
         """Update the device info."""
@@ -42,5 +60,13 @@ class TeslaDeviceTracker:
                 lon = location["longitude"]
                 attrs = {"trackr_id": dev_id, "id": dev_id, "name": name}
                 self.see(
-                    dev_id=dev_id, host_name=name, gps=(lat, lon), attributes=attrs
+                    self.hass,
+                    dev_id=dev_id,
+                    host_name=name,
+                    gps=(lat, lon),
+                    attributes=attrs,
                 )
+
+    async def unload(self):
+        """Update the device info."""
+        self.hass.async_add_executor_job(self._listener)

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -16,6 +16,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]
     ]
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaLock(TeslaDevice, LockDevice):

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "tesla",
   "name": "Tesla",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
-  "requirements": ["teslajsonpy==0.0.26"],
+  "requirements": ["teslajsonpy==0.1.0"],
   "dependencies": [],
   "codeowners": ["@zabuldon"]
 }

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -29,6 +29,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         else:
             devices.append(TeslaSensor(device, controller))
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["sensor"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaSensor(TeslaDevice, Entity):

--- a/homeassistant/components/tesla/strings.json
+++ b/homeassistant/components/tesla/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "error": {
+      "connection_error": "Error connecting; check network and retry",
+      "identifier_exists": "Email already registered",
+      "invalid_credentials": "Invalid credentials",
+      "unknown_error": "Unknown error, please report log info"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Seconds between scans"
+        },
+        "description": "Please enter your information.",
+        "title": "Tesla - Configuration"
+      }
+    },
+    "title": "Tesla"
+  }
+}

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -20,6 +20,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         elif device.bin_type == 0x9:
             devices.append(RangeSwitch(device, controller))
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["switch"]:
+        await device.async_remove()
+    return True
 
 
 class ChargerSwitch(TeslaDevice, SwitchDevice):

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -64,6 +64,7 @@ FLOWS = [
     "somfy",
     "sonos",
     "tellduslive",
+    "tesla",
     "toon",
     "tplink",
     "traccar",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1876,7 +1876,7 @@ temperusb==1.5.3
 # tensorflow==1.13.2
 
 # homeassistant.components.tesla
-teslajsonpy==0.0.26
+teslajsonpy==0.1.0
 
 # homeassistant.components.thermoworks_smoke
 thermoworks_smoke==0.1.8


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This adds config flow support for the Tesla component.

**Related issue (if applicable):** 
N/A
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
N/A, it will import configuration.yaml if it exists

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
