### PR TITLE
Add device condition support for media_player

### DIFF
--- a/homeassistant/components/media_player/device_condition.py
+++ b/homeassistant/components/media_player/device_condition.py
@@ -1,0 +1,117 @@
+"""Provides device automations for Media player."""
+from typing import Dict, List
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_CONDITION,
+    CONF_DOMAIN,
+    CONF_TYPE,
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_IDLE,
+    STATE_PAUSED,
+    STATE_PLAYING,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import condition, config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from . import DOMAIN
+
+CONDITION_TYPES = {"is_on", "is_off", "is_idle", "is_paused", "is_playing"}
+
+CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(CONDITION_TYPES),
+    }
+)
+
+
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> List[Dict[str, str]]:
+    """List device conditions for Media player devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    conditions = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        # Add conditions for each entity that belongs to this integration
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_on",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_off",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_idle",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_paused",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_playing",
+            }
+        )
+
+    return conditions
+
+
+def async_condition_from_config(
+    config: ConfigType, config_validation: bool
+) -> condition.ConditionCheckerType:
+    """Create a function to test a device condition."""
+    if config_validation:
+        config = CONDITION_SCHEMA(config)
+    if config[CONF_TYPE] == "is_playing":
+        state = STATE_PLAYING
+    elif config[CONF_TYPE] == "is_idle":
+        state = STATE_IDLE
+    elif config[CONF_TYPE] == "is_paused":
+        state = STATE_PAUSED
+    elif config[CONF_TYPE] == "is_on":
+        state = STATE_ON
+    else:
+        state = STATE_OFF
+
+    def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if an entity is a certain state."""
+        return condition.state(hass, config[ATTR_ENTITY_ID], state)
+
+    return test_is_state

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -1,6 +1,6 @@
 {
   "device_automation": {
-    "condtion_type": {
+    "condition_type": {
       "is_on": "{entity_name} is on",
       "is_off": "{entity_name} is off",
       "is_idle": "{entity_name} is idle",

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -1,0 +1,11 @@
+{
+  "device_automation": {
+    "condtion_type": {
+      "is_on": "{entity_name} is on",
+      "is_off": "{entity_name} is off",
+      "is_idle": "{entity_name} is idle",
+      "is_paused": "{entity_name} is paused",
+      "is_playing": "{entity_name} is playing"
+    }
+  }
+}

--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -1,0 +1,243 @@
+"""The tests for Media player device conditions."""
+import pytest
+
+from homeassistant.components.media_player import DOMAIN
+from homeassistant.const import (
+    STATE_ON,
+    STATE_OFF,
+    STATE_IDLE,
+    STATE_PAUSED,
+    STATE_PLAYING,
+)
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock serivce."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_conditions(hass, device_reg, entity_reg):
+    """Test we get the expected conditions from a media_player."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_conditions = [
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_off",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_on",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_idle",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_paused",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_playing",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+    ]
+    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    assert_lists_same(conditions, expected_conditions)
+
+
+async def test_if_state(hass, calls):
+    """Test for turn_on and turn_off conditions."""
+    hass.states.async_set("media_player.entity", STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "media_player.entity",
+                            "type": "is_on",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_on - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event2"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "media_player.entity",
+                            "type": "is_off",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_off - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event3"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "media_player.entity",
+                            "type": "is_idle",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_idle - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event4"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "media_player.entity",
+                            "type": "is_paused",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_paused - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event5"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "media_player.entity",
+                            "type": "is_playing",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_playing - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "is_on - event - test_event1"
+
+    hass.states.async_set("media_player.entity", STATE_OFF)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "is_off - event - test_event2"
+
+    hass.states.async_set("media_player.entity", STATE_IDLE)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[2].data["some"] == "is_idle - event - test_event3"
+
+    hass.states.async_set("media_player.entity", STATE_PAUSED)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    await hass.async_block_till_done()
+    assert len(calls) == 4
+    assert calls[3].data["some"] == "is_paused - event - test_event4"
+
+    hass.states.async_set("media_player.entity", STATE_PLAYING)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    await hass.async_block_till_done()
+    assert len(calls) == 5
+    assert calls[4].data["some"] == "is_playing - event - test_event5"


### PR DESCRIPTION
## Description:
Adds basic device condition support for media_player integration - on, off, idle, paused, playing.

**Related issue (if applicable):** fixes #27004

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
