### PR TITLE
Support wildcard in services.yaml

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -217,6 +217,13 @@ async def async_get_all_descriptions(hass):
                 domain_yaml = loaded[domain]
                 yaml_description = domain_yaml.get(service, {})
 
+                # if no description is found check if service name in yaml
+                # ends with '_'. if yes check if key is a substring of service name
+                for key in domain_yaml:
+                    if "_" == key[-1:] and key == service[: len(key)]:
+                        yaml_description = domain_yaml.get(key, {})
+                        break
+
                 # Don't warn for missing services, because it triggers false
                 # positives for things like scripts, that register as a service
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -220,7 +220,7 @@ async def async_get_all_descriptions(hass):
                 # if no description is found check if service name in yaml
                 # ends with '_'. if yes check if key is a substring of service name
                 for key in domain_yaml:
-                    if "_" == key[-1:] and key == service[: len(key)]:
+                    if key[-1:] == "_" and key == service[: len(key)]:
                         yaml_description = domain_yaml.get(key, {})
                         break
 


### PR DESCRIPTION
## Description:
Add support for using a wildcard in services.yaml for integrations that have dynamic service names.
Example: 
The Transmission integration has an `add_torrent` service. This integration now supports multiple instances and that requires giving a dynamic name for the service (in this case it is `add_torrent_INSTANCE_NAME`).
`add_torrent` is common for all created instances. By adding "_" to the service name key in `services.yaml` (so it will be `add_torrent_`) this allows the service description to be picked by all services created by the integration for the different instances.

Of course this requires that integrations follow the same pattern (adding `_` to the end of the key in `services.yaml`) so that it will be picked up by all created services related to the integration.


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
