### PR TITLE
Add stop feature to tradfri covers

### DIFF
--- a/homeassistant/components/tradfri/const.py
+++ b/homeassistant/components/tradfri/const.py
@@ -2,7 +2,6 @@
 from homeassistant.components.light import SUPPORT_TRANSITION, SUPPORT_BRIGHTNESS
 from homeassistant.const import CONF_HOST  # noqa pylint: disable=unused-import
 
-ATTR_BATTERY = "battery"
 ATTR_DIMMER = "dimmer"
 ATTR_HUE = "hue"
 ATTR_SAT = "saturation"

--- a/homeassistant/components/tradfri/const.py
+++ b/homeassistant/components/tradfri/const.py
@@ -2,6 +2,7 @@
 from homeassistant.components.light import SUPPORT_TRANSITION, SUPPORT_BRIGHTNESS
 from homeassistant.const import CONF_HOST  # noqa pylint: disable=unused-import
 
+ATTR_BATTERY = "battery"
 ATTR_DIMMER = "dimmer"
 ATTR_HUE = "hue"
 ATTR_SAT = "saturation"

--- a/homeassistant/components/tradfri/cover.py
+++ b/homeassistant/components/tradfri/cover.py
@@ -1,13 +1,6 @@
 """Support for IKEA Tradfri covers."""
 
-from homeassistant.components.cover import (
-    CoverDevice,
-    ATTR_POSITION,
-    SUPPORT_OPEN,
-    SUPPORT_STOP,
-    SUPPORT_CLOSE,
-    SUPPORT_SET_POSITION,
-)
+from homeassistant.components.cover import CoverDevice, ATTR_POSITION
 from .base_class import TradfriBaseDevice
 from .const import KEY_GATEWAY, KEY_API, CONF_GATEWAY_ID
 
@@ -34,11 +27,6 @@ class TradfriCover(TradfriBaseDevice, CoverDevice):
         self._unique_id = f"{gateway_id}-{device.id}"
 
         self._refresh(device)
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION | SUPPORT_STOP
 
     @property
     def current_cover_position(self):

--- a/homeassistant/components/tradfri/cover.py
+++ b/homeassistant/components/tradfri/cover.py
@@ -9,7 +9,7 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION,
 )
 from .base_class import TradfriBaseDevice
-from .const import ATTR_BATTERY, KEY_GATEWAY, KEY_API, CONF_GATEWAY_ID
+from .const import KEY_GATEWAY, KEY_API, CONF_GATEWAY_ID
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -68,11 +68,6 @@ class TradfriCover(TradfriBaseDevice, CoverDevice):
     def is_closed(self):
         """Return if the cover is closed or not."""
         return self.current_cover_position == 0
-
-    @property
-    def device_state_attributes(self):
-        """Return the devices' state attributes."""
-        return {ATTR_BATTERY: self._device.device_info.battery_level}
 
     def _refresh(self, device):
         """Refresh the cover data."""

--- a/homeassistant/components/tradfri/cover.py
+++ b/homeassistant/components/tradfri/cover.py
@@ -4,11 +4,12 @@ from homeassistant.components.cover import (
     CoverDevice,
     ATTR_POSITION,
     SUPPORT_OPEN,
+    SUPPORT_STOP,
     SUPPORT_CLOSE,
     SUPPORT_SET_POSITION,
 )
 from .base_class import TradfriBaseDevice
-from .const import KEY_GATEWAY, KEY_API, CONF_GATEWAY_ID
+from .const import ATTR_BATTERY, KEY_GATEWAY, KEY_API, CONF_GATEWAY_ID
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -37,7 +38,7 @@ class TradfriCover(TradfriBaseDevice, CoverDevice):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION | SUPPORT_STOP
 
     @property
     def current_cover_position(self):
@@ -59,10 +60,19 @@ class TradfriCover(TradfriBaseDevice, CoverDevice):
         """Close cover."""
         await self._api(self._device_control.set_state(100))
 
+    async def async_stop_cover(self, **kwargs):
+        """Close cover."""
+        await self._api(self._device_control.trigger_blind())
+
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
         return self.current_cover_position == 0
+
+    @property
+    def device_state_attributes(self):
+        """Return the devices' state attributes."""
+        return {ATTR_BATTERY: self._device.device_info.battery_level}
 
     def _refresh(self, device):
         """Refresh the cover data."""

--- a/homeassistant/components/tradfri/manifest.json
+++ b/homeassistant/components/tradfri/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tradfri",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tradfri",
-  "requirements": ["pytradfri[async]==6.3.1"],
+  "requirements": ["pytradfri[async]==6.4.0"],
   "homekit": {
     "models": ["TRADFRI"]
   },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1612,7 +1612,7 @@ pytraccar==0.9.0
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri[async]==6.3.1
+pytradfri[async]==6.4.0
 
 # homeassistant.components.trafikverket_train
 # homeassistant.components.trafikverket_weatherstation

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -530,7 +530,7 @@ python_awair==0.0.4
 pytraccar==0.9.0
 
 # homeassistant.components.tradfri
-pytradfri[async]==6.3.1
+pytradfri[async]==6.4.0
 
 # homeassistant.components.vesync
 pyvesync==1.1.0


### PR DESCRIPTION
## Description:

- Adds stop capability to the cover.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
-->
If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
<!--
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
