### PR TITLE
Bump aioesphomeapi to 2.4.1

### DIFF
--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
   "requirements": [
-    "aioesphomeapi==2.4.0"
+    "aioesphomeapi==2.4.1"
   ],
   "dependencies": [],
   "zeroconf": ["_esphomelib._tcp.local."],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
   "requirements": [
-    "aioesphomeapi==2.4.1"
+    "aioesphomeapi==2.4.2"
   ],
   "dependencies": [],
   "zeroconf": ["_esphomelib._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -139,7 +139,7 @@ aiobotocore==0.10.2
 aiodns==2.0.0
 
 # homeassistant.components.esphome
-aioesphomeapi==2.4.1
+aioesphomeapi==2.4.2
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -139,7 +139,7 @@ aiobotocore==0.10.2
 aiodns==2.0.0
 
 # homeassistant.components.esphome
-aioesphomeapi==2.4.0
+aioesphomeapi==2.4.1
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -70,7 +70,7 @@ aioautomatic==0.6.5
 aiobotocore==0.10.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.4.0
+aioesphomeapi==2.4.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -70,7 +70,7 @@ aioautomatic==0.6.5
 aiobotocore==0.10.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.4.1
+aioesphomeapi==2.4.2
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

See also https://github.com/esphome/aioesphomeapi/compare/v2.4.0...v2.4.1

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/28157

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
