### PR TITLE
Add option for logging in debug on glances failed fetch

### DIFF
--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
+    CONF_ACCEPT_UNAVAILABLE,
 )
 from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -47,6 +48,7 @@ GLANCES_SCHEMA = vol.All(
             vol.Optional(CONF_SSL, default=False): cv.boolean,
             vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
             vol.Optional(CONF_VERSION, default=DEFAULT_VERSION): vol.In([2, 3]),
+            vol.Optional(CONF_ACCEPT_UNAVAILABLE, default=False): cv.boolean,
         }
     )
 )
@@ -108,7 +110,10 @@ class GlancesData:
             await self.api.get_data()
             self.available = True
         except exceptions.GlancesApiError:
-            _LOGGER.error("Unable to fetch data from Glances")
+            if CONF_ACCEPT_UNAVAILABLE:
+                _LOGGER.debug("Unable to fetch data from Glances")
+            else:
+                _LOGGER.error("Unable to fetch data from Glances")
             self.available = False
         _LOGGER.debug("Glances data updated")
         async_dispatcher_send(self.hass, DATA_UPDATED)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -24,6 +24,7 @@ SUN_EVENT_SUNRISE = "sunrise"
 
 # #### CONFIG ####
 CONF_ABOVE = "above"
+CONF_ACCEPT_UNAVAILABLE = "accept_unavailable"
 CONF_ACCESS_TOKEN = "access_token"
 CONF_ADDRESS = "address"
 CONF_AFTER = "after"


### PR DESCRIPTION
## Description:
Log flooded when glances is set up on non 24/7 machines.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: glances
    host: IP_ADDRESS
    accept_unavailable: True
    resources:
      - 'disk_use_percent'
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
