### PR TITLE
Enable transition time for HmIP-BSL - HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -264,7 +264,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     device_registry = await dr.async_get_registry(hass)
     home = hap.home
     # Add the HAP name from configuration if set.
-    hapname = home.label if not home.name else f"{home.label} {home.name}"
+    hapname = home.label if not home.name else f"{home.name} {home.label}"
     device_registry.async_get_or_create(
         config_entry_id=home.id,
         identifiers={(DOMAIN, home.id)},

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -52,6 +52,8 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
         """Initialize the alarm control panel."""
         self._home = hap.home
         self.alarm_state = STATE_ALARM_DISARMED
+        self._internal_alarm_zone = None
+        self._external_alarm_zone = None
 
         for security_zone in security_zones:
             if security_zone.label == "INTERNAL":

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -56,7 +56,7 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
         for security_zone in security_zones:
             if security_zone.label == "INTERNAL":
                 self._internal_alarm_zone = security_zone
-            else:
+            elif security_zone.label == "EXTERNAL":
                 self._external_alarm_zone = security_zone
 
     @property
@@ -110,8 +110,10 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._internal_alarm_zone.on_update(self._async_device_changed)
-        self._external_alarm_zone.on_update(self._async_device_changed)
+        if self._internal_alarm_zone:
+            self._internal_alarm_zone.on_update(self._async_device_changed)
+        if self._external_alarm_zone:
+            self._external_alarm_zone.on_update(self._async_device_changed)
 
     def _async_device_changed(self, *args, **kwargs):
         """Handle device state changes."""
@@ -146,7 +148,7 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
 
 
 def _get_zone_alarm_state(security_zone) -> bool:
-    if security_zone.active:
+    if security_zone and security_zone.active:
         if (
             security_zone.sabotage
             or security_zone.motionDetected

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -16,6 +16,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_NAME,
     ATTR_HS_COLOR,
+    ATTR_TRANSITION,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     Light,
@@ -225,13 +226,28 @@ class HomematicipNotificationLight(HomematicipGenericDevice, Light):
         # Minimum brightness is 10, otherwise the led is disabled
         brightness = max(10, brightness)
         dim_level = brightness / 255.0
+        transition = kwargs.get(ATTR_TRANSITION, 0.5)
 
-        await self._device.set_rgb_dim_level(self.channel, simple_rgb_color, dim_level)
+        await self._device.set_rgb_dim_level_with_time(
+            channelIndex=self.channel,
+            rgb=simple_rgb_color,
+            dimLevel=dim_level,
+            onTime=0,
+            rampTime=transition,
+        )
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
         simple_rgb_color = self._func_channel.simpleRGBColorState
-        await self._device.set_rgb_dim_level(self.channel, simple_rgb_color, 0.0)
+        transition = kwargs.get(ATTR_TRANSITION, 0.5)
+
+        await self._device.set_rgb_dim_level_with_time(
+            channelIndex=self.channel,
+            rgb=simple_rgb_color,
+            dimLevel=0.0,
+            onTime=0,
+            rampTime=transition,
+        )
 
 
 def _convert_color(color) -> RGBColorState:

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -81,8 +81,14 @@ async def test_hmip_notification_light(hass, default_mock_hap):
     await hass.services.async_call(
         "light", "turn_on", {"entity_id": entity_id}, blocking=True
     )
-    assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level"
-    assert hmip_device.mock_calls[-1][1] == (2, RGBColorState.RED, 1.0)
+    assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level_with_time"
+    assert hmip_device.mock_calls[-1][2] == {
+        "channelIndex": 2,
+        "rgb": "RED",
+        "dimLevel": 1.0,
+        "onTime": 0,
+        "rampTime": 0.5,
+    }
 
     color_list = {
         RGBColorState.WHITE: [0.0, 0.0],
@@ -101,17 +107,25 @@ async def test_hmip_notification_light(hass, default_mock_hap):
             {"entity_id": entity_id, "hs_color": hs_color},
             blocking=True,
         )
-        assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level"
-        assert hmip_device.mock_calls[-1][1] == (2, color, 0.0392156862745098)
+        assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level_with_time"
+        assert hmip_device.mock_calls[-1][2] == {
+            "channelIndex": 2,
+            "dimLevel": 0.0392156862745098,
+            "onTime": 0,
+            "rampTime": 0.5,
+            "rgb": color,
+        }
 
     assert len(hmip_device.mock_calls) == service_call_counter + 8
 
-    assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level"
-    assert hmip_device.mock_calls[-1][1] == (
-        2,
-        RGBColorState.PURPLE,
-        0.0392156862745098,
-    )
+    assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level_with_time"
+    assert hmip_device.mock_calls[-1][2] == {
+        "channelIndex": 2,
+        "dimLevel": 0.0392156862745098,
+        "onTime": 0,
+        "rampTime": 0.5,
+        "rgb": "PURPLE",
+    }
     await async_manipulate_test_data(hass, hmip_device, "dimLevel", 1, 2)
     await async_manipulate_test_data(
         hass, hmip_device, "simpleRGBColorState", RGBColorState.PURPLE, 2
@@ -125,8 +139,14 @@ async def test_hmip_notification_light(hass, default_mock_hap):
         "light", "turn_off", {"entity_id": entity_id}, blocking=True
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 11
-    assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level"
-    assert hmip_device.mock_calls[-1][1] == (2, RGBColorState.PURPLE, 0.0)
+    assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level_with_time"
+    assert hmip_device.mock_calls[-1][2] == {
+        "channelIndex": 2,
+        "dimLevel": 0.0,
+        "onTime": 0,
+        "rampTime": 0.5,
+        "rgb": "PURPLE",
+    }
     await async_manipulate_test_data(hass, hmip_device, "dimLevel", 0, 2)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_OFF

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -79,7 +79,10 @@ async def test_hmip_notification_light(hass, default_mock_hap):
 
     # Send all color via service call.
     await hass.services.async_call(
-        "light", "turn_on", {"entity_id": entity_id}, blocking=True
+        "light",
+        "turn_on",
+        {"entity_id": entity_id, "brightness_pct": "100", "transition": 100},
+        blocking=True,
     )
     assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level_with_time"
     assert hmip_device.mock_calls[-1][2] == {
@@ -87,7 +90,7 @@ async def test_hmip_notification_light(hass, default_mock_hap):
         "rgb": "RED",
         "dimLevel": 1.0,
         "onTime": 0,
-        "rampTime": 0.5,
+        "rampTime": 100.0,
     }
 
     color_list = {
@@ -118,14 +121,6 @@ async def test_hmip_notification_light(hass, default_mock_hap):
 
     assert len(hmip_device.mock_calls) == service_call_counter + 8
 
-    assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level_with_time"
-    assert hmip_device.mock_calls[-1][2] == {
-        "channelIndex": 2,
-        "dimLevel": 0.0392156862745098,
-        "onTime": 0,
-        "rampTime": 0.5,
-        "rgb": "PURPLE",
-    }
     await async_manipulate_test_data(hass, hmip_device, "dimLevel", 1, 2)
     await async_manipulate_test_data(
         hass, hmip_device, "simpleRGBColorState", RGBColorState.PURPLE, 2
@@ -136,7 +131,7 @@ async def test_hmip_notification_light(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_BRIGHTNESS] == 255
 
     await hass.services.async_call(
-        "light", "turn_off", {"entity_id": entity_id}, blocking=True
+        "light", "turn_off", {"entity_id": entity_id, "transition": 100}, blocking=True
     )
     assert len(hmip_device.mock_calls) == service_call_counter + 11
     assert hmip_device.mock_calls[-1][0] == "set_rgb_dim_level_with_time"
@@ -144,7 +139,7 @@ async def test_hmip_notification_light(hass, default_mock_hap):
         "channelIndex": 2,
         "dimLevel": 0.0,
         "onTime": 0,
-        "rampTime": 0.5,
+        "rampTime": 100,
         "rgb": "PURPLE",
     }
     await async_manipulate_test_data(hass, hmip_device, "dimLevel", 0, 2)


### PR DESCRIPTION
## Description:

- Enable transition time for HmIP-BSL - HomematicIP Cloud
- Harden ACP
- Fix AP device name

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
