### PR TITLE
Partially revert tensorflow import move

### DIFF
--- a/homeassistant/components/tensorflow/image_processing.py
+++ b/homeassistant/components/tensorflow/image_processing.py
@@ -1,12 +1,13 @@
 """Support for performing TensorFlow classification on images."""
-import logging
 import io
-import numpy as np
+import logging
 import os
 import sys
-import voluptuous as vol
 
 from PIL import Image, ImageDraw
+import numpy as np
+import voluptuous as vol
+
 from homeassistant.components.image_processing import (
     CONF_CONFIDENCE,
     CONF_ENTITY_ID,

--- a/homeassistant/components/tensorflow/image_processing.py
+++ b/homeassistant/components/tensorflow/image_processing.py
@@ -1,10 +1,12 @@
 """Support for performing TensorFlow classification on images."""
 import logging
+import io
+import numpy as np
 import os
 import sys
-
 import voluptuous as vol
 
+from PIL import Image, ImageDraw
 from homeassistant.components.image_processing import (
     CONF_CONFIDENCE,
     CONF_ENTITY_ID,
@@ -236,9 +238,6 @@ class TensorFlowImageProcessor(ImageProcessingEntity):
         }
 
     def _save_image(self, image, matches, paths):
-        from PIL import Image, ImageDraw
-        import io
-
         img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
         img_width, img_height = img.size
         draw = ImageDraw.Draw(img)
@@ -280,7 +279,6 @@ class TensorFlowImageProcessor(ImageProcessingEntity):
 
     def process_image(self, image):
         """Process the image."""
-        import numpy as np
 
         try:
             import cv2  # pylint: disable=import-error
@@ -289,9 +287,6 @@ class TensorFlowImageProcessor(ImageProcessingEntity):
             inp = img[:, :, [2, 1, 0]]  # BGR->RGB
             inp_expanded = inp.reshape(1, inp.shape[0], inp.shape[1], 3)
         except ImportError:
-            from PIL import Image
-            import io
-
             img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
             img.thumbnail((460, 460), Image.ANTIALIAS)
             img_width, img_height = img.size

--- a/homeassistant/components/tensorflow/image_processing.py
+++ b/homeassistant/components/tensorflow/image_processing.py
@@ -91,6 +91,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         # Verify that the TensorFlow Object Detection API is pre-installed
         # pylint: disable=unused-import,unused-variable
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+        # These imports shouldn't be moved to the top, because they depend on code from the model_dir.
+        # (The model_dir is created during the manual setup process. See integration docs.)
         import tensorflow as tf  # noqa
         from object_detection.utils import label_map_util  # noqa
     except ImportError:

--- a/homeassistant/components/tensorflow/image_processing.py
+++ b/homeassistant/components/tensorflow/image_processing.py
@@ -2,22 +2,8 @@
 import logging
 import os
 import sys
-import io
+
 import voluptuous as vol
-from PIL import Image, ImageDraw
-import numpy as np
-
-try:
-    import cv2
-except ImportError:
-    cv2 = None
-
-try:
-    # Verify that the TensorFlow Object Detection API is pre-installed
-    import tensorflow as tf  # noqa
-    from object_detection.utils import label_map_util  # noqa
-except ImportError:
-    label_map_util = None
 
 from homeassistant.components.image_processing import (
     CONF_CONFIDENCE,
@@ -98,8 +84,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # append custom model path to sys.path
     sys.path.append(model_dir)
 
-    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
-    if label_map_util is None:
+    try:
+        # Verify that the TensorFlow Object Detection API is pre-installed
+        # pylint: disable=unused-import,unused-variable
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+        import tensorflow as tf  # noqa
+        from object_detection.utils import label_map_util  # noqa
+    except ImportError:
+        # pylint: disable=line-too-long
         _LOGGER.error(
             "No TensorFlow Object Detection library found! Install or compile "
             "for your system following instructions here: "
@@ -107,7 +99,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         )  # noqa
         return
 
-    if cv2 is None:
+    try:
+        # Display warning that PIL will be used if no OpenCV is found.
+        # pylint: disable=unused-import,unused-variable
+        import cv2  # noqa
+    except ImportError:
         _LOGGER.warning(
             "No OpenCV library found. TensorFlow will process image with "
             "PIL at reduced resolution"
@@ -240,6 +236,9 @@ class TensorFlowImageProcessor(ImageProcessingEntity):
         }
 
     def _save_image(self, image, matches, paths):
+        from PIL import Image, ImageDraw
+        import io
+
         img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
         img_width, img_height = img.size
         draw = ImageDraw.Draw(img)
@@ -281,8 +280,18 @@ class TensorFlowImageProcessor(ImageProcessingEntity):
 
     def process_image(self, image):
         """Process the image."""
+        import numpy as np
 
-        if cv2 is None:
+        try:
+            import cv2  # pylint: disable=import-error
+
+            img = cv2.imdecode(np.asarray(bytearray(image)), cv2.IMREAD_UNCHANGED)
+            inp = img[:, :, [2, 1, 0]]  # BGR->RGB
+            inp_expanded = inp.reshape(1, inp.shape[0], inp.shape[1], 3)
+        except ImportError:
+            from PIL import Image
+            import io
+
             img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
             img.thumbnail((460, 460), Image.ANTIALIAS)
             img_width, img_height = img.size
@@ -292,10 +301,6 @@ class TensorFlowImageProcessor(ImageProcessingEntity):
                 .astype(np.uint8)
             )
             inp_expanded = np.expand_dims(inp, axis=0)
-        else:
-            img = cv2.imdecode(np.asarray(bytearray(image)), cv2.IMREAD_UNCHANGED)
-            inp = img[:, :, [2, 1, 0]]  # BGR->RGB
-            inp_expanded = inp.reshape(1, inp.shape[0], inp.shape[1], 3)
 
         image_tensor = self._graph.get_tensor_by_name("image_tensor:0")
         boxes = self._graph.get_tensor_by_name("detection_boxes:0")


### PR DESCRIPTION
## Description:
Need to partially revert Tensorflow import move.
Otherwise the custom model path is not loaded before importing object_detection.utils.

```
    # append custom model path to sys.path
    sys.path.append(model_dir)

    try:
        # Verify that the TensorFlow Object Detection API is pre-installed
        # pylint: disable=unused-import,unused-variable
        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
        import tensorflow as tf  # noqa
        from object_detection.utils import label_map_util  # noqa
    except ImportError:
```


I also left the cv import untouched. which is also in a try/except, because i couldn' t test it.

**Related issue (if applicable):** fixes #28174


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
