### PR TITLE
Include all SSDP data in discovery info

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow to configure deCONZ component."""
 import asyncio
+from urllib.parse import urlparse
 
 import async_timeout
 from pydeconz.errors import RequestError, ResponseError
@@ -7,7 +8,12 @@ from pydeconz.utils import async_discovery, async_get_api_key, async_get_gateway
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
+from homeassistant.components.ssdp import (
+    ATTR_MANUFACTURERURL,
+    ATTR_SERIAL,
+    ATTR_SSDP_LOCATION,
+    ATTR_UDN,
+)
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -26,7 +32,6 @@ from .const import (
 
 DECONZ_MANUFACTURERURL = "http://www.dresden-elektronik.de"
 CONF_SERIAL = "serial"
-ATTR_UUID = "udn"
 
 
 @callback
@@ -173,13 +178,15 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if discovery_info[ATTR_MANUFACTURERURL] != DECONZ_MANUFACTURERURL:
             return self.async_abort(reason="not_deconz_bridge")
 
-        uuid = discovery_info[ATTR_UUID].replace("uuid:", "")
+        uuid = discovery_info[ATTR_UDN].replace("uuid:", "")
 
         _LOGGER.debug("deCONZ gateway discovered (%s)", uuid)
 
+        parsed_url = urlparse(discovery_info[ATTR_SSDP_LOCATION])
+
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if uuid == entry.data.get(CONF_UUID):
-                return await self._update_entry(entry, discovery_info[CONF_HOST])
+                return await self._update_entry(entry, parsed_url.hostname)
 
         bridgeid = discovery_info[ATTR_SERIAL]
         if any(
@@ -190,11 +197,11 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context[CONF_BRIDGEID] = bridgeid
-        self.context["title_placeholders"] = {"host": discovery_info[CONF_HOST]}
+        self.context["title_placeholders"] = {"host": parsed_url.hostname}
 
         self.deconz_config = {
-            CONF_HOST: discovery_info[CONF_HOST],
-            CONF_PORT: discovery_info[CONF_PORT],
+            CONF_HOST: parsed_url.hostname,
+            CONF_PORT: parsed_url.port,
         }
 
         return await self.async_step_link()

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -1,9 +1,12 @@
 """Config flow to configure Heos."""
+from urllib.parse import urlparse
+
 from pyheos import Heos, HeosError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.components.ssdp import ATTR_NAME, ATTR_SSDP_LOCATION
+from homeassistant.const import CONF_HOST
 
 from .const import DATA_DISCOVERED_HOSTS, DOMAIN
 
@@ -23,11 +26,10 @@ class HeosFlowHandler(config_entries.ConfigFlow):
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered Heos device."""
         # Store discovered host
-        friendly_name = "{} ({})".format(
-            discovery_info[CONF_NAME], discovery_info[CONF_HOST]
-        )
+        hostname = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
+        friendly_name = "{} ({})".format(discovery_info[ATTR_NAME], hostname)
         self.hass.data.setdefault(DATA_DISCOVERED_HOSTS, {})
-        self.hass.data[DATA_DISCOVERED_HOSTS][friendly_name] = discovery_info[CONF_HOST]
+        self.hass.data[DATA_DISCOVERED_HOSTS][friendly_name] = hostname
         # Abort if other flows in progress or an entry already exists
         if self._async_in_progress() or self._async_current_entries():
             return self.async_abort(reason="already_setup")

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -5,7 +5,7 @@ from pyheos import Heos, HeosError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import ATTR_NAME, ATTR_SSDP_LOCATION
+from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST
 
 from .const import DATA_DISCOVERED_HOSTS, DOMAIN
@@ -26,8 +26,10 @@ class HeosFlowHandler(config_entries.ConfigFlow):
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered Heos device."""
         # Store discovered host
-        hostname = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
-        friendly_name = "{} ({})".format(discovery_info[ATTR_NAME], hostname)
+        hostname = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
+        friendly_name = "{} ({})".format(
+            discovery_info[ssdp.ATTR_UPNP_FRIENDLY_NAME], hostname
+        )
         self.hass.data.setdefault(DATA_DISCOVERED_HOSTS, {})
         self.hass.data[DATA_DISCOVERED_HOSTS][friendly_name] = hostname
         # Abort if other flows in progress or an entry already exists

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
 from huawei_lte_api.Client import Client
@@ -19,7 +20,11 @@ from url_normalize import url_normalize
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import ATTR_HOST, ATTR_NAME, ATTR_PRESENTATIONURL
+from homeassistant.components.ssdp import (
+    ATTR_NAME,
+    ATTR_PRESENTATIONURL,
+    ATTR_SSDP_LOCATION,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_RECIPIENT, CONF_URL, CONF_USERNAME
 from homeassistant.core import callback
 
@@ -214,7 +219,8 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # https://github.com/PyCQA/pylint/issues/3167
         url = self.context[CONF_URL] = url_normalize(  # pylint: disable=no-member
             discovery_info.get(
-                ATTR_PRESENTATIONURL, f"http://{discovery_info[ATTR_HOST]}/"
+                ATTR_PRESENTATIONURL,
+                f"http://{urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname}/",
             )
         )
 

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -20,11 +20,7 @@ from url_normalize import url_normalize
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import (
-    ATTR_NAME,
-    ATTR_PRESENTATIONURL,
-    ATTR_SSDP_LOCATION,
-)
+from homeassistant.components import ssdp
 from homeassistant.const import CONF_PASSWORD, CONF_RECIPIENT, CONF_URL, CONF_USERNAME
 from homeassistant.core import callback
 
@@ -213,14 +209,14 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle SSDP initiated config flow."""
         # Attempt to distinguish from other non-LTE Huawei router devices, at least
         # some ones we are interested in have "Mobile Wi-Fi" friendlyName.
-        if "mobile" not in discovery_info.get(ATTR_NAME, "").lower():
+        if "mobile" not in discovery_info.get(ssdp.ATTR_UPNP_FRIENDLY_NAME, "").lower():
             return self.async_abort(reason="not_huawei_lte")
 
         # https://github.com/PyCQA/pylint/issues/3167
         url = self.context[CONF_URL] = url_normalize(  # pylint: disable=no-member
             discovery_info.get(
-                ATTR_PRESENTATIONURL,
-                f"http://{urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname}/",
+                ssdp.ATTR_UPNP_PRESENTATION_URL,
+                f"http://{urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname}/",
             )
         )
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -9,12 +9,7 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries, core
-from homeassistant.components.ssdp import (
-    ATTR_MANUFACTURERURL,
-    ATTR_NAME,
-    ATTR_SERIAL,
-    ATTR_SSDP_LOCATION,
-)
+from homeassistant.components import ssdp
 from homeassistant.helpers import aiohttp_client
 
 from .bridge import authenticate_bridge
@@ -153,25 +148,25 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         host is already configured and delegate to the import step if not.
         """
         # Filter out non-Hue bridges #1
-        if discovery_info[ATTR_MANUFACTURERURL] != HUE_MANUFACTURERURL:
+        if discovery_info[ssdp.ATTR_UPNP_MANUFACTURER_URL] != HUE_MANUFACTURERURL:
             return self.async_abort(reason="not_hue_bridge")
 
         # Filter out non-Hue bridges #2
         if any(
-            name in discovery_info.get(ATTR_NAME, "")
+            name in discovery_info.get(ssdp.ATTR_UPNP_FRIENDLY_NAME, "")
             for name in HUE_IGNORED_BRIDGE_NAMES
         ):
             return self.async_abort(reason="not_hue_bridge")
 
         if (
-            ATTR_SSDP_LOCATION not in discovery_info
-            or ATTR_SERIAL not in discovery_info
+            ssdp.ATTR_SSDP_LOCATION not in discovery_info
+            or ssdp.ATTR_UPNP_SERIAL not in discovery_info
         ):
             return self.async_abort(reason="not_hue_bridge")
 
-        host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
+        host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
 
-        bridge = self._async_get_bridge(host, discovery_info[ATTR_SERIAL])
+        bridge = self._async_get_bridge(host, discovery_info[ssdp.ATTR_UPNP_SERIAL])
 
         await self.async_set_unique_id(bridge.id)
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -18,6 +18,8 @@ ATTR_HOST = "host"
 ATTR_PORT = "port"
 ATTR_SSDP_DESCRIPTION = "ssdp_description"
 ATTR_ST = "ssdp_st"
+ATTR_SSDP_DATA = "ssdp_data"
+# Deprecated attributes, use from SSDP_DATA directly instead
 ATTR_NAME = "name"
 ATTR_MODEL_NAME = "model_name"
 ATTR_MODEL_NUMBER = "model_number"
@@ -167,6 +169,8 @@ def info_from_entry(entry, device_info):
     }
 
     if device_info:
+        info[ATTR_SSDP_DATA] = device_info
+        # Deprecated below, use from device_info instead
         info[ATTR_NAME] = device_info.get("friendlyName")
         info[ATTR_MODEL_NAME] = device_info.get("modelName")
         info[ATTR_MODEL_NUMBER] = device_info.get("modelNumber")

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -14,21 +14,21 @@ from homeassistant.helpers.event import async_track_time_interval
 DOMAIN = "ssdp"
 SCAN_INTERVAL = timedelta(seconds=60)
 
+# Attributes for accessing info from SSDP response
 ATTR_HOST = "host"
 ATTR_PORT = "port"
 ATTR_SSDP_DESCRIPTION = "ssdp_description"
 ATTR_ST = "ssdp_st"
-ATTR_SSDP_DATA = "ssdp_data"
-# Deprecated attributes, use from SSDP_DATA directly instead
-ATTR_NAME = "name"
-ATTR_MODEL_NAME = "model_name"
-ATTR_MODEL_NUMBER = "model_number"
-ATTR_SERIAL = "serial_number"
+# Attributes for accessing info from retrieved UPnP device description
+ATTR_NAME = "friendlyName"
+ATTR_MODEL_NAME = "modelName"
+ATTR_MODEL_NUMBER = "modelNumber"
+ATTR_SERIAL = "serialNumber"
 ATTR_MANUFACTURER = "manufacturer"
 ATTR_MANUFACTURERURL = "manufacturerURL"
-ATTR_UDN = "udn"
-ATTR_UPNP_DEVICE_TYPE = "upnp_device_type"
-ATTR_PRESENTATIONURL = "presentation_url"
+ATTR_UDN = "UDN"
+ATTR_UPNP_DEVICE_TYPE = "deviceType"
+ATTR_PRESENTATIONURL = "presentationURL"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ class Scanner:
 
 
 def info_from_entry(entry, device_info):
-    """Get most important info from an entry."""
+    """Get info from an entry."""
     url = urlparse(entry.location)
     info = {
         ATTR_HOST: url.hostname,
@@ -167,18 +167,7 @@ def info_from_entry(entry, device_info):
         ATTR_SSDP_DESCRIPTION: entry.location,
         ATTR_ST: entry.st,
     }
-
     if device_info:
-        info[ATTR_SSDP_DATA] = device_info
-        # Deprecated below, use from device_info instead
-        info[ATTR_NAME] = device_info.get("friendlyName")
-        info[ATTR_MODEL_NAME] = device_info.get("modelName")
-        info[ATTR_MODEL_NUMBER] = device_info.get("modelNumber")
-        info[ATTR_SERIAL] = device_info.get("serialNumber")
-        info[ATTR_MANUFACTURER] = device_info.get("manufacturer")
-        info[ATTR_MANUFACTURERURL] = device_info.get("manufacturerURL")
-        info[ATTR_UDN] = device_info.get("UDN")
-        info[ATTR_UPNP_DEVICE_TYPE] = device_info.get("deviceType")
-        info[ATTR_PRESENTATIONURL] = device_info.get("presentationURL")
+        info.update(device_info)
 
     return info

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -17,15 +17,15 @@ SCAN_INTERVAL = timedelta(seconds=60)
 ATTR_SSDP_LOCATION = "ssdp_location"
 ATTR_SSDP_ST = "ssdp_st"
 # Attributes for accessing info from retrieved UPnP device description
-ATTR_NAME = "friendlyName"
-ATTR_MODEL_NAME = "modelName"
-ATTR_MODEL_NUMBER = "modelNumber"
-ATTR_SERIAL = "serialNumber"
-ATTR_MANUFACTURER = "manufacturer"
-ATTR_MANUFACTURERURL = "manufacturerURL"
-ATTR_UDN = "UDN"
 ATTR_UPNP_DEVICE_TYPE = "deviceType"
-ATTR_PRESENTATIONURL = "presentationURL"
+ATTR_UPNP_FRIENDLY_NAME = "friendlyName"
+ATTR_UPNP_MANUFACTURER = "manufacturer"
+ATTR_UPNP_MANUFACTURER_URL = "manufacturerURL"
+ATTR_UPNP_MODEL_NAME = "modelName"
+ATTR_UPNP_MODEL_NUMBER = "modelNumber"
+ATTR_UPNP_PRESENTATION_URL = "presentationURL"
+ATTR_UPNP_SERIAL = "serialNumber"
+ATTR_UPNP_UDN = "UDN"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 from datetime import timedelta
 import logging
-from urllib.parse import urlparse
 
 import aiohttp
 from defusedxml import ElementTree
@@ -15,10 +14,8 @@ DOMAIN = "ssdp"
 SCAN_INTERVAL = timedelta(seconds=60)
 
 # Attributes for accessing info from SSDP response
-ATTR_HOST = "host"
-ATTR_PORT = "port"
-ATTR_SSDP_DESCRIPTION = "ssdp_description"
-ATTR_ST = "ssdp_st"
+ATTR_SSDP_LOCATION = "ssdp_location"
+ATTR_SSDP_ST = "ssdp_st"
 # Attributes for accessing info from retrieved UPnP device description
 ATTR_NAME = "friendlyName"
 ATTR_MODEL_NAME = "modelName"
@@ -160,12 +157,9 @@ class Scanner:
 
 def info_from_entry(entry, device_info):
     """Get info from an entry."""
-    url = urlparse(entry.location)
     info = {
-        ATTR_HOST: url.hostname,
-        ATTR_PORT: url.port,
-        ATTR_SSDP_DESCRIPTION: entry.location,
-        ATTR_ST: entry.st,
+        ATTR_SSDP_LOCATION: entry.location,
+        ATTR_SSDP_ST: entry.st,
     }
     if device_info:
         info.update(device_info)

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -4,13 +4,8 @@ from unittest.mock import Mock, patch
 
 import pydeconz
 
+from homeassistant.components import ssdp
 from homeassistant.components.deconz import config_flow
-from homeassistant.components.ssdp import (
-    ATTR_MANUFACTURERURL,
-    ATTR_SERIAL,
-    ATTR_SSDP_LOCATION,
-    ATTR_UDN,
-)
 
 from tests.common import MockConfigEntry
 
@@ -218,10 +213,10 @@ async def test_bridge_ssdp_discovery(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         data={
-            ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
-            ATTR_SERIAL: "id",
-            ATTR_MANUFACTURERURL: config_flow.DECONZ_MANUFACTURERURL,
-            ATTR_UDN: "uuid:1234",
+            ssdp.ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.DECONZ_MANUFACTURERURL,
+            ssdp.ATTR_UPNP_SERIAL: "id",
+            ssdp.ATTR_UPNP_UDN: "uuid:1234",
         },
         context={"source": "ssdp"},
     )
@@ -234,7 +229,7 @@ async def test_bridge_ssdp_discovery_not_deconz_bridge(hass):
     """Test a non deconz bridge being discovered over ssdp."""
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        data={ATTR_MANUFACTURERURL: "not deconz bridge"},
+        data={ssdp.ATTR_UPNP_MANUFACTURER_URL: "not deconz bridge"},
         context={"source": "ssdp"},
     )
 
@@ -261,10 +256,10 @@ async def test_bridge_discovery_update_existing_entry(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         data={
-            ATTR_SSDP_LOCATION: "http://mock-deconz/",
-            ATTR_SERIAL: "123ABC",
-            ATTR_MANUFACTURERURL: config_flow.DECONZ_MANUFACTURERURL,
-            ATTR_UDN: "uuid:456DEF",
+            ssdp.ATTR_SSDP_LOCATION: "http://mock-deconz/",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.DECONZ_MANUFACTURERURL,
+            ssdp.ATTR_UPNP_SERIAL: "123ABC",
+            ssdp.ATTR_UPNP_UDN: "uuid:456DEF",
         },
         context={"source": "ssdp"},
     )

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -5,7 +5,12 @@ from unittest.mock import Mock, patch
 import pydeconz
 
 from homeassistant.components.deconz import config_flow
-from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
+from homeassistant.components.ssdp import (
+    ATTR_MANUFACTURERURL,
+    ATTR_SERIAL,
+    ATTR_SSDP_LOCATION,
+    ATTR_UDN,
+)
 
 from tests.common import MockConfigEntry
 
@@ -213,11 +218,10 @@ async def test_bridge_ssdp_discovery(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         data={
-            config_flow.CONF_HOST: "1.2.3.4",
-            config_flow.CONF_PORT: 80,
+            ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
             ATTR_SERIAL: "id",
             ATTR_MANUFACTURERURL: config_flow.DECONZ_MANUFACTURERURL,
-            config_flow.ATTR_UUID: "uuid:1234",
+            ATTR_UDN: "uuid:1234",
         },
         context={"source": "ssdp"},
     )
@@ -257,10 +261,10 @@ async def test_bridge_discovery_update_existing_entry(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         data={
-            config_flow.CONF_HOST: "mock-deconz",
+            ATTR_SSDP_LOCATION: "http://mock-deconz/",
             ATTR_SERIAL: "123ABC",
             ATTR_MANUFACTURERURL: config_flow.DECONZ_MANUFACTURERURL,
-            config_flow.ATTR_UUID: "uuid:456DEF",
+            ATTR_UDN: "uuid:456DEF",
         },
         context={"source": "ssdp"},
     )

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -146,9 +146,9 @@ async def test_update_address(hass):
         deconz.config_flow.DOMAIN,
         data={
             ssdp.ATTR_SSDP_LOCATION: "http://2.3.4.5:80/",
-            ssdp.ATTR_SERIAL: BRIDGEID,
-            ssdp.ATTR_MANUFACTURERURL: deconz.config_flow.DECONZ_MANUFACTURERURL,
-            deconz.config_flow.ATTR_UDN: "uuid:456DEF",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: deconz.config_flow.DECONZ_MANUFACTURERURL,
+            ssdp.ATTR_UPNP_SERIAL: BRIDGEID,
+            ssdp.ATTR_UPNP_UDN: "uuid:456DEF",
         },
         context={"source": "ssdp"},
     )

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -145,11 +145,10 @@ async def test_update_address(hass):
     await hass.config_entries.flow.async_init(
         deconz.config_flow.DOMAIN,
         data={
-            deconz.config_flow.CONF_HOST: "2.3.4.5",
-            deconz.config_flow.CONF_PORT: 80,
+            ssdp.ATTR_SSDP_LOCATION: "http://2.3.4.5:80/",
             ssdp.ATTR_SERIAL: BRIDGEID,
             ssdp.ATTR_MANUFACTURERURL: deconz.config_flow.DECONZ_MANUFACTURERURL,
-            deconz.config_flow.ATTR_UUID: "uuid:456DEF",
+            deconz.config_flow.ATTR_UDN: "uuid:456DEF",
         },
         context={"source": "ssdp"},
     )

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -5,17 +5,8 @@ from asynctest.mock import Mock, patch as patch
 from pyheos import Dispatcher, Heos, HeosPlayer, HeosSource, InputSource, const
 import pytest
 
+from homeassistant.components import ssdp
 from homeassistant.components.heos import DOMAIN
-from homeassistant.components.ssdp import (
-    ATTR_MANUFACTURER,
-    ATTR_MODEL_NAME,
-    ATTR_MODEL_NUMBER,
-    ATTR_NAME,
-    ATTR_SERIAL,
-    ATTR_SSDP_LOCATION,
-    ATTR_UDN,
-    ATTR_UPNP_DEVICE_TYPE,
-)
 from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
@@ -128,14 +119,14 @@ def dispatcher_fixture() -> Dispatcher:
 def discovery_data_fixture() -> dict:
     """Return mock discovery data for testing."""
     return {
-        ATTR_SSDP_LOCATION: "http://127.0.0.1:60006/upnp/desc/aios_device/aios_device.xml",
-        ATTR_MANUFACTURER: "Denon",
-        ATTR_MODEL_NAME: "HEOS Drive",
-        ATTR_MODEL_NUMBER: "DWSA-10 4.0",
-        ATTR_NAME: "Office",
-        ATTR_SERIAL: None,
-        ATTR_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
-        ATTR_UPNP_DEVICE_TYPE: "urn:schemas-denon-com:device:AiosDevice:1",
+        ssdp.ATTR_SSDP_LOCATION: "http://127.0.0.1:60006/upnp/desc/aios_device/aios_device.xml",
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-denon-com:device:AiosDevice:1",
+        ssdp.ATTR_UPNP_FRIENDLY_NAME: "Office",
+        ssdp.ATTR_UPNP_MANUFACTURER: "Denon",
+        ssdp.ATTR_UPNP_MODEL_NAME: "HEOS Drive",
+        ssdp.ATTR_UPNP_MODEL_NUMBER: "DWSA-10 4.0",
+        ssdp.ATTR_UPNP_SERIAL: None,
+        ssdp.ATTR_UPNP_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
     }
 
 

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -6,6 +6,16 @@ from pyheos import Dispatcher, Heos, HeosPlayer, HeosSource, InputSource, const
 import pytest
 
 from homeassistant.components.heos import DOMAIN
+from homeassistant.components.ssdp import (
+    ATTR_MANUFACTURER,
+    ATTR_MODEL_NAME,
+    ATTR_MODEL_NUMBER,
+    ATTR_NAME,
+    ATTR_SERIAL,
+    ATTR_SSDP_LOCATION,
+    ATTR_UDN,
+    ATTR_UPNP_DEVICE_TYPE,
+)
 from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
@@ -118,16 +128,14 @@ def dispatcher_fixture() -> Dispatcher:
 def discovery_data_fixture() -> dict:
     """Return mock discovery data for testing."""
     return {
-        "host": "127.0.0.1",
-        "manufacturer": "Denon",
-        "model_name": "HEOS Drive",
-        "model_number": "DWSA-10 4.0",
-        "name": "Office",
-        "port": 60006,
-        "serial": None,
-        "ssdp_description": "http://127.0.0.1:60006/upnp/desc/aios_device/aios_device.xml",
-        "udn": "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
-        "upnp_device_type": "urn:schemas-denon-com:device:AiosDevice:1",
+        ATTR_SSDP_LOCATION: "http://127.0.0.1:60006/upnp/desc/aios_device/aios_device.xml",
+        ATTR_MANUFACTURER: "Denon",
+        ATTR_MODEL_NAME: "HEOS Drive",
+        ATTR_MODEL_NUMBER: "DWSA-10 4.0",
+        ATTR_NAME: "Office",
+        ATTR_SERIAL: None,
+        ATTR_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
+        ATTR_UPNP_DEVICE_TYPE: "urn:schemas-denon-com:device:AiosDevice:1",
     }
 
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -4,9 +4,9 @@ from urllib.parse import urlparse
 from pyheos import HeosError
 
 from homeassistant import data_entry_flow
+from homeassistant.components import ssdp
 from homeassistant.components.heos.config_flow import HeosFlowHandler
 from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS, DOMAIN
-from homeassistant.components.ssdp import ATTR_NAME, ATTR_SSDP_LOCATION
 from homeassistant.const import CONF_HOST
 
 
@@ -82,9 +82,9 @@ async def test_discovery_shows_create_form(hass, controller, discovery_data):
     assert len(hass.config_entries.flow.async_progress()) == 1
     assert hass.data[DATA_DISCOVERED_HOSTS] == {"Office (127.0.0.1)": "127.0.0.1"}
 
-    port = urlparse(discovery_data[ATTR_SSDP_LOCATION]).port
-    discovery_data[ATTR_SSDP_LOCATION] = f"http://127.0.0.2:{port}/"
-    discovery_data[ATTR_NAME] = "Bedroom"
+    port = urlparse(discovery_data[ssdp.ATTR_SSDP_LOCATION]).port
+    discovery_data[ssdp.ATTR_SSDP_LOCATION] = f"http://127.0.0.2:{port}/"
+    discovery_data[ssdp.ATTR_UPNP_FRIENDLY_NAME] = "Bedroom"
     await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "ssdp"}, data=discovery_data
     )

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -1,10 +1,13 @@
 """Tests for the Heos config flow module."""
+from urllib.parse import urlparse
+
 from pyheos import HeosError
 
 from homeassistant import data_entry_flow
 from homeassistant.components.heos.config_flow import HeosFlowHandler
 from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS, DOMAIN
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.components.ssdp import ATTR_NAME, ATTR_SSDP_LOCATION
+from homeassistant.const import CONF_HOST
 
 
 async def test_flow_aborts_already_setup(hass, config_entry):
@@ -79,8 +82,9 @@ async def test_discovery_shows_create_form(hass, controller, discovery_data):
     assert len(hass.config_entries.flow.async_progress()) == 1
     assert hass.data[DATA_DISCOVERED_HOSTS] == {"Office (127.0.0.1)": "127.0.0.1"}
 
-    discovery_data[CONF_HOST] = "127.0.0.2"
-    discovery_data[CONF_NAME] = "Bedroom"
+    port = urlparse(discovery_data[ATTR_SSDP_LOCATION]).port
+    discovery_data[ATTR_SSDP_LOCATION] = f"http://127.0.0.2:{port}/"
+    discovery_data[ATTR_NAME] = "Bedroom"
     await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "ssdp"}, data=discovery_data
     )

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -7,21 +7,9 @@ from requests.exceptions import ConnectionError
 from requests_mock import ANY
 
 from homeassistant import data_entry_flow
+from homeassistant.components import ssdp
 from homeassistant.components.huawei_lte.config_flow import ConfigFlowHandler
 from homeassistant.components.huawei_lte.const import DOMAIN
-from homeassistant.components.ssdp import (
-    ATTR_MANUFACTURER,
-    ATTR_MANUFACTURERURL,
-    ATTR_MODEL_NAME,
-    ATTR_MODEL_NUMBER,
-    ATTR_NAME,
-    ATTR_PRESENTATIONURL,
-    ATTR_SERIAL,
-    ATTR_SSDP_LOCATION,
-    ATTR_SSDP_ST,
-    ATTR_UDN,
-    ATTR_UPNP_DEVICE_TYPE,
-)
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 
 from tests.common import MockConfigEntry
@@ -155,17 +143,17 @@ async def test_ssdp(flow):
     url = "http://192.168.100.1/"
     result = await flow.async_step_ssdp(
         discovery_info={
-            ATTR_SSDP_LOCATION: "http://192.168.100.1:60957/rootDesc.xml",
-            ATTR_SSDP_ST: "upnp:rootdevice",
-            ATTR_MANUFACTURER: "Huawei",
-            ATTR_MANUFACTURERURL: "http://www.huawei.com/",
-            ATTR_MODEL_NAME: "Huawei router",
-            ATTR_MODEL_NUMBER: "12345678",
-            ATTR_NAME: "Mobile Wi-Fi",
-            ATTR_PRESENTATIONURL: url,
-            ATTR_SERIAL: "00000000",
-            ATTR_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-            ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+            ssdp.ATTR_SSDP_LOCATION: "http://192.168.100.1:60957/rootDesc.xml",
+            ssdp.ATTR_SSDP_ST: "upnp:rootdevice",
+            ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+            ssdp.ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
+            ssdp.ATTR_UPNP_MANUFACTURER: "Huawei",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: "http://www.huawei.com/",
+            ssdp.ATTR_UPNP_MODEL_NAME: "Huawei router",
+            ssdp.ATTR_UPNP_MODEL_NUMBER: "12345678",
+            ssdp.ATTR_UPNP_PRESENTATION_URL: url,
+            ssdp.ATTR_UPNP_SERIAL: "00000000",
+            ssdp.ATTR_UPNP_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
         }
     )
 

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -10,16 +10,15 @@ from homeassistant import data_entry_flow
 from homeassistant.components.huawei_lte.config_flow import ConfigFlowHandler
 from homeassistant.components.huawei_lte.const import DOMAIN
 from homeassistant.components.ssdp import (
-    ATTR_HOST,
     ATTR_MANUFACTURER,
     ATTR_MANUFACTURERURL,
     ATTR_MODEL_NAME,
     ATTR_MODEL_NUMBER,
     ATTR_NAME,
-    ATTR_PORT,
     ATTR_PRESENTATIONURL,
     ATTR_SERIAL,
-    ATTR_ST,
+    ATTR_SSDP_LOCATION,
+    ATTR_SSDP_ST,
     ATTR_UDN,
     ATTR_UPNP_DEVICE_TYPE,
 )
@@ -156,9 +155,8 @@ async def test_ssdp(flow):
     url = "http://192.168.100.1/"
     result = await flow.async_step_ssdp(
         discovery_info={
-            ATTR_ST: "upnp:rootdevice",
-            ATTR_PORT: 60957,
-            ATTR_HOST: "192.168.100.1",
+            ATTR_SSDP_LOCATION: "http://192.168.100.1:60957/rootDesc.xml",
+            ATTR_SSDP_ST: "upnp:rootdevice",
             ATTR_MANUFACTURER: "Huawei",
             ATTR_MANUFACTURERURL: "http://www.huawei.com/",
             ATTR_MODEL_NAME: "Huawei router",

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -8,6 +8,12 @@ import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.hue import config_flow, const
+from homeassistant.components.ssdp import (
+    ATTR_MANUFACTURERURL,
+    ATTR_NAME,
+    ATTR_SERIAL,
+    ATTR_SSDP_LOCATION,
+)
 
 from tests.common import MockConfigEntry, mock_coro
 
@@ -208,9 +214,9 @@ async def test_bridge_ssdp(hass):
 
     result = await flow.async_step_ssdp(
         {
-            "host": "0.0.0.0",
-            "serial": "1234",
-            "manufacturerURL": config_flow.HUE_MANUFACTURERURL,
+            ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+            ATTR_SERIAL: "1234",
+            ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
         }
     )
 
@@ -224,7 +230,7 @@ async def test_bridge_ssdp_discover_other_bridge(hass):
     flow.hass = hass
 
     result = await flow.async_step_ssdp(
-        {"manufacturerURL": "http://www.notphilips.com"}
+        {ATTR_MANUFACTURERURL: "http://www.notphilips.com"}
     )
 
     assert result["type"] == "abort"
@@ -238,10 +244,10 @@ async def test_bridge_ssdp_emulated_hue(hass):
 
     result = await flow.async_step_ssdp(
         {
-            "name": "HASS Bridge",
-            "host": "0.0.0.0",
-            "serial": "1234",
-            "manufacturerURL": config_flow.HUE_MANUFACTURERURL,
+            ATTR_NAME: "HASS Bridge",
+            ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+            ATTR_SERIAL: "1234",
+            ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
         }
     )
 
@@ -257,10 +263,10 @@ async def test_bridge_ssdp_espalexa(hass):
 
     result = await flow.async_step_ssdp(
         {
-            "name": "Espalexa (0.0.0.0)",
-            "host": "0.0.0.0",
-            "serial": "1234",
-            "manufacturerURL": config_flow.HUE_MANUFACTURERURL,
+            ATTR_NAME: "Espalexa (0.0.0.0)",
+            ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+            ATTR_SERIAL: "1234",
+            ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
         }
     )
 
@@ -281,9 +287,9 @@ async def test_bridge_ssdp_already_configured(hass):
     with pytest.raises(data_entry_flow.AbortFlow):
         await flow.async_step_ssdp(
             {
-                "host": "0.0.0.0",
-                "serial": "1234",
-                "manufacturerURL": config_flow.HUE_MANUFACTURERURL,
+                ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+                ATTR_SERIAL: "1234",
+                ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
             }
         )
 

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -7,13 +7,8 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import ssdp
 from homeassistant.components.hue import config_flow, const
-from homeassistant.components.ssdp import (
-    ATTR_MANUFACTURERURL,
-    ATTR_NAME,
-    ATTR_SERIAL,
-    ATTR_SSDP_LOCATION,
-)
 
 from tests.common import MockConfigEntry, mock_coro
 
@@ -214,9 +209,9 @@ async def test_bridge_ssdp(hass):
 
     result = await flow.async_step_ssdp(
         {
-            ATTR_SSDP_LOCATION: "http://0.0.0.0/",
-            ATTR_SERIAL: "1234",
-            ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
+            ssdp.ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.HUE_MANUFACTURERURL,
+            ssdp.ATTR_UPNP_SERIAL: "1234",
         }
     )
 
@@ -230,7 +225,7 @@ async def test_bridge_ssdp_discover_other_bridge(hass):
     flow.hass = hass
 
     result = await flow.async_step_ssdp(
-        {ATTR_MANUFACTURERURL: "http://www.notphilips.com"}
+        {ssdp.ATTR_UPNP_MANUFACTURER_URL: "http://www.notphilips.com"}
     )
 
     assert result["type"] == "abort"
@@ -244,10 +239,10 @@ async def test_bridge_ssdp_emulated_hue(hass):
 
     result = await flow.async_step_ssdp(
         {
-            ATTR_NAME: "HASS Bridge",
-            ATTR_SSDP_LOCATION: "http://0.0.0.0/",
-            ATTR_SERIAL: "1234",
-            ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
+            ssdp.ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+            ssdp.ATTR_UPNP_FRIENDLY_NAME: "HASS Bridge",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.HUE_MANUFACTURERURL,
+            ssdp.ATTR_UPNP_SERIAL: "1234",
         }
     )
 
@@ -263,10 +258,10 @@ async def test_bridge_ssdp_espalexa(hass):
 
     result = await flow.async_step_ssdp(
         {
-            ATTR_NAME: "Espalexa (0.0.0.0)",
-            ATTR_SSDP_LOCATION: "http://0.0.0.0/",
-            ATTR_SERIAL: "1234",
-            ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
+            ssdp.ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+            ssdp.ATTR_UPNP_FRIENDLY_NAME: "Espalexa (0.0.0.0)",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.HUE_MANUFACTURERURL,
+            ssdp.ATTR_UPNP_SERIAL: "1234",
         }
     )
 
@@ -287,9 +282,9 @@ async def test_bridge_ssdp_already_configured(hass):
     with pytest.raises(data_entry_flow.AbortFlow):
         await flow.async_step_ssdp(
             {
-                ATTR_SSDP_LOCATION: "http://0.0.0.0/",
-                ATTR_SERIAL: "1234",
-                ATTR_MANUFACTURERURL: config_flow.HUE_MANUFACTURERURL,
+                ssdp.ATTR_SSDP_LOCATION: "http://0.0.0.0/",
+                ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.HUE_MANUFACTURERURL,
+                ssdp.ATTR_UPNP_SERIAL: "1234",
             }
         )
 

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -27,7 +27,9 @@ async def test_scan_match_st(hass):
     assert mock_init.mock_calls[0][2]["context"] == {"source": "ssdp"}
 
 
-@pytest.mark.parametrize("key", ("manufacturer", "deviceType"))
+@pytest.mark.parametrize(
+    "key", (ssdp.ATTR_UPNP_MANUFACTURER, ssdp.ATTR_UPNP_DEVICE_TYPE)
+)
 async def test_scan_match_upnp_devicedesc(hass, aioclient_mock, key):
     """Test matching based on UPnP device description data."""
     aioclient_mock.get(
@@ -74,7 +76,14 @@ async def test_scan_not_all_present(hass, aioclient_mock):
         return_value=[Mock(st="mock-st", location="http://1.1.1.1")],
     ), patch.dict(
         gn_ssdp.SSDP,
-        {"mock-domain": [{"deviceType": "Paulus", "manufacturer": "Paulus"}]},
+        {
+            "mock-domain": [
+                {
+                    ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+                    ssdp.ATTR_UPNP_MANUFACTURER: "Paulus",
+                }
+            ]
+        },
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -103,7 +112,14 @@ async def test_scan_not_all_match(hass, aioclient_mock):
         return_value=[Mock(st="mock-st", location="http://1.1.1.1")],
     ), patch.dict(
         gn_ssdp.SSDP,
-        {"mock-domain": [{"deviceType": "Paulus", "manufacturer": "Not-Paulus"}]},
+        {
+            "mock-domain": [
+                {
+                    ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+                    ssdp.ATTR_UPNP_MANUFACTURER: "Not-Paulus",
+                }
+            ]
+        },
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

Structure and constant names for SSDP discovery data has changed. All UPnP device description data is now made available, but the previously available host and port no longer are -- they can be obtained by urlparsing the `ATTR_SSDP_LOCATION` value if needed. Consult `homeassistant.components.ssdp` for the new attribute name constants.

## Description:

Some data is missing from SSDP discovery info, not sure why all of it wouldn't be passed on. See #28196 for some more info and an alternative PR.

**Related issue (if applicable):** #28196

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
