### PR TITLE
Fix tzinfo type for onvif component

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -206,7 +206,7 @@ class ONVIFHassCamera(Camera):
             else:
                 tzone = (
                     dt_util.get_time_zone(device_time.TimeZone)
-                    or dt_util.DEFAULT_TIME_ZONE,
+                    or dt_util.DEFAULT_TIME_ZONE
                 )
                 cdate = device_time.LocalDateTime
 


### PR DESCRIPTION
## Description:
Removal of the `,` character, which caused a tuple to be assigned to the `tzinfo` variable.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
