### PR TITLE
Tradfri config_flow enhancements

### DIFF
--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -8,6 +8,7 @@ from pytradfri.api.aiocoap_api import APIFactory
 import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.util.json import load_json
 from . import config_flow  # noqa  pylint_disable=unused-import
 from .const import (
@@ -113,8 +114,8 @@ async def async_setup_entry(hass, entry):
     try:
         gateway_info = await api(gateway.get_gateway_info())
     except RequestError:
-        _LOGGER.error("Tradfri setup failed.")
-        return False
+        await factory.shutdown()
+        raise ConfigEntryNotReady
 
     hass.data.setdefault(KEY_API, {})[entry.entry_id] = api
     hass.data.setdefault(KEY_GATEWAY, {})[entry.entry_id] = gateway

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -64,13 +64,17 @@ class FlowHandler(config_entries.ConfigFlow):
                     errors[KEY_SECURITY_CODE] = err.code
                 else:
                     errors["base"] = err.code
+        else:
+            user_input = {}
 
         fields = OrderedDict()
 
         if self._host is None:
-            fields[vol.Required(CONF_HOST)] = str
+            fields[vol.Required(CONF_HOST, default=user_input.get(CONF_HOST))] = str
 
-        fields[vol.Required(KEY_SECURITY_CODE)] = str
+        fields[
+            vol.Required(KEY_SECURITY_CODE, default=user_input.get(KEY_SECURITY_CODE))
+        ] = str
 
         return self.async_show_form(
             step_id="auth", data_schema=vol.Schema(fields), errors=errors


### PR DESCRIPTION
## Description:

Makes the form "remember" what you typed in, so it will not be erased if you get an error.
Adds `ConfigEntryNotReady` if set up for the entry failed, can happen due to communication issues, with this it will retry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
