### PR TITLE
Fix microsoft tts

### DIFF
--- a/homeassistant/components/microsoft/manifest.json
+++ b/homeassistant/components/microsoft/manifest.json
@@ -3,7 +3,7 @@
   "name": "Microsoft",
   "documentation": "https://www.home-assistant.io/integrations/microsoft",
   "requirements": [
-    "pycsspeechtts==1.0.2"
+    "pycsspeechtts==1.0.3"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/microsoft/tts.py
+++ b/homeassistant/components/microsoft/tts.py
@@ -14,6 +14,7 @@ CONF_RATE = "rate"
 CONF_VOLUME = "volume"
 CONF_PITCH = "pitch"
 CONF_CONTOUR = "contour"
+CONF_REGION = "region"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +73,7 @@ DEFAULT_RATE = 0
 DEFAULT_VOLUME = 0
 DEFAULT_PITCH = "default"
 DEFAULT_CONTOUR = ""
+DEFAULT_REGION = "eastus"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -87,6 +89,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         ),
         vol.Optional(CONF_PITCH, default=DEFAULT_PITCH): cv.string,
         vol.Optional(CONF_CONTOUR, default=DEFAULT_CONTOUR): cv.string,
+        vol.Optional(CONF_REGION, default=DEFAULT_REGION): cv.string,
     }
 )
 
@@ -102,13 +105,16 @@ def get_engine(hass, config):
         config[CONF_VOLUME],
         config[CONF_PITCH],
         config[CONF_CONTOUR],
+        config[CONF_REGION],
     )
 
 
 class MicrosoftProvider(Provider):
     """The Microsoft speech API provider."""
 
-    def __init__(self, apikey, lang, gender, ttype, rate, volume, pitch, contour):
+    def __init__(
+        self, apikey, lang, gender, ttype, rate, volume, pitch, contour, region
+    ):
         """Init Microsoft TTS service."""
         self._apikey = apikey
         self._lang = lang
@@ -119,6 +125,7 @@ class MicrosoftProvider(Provider):
         self._volume = f"{volume}%"
         self._pitch = pitch
         self._contour = contour
+        self._region = region
         self.name = "Microsoft"
 
     @property
@@ -138,7 +145,7 @@ class MicrosoftProvider(Provider):
         from pycsspeechtts import pycsspeechtts
 
         try:
-            trans = pycsspeechtts.TTSTranslator(self._apikey)
+            trans = pycsspeechtts.TTSTranslator(self._apikey, self._region)
             data = trans.speak(
                 language=language,
                 gender=self._gender,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1129,7 +1129,7 @@ pycomfoconnect==0.3
 pycoolmasternet==0.0.4
 
 # homeassistant.components.microsoft
-pycsspeechtts==1.0.2
+pycsspeechtts==1.0.3
 
 # homeassistant.components.cups
 # pycups==1.9.73


### PR DESCRIPTION
## Description:

Update pycsspeechtts version to one that supports new azure api.
Add a config for region.

**Related issue (if applicable):** fixes #26217

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10983

## Example entry for `configuration.yaml` (if applicable):
```yaml
tts:
  - platform: microsoft
    api_key: YOUR_API_KEY
    region: eastus
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
