### PR TITLE
Add switches (on/off zones) to geniushub

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -232,7 +232,7 @@ class GeniusHeatingZone(GeniusZone):
 
     def __init__(self, broker, zone) -> None:
         """Initialize the Zone."""
-        super().__init__()
+        super().__init__(broker, zone)
 
         self._max_temp = self._min_temp = self._supported_features = None
 

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -93,7 +93,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
 
     async_track_time_interval(hass, broker.async_update, SCAN_INTERVAL)
 
-    for platform in ["climate", "water_heater", "sensor", "binary_sensor"]:
+    for platform in ["climate", "water_heater", "sensor", "binary_sensor", "switch"]:
         hass.async_create_task(async_load_platform(hass, platform, DOMAIN, {}, config))
 
     return True

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -215,8 +215,6 @@ class GeniusZone(GeniusEntity):
         self._zone = zone
         self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
 
-        self._max_temp = self._min_temp = self._supported_features = None
-
     @property
     def name(self) -> str:
         """Return the name of the climate device."""
@@ -227,6 +225,16 @@ class GeniusZone(GeniusEntity):
         """Return the device state attributes."""
         status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}
         return {"status": status}
+
+
+class GeniusHeatingZone(GeniusZone):
+    """Base for Genius Heating Zones."""
+
+    def __init__(self, broker, zone) -> None:
+        """Initialize the Zone."""
+        super().__init__()
+
+        self._max_temp = self._min_temp = self._supported_features = None
 
     @property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/geniushub/climate.py
+++ b/homeassistant/components/geniushub/climate.py
@@ -15,7 +15,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, GeniusZone
+from . import DOMAIN, GeniusHeatingZone
 
 # GeniusHub Zones support: Off, Timer, Override/Boost, Footprint & Linked modes
 HA_HVAC_TO_GH = {HVAC_MODE_OFF: "off", HVAC_MODE_HEAT: "timer"}
@@ -45,7 +45,7 @@ async def async_setup_platform(
     )
 
 
-class GeniusClimateZone(GeniusZone, ClimateDevice):
+class GeniusClimateZone(GeniusHeatingZone, ClimateDevice):
     """Representation of a Genius Hub climate device."""
 
     def __init__(self, broker, zone) -> None:

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/integrations/geniushub",
   "requirements": [
-    "geniushub-client==0.6.28"
+    "geniushub-client==0.6.29"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/integrations/geniushub",
   "requirements": [
-    "geniushub-client==0.6.29"
+    "geniushub-client==0.6.30"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -19,7 +19,7 @@ async def async_setup_platform(
     switches = [
         GeniusSwitch(broker, z)
         for z in broker.client.zone_objs
-        z.data["type"] == GH_ON_OFF_ZONE
+        if z.data["type"] == GH_ON_OFF_ZONE
     ]
 
     async_add_entities(switches)

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,7 +2,7 @@
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
+from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusEntity
 
 GH_ON_OFF_ZONE = "on / off"
 
@@ -25,8 +25,26 @@ async def async_setup_platform(
     async_add_entities(switches)
 
 
-class GeniusSwitch(GeniusZone, SwitchDevice):
+class GeniusSwitch(GeniusEntity, SwitchDevice):
     """Representation of a Genius Hub switch."""
+
+    def __init__(self, broker, zone) -> None:
+        """Initialize the Zone."""
+        super().__init__()
+
+        self._zone = zone
+        self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the climate device."""
+        return self._zone.name
+
+    @property
+    def device_state_attributes(self) -> Dict[str, Any]:
+        """Return the device state attributes."""
+        status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}
+        return {"status": status}
 
     @property
     def device_class(self):

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,7 +2,7 @@
 from homeassistant.components.switch import SwitchDevice, DEVICE_CLASS_OUTLET
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
+from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusEntity
 
 ATTR_DURATION = "duration"
 
@@ -27,8 +27,26 @@ async def async_setup_platform(
     )
 
 
-class GeniusSwitch(GeniusZone, SwitchDevice):
+class GeniusSwitch(GeniusEntity, SwitchDevice):
     """Representation of a Genius Hub switch."""
+
+    def __init__(self, broker, zone) -> None:
+        """Initialize the Zone."""
+        super().__init__()
+
+        self._zone = zone
+        self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the climate device."""
+        return self._zone.name
+
+    @property
+    def device_state_attributes(self) -> Dict[str, Any]:
+        """Return the device state attributes."""
+        status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}
+        return {"status": status}
 
     @property
     def device_class(self):

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,7 +2,7 @@
 from homeassistant.components.switch import SwitchDevice, DEVICE_CLASS_OUTLET
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusEntity
+from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
 
 ATTR_DURATION = "duration"
 
@@ -27,26 +27,8 @@ async def async_setup_platform(
     )
 
 
-class GeniusSwitch(GeniusEntity, SwitchDevice):
+class GeniusSwitch(GeniusZone, SwitchDevice):
     """Representation of a Genius Hub switch."""
-
-    def __init__(self, broker, zone) -> None:
-        """Initialize the Zone."""
-        super().__init__()
-
-        self._zone = zone
-        self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
-
-    @property
-    def name(self) -> str:
-        """Return the name of the climate device."""
-        return self._zone.name
-
-    @property
-    def device_state_attributes(self) -> Dict[str, Any]:
-        """Return the device state attributes."""
-        status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}
-        return {"status": status}
 
     @property
     def device_class(self):

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -1,0 +1,55 @@
+"""Support for Genius Hub switch/outlet devices."""
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+
+from . import DOMAIN, GeniusZone
+
+GH_ZONE_ATTR = "on / off"
+
+
+async def async_setup_platform(
+    hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
+) -> None:
+    """Set up the Genius Hub switch entities."""
+    if discovery_info is None:
+        return
+
+    broker = hass.data[DOMAIN]["broker"]
+
+    switches = [
+        GeniusSwitch(broker, z)
+        for z in broker.client.zone_objs
+        if GH_ZONE_ATTR in z.data["type"]
+    ]
+
+    async_add_entities(switches, update_before_add=True)
+
+
+class GeniusSwitch(GeniusZone, SwitchDevice):
+    """Representation of a Genius Hub switch."""
+
+    def __init__(self, broker, zone) -> None:
+        """Initialize the switch."""
+        super().__init__(broker, zone)
+
+    @property
+    def is_on(self) -> bool:
+        """Return the status of the sensor."""
+        # off, override, timer, footprint
+        # technially this could be untrue, if we're using the timer
+        return self._zone.data["mode"] != "off"
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the switch off."""
+        await self._zone.set_mode("off")
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_schedule_update_ha_state()
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        # geniusclient doesn't (yet) have a way to specify the override for this
+        await self._zone.set_mode("override")
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,7 +2,7 @@
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusEntity
+from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
 
 GH_ON_OFF_ZONE = "on / off"
 
@@ -25,26 +25,8 @@ async def async_setup_platform(
     async_add_entities(switches)
 
 
-class GeniusSwitch(GeniusEntity, SwitchDevice):
+class GeniusSwitch(GeniusZone, SwitchDevice):
     """Representation of a Genius Hub switch."""
-
-    def __init__(self, broker, zone) -> None:
-        """Initialize the Zone."""
-        super().__init__()
-
-        self._zone = zone
-        self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
-
-    @property
-    def name(self) -> str:
-        """Return the name of the climate device."""
-        return self._zone.name
-
-    @property
-    def device_state_attributes(self) -> Dict[str, Any]:
-        """Return the device state attributes."""
-        status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}
-        return {"status": status}
 
     @property
     def device_class(self):

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -61,14 +61,8 @@ class GeniusSwitch(GeniusEntity, SwitchDevice):
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         await self._zone.set_mode("off")
-        # State is set optimistically in the command above, therefore update
-        # the entity state ahead of receiving the confirming push updates
-        self.async_schedule_update_ha_state()
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         # geniusclient doesn't (yet) have a way to specify the override for this
         await self._zone.set_mode("override")
-        # State is set optimistically in the command above, therefore update
-        # the entity state ahead of receiving the confirming push updates
-        self.async_schedule_update_ha_state()

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,7 +2,7 @@
 from homeassistant.components.switch import SwitchDevice, DEVICE_CLASS_OUTLET
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
+from . import DOMAIN, GeniusZone
 
 ATTR_DURATION = "duration"
 

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -16,13 +16,13 @@ async def async_setup_platform(
 
     broker = hass.data[DOMAIN]["broker"]
 
-    switches = [
-        GeniusSwitch(broker, z)
-        for z in broker.client.zone_objs
-        if z.data["type"] == GH_ON_OFF_ZONE
-    ]
-
-    async_add_entities(switches)
+    async_add_entities(
+        [
+            GeniusSwitch(broker, z)
+            for z in broker.client.zone_objs
+            if z.data["type"] == GH_ON_OFF_ZONE
+        ]
+    )
 
 
 class GeniusSwitch(GeniusZone, SwitchDevice):

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -38,15 +38,16 @@ class GeniusSwitch(GeniusZone, SwitchDevice):
     @property
     def is_on(self) -> bool:
         """Return the current state of the on/off zone.
-        
+
         The zone is considered 'on' if & only if it is override/on (e.g. timer/on is 'off').
         """
         return self._zone.data["mode"] == "override" and self._zone.data["setpoint"]
 
     async def async_turn_off(self, **kwargs) -> None:
         """Send the zone to Timer mode.
-        
-        The zone is deemed 'off' in this mode, although the plugs may actually be on. """
+
+        The zone is deemed 'off' in this mode, although the plugs may actually be on.
+        """
         await self._zone.set_mode("timer")
 
     async def async_turn_on(self, **kwargs) -> None:

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -35,16 +35,18 @@ class GeniusSwitch(GeniusZone, SwitchDevice):
 
     @property
     def is_on(self) -> bool:
-        """Return the status of the sensor."""
-        # off, override, timer, footprint
-        # technially this could be untrue, if we're using the timer
-        return self._zone.data["mode"] != "off"
+        """Return the current state of the on/off zone.
+        
+        The zone is considered 'on' if & only if it is override/on (e.g. timer/on is 'off').
+        """
+        return self._zone.data["mode"] == "override" and self._zone.data["setpoint"]
 
     async def async_turn_off(self, **kwargs) -> None:
-        """Turn the switch off."""
-        await self._zone.set_mode("off")
+        """Send the zone to Timer mode.
+        
+        The zone is deemed 'off' in this mode, although the plugs may actually be on. """
+        await self._zone.set_mode("timer")
 
     async def async_turn_on(self, **kwargs) -> None:
-        """Turn the switch on."""
-        # geniusclient doesn't (yet) have a way to specify the override for this
-        await self._zone.set_mode("override")
+        """Set the zone to override/on ({'setpoint': true}) for 3600 seconds."""
+        await self._zone.set_override(1)

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,7 +2,7 @@
 from homeassistant.components.switch import SwitchDevice, DEVICE_CLASS_OUTLET
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, GeniusZone
+from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
 
 ATTR_DURATION = "duration"
 

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,9 +2,9 @@
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, GeniusZone
+from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
 
-GH_ZONE_ATTR = "on / off"
+GH_ON_OFF_ZONE = "on / off"
 
 
 async def async_setup_platform(
@@ -19,14 +19,19 @@ async def async_setup_platform(
     switches = [
         GeniusSwitch(broker, z)
         for z in broker.client.zone_objs
-        if GH_ZONE_ATTR in z.data["type"]
+        z.data["type"] == GH_ON_OFF_ZONE
     ]
 
-    async_add_entities(switches, update_before_add=True)
+    async_add_entities(switches)
 
 
 class GeniusSwitch(GeniusZone, SwitchDevice):
     """Representation of a Genius Hub switch."""
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_OUTLET
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -1,8 +1,8 @@
 """Support for Genius Hub switch/outlet devices."""
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.switch import SwitchDevice, DEVICE_CLASS_OUTLET
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, DEVICE_CLASS_OUTLET, GeniusZone
+from . import DOMAIN, GeniusZone
 
 GH_ON_OFF_ZONE = "on / off"
 

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -28,10 +28,6 @@ async def async_setup_platform(
 class GeniusSwitch(GeniusZone, SwitchDevice):
     """Representation of a Genius Hub switch."""
 
-    def __init__(self, broker, zone) -> None:
-        """Initialize the switch."""
-        super().__init__(broker, zone)
-
     @property
     def is_on(self) -> bool:
         """Return the status of the sensor."""

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -4,6 +4,8 @@ from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import DOMAIN, GeniusZone
 
+ATTR_DURATION = "duration"
+
 GH_ON_OFF_ZONE = "on / off"
 
 
@@ -48,5 +50,5 @@ class GeniusSwitch(GeniusZone, SwitchDevice):
         await self._zone.set_mode("timer")
 
     async def async_turn_on(self, **kwargs) -> None:
-        """Set the zone to override/on ({'setpoint': true}) for 3600 seconds."""
-        await self._zone.set_override(1)
+        """Set the zone to override/on ({'setpoint': true}) for x seconds."""
+        await self._zone.set_override(1, kwargs.get(ATTR_DURATION, 3600))

--- a/homeassistant/components/geniushub/water_heater.py
+++ b/homeassistant/components/geniushub/water_heater.py
@@ -9,7 +9,7 @@ from homeassistant.components.water_heater import (
 from homeassistant.const import STATE_OFF
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import DOMAIN, GeniusZone
+from . import DOMAIN, GeniusHeatingZone
 
 STATE_AUTO = "auto"
 STATE_MANUAL = "manual"
@@ -49,7 +49,7 @@ async def async_setup_platform(
     )
 
 
-class GeniusWaterHeater(GeniusZone, WaterHeaterDevice):
+class GeniusWaterHeater(GeniusHeatingZone, WaterHeaterDevice):
     """Representation of a Genius Hub water_heater device."""
 
     def __init__(self, broker, zone) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -540,7 +540,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.6.29
+geniushub-client==0.6.30
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -540,7 +540,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.6.28
+geniushub-client==0.6.29
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
## Description:

The **geniushub** integration shows smart plug Devices as BinarySensors; it can report when they are on or off, but can not change their state (this is done in GH via the parent Zone). 

This PR adds on/off Zones as SwitchDevices:
 - 'turn_on' - set Zone to GH's Override/On mode
 - 'turn_off' - set Zone to GH's Timer mode

Also bumps **geniushub-client** from 0.6.28 to 0.6.29, see: https://github.com/zxdavb/geniushub-client/compare/v0.6.28...v0.630, which fixes:
 - https://github.com/zxdavb/geniushub-client/issues/25, and
 - https://github.com/zxdavb/geniushub-client/issues/27

**Pull request with documentation for home-assistant.io:** home-assistant/home-assistant.io#11095

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** - no tests for geniushub
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`. - nothing changed
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`. - no new ones
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
