### PR TITLE
Downgrade aioHTTP 3.6.2 to 3.6.1

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==1.7.1
 PyNaCl==1.3.0
-aiohttp==3.6.2
+aiohttp==3.6.1
 aiohttp_cors==0.7.0
 astral==1.10.1
 async_timeout==3.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-aiohttp==3.6.2
+aiohttp==3.6.1
 astral==1.10.1
 async_timeout==3.0.1
 attrs==19.2.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ PROJECT_URLS = {
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 
 REQUIRES = [
-    "aiohttp==3.6.2",
+    "aiohttp==3.6.1",
     "astral==1.10.1",
     "async_timeout==3.0.1",
     "attrs==19.2.0",


### PR DESCRIPTION
## Description:

We run aiohttp 3.6.2 before on Hass.io 190. After we had some issues with ingress, we detect that request going lost or more specific was blocked and never response inside aiohttp core.

There is a bug. I will open a bug request on aiohttp, but with this bad experience from Hass.io, we should not use this version until the bug is fixed.

https://github.com/aio-libs/aiohttp/issues/4258