### PR TITLE
Emulated Hue overhaul

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -1,7 +1,6 @@
 """Support for a Hue API to control Home Assistant."""
 import logging
-
-from aiohttp import web
+import hashlib
 
 from homeassistant import core
 from homeassistant.components import (
@@ -36,8 +35,10 @@ from homeassistant.components.http.const import KEY_REAL_IP
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
+    ATTR_COLOR_TEMP,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
+    SUPPORT_COLOR_TEMP,
 )
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_VOLUME_LEVEL,
@@ -48,6 +49,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     HTTP_BAD_REQUEST,
+    HTTP_UNAUTHORIZED,
     HTTP_NOT_FOUND,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
@@ -61,18 +63,30 @@ from homeassistant.util.network import is_local
 
 _LOGGER = logging.getLogger(__name__)
 
+STATE_BRIGHTNESS = "bri"
+STATE_COLORMODE = "colormode"
+STATE_HUE = "hue"
+STATE_SATURATION = "sat"
+STATE_COLOR_TEMP = "ct"
+
+# Hue API states, defined separately in case they change
 HUE_API_STATE_ON = "on"
 HUE_API_STATE_BRI = "bri"
+HUE_API_STATE_COLORMODE = "colormode"
 HUE_API_STATE_HUE = "hue"
 HUE_API_STATE_SAT = "sat"
+HUE_API_STATE_CT = "ct"
+HUE_API_STATE_EFFECT = "effect"
 
-HUE_API_STATE_HUE_MAX = 65535.0
-HUE_API_STATE_SAT_MAX = 254.0
-HUE_API_STATE_BRI_MAX = 255.0
-
-STATE_BRIGHTNESS = HUE_API_STATE_BRI
-STATE_HUE = HUE_API_STATE_HUE
-STATE_SATURATION = HUE_API_STATE_SAT
+# Hue API min/max values - https://developers.meethue.com/develop/hue-api/lights-api/
+HUE_API_STATE_BRI_MIN = 1     # Brightness
+HUE_API_STATE_BRI_MAX = 254
+HUE_API_STATE_HUE_MIN = 0     # Hue
+HUE_API_STATE_HUE_MAX = 65535
+HUE_API_STATE_SAT_MIN = 0     # Saturation
+HUE_API_STATE_SAT_MAX = 254
+HUE_API_STATE_CT_MIN = 153    # Color temp
+HUE_API_STATE_CT_MAX = 500
 
 
 class HueUsernameView(HomeAssistantView):
@@ -85,6 +99,9 @@ class HueUsernameView(HomeAssistantView):
 
     async def post(self, request):
         """Handle a POST request."""
+        if not is_local(request[KEY_REAL_IP]):
+            return self.json_message("Only local IPs allowed", HTTP_UNAUTHORIZED)
+
         try:
             data = await request.json()
         except ValueError:
@@ -93,14 +110,11 @@ class HueUsernameView(HomeAssistantView):
         if "devicetype" not in data:
             return self.json_message("devicetype not specified", HTTP_BAD_REQUEST)
 
-        if not is_local(request[KEY_REAL_IP]):
-            return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
-
         return self.json([{"success": {"username": "12345678901234567890"}}])
 
 
 class HueAllGroupsStateView(HomeAssistantView):
-    """Group handler."""
+    """Handle requests for getting info about entity groups."""
 
     url = "/api/{username}/groups"
     name = "emulated_hue:all_groups:state"
@@ -114,7 +128,7 @@ class HueAllGroupsStateView(HomeAssistantView):
     def get(self, request, username):
         """Process a request to make the Brilliant Lightpad work."""
         if not is_local(request[KEY_REAL_IP]):
-            return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
+            return self.json_message("Only local IPs allowed", HTTP_UNAUTHORIZED)
 
         return self.json({})
 
@@ -134,7 +148,7 @@ class HueGroupView(HomeAssistantView):
     def put(self, request, username):
         """Process a request to make the Logitech Pop working."""
         if not is_local(request[KEY_REAL_IP]):
-            return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
+            return self.json_message("Only local IPs allowed", HTTP_UNAUTHORIZED)
 
         return self.json(
             [
@@ -150,7 +164,7 @@ class HueGroupView(HomeAssistantView):
 
 
 class HueAllLightsStateView(HomeAssistantView):
-    """Handle requests for getting and setting info about entities."""
+    """Handle requests for getting info about all entities."""
 
     url = "/api/{username}/lights"
     name = "emulated_hue:lights:state"
@@ -164,7 +178,7 @@ class HueAllLightsStateView(HomeAssistantView):
     def get(self, request, username):
         """Process a request to get the list of available lights."""
         if not is_local(request[KEY_REAL_IP]):
-            return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
+            return self.json_message("Only local IPs allowed", HTTP_UNAUTHORIZED)
 
         hass = request.app["hass"]
         json_response = {}
@@ -180,7 +194,7 @@ class HueAllLightsStateView(HomeAssistantView):
 
 
 class HueOneLightStateView(HomeAssistantView):
-    """Handle requests for getting and setting info about entities."""
+    """Handle requests for getting info about a single entity."""
 
     url = "/api/{username}/lights/{entity_id}"
     name = "emulated_hue:light:state"
@@ -194,7 +208,7 @@ class HueOneLightStateView(HomeAssistantView):
     def get(self, request, username, entity_id):
         """Process a request to get the state of an individual light."""
         if not is_local(request[KEY_REAL_IP]):
-            return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
+            return self.json_message("Only local IPs allowed", HTTP_UNAUTHORIZED)
 
         hass = request.app["hass"]
         hass_entity_id = self.config.number_to_entity_id(entity_id)
@@ -204,17 +218,17 @@ class HueOneLightStateView(HomeAssistantView):
                 "Unknown entity number: %s not found in emulated_hue_ids.json",
                 entity_id,
             )
-            return web.Response(text="Entity not found", status=404)
+            return self.json_message("Entity not found", HTTP_NOT_FOUND)
 
         entity = hass.states.get(hass_entity_id)
 
         if entity is None:
             _LOGGER.error("Entity not found: %s", hass_entity_id)
-            return web.Response(text="Entity not found", status=404)
+            return self.json_message("Entity not found", HTTP_NOT_FOUND)
 
         if not self.config.is_entity_exposed(entity):
             _LOGGER.error("Entity not exposed: %s", entity_id)
-            return web.Response(text="Entity not exposed", status=404)
+            return self.json_message("Entity not exposed", HTTP_UNAUTHORIZED)
 
         state = get_entity_state(self.config, entity)
 
@@ -224,7 +238,7 @@ class HueOneLightStateView(HomeAssistantView):
 
 
 class HueOneLightChangeView(HomeAssistantView):
-    """Handle requests for getting and setting info about entities."""
+    """Handle requests for setting info about entities."""
 
     url = "/api/{username}/lights/{entity_number}/state"
     name = "emulated_hue:light:state"
@@ -237,7 +251,7 @@ class HueOneLightChangeView(HomeAssistantView):
     async def put(self, request, username, entity_number):
         """Process a request to set the state of an individual light."""
         if not is_local(request[KEY_REAL_IP]):
-            return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
+            return self.json_message("Only local IPs allowed", HTTP_UNAUTHORIZED)
 
         config = self.config
         hass = request.app["hass"]
@@ -255,7 +269,7 @@ class HueOneLightChangeView(HomeAssistantView):
 
         if not config.is_entity_exposed(entity):
             _LOGGER.error("Entity not exposed: %s", entity_id)
-            return web.Response(text="Entity not exposed", status=404)
+            return self.json_message("Entity not exposed", HTTP_UNAUTHORIZED)
 
         try:
             request_json = await request.json()
@@ -263,12 +277,12 @@ class HueOneLightChangeView(HomeAssistantView):
             _LOGGER.error("Received invalid json")
             return self.json_message("Invalid JSON", HTTP_BAD_REQUEST)
 
-        # Parse the request into requested "on" status and brightness
+        # Parse the request
         parsed = parse_hue_api_put_light_body(request_json, entity)
 
         if parsed is None:
             _LOGGER.error("Unable to parse data: %s", request_json)
-            return web.Response(text="Bad request", status=400)
+            return self.json_message("Bad request", HTTP_BAD_REQUEST)
 
         # Choose general HA domain
         domain = core.DOMAIN
@@ -282,7 +296,7 @@ class HueOneLightChangeView(HomeAssistantView):
         # Construct what we need to send to the service
         data = {ATTR_ENTITY_ID: entity_id}
 
-        # Make sure the entity actually supports brightness
+        # Get the entity's supported features
         entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         if entity.domain == light.DOMAIN:
@@ -290,21 +304,26 @@ class HueOneLightChangeView(HomeAssistantView):
                 if entity_features & SUPPORT_BRIGHTNESS:
                     if parsed[STATE_BRIGHTNESS] is not None:
                         data[ATTR_BRIGHTNESS] = parsed[STATE_BRIGHTNESS]
+
                 if entity_features & SUPPORT_COLOR:
                     if parsed[STATE_HUE] is not None:
+                        hue = parsed[STATE_HUE]
                         if parsed[STATE_SATURATION]:
                             sat = parsed[STATE_SATURATION]
                         else:
                             sat = 0
-                        hue = parsed[STATE_HUE]
 
                         # Convert hs values to hass hs values
-                        sat = int((sat / HUE_API_STATE_SAT_MAX) * 100)
                         hue = int((hue / HUE_API_STATE_HUE_MAX) * 360)
+                        sat = int((sat / HUE_API_STATE_SAT_MAX) * 100)
 
                         data[ATTR_HS_COLOR] = (hue, sat)
 
-        # If the requested entity is a script add some variables
+                if entity_features & SUPPORT_COLOR_TEMP:
+                    if parsed[STATE_COLOR_TEMP] is not None:
+                        data[ATTR_COLOR_TEMP] = parsed[STATE_COLOR_TEMP]
+
+        # If the requested entity is a script, add some variables
         elif entity.domain == script.DOMAIN:
             data["variables"] = {
                 "requested_state": STATE_ON if parsed[STATE_ON] else STATE_OFF
@@ -365,8 +384,8 @@ class HueOneLightChangeView(HomeAssistantView):
                     elif 66.6 < brightness <= 100:
                         data[ATTR_SPEED] = SPEED_HIGH
 
+        # Map the off command to on
         if entity.domain in config.off_maps_to_on_domains:
-            # Map the off command to on
             service = SERVICE_TURN_ON
 
             # Caching is required because things like scripts and scenes won't
@@ -396,88 +415,60 @@ class HueOneLightChangeView(HomeAssistantView):
             create_hue_success_response(entity_id, HUE_API_STATE_ON, parsed[STATE_ON])
         ]
 
-        if parsed[STATE_BRIGHTNESS] is not None:
-            json_response.append(
-                create_hue_success_response(
-                    entity_id, HUE_API_STATE_BRI, parsed[STATE_BRIGHTNESS]
+        for (key, val) in (
+            (STATE_BRIGHTNESS, HUE_API_STATE_BRI),
+            (STATE_HUE,        HUE_API_STATE_HUE),
+            (STATE_SATURATION, HUE_API_STATE_SAT),
+            (STATE_COLOR_TEMP, HUE_API_STATE_CT)
+        ):
+            if parsed[key] is not None:
+                json_response.append(
+                    create_hue_success_response(entity_id, val, parsed[key])
                 )
-            )
-        if parsed[STATE_HUE] is not None:
-            json_response.append(
-                create_hue_success_response(
-                    entity_id, HUE_API_STATE_HUE, parsed[STATE_HUE]
-                )
-            )
-        if parsed[STATE_SATURATION] is not None:
-            json_response.append(
-                create_hue_success_response(
-                    entity_id, HUE_API_STATE_SAT, parsed[STATE_SATURATION]
-                )
-            )
 
         return self.json(json_response)
 
 
 def parse_hue_api_put_light_body(request_json, entity):
-    """Parse the body of a request to change the state of a light."""
+    """Parse the body of a request to change the state of an entity."""
     data = {
+        STATE_ON: False,
         STATE_BRIGHTNESS: None,
         STATE_HUE: None,
-        STATE_ON: False,
         STATE_SATURATION: None,
+        STATE_COLOR_TEMP: None,
     }
 
-    # Make sure the entity actually supports brightness
+    # Get the entity's supported features
     entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
     if HUE_API_STATE_ON in request_json:
         if not isinstance(request_json[HUE_API_STATE_ON], bool):
             return None
 
-        if request_json[HUE_API_STATE_ON]:
-            # Echo requested device be turned on
-            data[STATE_BRIGHTNESS] = None
-            data[STATE_ON] = True
-        else:
-            # Echo requested device be turned off
-            data[STATE_BRIGHTNESS] = None
-            data[STATE_ON] = False
+        data[STATE_ON] = request_json[HUE_API_STATE_ON]
+        data[STATE_BRIGHTNESS] = None
 
-    if HUE_API_STATE_HUE in request_json:
-        try:
-            # Clamp brightness from 0 to 65535
-            data[STATE_HUE] = max(
-                0, min(int(request_json[HUE_API_STATE_HUE]), HUE_API_STATE_HUE_MAX)
-            )
-        except ValueError:
-            return None
+    for (key, attr, v_min, v_max) in (
+        (HUE_API_STATE_BRI, STATE_BRIGHTNESS, HUE_API_STATE_BRI_MIN, HUE_API_STATE_BRI_MAX),
+        (HUE_API_STATE_HUE, STATE_HUE,        HUE_API_STATE_HUE_MIN, HUE_API_STATE_HUE_MAX),
+        (HUE_API_STATE_SAT, STATE_SATURATION, HUE_API_STATE_SAT_MIN, HUE_API_STATE_SAT_MAX),
+        (HUE_API_STATE_CT,  STATE_COLOR_TEMP, HUE_API_STATE_CT_MIN,  HUE_API_STATE_CT_MAX)
+    ):
+        if key in request_json:
+            try:
+                data[attr] = max(v_min, min(int(request_json[key]), v_max))
+            except ValueError:
+                return None
 
     if HUE_API_STATE_SAT in request_json:
-        try:
-            # Clamp saturation from 0 to 254
-            data[STATE_SATURATION] = max(
-                0, min(int(request_json[HUE_API_STATE_SAT]), HUE_API_STATE_SAT_MAX)
-            )
-        except ValueError:
-            return None
-
-    if HUE_API_STATE_BRI in request_json:
-        try:
-            # Clamp brightness from 0 to 255
-            data[STATE_BRIGHTNESS] = max(
-                0, min(int(request_json[HUE_API_STATE_BRI]), HUE_API_STATE_BRI_MAX)
-            )
-        except ValueError:
-            return None
-
         if entity.domain == light.DOMAIN:
-            data[STATE_ON] = data[STATE_BRIGHTNESS] > 0
             if not entity_features & SUPPORT_BRIGHTNESS:
                 data[STATE_BRIGHTNESS] = None
 
         elif entity.domain == scene.DOMAIN:
-            data[STATE_BRIGHTNESS] = None
             data[STATE_ON] = True
+            data[STATE_BRIGHTNESS] = None
 
         elif entity.domain in [
             script.DOMAIN,
@@ -488,8 +479,8 @@ def parse_hue_api_put_light_body(request_json, entity):
         ]:
             # Convert 0-255 to 0-100
             level = (data[STATE_BRIGHTNESS] / HUE_API_STATE_BRI_MAX) * 100
-            data[STATE_BRIGHTNESS] = round(level)
             data[STATE_ON] = True
+            data[STATE_BRIGHTNESS] = round(level)
 
     return data
 
@@ -498,35 +489,42 @@ def get_entity_state(config, entity):
     """Retrieve and convert state and brightness values for an entity."""
     cached_state = config.cached_states.get(entity.entity_id, None)
     data = {
+        STATE_ON: False,
         STATE_BRIGHTNESS: None,
         STATE_HUE: None,
-        STATE_ON: False,
         STATE_SATURATION: None,
+        STATE_COLOR_TEMP: None,
     }
 
     if cached_state is None:
         data[STATE_ON] = entity.state != STATE_OFF
+
         if data[STATE_ON]:
             data[STATE_BRIGHTNESS] = entity.attributes.get(ATTR_BRIGHTNESS, 0)
             hue_sat = entity.attributes.get(ATTR_HS_COLOR, None)
             if hue_sat is not None:
                 hue = hue_sat[0]
                 sat = hue_sat[1]
-                # convert hass hs values back to hue hs values
+                # Convert hass hs values back to hue hs values
                 data[STATE_HUE] = int((hue / 360.0) * HUE_API_STATE_HUE_MAX)
                 data[STATE_SATURATION] = int((sat / 100.0) * HUE_API_STATE_SAT_MAX)
+            else:
+                data[STATE_HUE] = HUE_API_STATE_HUE_MIN
+                data[STATE_SATURATION] = HUE_API_STATE_SAT_MIN
+            data[STATE_COLOR_TEMP] = entity.attributes.get(ATTR_COLOR_TEMP, 0)
+
         else:
             data[STATE_BRIGHTNESS] = 0
             data[STATE_HUE] = 0
             data[STATE_SATURATION] = 0
+            data[STATE_COLOR_TEMP] = 0
 
-        # Make sure the entity actually supports brightness
+        # Get the entity's supported features
         entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         if entity.domain == light.DOMAIN:
             if entity_features & SUPPORT_BRIGHTNESS:
                 pass
-
         elif entity.domain == climate.DOMAIN:
             temperature = entity.attributes.get(ATTR_TEMPERATURE, 0)
             # Convert 0-100 to 0-255
@@ -555,6 +553,7 @@ def get_entity_state(config, entity):
         # Make sure brightness is valid
         if data[STATE_BRIGHTNESS] is None:
             data[STATE_BRIGHTNESS] = 255 if data[STATE_ON] else 0
+
         # Make sure hue/saturation are valid
         if (data[STATE_HUE] is None) or (data[STATE_SATURATION] is None):
             data[STATE_HUE] = 0
@@ -565,35 +564,114 @@ def get_entity_state(config, entity):
             data[STATE_HUE] = 0
             data[STATE_SATURATION] = 0
 
+    # Clamp brightness, hue, saturation, and color temp to valid values
+    for (key, v_min, v_max) in (
+        (STATE_BRIGHTNESS, HUE_API_STATE_BRI_MIN, HUE_API_STATE_BRI_MAX),
+        (STATE_HUE,        HUE_API_STATE_HUE_MIN, HUE_API_STATE_HUE_MAX),
+        (STATE_SATURATION, HUE_API_STATE_SAT_MIN, HUE_API_STATE_SAT_MAX),
+        (STATE_COLOR_TEMP, HUE_API_STATE_CT_MIN,  HUE_API_STATE_CT_MAX )
+    ):
+        if data[key] is not None:
+            data[key] = max(v_min, min(data[key], v_max))
+
     return data
 
 
 def entity_to_json(config, entity, state):
     """Convert an entity to its Hue bridge JSON representation."""
     entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain != light.DOMAIN:
-        return {
-            "state": {
-                HUE_API_STATE_ON: state[STATE_ON],
+    unique_id = hashlib.md5(entity.entity_id.encode()).hexdigest()
+    unique_id = "00:%s:%s:%s:%s:%s:%s:%s-%s" % (
+        unique_id[0:2],
+        unique_id[2:4],
+        unique_id[4:6],
+        unique_id[6:8],
+        unique_id[8:10],
+        unique_id[10:12],
+        unique_id[12:14],
+        unique_id[14:16],
+    )
+
+    retval = {
+        "state": {
+            HUE_API_STATE_ON: state[STATE_ON],
+            "reachable": True,
+            "mode": "homeautomation",
+        },
+        "name": config.get_entity_name(entity),
+        "uniqueid": unique_id,
+        "manufacturername": "Home Assistant",
+        "swversion": "123",
+    }
+
+    if (entity_features & SUPPORT_BRIGHTNESS) and (
+        entity_features & SUPPORT_COLOR) and (
+        entity_features & SUPPORT_COLOR_TEMP
+    ):
+        # Extended Color light (ZigBee Device ID: 0x0210)
+        # Same as Color light, but which supports additional setting of color temperature
+        retval["type"] = "Extended color light"
+        retval["modelid"] = "HASS231"
+        retval["state"].update(
+            {
                 HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],
                 HUE_API_STATE_HUE: state[STATE_HUE],
                 HUE_API_STATE_SAT: state[STATE_SATURATION],
-                "reachable": True,
-            },
-            "type": "Dimmable light",
-            "name": config.get_entity_name(entity),
-            "modelid": "HASS123",
-            "uniqueid": entity.entity_id,
-            "swversion": "123",
-        }
-    return {
-        "state": {HUE_API_STATE_ON: state[STATE_ON], "reachable": True},
-        "type": "On/off light",
-        "name": config.get_entity_name(entity),
-        "modelid": "HASS321",
-        "uniqueid": entity.entity_id,
-        "swversion": "123",
-    }
+                HUE_API_STATE_CT: state[STATE_COLOR_TEMP],
+                HUE_API_STATE_EFFECT: "none",
+            }
+        )
+        if state[STATE_HUE] > 0 or state[STATE_SATURATION] > 0:
+            retval["state"][HUE_API_STATE_COLORMODE] = "hs"
+        else:
+            retval["state"][HUE_API_STATE_COLORMODE] = "ct"
+    elif (entity_features & SUPPORT_BRIGHTNESS) and (entity_features & SUPPORT_COLOR):
+        # Color light (ZigBee Device ID: 0x0200)
+        # Supports on/off, dimming and color control (hue/saturation, enhanced hue, color loop and XY)
+        retval["type"] = "Color light"
+        retval["modelid"] = "HASS213"
+        retval["state"].update(
+            {
+                HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],
+                HUE_API_STATE_COLORMODE: "hs",
+                HUE_API_STATE_HUE: state[STATE_HUE],
+                HUE_API_STATE_SAT: state[STATE_SATURATION],
+                HUE_API_STATE_EFFECT: "none",
+            }
+        )
+    elif (entity_features & SUPPORT_BRIGHTNESS) and (entity_features & SUPPORT_COLOR_TEMP):
+        # Color temperature light (ZigBee Device ID: 0x0220)
+        # Supports groups, scenes, on/off, dimming, and setting of a color temperature
+        retval["type"] = "Color temperature light"
+        retval["modelid"] = "HASS312"
+        retval["state"].update(
+            {
+                HUE_API_STATE_COLORMODE: "ct",
+                HUE_API_STATE_CT: state[STATE_COLOR_TEMP],
+            }
+        )
+    elif (
+        entity_features
+        & (
+            SUPPORT_BRIGHTNESS
+            | SUPPORT_SET_POSITION
+            | SUPPORT_SET_SPEED
+            | SUPPORT_VOLUME_SET
+            | SUPPORT_TARGET_TEMPERATURE
+        )
+    ) or entity.domain == script.DOMAIN:
+        # Dimmable light (ZigBee Device ID: 0x0100)
+        # Supports groups, scenes, on/off and dimming
+        retval["type"] = "Dimmable light"
+        retval["modelid"] = "HASS123"
+        retval["state"].update({HUE_API_STATE_BRI: state[STATE_BRIGHTNESS]})
+    else:
+        # On/off light (ZigBee Device ID: 0x0000)
+        # Supports groups, scenes and on/off control
+        retval["type"] = "On/off light"
+        retval["modelid"] = "HASS321"
+
+    return retval
 
 
 def create_hue_success_response(entity_id, attr, value):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -79,13 +79,13 @@ HUE_API_STATE_CT = "ct"
 HUE_API_STATE_EFFECT = "effect"
 
 # Hue API min/max values - https://developers.meethue.com/develop/hue-api/lights-api/
-HUE_API_STATE_BRI_MIN = 1     # Brightness
+HUE_API_STATE_BRI_MIN = 1  # Brightness
 HUE_API_STATE_BRI_MAX = 254
-HUE_API_STATE_HUE_MIN = 0     # Hue
+HUE_API_STATE_HUE_MIN = 0  # Hue
 HUE_API_STATE_HUE_MAX = 65535
-HUE_API_STATE_SAT_MIN = 0     # Saturation
+HUE_API_STATE_SAT_MIN = 0  # Saturation
 HUE_API_STATE_SAT_MAX = 254
-HUE_API_STATE_CT_MIN = 153    # Color temp
+HUE_API_STATE_CT_MIN = 153  # Color temp
 HUE_API_STATE_CT_MAX = 500
 
 
@@ -417,9 +417,9 @@ class HueOneLightChangeView(HomeAssistantView):
 
         for (key, val) in (
             (STATE_BRIGHTNESS, HUE_API_STATE_BRI),
-            (STATE_HUE,        HUE_API_STATE_HUE),
+            (STATE_HUE, HUE_API_STATE_HUE),
             (STATE_SATURATION, HUE_API_STATE_SAT),
-            (STATE_COLOR_TEMP, HUE_API_STATE_CT)
+            (STATE_COLOR_TEMP, HUE_API_STATE_CT),
         ):
             if parsed[key] is not None:
                 json_response.append(
@@ -450,10 +450,25 @@ def parse_hue_api_put_light_body(request_json, entity):
         data[STATE_BRIGHTNESS] = None
 
     for (key, attr, v_min, v_max) in (
-        (HUE_API_STATE_BRI, STATE_BRIGHTNESS, HUE_API_STATE_BRI_MIN, HUE_API_STATE_BRI_MAX),
-        (HUE_API_STATE_HUE, STATE_HUE,        HUE_API_STATE_HUE_MIN, HUE_API_STATE_HUE_MAX),
-        (HUE_API_STATE_SAT, STATE_SATURATION, HUE_API_STATE_SAT_MIN, HUE_API_STATE_SAT_MAX),
-        (HUE_API_STATE_CT,  STATE_COLOR_TEMP, HUE_API_STATE_CT_MIN,  HUE_API_STATE_CT_MAX)
+        (
+            HUE_API_STATE_BRI,
+            STATE_BRIGHTNESS,
+            HUE_API_STATE_BRI_MIN,
+            HUE_API_STATE_BRI_MAX,
+        ),
+        (HUE_API_STATE_HUE, STATE_HUE, HUE_API_STATE_HUE_MIN, HUE_API_STATE_HUE_MAX),
+        (
+            HUE_API_STATE_SAT,
+            STATE_SATURATION,
+            HUE_API_STATE_SAT_MIN,
+            HUE_API_STATE_SAT_MAX,
+        ),
+        (
+            HUE_API_STATE_CT,
+            STATE_COLOR_TEMP,
+            HUE_API_STATE_CT_MIN,
+            HUE_API_STATE_CT_MAX,
+        ),
     ):
         if key in request_json:
             try:
@@ -567,9 +582,9 @@ def get_entity_state(config, entity):
     # Clamp brightness, hue, saturation, and color temp to valid values
     for (key, v_min, v_max) in (
         (STATE_BRIGHTNESS, HUE_API_STATE_BRI_MIN, HUE_API_STATE_BRI_MAX),
-        (STATE_HUE,        HUE_API_STATE_HUE_MIN, HUE_API_STATE_HUE_MAX),
+        (STATE_HUE, HUE_API_STATE_HUE_MIN, HUE_API_STATE_HUE_MAX),
         (STATE_SATURATION, HUE_API_STATE_SAT_MIN, HUE_API_STATE_SAT_MAX),
-        (STATE_COLOR_TEMP, HUE_API_STATE_CT_MIN,  HUE_API_STATE_CT_MAX )
+        (STATE_COLOR_TEMP, HUE_API_STATE_CT_MIN, HUE_API_STATE_CT_MAX),
     ):
         if data[key] is not None:
             data[key] = max(v_min, min(data[key], v_max))
@@ -604,9 +619,10 @@ def entity_to_json(config, entity, state):
         "swversion": "123",
     }
 
-    if (entity_features & SUPPORT_BRIGHTNESS) and (
-        entity_features & SUPPORT_COLOR) and (
-        entity_features & SUPPORT_COLOR_TEMP
+    if (
+        (entity_features & SUPPORT_BRIGHTNESS)
+        and (entity_features & SUPPORT_COLOR)
+        and (entity_features & SUPPORT_COLOR_TEMP)
     ):
         # Extended Color light (ZigBee Device ID: 0x0210)
         # Same as Color light, but which supports additional setting of color temperature
@@ -639,16 +655,15 @@ def entity_to_json(config, entity, state):
                 HUE_API_STATE_EFFECT: "none",
             }
         )
-    elif (entity_features & SUPPORT_BRIGHTNESS) and (entity_features & SUPPORT_COLOR_TEMP):
+    elif (entity_features & SUPPORT_BRIGHTNESS) and (
+        entity_features & SUPPORT_COLOR_TEMP
+    ):
         # Color temperature light (ZigBee Device ID: 0x0220)
         # Supports groups, scenes, on/off, dimming, and setting of a color temperature
         retval["type"] = "Color temperature light"
         retval["modelid"] = "HASS312"
         retval["state"].update(
-            {
-                HUE_API_STATE_COLORMODE: "ct",
-                HUE_API_STATE_CT: state[STATE_COLOR_TEMP],
-            }
+            {HUE_API_STATE_COLORMODE: "ct", HUE_API_STATE_CT: state[STATE_COLOR_TEMP]}
         )
     elif (
         entity_features


### PR DESCRIPTION
Defined additional min/max values, and enforced stronger value clamping when presenting to Alexa (see https://github.com/home-assistant/home-assistant/issues/25047)
&nbsp;

Adjusted response codes for error and unauthorized request responses
- Converted all responses to self.json_message format and removed dependency on `aiohttp`
- Changed some `HTTP_NOT_FOUND` to `HTTP_UNAUTHORIZED` where appropriate
&nbsp;

Changed "uniqueid" to match Hue bridge format:
- Format: `00:%s:%s:%s:%s:%s:%s:%s-%s`
- Noticed that when using some hex prefixes, Alexa would not detect some devices; prefixing everything with 00: seems to resolve that issue
&nbsp;

Added basic support for all light types:
- On/off light: Supports groups, scenes and on/off control
- Dimmable light: Supports groups, scenes, on/off and dimming
- Color temperature light: Supports groups, scenes, on/off, dimming, and setting of a color temperature
- Color light: Supports on/off, dimming and color control (hue/saturation, enhanced hue, color loop and XY)
- Extended Color light: Same as Color light, but which supports additional setting of color temperature
&nbsp;

General code cleanups; examples:
- Within `HueOneLightStateView()` - success response creation routine
- Within `get_entity_state()` - clamping routine
&nbsp;

To Do:
- Still needs XY color support, but this commit fixes many other issues and XY support can come later. Need to work out a better way of detecting the light's colormode value for lights that support multiple colormodes (hs, ct, xy); perhaps we could set the other values to None when a request is submitted? Don't know how else we can keep track of this.
- Several spots throughout, the code still sets brightness to 0 or 255; this is technically outside of the limits of the Hue API, but with clamping there is little or no effect; that is, Alexa never sees the true value, so leaving this as-is is of no consequence. To correct this, we need to discuss how to best handle this as at present time, other apps such as the LIFX app can set the value of lights to 0 or 255. Generally speaking, these devices weren't ever designed to be Hue bridge compliant, so perhaps the clamping that's being done is sufficient.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
