### PR TITLE
Add bluesound speaker group attribute

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -846,7 +846,7 @@ class BluesoundPlayer(MediaPlayerDevice):
     def device_state_attributes(self):
         """List members in group."""
         attributes = {}
-        if self._group_list != []:
+        if self._group_list is not None:
             attributes = {ATTR_BLUESOUND_GROUP: self._group_list}
 
         attributes[ATTR_MASTER] = self._is_master

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -220,7 +220,7 @@ class BluesoundPlayer(MediaPlayerDevice):
         self._master = None
         self._is_master = False
         self._group_name = None
-        self._group_list = None
+        self._group_list = []
         self._bluesound_device_name = None
 
         self._init_callback = init_callback
@@ -846,7 +846,7 @@ class BluesoundPlayer(MediaPlayerDevice):
     def device_state_attributes(self):
         """List members in group."""
         attributes = {}
-        if self._group_list is not None:
+        if self._group_list != []:
             attributes = {ATTR_BLUESOUND_GROUP: self._group_list}
 
         attributes[ATTR_MASTER] = self._is_master

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -220,7 +220,7 @@ class BluesoundPlayer(MediaPlayerDevice):
         self._master = None
         self._is_master = False
         self._group_name = None
-        self._group_list = []
+        self._group_list = None
         self._bluesound_device_name = None
 
         self._init_callback = init_callback

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -855,6 +855,9 @@ class BluesoundPlayer(MediaPlayerDevice):
 
     def rebuild_bluesound_group(self):
         """Rebuild the list of entities in speaker group."""
+        if self._group_name is None:
+            return None
+
         bluesound_group = []
 
         device_group = self._group_name.split("+")

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -846,7 +846,7 @@ class BluesoundPlayer(MediaPlayerDevice):
     def device_state_attributes(self):
         """List members in group."""
         attributes = {}
-        if self._group_list != []:
+        if self._group_list:
             attributes = {ATTR_BLUESOUND_GROUP: self._group_list}
 
         attributes[ATTR_MASTER] = self._is_master
@@ -855,25 +855,20 @@ class BluesoundPlayer(MediaPlayerDevice):
 
     def rebuild_bluesound_group(self):
         """Rebuild the list of entities in speaker group."""
-        if self._group_name is None:
-            return None
-
-        device_group = []
         bluesound_group = []
 
         device_group = self._group_name.split("+")
-        for entity in self._hass.data[DATA_BLUESOUND]:
-            if (
-                entity.bluesound_device_name in device_group
-                and entity.is_master is True
-            ):
-                bluesound_group.append(entity.name)
-        for entity in self._hass.data[DATA_BLUESOUND]:
-            if (
-                entity.bluesound_device_name in device_group
-                and entity.is_master is False
-            ):
-                bluesound_group.append(entity.name)
+
+        sorted_entities = sorted(
+            self._hass.data[DATA_BLUESOUND],
+            key=lambda entity: entity.is_master,
+            reverse=True,
+        )
+        bluesound_group = [
+            entity.name
+            for entity in sorted_entities
+            if entity.bluesound_device_name in device_group
+        ]
 
         return bluesound_group
 


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Added device attribute `bluesound_group` with a list of entities that are in a speaker group (analogous to the sonos component) and `master` to indicate whether the device is the master. The master is the first item in the list, followed by one or more slaves.

This change makes it possible for i.e. mini-media-player to properly display speaker groups of bluesound devices in much the same way as is done for Sonos devices already.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
