### PR TITLE
changed STATE_OFF to STATE_STANDBY

### DIFF
--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_IDLE,
     STATE_PLAYING,
-    STATE_OFF,
+    STATE_STANDBY,
 )
 
 DEFAULT_PORT = 8060
@@ -98,7 +98,7 @@ class RokuDevice(MediaPlayerDevice):
     def state(self):
         """Return the state of the device."""
         if self._power_state == "Off":
-            return STATE_OFF
+            return STATE_STANDBY
 
         if self.current_app is None:
             return None


### PR DESCRIPTION
## Breaking Change:

Roku TVs will now report "standby" instead of "off" when they are turned off.

## Description:
Roku TVs can be turned on directly to a source by selecting from the source list. When a media_player returns STATE_OFF it loses access to the source list. By returning STATE_STANDBY instead the state is more accurately reflected and the source_list attribute is now accessible when the TV screen is off.

**Related issue (if applicable):** fixes #25662

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
