### PR TITLE
Fixes/zha ieee tail

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -40,7 +40,7 @@ class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
         self._unique_id = unique_id
         if not skip_entity_id:
             ieee = zha_device.ieee
-            ieeetail = "".join(["%02x" % (o,) for o in ieee[-4:]])
+            ieeetail = "".join([f"{o:02x}" for o in ieee[:4]])
             self.entity_id = "{}.{}_{}_{}_{}{}".format(
                 self._domain,
                 slugify(zha_device.manufacturer),

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -168,7 +168,7 @@ def make_entity_id(domain, device, cluster, use_suffix=True):
     machine so that we can test state changes.
     """
     ieee = device.ieee
-    ieeetail = "".join(["%02x" % (o,) for o in ieee[-4:]])
+    ieeetail = "".join([f"{o:02x}" for o in ieee[:4]])
     entity_id = "{}.{}_{}_{}_{}{}".format(
         domain,
         slugify(device.manufacturer),


### PR DESCRIPTION
## Description:
Fixes regression introduced in #27972 Use unique part of IEEE address to generate a part of entity_id. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
