### PR TITLE
Cleanup typing and asserts for HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -7,11 +7,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import comp_entity_ids
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .config_flow import configured_haps
 from .const import (
@@ -98,7 +97,7 @@ SCHEMA_SET_ACTIVE_CLIMATE_PROFILE = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     """Set up the HomematicIP Cloud component."""
     hass.data[DOMAIN] = {}
 
@@ -252,7 +251,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up an access point from a config entry."""
     hap = HomematicipHAP(hass, entry)
     hapid = entry.data[HMIPC_HAPID].replace("-", "").upper()

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID
 from .hap import HomematicipHAP
@@ -28,7 +28,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP alrm control panel from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -36,7 +36,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 from .device import ATTR_GROUP_MEMBER_UNREACHABLE
@@ -82,7 +82,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP Cloud binary sensor from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -20,7 +20,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 from .hap import HomematicipHAP
@@ -41,7 +41,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP climate from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -4,7 +4,8 @@ from typing import Set
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import (
     _LOGGER,
@@ -18,7 +19,7 @@ from .hap import HomematicipAuth
 
 
 @callback
-def configured_haps(hass: HomeAssistant) -> Set[str]:
+def configured_haps(hass: HomeAssistantType) -> Set[str]:
     """Return a set of the configured access points."""
     return set(
         entry.data[HMIPC_HAPID]

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -10,7 +10,7 @@ from homeassistant.components.cover import (
     CoverDevice,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 
@@ -28,7 +28,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP cover from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -5,11 +5,11 @@ from typing import Optional
 from homematicip.aio.device import AsyncDevice
 from homematicip.aio.group import AsyncGroup
 
-from homeassistant.components import homematicip_cloud
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import Entity
 
+from .const import DOMAIN as HMIPC_DOMAIN
 from .hap import HomematicipHAP
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,13 +70,13 @@ class HomematicipGenericDevice(Entity):
             return {
                 "identifiers": {
                     # Serial numbers of Homematic IP device
-                    (homematicip_cloud.DOMAIN, self._device.id)
+                    (HMIPC_DOMAIN, self._device.id)
                 },
                 "name": self._device.label,
                 "manufacturer": self._device.oem,
                 "model": self._device.modelType,
                 "sw_version": self._device.firmwareVersion,
-                "via_device": (homematicip_cloud.DOMAIN, self._device.homeId),
+                "via_device": (HMIPC_DOMAIN, self._device.homeId),
             }
         return None
 

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -8,9 +8,10 @@ from homematicip.base.base_connection import HmipConnectionError
 from homematicip.base.enums import EventType
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import COMPONENTS, HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN
 from .errors import HmipcConnectionError
@@ -53,7 +54,7 @@ class HomematicipAuth:
         except HmipConnectionError:
             return False
 
-    async def get_auth(self, hass: HomeAssistant, hapid, pin):
+    async def get_auth(self, hass: HomeAssistantType, hapid, pin):
         """Create a HomematicIP access point object."""
         auth = AsyncAuth(hass.loop, async_get_clientsession(hass))
         try:
@@ -69,7 +70,7 @@ class HomematicipAuth:
 class HomematicipHAP:
     """Manages HomematicIP HTTP and WebSocket connection."""
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistantType, config_entry: ConfigEntry) -> None:
         """Initialize HomematicIP Cloud connection."""
         self.hass = hass
         self.config_entry = config_entry
@@ -224,7 +225,7 @@ class HomematicipHAP:
         return True
 
     async def get_hap(
-        self, hass: HomeAssistant, hapid: str, authtoken: str, name: str
+        self, hass: HomeAssistantType, hapid: str, authtoken: str, name: str
     ) -> AsyncHome:
         """Create a HomematicIP access point object."""
         home = AsyncHome(hass.loop, async_get_clientsession(hass))

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -21,7 +21,7 @@ from homeassistant.components.light import (
     Light,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 from .hap import HomematicipHAP
@@ -38,7 +38,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP Cloud lights from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
     POWER_WATT,
     TEMP_CELSIUS,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 from .device import ATTR_IS_GROUP, ATTR_MODEL_TYPE
@@ -52,7 +52,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP Cloud sensors from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -15,7 +15,7 @@ from homematicip.aio.group import AsyncSwitchingGroup
 
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 from .device import ATTR_GROUP_MEMBER_UNREACHABLE
@@ -30,7 +30,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP switch from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/homeassistant/components/homematicip_cloud/weather.py
+++ b/homeassistant/components/homematicip_cloud/weather.py
@@ -11,7 +11,7 @@ from homematicip.base.enums import WeatherCondition
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 from .hap import HomematicipHAP
@@ -43,7 +43,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP weather sensor from a config entry."""
     hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -12,7 +12,7 @@ from homeassistant.components.homematicip_cloud import (
     const as hmipc,
     hap as hmip_hap,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 
 from .helper import AUTH_TOKEN, HAPID, HAPPIN, HomeTemplate
 
@@ -20,7 +20,7 @@ from tests.common import MockConfigEntry, mock_coro
 
 
 @pytest.fixture(name="mock_connection")
-def mock_connection_fixture():
+def mock_connection_fixture() -> AsyncConnection:
     """Return a mocked connection."""
     connection = MagicMock(spec=AsyncConnection)
 
@@ -35,7 +35,7 @@ def mock_connection_fixture():
 
 
 @pytest.fixture(name="hmip_config_entry")
-def hmip_config_entry_fixture():
+def hmip_config_entry_fixture() -> config_entries.ConfigEntry:
     """Create a mock config entriy for homematic ip cloud."""
     entry_data = {
         hmipc.HMIPC_HAPID: HAPID,
@@ -57,20 +57,24 @@ def hmip_config_entry_fixture():
 
 
 @pytest.fixture(name="default_mock_home")
-def default_mock_home_fixture(mock_connection):
+def default_mock_home_fixture(mock_connection) -> AsyncHome:
     """Create a fake homematic async home."""
     return HomeTemplate(connection=mock_connection).init_home().get_async_home_mock()
 
 
 @pytest.fixture(name="default_mock_hap")
 async def default_mock_hap_fixture(
-    hass: HomeAssistant, mock_connection, hmip_config_entry
-):
+    hass: HomeAssistantType, mock_connection, hmip_config_entry
+) -> hmip_hap.HomematicipHAP:
     """Create a mocked homematic access point."""
     return await get_mock_hap(hass, mock_connection, hmip_config_entry)
 
 
-async def get_mock_hap(hass: HomeAssistant, mock_connection, hmip_config_entry):
+async def get_mock_hap(
+    hass: HomeAssistantType,
+    mock_connection,
+    hmip_config_entry: config_entries.ConfigEntry,
+) -> hmip_hap.HomematicipHAP:
     """Create a mocked homematic access point."""
     hass.config.components.add(HMIPC_DOMAIN)
     hap = hmip_hap.HomematicipHAP(hass, hmip_config_entry)
@@ -81,7 +85,7 @@ async def get_mock_hap(hass: HomeAssistant, mock_connection, hmip_config_entry):
         .get_async_home_mock()
     )
     with patch.object(hap, "get_hap", return_value=mock_coro(mock_home)):
-        assert await hap.async_setup() is True
+        assert await hap.async_setup()
     mock_home.on_update(hap.async_update)
     mock_home.on_create(hap.async_create_entity)
 
@@ -93,7 +97,7 @@ async def get_mock_hap(hass: HomeAssistant, mock_connection, hmip_config_entry):
 
 
 @pytest.fixture(name="hmip_config")
-def hmip_config_fixture():
+def hmip_config_fixture() -> ConfigType:
     """Create a config for homematic ip cloud."""
 
     entry_data = {
@@ -107,15 +111,15 @@ def hmip_config_fixture():
 
 
 @pytest.fixture(name="dummy_config")
-def dummy_config_fixture():
+def dummy_config_fixture() -> ConfigType:
     """Create a dummy config."""
     return {"blabla": None}
 
 
 @pytest.fixture(name="mock_hap_with_service")
 async def mock_hap_with_service_fixture(
-    hass: HomeAssistant, default_mock_hap, dummy_config
-):
+    hass: HomeAssistantType, default_mock_hap, dummy_config
+) -> hmip_hap.HomematicipHAP:
     """Create a fake homematic access point with hass services."""
     await hmip_async_setup(hass, dummy_config)
     await hass.async_block_till_done()
@@ -124,7 +128,7 @@ async def mock_hap_with_service_fixture(
 
 
 @pytest.fixture(name="simple_mock_home")
-def simple_mock_home_fixture():
+def simple_mock_home_fixture() -> AsyncHome:
     """Return a simple AsyncHome Mock."""
     return Mock(
         spec=AsyncHome,
@@ -139,6 +143,6 @@ def simple_mock_home_fixture():
 
 
 @pytest.fixture(name="simple_mock_auth")
-def simple_mock_auth_fixture():
+def simple_mock_auth_fixture() -> AsyncAuth:
     """Return a simple AsyncAuth Mock."""
     return Mock(spec=AsyncAuth, pin=HAPPIN, create=True)

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -12,7 +12,7 @@ from homeassistant.components.homematicip_cloud import (
     const as hmipc,
     hap as hmip_hap,
 )
-from homeassistant.helpers.typing import HomeAssistantType, ConfigType
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .helper import AUTH_TOKEN, HAPID, HAPPIN, HomeTemplate
 

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -31,7 +31,7 @@ async def test_auth_setup(hass):
     }
     hap = hmipc.HomematicipAuth(hass, config)
     with patch.object(hap, "get_auth", return_value=mock_coro()):
-        assert await hap.async_setup() is True
+        assert await hap.async_setup()
 
 
 async def test_auth_setup_connection_error(hass):
@@ -43,7 +43,7 @@ async def test_auth_setup_connection_error(hass):
     }
     hap = hmipc.HomematicipAuth(hass, config)
     with patch.object(hap, "get_auth", side_effect=errors.HmipcConnectionError):
-        assert await hap.async_setup() is False
+        assert not await hap.async_setup()
 
 
 async def test_auth_auth_check_and_register(hass):
@@ -62,7 +62,7 @@ async def test_auth_auth_check_and_register(hass):
     ), patch.object(
         hap.auth, "confirmAuthToken", return_value=mock_coro()
     ):
-        assert await hap.async_checkbutton() is True
+        assert await hap.async_checkbutton()
         assert await hap.async_register() == "ABC"
 
 
@@ -78,7 +78,7 @@ async def test_auth_auth_check_and_register_with_exception(hass):
     with patch.object(
         hap.auth, "isRequestAcknowledged", side_effect=HmipConnectionError
     ), patch.object(hap.auth, "requestAuthToken", side_effect=HmipConnectionError):
-        assert await hap.async_checkbutton() is False
+        assert not await hap.async_checkbutton()
         assert await hap.async_register() is False
 
 
@@ -94,7 +94,7 @@ async def test_hap_setup_works(aioclient_mock):
     }
     hap = hmipc.HomematicipHAP(hass, entry)
     with patch.object(hap, "get_hap", return_value=mock_coro(home)):
-        assert await hap.async_setup() is True
+        assert await hap.async_setup()
 
     assert hap.home is home
     assert len(hass.config_entries.async_forward_entry_setup.mock_calls) == 8
@@ -140,7 +140,7 @@ async def test_hap_reset_unloads_entry_if_setup():
     }
     hap = hmipc.HomematicipHAP(hass, entry)
     with patch.object(hap, "get_hap", return_value=mock_coro(home)):
-        assert await hap.async_setup() is True
+        assert await hap.async_setup()
 
     assert hap.home is home
     assert not hass.services.async_register.mock_calls
@@ -161,7 +161,7 @@ async def test_hap_create(hass, hmip_config_entry, simple_mock_home):
         "homeassistant.components.homematicip_cloud.hap.AsyncHome",
         return_value=simple_mock_home,
     ), patch.object(hap, "async_connect", return_value=mock_coro(None)):
-        assert await hap.async_setup() is True
+        assert await hap.async_setup()
 
 
 async def test_hap_create_exception(hass, hmip_config_entry, simple_mock_home):
@@ -197,7 +197,7 @@ async def test_auth_create(hass, simple_mock_auth):
         "homeassistant.components.homematicip_cloud.hap.AsyncAuth",
         return_value=simple_mock_auth,
     ):
-        assert await hmip_auth.async_setup() is True
+        assert await hmip_auth.async_setup()
         await hass.async_block_till_done()
         assert hmip_auth.auth.pin == HAPPIN
 
@@ -216,12 +216,12 @@ async def test_auth_create_exception(hass, simple_mock_auth):
         "homeassistant.components.homematicip_cloud.hap.AsyncAuth",
         return_value=simple_mock_auth,
     ):
-        assert await hmip_auth.async_setup() is True
+        assert await hmip_auth.async_setup()
         await hass.async_block_till_done()
-        assert hmip_auth.auth is False
+        assert not hmip_auth.auth
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.AsyncAuth",
         return_value=simple_mock_auth,
     ):
-        assert await hmip_auth.get_auth(hass, HAPID, HAPPIN) is False
+        assert not await hmip_auth.get_auth(hass, HAPID, HAPPIN)


### PR DESCRIPTION
## Description:
Cleanup typing --> homeassistant.helpers.typing.*
Cleanup asserts in test_hap.py


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
