### PR TITLE
Avoid query operations on a pjlink powered off projector

### DIFF
--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -105,10 +105,12 @@ class PjLinkDevice(MediaPlayerDevice):
                 pwstate = projector.get_power()
                 if pwstate in ("on", "warm-up"):
                     self._pwstate = STATE_ON
+                    self._muted = projector.get_mute()[1]
+                    self._current_source = format_input_source(*projector.get_input())
                 else:
                     self._pwstate = STATE_OFF
-                self._muted = projector.get_mute()[1]
-                self._current_source = format_input_source(*projector.get_input())
+                    self._muted = False
+                    self._current_source = None
             except KeyError as err:
                 if str(err) == "'OK'":
                     self._pwstate = STATE_OFF


### PR DESCRIPTION
# Description:

Won't perform query operations (like checking input source or mute status) on projectors that are powered off. This also breaks functionality for some brands of projectors (for instance NEC) as they return "POWR=0" no matter what you ask them when they are powered off.

fixes #26719

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
