### PR TITLE
Removes unwanted tradfri battery sensor

### DIFF
--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -19,6 +19,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if not dev.has_light_control
         and not dev.has_socket_control
         and not dev.has_blind_control
+        and not dev.has_signal_repeater_control
     )
     if devices:
         async_add_entities(TradfriSensor(device, api, gateway_id) for device in devices)


### PR DESCRIPTION
## Breaking Change:

This removes the battery sensor that was created for the signal repeater.
The sensor would never have a state, and after some inspection, it does not look like that device present any valuable metrics.

## Description:

Adds a condition so signal repeaters are not added as battery sensors.

Version bump of the pyradfri lib will happen in #28180 if that is not accepted I will update this PR with it before removing the draft status.

**Related issue (if applicable):** fixes #27923 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
