### PR TITLE
Fix ESPHome stacktraces when removing entity and shutting down

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -56,6 +56,13 @@ class RuntimeEntryData:
     reconnect_task = attr.ib(type=Optional[asyncio.Task], default=None)
     state = attr.ib(type=Dict[str, Dict[str, Any]], factory=dict)
     info = attr.ib(type=Dict[str, Dict[str, Any]], factory=dict)
+
+    # A second list of EntityInfo objects
+    # This is necessary for when an entity is being removed. HA requires
+    # some static info to be accessible during removal (unique_id, maybe others)
+    # If an entity can't find anything in the info array, it will look for info here.
+    old_info = attr.ib(type=Dict[str, Dict[str, Any]], factory=dict)
+
     services = attr.ib(type=Dict[int, "UserService"], factory=dict)
     available = attr.ib(type=bool, default=False)
     device_info = attr.ib(type=DeviceInfo, default=None)


### PR DESCRIPTION
## Description:

This fixes two issues in the esphome integration that have been there for some time (but are mostly just spamming logs, functionality works fine).

First, when removing an entity there's a not-so-nice race condition between Home Assistant removing the entity and the integration removing the info object.

```
2019-10-24 20:49:26 ERROR (MainThread) [homeassistant.util.logging] Exception in async_remove when dispatching 'esphome_cbb2ae622eb5401d94417798b83191ef_remove_text_sensor_1873025163': ()
Traceback (most recent call last):
  File "~/repos/home-assistant/homeassistant/core.py", line 674, in _async_remove_listener
    self._listeners[event_type].remove(listener)
  File "~/repos/home-assistant/homeassistant/helpers/entity.py", line 539, in __eq__
    if self.unique_id is None or other.unique_id is None:
  File "~/repos/home-assistant/homeassistant/components/esphome/__init__.py", line 559, in unique_id
    if not self._static_info.unique_id:
  File "~/repos/home-assistant/homeassistant/components/esphome/sensor.py", line 85, in _static_info
    return super()._static_info
  File "~/repos/home-assistant/homeassistant/components/esphome/__init__.py", line 527, in _static_info
    return self._entry_data.info[self._component_key][self._key]
KeyError: 2544985372
```

This is fixed by adding a second `old_info` dictionary that stores the previous info object. I know it's not so nice but I tried a bunch of options and this turned out to be the best (tradeoff is if you want to keep a single source of truth).

The second is when shutting down HA, ESPHome used to throw `2019-10-24 21:08:36 WARNING (MainThread) [homeassistant.core] Unable to remove unknown listener <function EventBus.async_listen_once.<locals>.onetime_listener at 0x1105df050>` because the cleanup listener was called twice. This is fixed by listening to the STOP event through `async_listen`.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
