### PR TITLE
Adding device_class to samsungtv

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -6,7 +6,11 @@ import socket
 
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import (
+    MediaPlayerDevice,
+    PLATFORM_SCHEMA,
+    DEVICE_CLASS_TV,
+)
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,
@@ -226,6 +230,11 @@ class SamsungTVDevice(MediaPlayerDevice):
         if self._mac:
             return SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON
         return SUPPORT_SAMSUNGTV
+
+    @property
+    def device_class(self):
+        """ Set the device class to TV."""
+        return DEVICE_CLASS_TV
 
     def turn_off(self):
         """Turn off media player."""

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -233,7 +233,7 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     @property
     def device_class(self):
-        """ Set the device class to TV."""
+        """Set the device class to TV."""
         return DEVICE_CLASS_TV
 
     def turn_off(self):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -8,6 +8,7 @@ from asynctest import mock
 import pytest
 
 import tests.common
+from homeassistant.components.media_player import DEVICE_CLASS_TV
 from homeassistant.components.media_player.const import (
     SUPPORT_TURN_ON,
     MEDIA_TYPE_CHANNEL,
@@ -196,6 +197,10 @@ class TestSamsungTv(unittest.TestCase):
         assert SUPPORT_SAMSUNGTV == self.device.supported_features
         self.device._mac = "fake"
         assert SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON == self.device.supported_features
+
+    def test_device_class(self):
+        """Test for device_class property."""
+        assert DEVICE_CLASS_TV == self.device.device_class
 
     def test_turn_off(self):
         """Test for turn_off."""


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Adding TV as device_class

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]