### PR TITLE
ISY994 Node Filter Update

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -62,7 +62,7 @@ NODE_FILTERS = {
     "binary_sensor": {
         "uom": [],
         "states": [],
-        "node_def_id": ["BinaryAlarm"],
+        "node_def_id": ["BinaryAlarm", "BinaryAlarm_ADV"],
         "insteon_type": ["16."],  # Does a startswith() match; include the dot
     },
     "sensor": {
@@ -112,6 +112,8 @@ NODE_FILTERS = {
             "BallastRelayLampSwitch_ADV",
             "RemoteLinc2",
             "RemoteLinc2_ADV",
+            "KeypadDimmer",
+            "KeypadDimmer_ADV"
         ],
         "insteon_type": ["1."],
     },

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -113,7 +113,7 @@ NODE_FILTERS = {
             "RemoteLinc2",
             "RemoteLinc2_ADV",
             "KeypadDimmer",
-            "KeypadDimmer_ADV",
+            "KeypadDimmer_ADV"
         ],
         "insteon_type": ["1."],
     },

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -113,7 +113,7 @@ NODE_FILTERS = {
             "RemoteLinc2",
             "RemoteLinc2_ADV",
             "KeypadDimmer",
-            "KeypadDimmer_ADV"
+            "KeypadDimmer_ADV",
         ],
         "insteon_type": ["1."],
     },


### PR DESCRIPTION
## Description:

I after updating to 0.100.3, I started seeing these errors. I don't remember what version I came from, it was a bit old.
```
2019-10-23 14:17:36 WARNING (SyncWorker_1) [homeassistant.components.isy994] Unsupported node: Driveway Lights, type: 1.66.67.0	
...
2019-10-23 14:17:36 WARNING (SyncWorker_1) [homeassistant.components.isy994] Unsupported node: SmokeBridge-Smoke, type: 16.10.67.0
...
```

Looking at the /rest/nodes of my ISY994 (v5.0.15) I needed to add these to the filters.

```
<node flag="128" nodeDefId="KeypadDimmer_ADV">
	<address>2A 95 3B 1</address>
	<name>Driveway Lights</name>
	<parent type="3">54193</parent>
	<type>1.66.67.0</type>
	<enabled>true</enabled>
	<deviceClass>0</deviceClass>
	<wattage>0</wattage>
	<dcPeriod>0</dcPeriod>
	<startDelay>0</startDelay>
	<endDelay>0</endDelay>
	<pnode>2A 95 3B 1</pnode>
	<ELK_ID>E08</ELK_ID>
	<property id="ST" value="0" formatted="Off" uom="100"/>
</node>
```

```
<node flag="128" nodeDefId="BinaryAlarm_ADV">
	<address>44 A1 21 1</address>
	<name>SmokeBridge-Smoke</name>
	<parent type="3">26288</parent>
	<type>16.10.67.0</type>
	<enabled>true</enabled>
	<deviceClass>0</deviceClass>
	<wattage>0</wattage>
	<dcPeriod>0</dcPeriod>
	<startDelay>0</startDelay>
	<endDelay>0</endDelay>
	<pnode>44 A1 21 1</pnode>
	<ELK_ID>I11</ELK_ID>
	<property id="ST" value="" formatted=" " uom="0"/>
</node>
```