### PR TITLE
Add Atlona Juno HDMI Switch component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -62,6 +62,7 @@ omit =
     homeassistant/components/asterisk_cdr/mailbox.py
     homeassistant/components/asterisk_mbox/*
     homeassistant/components/asuswrt/device_tracker.py
+    homeassistant/components/atlona_juno/media_player.py
     homeassistant/components/atome/*
     homeassistant/components/august/*
     homeassistant/components/aurora_abb_powerone/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,6 +32,7 @@ homeassistant/components/arcam_fmj/* @elupus
 homeassistant/components/arduino/* @fabaff
 homeassistant/components/arest/* @fabaff
 homeassistant/components/asuswrt/* @kennedyshead
+homeassistant/components/atlona_juno/* @bluestripe
 homeassistant/components/atome/* @baqs
 homeassistant/components/aurora_abb_powerone/* @davet2001
 homeassistant/components/auth/* @home-assistant/core

--- a/homeassistant/components/atlona_juno/__init__.py
+++ b/homeassistant/components/atlona_juno/__init__.py
@@ -1,0 +1,1 @@
+"""Atlona Juno 451 Integration."""

--- a/homeassistant/components/atlona_juno/manifest.json
+++ b/homeassistant/components/atlona_juno/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "media_player",
+  "name": "Atlona Juno 451",
+  "documentation": "https://www.home-assistant.io/components/atlona_juno",
+  "requirements": [
+    "pyatlonajuno==1.1.1"
+  ],
+  "dependencies": [],
+  "codeowners": ["@bluestripe"]
+}

--- a/homeassistant/components/atlona_juno/manifest.json
+++ b/homeassistant/components/atlona_juno/manifest.json
@@ -1,5 +1,5 @@
 {
-  "domain": "media_player",
+  "domain": "atlona_juno",
   "name": "Atlona Juno 451",
   "documentation": "https://www.home-assistant.io/components/atlona_juno",
   "requirements": [

--- a/homeassistant/components/atlona_juno/media_player.py
+++ b/homeassistant/components/atlona_juno/media_player.py
@@ -1,0 +1,146 @@
+"""Support for interfacing with Atlona Juno 451 HDMI 4x1 Switch."""
+import logging
+
+from pyatlonajuno.lib import Juno451
+import voluptuous as vol
+
+from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player.const import (
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_PROTOCOL,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_NAME,
+    STATE_OFF,
+    STATE_ON,
+)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "Atlona Juno 451"
+DEFAULT_PORT = 80
+DEFAULT_PROTOCOL = "http"
+
+SUPPORT_ATLONAJUNO = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
+
+
+CONF_SOURCES = "sources"
+ATTR_SOURCE = "source"
+
+# Valid source ids: 1-4
+MEDIA_PLAYER_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.comp_entity_ids})
+SOURCE_IDS = vol.All(vol.Coerce(int), vol.Range(min=1, max=4))
+SOURCE_SCHEMA = vol.Schema({vol.Required(CONF_NAME): cv.string})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): cv.string,
+        vol.Required(CONF_SOURCES): vol.Schema({SOURCE_IDS: SOURCE_SCHEMA}),
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Atlona Juno 451 HDMI switch."""
+    url = "{}://{}:{}".format(
+        config.get(CONF_PROTOCOL), config.get(CONF_HOST), config.get(CONF_PORT)
+    )
+    _LOGGER.debug("Composed URL for Atlona Juno %s", url)
+    sources = {
+        source_id: extra[CONF_NAME] for source_id, extra in config[CONF_SOURCES].items()
+    }
+
+    atlona_device = AtlonaJuno(hass, config.get(CONF_NAME), Juno451(url), sources)
+
+    add_entities([atlona_device], True)
+
+
+class AtlonaJuno(MediaPlayerDevice):
+    """Representation of a Atlona Juno 451 HDMI switch."""
+
+    def __init__(self, hass, name, atlona_device, sources):
+        """Initialize."""
+        self._name = name
+        self._atlona_device = atlona_device
+
+        # dict source_id -> source name
+        self._source_id_name = sources
+        # dict source name -> source_id
+        self._source_name_id = {v: k for k, v in sources.items()}
+        # ordered list of all source names
+        self._source_names = sorted(
+            self._source_name_id.keys(), key=lambda v: self._source_name_id[v]
+        )
+
+        self._state = None
+        self._source = None
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the on/off state of the device."""
+        return self._state
+
+    @property
+    def source(self):
+        """Return the current input source of the device."""
+        return self._source
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._source_names
+
+    @property
+    def supported_features(self):
+        """Return supported features flag."""
+        return SUPPORT_ATLONAJUNO
+
+    @property
+    def device_state_attributes(self):
+        """Set device attributes."""
+        attributes = {}
+        attributes[ATTR_SOURCE] = self._source
+        return attributes
+
+    def turn_on(self):
+        """Turn the power on."""
+        self._state = STATE_ON
+        self._atlona_device.setPowerState("on")
+        self.schedule_update_ha_state()
+
+    def turn_off(self):
+        """Turn the power off."""
+        self._state = STATE_OFF
+        self._atlona_device.setPowerState("off")
+        self.schedule_update_ha_state()
+
+    def select_source(self, source):
+        """Set input source."""
+        if source not in self._source_name_id:
+            return
+        source_index = self._source_name_id[source]
+        _LOGGER.debug("Setting input source to %s", source)
+        self._atlona_device.setSource(source_index)
+
+    def update(self):
+        """Retrieve state."""
+        self._state = self._atlona_device.getPowerState()
+        source_index = self._atlona_device.getSource()
+        if source_index in self._source_id_name:
+            self._source = self._source_id_name[source_index]
+        else:
+            self._source = None

--- a/homeassistant/components/atlona_juno/media_player.py
+++ b/homeassistant/components/atlona_juno/media_player.py
@@ -141,6 +141,10 @@ class AtlonaJuno(MediaPlayerDevice):
         source_index = self._source_name_id[source]
         _LOGGER.debug("Setting input source to %s", source)
         self._atlona_device.setSource(source_index)
+        if source_index in self._source_id_name:
+            self._source = self._source_id_name[source_index]
+        else:
+            self._source = None
 
     def update(self):
         """Retrieve state."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1086,6 +1086,9 @@ pyalarmdotcom==0.3.2
 # homeassistant.components.arlo
 pyarlo==0.2.3
 
+# homeassistant.components.atlona_juno
+pyatlonajuno==1.1.1
+
 # homeassistant.components.netatmo
 pyatmo==2.3.2
 


### PR DESCRIPTION
## Description:
This component implements Atlona Juno 451 4x1 HDMI Switch on the media_player platform with the ability to turn the switch on and off and select what input channel to use. The component uses an existing python library, which in turn uses IP connection to control the switch. 

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: atlona_juno
    host: 192.168.10.10
    sources:
      1:
        name: TV
      2:
        name: Nintendo
      3:
        name: PS4
      4:
        name: Plex
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in https://github.com/home-assistant/home-assistant.io/commit/ab6431dca4bf5274137bf1434315dbc2c037903f

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
