### PR TITLE
Improved Alexa ThermostatController thermostatMode handling

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -704,6 +704,34 @@ class AlexaThermostatController(AlexaCapability):
 
         return {"value": temp, "scale": API_TEMP_UNITS[unit]}
 
+    def configuration(self):
+        """Return configuration object.
+
+        Translates climate HVAC_MODES and PRESETS to supported Alexa ThermostatMode Values.
+        ThermostatMode Value must be AUTO, COOL, HEAT, ECO, OFF, or CUSTOM.
+        """
+        supported_modes = []
+        hvac_modes = self.entity.attributes.get(climate.ATTR_HVAC_MODES)
+        for mode in hvac_modes:
+            thermostat_mode = API_THERMOSTAT_MODES.get(mode)
+            if thermostat_mode:
+                supported_modes.append(thermostat_mode)
+
+        preset_modes = self.entity.attributes.get(climate.ATTR_PRESET_MODES)
+        for mode in preset_modes:
+            thermostat_mode = API_THERMOSTAT_PRESETS.get(mode)
+            if thermostat_mode:
+                supported_modes.append(thermostat_mode)
+
+        # track_point_in_time() listener can be used to support utterances for scheduling and durations.
+        # Return False for supportsScheduling until supported.
+        configuration = {"supportsScheduling": False}
+
+        if supported_modes:
+            configuration["supportedModes"] = [mode for mode in supported_modes]
+
+        return configuration
+
 
 class AlexaPowerLevelController(AlexaCapability):
     """Implements Alexa.PowerLevelController.

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -723,8 +723,7 @@ class AlexaThermostatController(AlexaCapability):
             if thermostat_mode:
                 supported_modes.append(thermostat_mode)
 
-        # track_point_in_time() listener can be used to support utterances for scheduling and durations.
-        # Return False for supportsScheduling until supported.
+        # Return False for supportsScheduling until supported with event listener in handler.
         configuration = {"supportsScheduling": False}
 
         if supported_modes:

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -727,7 +727,7 @@ class AlexaThermostatController(AlexaCapability):
         configuration = {"supportsScheduling": False}
 
         if supported_modes:
-            configuration["supportedModes"] = [mode for mode in supported_modes]
+            configuration["supportedModes"] = supported_modes
 
         return configuration
 

--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -56,9 +56,10 @@ API_THERMOSTAT_MODES = OrderedDict(
         (climate.HVAC_MODE_AUTO, "AUTO"),
         (climate.HVAC_MODE_OFF, "OFF"),
         (climate.HVAC_MODE_FAN_ONLY, "OFF"),
-        (climate.HVAC_MODE_DRY, "OFF"),
+        (climate.HVAC_MODE_DRY, "CUSTOM"),
     ]
 )
+API_THERMOSTAT_MODES_CUSTOM = {climate.HVAC_MODE_DRY: "DEHUMIDIFY"}
 API_THERMOSTAT_PRESETS = {climate.PRESET_ECO: "ECO"}
 
 PERCENTAGE_FAN_MAP = {

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -38,6 +38,7 @@ from homeassistant.util.temperature import convert as convert_temperature
 
 from .const import (
     API_TEMP_UNITS,
+    API_THERMOSTAT_MODES_CUSTOM,
     API_THERMOSTAT_MODES,
     API_THERMOSTAT_PRESETS,
     Cause,
@@ -767,11 +768,28 @@ async def async_api_set_thermostat_mode(hass, config, directive, context):
             raise AlexaUnsupportedThermostatModeError(msg)
 
         service = climate.SERVICE_SET_PRESET_MODE
-        data[climate.ATTR_PRESET_MODE] = climate.PRESET_ECO
+        data[climate.ATTR_PRESET_MODE] = ha_preset
+
+    elif mode == "CUSTOM":
+        operation_list = entity.attributes.get(climate.ATTR_HVAC_MODES)
+        custom_mode = directive.payload["thermostatMode"]["customName"]
+        custom_mode = next(
+            (k for k, v in API_THERMOSTAT_MODES_CUSTOM.items() if v == custom_mode),
+            None,
+        )
+        if custom_mode not in operation_list:
+            msg = (
+                f"The requested thermostat mode {mode}: {custom_mode} is not supported"
+            )
+            raise AlexaUnsupportedThermostatModeError(msg)
+
+        service = climate.SERVICE_SET_HVAC_MODE
+        data[climate.ATTR_HVAC_MODE] = custom_mode
 
     else:
         operation_list = entity.attributes.get(climate.ATTR_HVAC_MODES)
-        ha_mode = next((k for k, v in API_THERMOSTAT_MODES.items() if v == mode), None)
+        ha_modes = {k: v for k, v in API_THERMOSTAT_MODES.items() if v == mode}
+        ha_mode = next(iter(set(ha_modes).intersection(operation_list)), None)
         if ha_mode not in operation_list:
             msg = f"The requested thermostat mode {mode} is not supported"
             raise AlexaUnsupportedThermostatModeError(msg)

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -472,11 +472,7 @@ async def test_report_climate_state(hass):
             {"value": 34.0, "scale": "CELSIUS"},
         )
 
-    for off_modes in (
-        climate.HVAC_MODE_OFF,
-        climate.HVAC_MODE_FAN_ONLY,
-        climate.HVAC_MODE_DRY,
-    ):
+    for off_modes in (climate.HVAC_MODE_OFF, climate.HVAC_MODE_FAN_ONLY):
         hass.states.async_set(
             "climate.downstairs",
             off_modes,
@@ -494,6 +490,23 @@ async def test_report_climate_state(hass):
             "temperature",
             {"value": 34.0, "scale": "CELSIUS"},
         )
+
+    # assert dry is reported as CUSTOM
+    hass.states.async_set(
+        "climate.downstairs",
+        "dry",
+        {
+            "friendly_name": "Climate Downstairs",
+            "supported_features": 91,
+            climate.ATTR_CURRENT_TEMPERATURE: 34,
+            ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
+        },
+    )
+    properties = await reported_properties(hass, "climate.downstairs")
+    properties.assert_equal("Alexa.ThermostatController", "thermostatMode", "CUSTOM")
+    properties.assert_equal(
+        "Alexa.TemperatureSensor", "temperature", {"value": 34.0, "scale": "CELSIUS"}
+    )
 
     hass.states.async_set(
         "climate.heat",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1453,7 +1453,6 @@ async def test_thermostat(hass):
         payload={"thermostatMode": {"value": "CUSTOM", "customName": "INVALID"}},
     )
     assert msg["event"]["payload"]["type"] == "UNSUPPORTED_THERMOSTAT_MODE"
-    hass.config.units.temperature_unit = TEMP_CELSIUS
 
     msg = await assert_request_fails(
         "Alexa.ThermostatController",
@@ -1464,7 +1463,6 @@ async def test_thermostat(hass):
         payload={"thermostatMode": {"value": "INVALID"}},
     )
     assert msg["event"]["payload"]["type"] == "UNSUPPORTED_THERMOSTAT_MODE"
-    hass.config.units.temperature_unit = TEMP_CELSIUS
 
     call, _ = await assert_request_calls_service(
         "Alexa.ThermostatController",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2,7 +2,7 @@
 import pytest
 
 from homeassistant.core import Context, callback
-from homeassistant.const import TEMP_FAHRENHEIT
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.components.alexa import smart_home, messages
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
@@ -1484,6 +1484,9 @@ async def test_thermostat(hass):
         payload={"thermostatMode": "ECO"},
     )
     assert call.data["preset_mode"] == "eco"
+
+    # Reset config temperature_unit back to CELSIUS, required for additional tests outside this component.
+    hass.config.units.temperature_unit = TEMP_CELSIUS
 
 
 async def test_exclude_filters(hass):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2,7 +2,7 @@
 import pytest
 
 from homeassistant.core import Context, callback
-from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import TEMP_FAHRENHEIT
 from homeassistant.components.alexa import smart_home, messages
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,


### PR DESCRIPTION
## Description:
This PR consists of the following improvements:

- this improves how `thermostatMode` is reported to the Alexa API, reports supported values at discovery based on entities supported modes. 
- adds support for `CUSTOM` mode
- adds support for `HVAC_MODE_DRY` mode using `CUSTOM` mode
- dynamically maps `SetThermostatMode` directive to correct `HVAC_MODE` based on entities supported `hvac_modes` and `preset_modes`. 
- prepares to support utterances for scheduling and duration


**Other Notes:**
The `CUSTOM` mode is not documented in the Alexa API docs at this time. However, `CUSTOM` mode is listed in the [official json validation schema](https://github.com/alexa/alexa-smarthome/tree/master/validation_schemas), but there is no information on the available `customNames`  that can be uttered. 
Based on issues opened by HA users "dry", "dehumidify" have been discovered. `fan_only` is still mapped to `off` until that directive is discovered.  

I suspect `capabilityResources` will be eventually extended to the ThermostatController, and will support additional custom names with that object. 


**Related issue (if applicable):** 
fixes #25310 
fixes #25595
implements change from PR #25868 This includes the missing tests. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
