### PR TITLE
Add presentation URL to SSDP discovery info

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -26,6 +26,7 @@ ATTR_MANUFACTURER = "manufacturer"
 ATTR_MANUFACTURERURL = "manufacturerURL"
 ATTR_UDN = "udn"
 ATTR_UPNP_DEVICE_TYPE = "upnp_device_type"
+ATTR_PRESENTATIONURL = "presentation_url"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -175,5 +176,6 @@ def info_from_entry(entry, device_info):
         info[ATTR_MANUFACTURERURL] = device_info.get("manufacturerURL")
         info[ATTR_UDN] = device_info.get("UDN")
         info[ATTR_UPNP_DEVICE_TYPE] = device_info.get("deviceType")
+        info[ATTR_PRESENTATIONURL] = device_info.get("presentationURL")
 
     return info


### PR DESCRIPTION
## Description:

Will be using the presentation URL for Huawei LTE; can get the API endpoint directly from there.

On the other hand, any particular reason why _all_ of the SSDP device info wouldn't be made available in `discovery_info`, say for example under a `ssdp_data` key, e.g. like `info[ATTR_SSDP_DATA] = device_info`? Edit: filed that alternative as #28197

**Related issue (if applicable):** #28197

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
