### PR TITLE
Change keys for samsung TV Next and Prev Track

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -273,11 +273,11 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def media_next_track(self):
         """Send next track command."""
-        self.send_key("KEY_FF")
+        self.send_key("KEY_CHUP")
 
     def media_previous_track(self):
         """Send the previous track command."""
-        self.send_key("KEY_REWIND")
+        self.send_key("KEY_CHDOWN")
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Support changing a channel."""

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -271,13 +271,13 @@ class TestSamsungTv(unittest.TestCase):
         """Test for media_next_track."""
         self.device.send_key = mock.Mock()
         self.device.media_next_track()
-        self.device.send_key.assert_called_once_with("KEY_FF")
+        self.device.send_key.assert_called_once_with("KEY_CHUP")
 
     def test_media_previous_track(self):
         """Test for media_previous_track."""
         self.device.send_key = mock.Mock()
         self.device.media_previous_track()
-        self.device.send_key.assert_called_once_with("KEY_REWIND")
+        self.device.send_key.assert_called_once_with("KEY_CHDOWN")
 
     def test_turn_on(self):
         """Test turn on."""


### PR DESCRIPTION
## Breaking Change:

Changed behaviour for next and previous track command for samsung TV's

## Description:

Currently the samsung tv component react to the two above command sending the KEY_FF and KEY_REWIND command. While watching TV programs those two command do nothing.
This patch sends the KEY_CHUP and KEY_CHDOWN commands instead.
The best solution would be to send the right command based on the status of the TV (just like in the LG webos component) but unluckily looks like there is no way to detect what the TV currently showing.
Since there is no next/prev command in the media player but only next/prev track one has to deal with this.
Another option can be the introduction of a new configuration parameter (for samsungtv component) that allows the user to choose between the two alternative behaviour.



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
