### PR TITLE
Fix digest auth rest sensors

### DIFF
--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -103,7 +103,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         auth = None
     rest = RestData(method, resource, auth, headers, payload, verify_ssl, timeout)
     rest.update()
-    if rest.response_data is None:
+    if rest.data is None:
         raise PlatformNotReady
 
     # Must update the sensor now (including fetching the rest resource) to
@@ -172,7 +172,7 @@ class RestSensor(Entity):
     @property
     def available(self):
         """Return if the sensor data are available."""
-        return self.rest.response_data is not None
+        return self.rest.data is not None
 
     @property
     def state(self):
@@ -190,7 +190,7 @@ class RestSensor(Entity):
             self.rest.set_url(self._resource_template.render())
 
         self.rest.update()
-        value = self.rest.response_data
+        value = self.rest.data
 
         if self._json_attrs:
             self._attributes = {}
@@ -234,7 +234,7 @@ class RestData:
         self._request_data = data
         self._verify_ssl = verify_ssl
         self._timeout = timeout
-        self.response_data = None
+        self.data = None
 
     def set_url(self, url):
         """Set url."""
@@ -253,7 +253,7 @@ class RestData:
                 timeout=self._timeout,
                 verify=self._verify_ssl,
             )
-            self.response_data = response.text
+            self.data = response.text
         except requests.exceptions.RequestException as ex:
             _LOGGER.error("Error fetching data: %s failed with %s", self._resource, ex)
-            self.response_data = None
+            self.data = None

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -229,14 +229,14 @@ class RestData:
         """Initialize the data object."""
         self._request = requests.Request(
             method, resource, headers=headers, auth=auth, data=data
-        ).prepare()
+        )
         self._verify_ssl = verify_ssl
         self._timeout = timeout
         self.data = None
 
     def set_url(self, url):
         """Set url."""
-        self._request.prepare_url(url, None)
+        self._request.url = url
 
     def update(self):
         """Get the latest data from REST service with provided method."""
@@ -244,7 +244,7 @@ class RestData:
         try:
             with requests.Session() as sess:
                 response = sess.send(
-                    self._request, timeout=self._timeout, verify=self._verify_ssl
+                    self._request.prepare(), timeout=self._timeout, verify=self._verify_ssl
                 )
 
             self.data = response.text

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -130,16 +130,16 @@ class RestSensor(Entity):
     """Implementation of a REST sensor."""
 
     def __init__(
-            self,
-            hass,
-            rest,
-            name,
-            unit_of_measurement,
-            device_class,
-            value_template,
-            json_attrs,
-            force_update,
-            resource_template,
+        self,
+        hass,
+        rest,
+        name,
+        unit_of_measurement,
+        device_class,
+        value_template,
+        json_attrs,
+        force_update,
+        resource_template,
     ):
         """Initialize the REST sensor."""
         self._hass = hass
@@ -224,7 +224,7 @@ class RestData:
     """Class for handling the data retrieval."""
 
     def __init__(
-            self, method, resource, auth, headers, data, verify_ssl, timeout=DEFAULT_TIMEOUT
+        self, method, resource, auth, headers, data, verify_ssl, timeout=DEFAULT_TIMEOUT
     ):
         """Initialize the data object."""
         self._method = method
@@ -244,14 +244,16 @@ class RestData:
         """Get the latest data from REST service with provided method."""
         _LOGGER.debug("Updating from %s", self._resource)
         try:
-            response = requests.request(self._method, self._resource, headers=self._headers,
-                                        auth=self._auth, data=self._request_data,
-                                        timeout=self._timeout, verify=self._verify_ssl)
+            response = requests.request(
+                self._method,
+                self._resource,
+                headers=self._headers,
+                auth=self._auth,
+                data=self._request_data,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+            )
             self.response_data = response.text
         except requests.exceptions.RequestException as ex:
-            _LOGGER.error(
-                "Error fetching data: %s failed with %s",
-                self._resource,
-                ex,
-            )
+            _LOGGER.error("Error fetching data: %s failed with %s", self._resource, ex)
             self.response_data = None

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -4,7 +4,7 @@ from pytest import raises
 from unittest.mock import patch, Mock
 
 import requests
-from requests.exceptions import Timeout, MissingSchema
+from requests.exceptions import Timeout
 import requests_mock
 
 from homeassistant.exceptions import PlatformNotReady
@@ -47,7 +47,7 @@ class TestRestBinarySensorSetup(unittest.TestCase):
 
     def test_setup_missing_schema(self):
         """Test setup with resource missing schema."""
-        with pytest.raises(MissingSchema):
+        with pytest.raises(PlatformNotReady):
             rest.setup_platform(
                 self.hass,
                 {"platform": "rest", "resource": "localhost", "method": "GET"},
@@ -60,7 +60,7 @@ class TestRestBinarySensorSetup(unittest.TestCase):
         with raises(PlatformNotReady):
             rest.setup_platform(
                 self.hass,
-                {"platform": "rest", "resource": "http://localhost"},
+                {"platform": "rest", "resource": "http://localhost", "method": "GET"},
                 self.add_devices,
                 None,
             )
@@ -72,7 +72,7 @@ class TestRestBinarySensorSetup(unittest.TestCase):
         with raises(PlatformNotReady):
             rest.setup_platform(
                 self.hass,
-                {"platform": "rest", "resource": "http://localhost"},
+                {"platform": "rest", "resource": "http://localhost", "method": "GET"},
                 self.add_devices,
                 None,
             )

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -37,7 +37,7 @@ class TestRestSensorSetup(unittest.TestCase):
 
     def test_setup_missing_schema(self):
         """Test setup with resource missing schema."""
-        with pytest.raises(MissingSchema):
+        with pytest.raises(PlatformNotReady):
             rest.setup_platform(
                 self.hass,
                 {"platform": "rest", "resource": "localhost", "method": "GET"},
@@ -50,7 +50,7 @@ class TestRestSensorSetup(unittest.TestCase):
         with raises(PlatformNotReady):
             rest.setup_platform(
                 self.hass,
-                {"platform": "rest", "resource": "http://localhost"},
+                {"platform": "rest", "resource": "http://localhost", "method": "GET"},
                 lambda devices, update=True: None,
             )
 
@@ -60,7 +60,7 @@ class TestRestSensorSetup(unittest.TestCase):
         with raises(PlatformNotReady):
             rest.setup_platform(
                 self.hass,
-                {"platform": "rest", "resource": "http://localhost"},
+                {"platform": "rest", "resource": "http://localhost", "method": "GET"},
                 lambda devices, update=True: None,
             )
 
@@ -397,7 +397,7 @@ class TestRestData(unittest.TestCase):
         self.rest.update()
         assert "test data" == self.rest.data
 
-    @patch("requests.Session", side_effect=RequestException)
+    @patch("requests.request", side_effect=RequestException)
     def test_update_request_exception(self, mock_req):
         """Test update when a request exception occurs."""
         self.rest.update()

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -4,7 +4,7 @@ from pytest import raises
 from unittest.mock import patch, Mock
 
 import requests
-from requests.exceptions import Timeout, MissingSchema, RequestException
+from requests.exceptions import Timeout, RequestException
 import requests_mock
 
 from homeassistant.exceptions import PlatformNotReady


### PR DESCRIPTION
## Description:
Any REST sensor which is using DIGEST authentication will fail with the following exception stack:

```
2019-10-03 19:52:51 ERROR (MainThread) [homeassistant.components.sensor] rest: Error on device update!
Traceback (most recent call last):
  File "/usr/home/hass/env/lib/python3.7/site-packages/homeassistant/helpers/entity_platform.py", line 292, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/home/hass/env/lib/python3.7/site-packages/homeassistant/helpers/entity.py", line 441, in async_device_update
    await self.hass.async_add_executor_job(self.update)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/home/hass/env/lib/python3.7/site-packages/homeassistant/components/rest/sensor.py", line 175, in update
    self.rest.update()
  File "/usr/home/hass/env/lib/python3.7/site-packages/homeassistant/components/rest/sensor.py", line 226, in update
    self._request, timeout=self._timeout, verify=self._verify_ssl
  File "/usr/home/hass/env/lib/python3.7/site-packages/requests/sessions.py", line 653, in send
    r = dispatch_hook('response', hooks, r, **kwargs)
  File "/usr/home/hass/env/lib/python3.7/site-packages/requests/hooks.py", line 31, in dispatch_hook
    _hook_data = hook(hook_data, **kwargs)
  File "/usr/home/hass/env/lib/python3.7/site-packages/requests/auth.py", line 247, in handle_401
    if self._thread_local.pos is not None:
AttributeError: '_thread._local' object has no attribute 'pos'
```

Fundamentally this is because the requests library stores a bunch of important information in thread local storage when the request is prepared, and this is needed when the thread is later used.

To fix this I've delayed preparing until we actually use the request - this does have the impact that we now prepare before every send rather than only once, but that doesn't appear to have much of a cost looking through the requests library and avoids this nasty issue.

**Related issue (if applicable):** fixes (closed aged issue) #13524


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
