### PR TITLE
Parallelize pylint everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - python: "3.6.1"
       env: TOXENV=lint
     - python: "3.6.1"
-      env: TOXENV=pylint
+      env: TOXENV=pylint PYLINT_ARGS=--jobs=0
     - python: "3.6.1"
       env: TOXENV=typing
     - python: "3.6.1"

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -167,7 +167,7 @@ stages:
       displayName: 'Install Home Assistant'
     - script: |
         . venv/bin/activate
-        pylint -j 2 homeassistant
+        pylint homeassistant
       displayName: 'Run pylint'
   - job: 'Mypy'
     pool:

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,8 @@
 [MASTER]
 ignore=tests
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs=2
 
 [BASIC]
 good-names=id,i,j,k,ex,Run,_,fp

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-     pylint {posargs} homeassistant
+     pylint {env:PYLINT_ARGS} {posargs} homeassistant
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
## Description:

If parallel pylint is ok in Azure, we should take advantage of it elsewhere too, for consistency and speedups. See discussion in #27919 and my earlier experiences and more background in #15226. Contrary to that report, my fresh tests in Travis show a speedup of about 25%.

**Related issue (if applicable):** #27919 #15226

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
