### PR TITLE
Change Alexa default display category based on media_player device_class

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -391,7 +391,11 @@ class MediaPlayerCapabilities(AlexaEntity):
 
     def default_display_categories(self):
         """Return the display categories for this entity."""
-        return [DisplayCategory.TV]
+        device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
+        if device_class == media_player.DEVICE_CLASS_SPEAKER:
+            return [DisplayCategory.SPEAKER]
+        else:
+            return [DisplayCategory.TV]
 
     def interfaces(self):
         """Yield the supported interfaces."""

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -394,8 +394,8 @@ class MediaPlayerCapabilities(AlexaEntity):
         device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
         if device_class == media_player.DEVICE_CLASS_SPEAKER:
             return [DisplayCategory.SPEAKER]
-        else:
-            return [DisplayCategory.TV]
+
+        return [DisplayCategory.TV]
 
     def interfaces(self):
         """Yield the supported interfaces."""

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -968,6 +968,25 @@ async def test_media_player_power(hass):
     )
 
 
+async def test_media_player_speaker(hass):
+    """Test media player discovery with device class speaker."""
+    device = (
+        "media_player.test",
+        "off",
+        {
+            "friendly_name": "Test media player",
+            "supported_features": 51765,
+            "volume_level": 0.75,
+            "device_class": "speaker",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "media_player#test"
+    assert appliance["displayCategories"][0] == "SPEAKER"
+    assert appliance["friendlyName"] == "Test media player"
+
+
 async def test_alert(hass):
     """Test alert discovery."""
     device = ("alert.test", "off", {"friendly_name": "Test alert"})


### PR DESCRIPTION
## Description:
Returns the default display category based on media_player device_class. Defaults to TV, to support existing entities or entities without device_class attribute.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
