### PR TITLE
Hue: Create new config flow when auth is lost

### DIFF
--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -5,12 +5,12 @@ import aiohue
 import async_timeout
 import voluptuous as vol
 
-from homeassistant import config_entries
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
 from .const import DOMAIN, LOGGER
 from .errors import AuthenticationRequired, CannotConnect
+from .helpers import create_config_flow
 
 SERVICE_HUE_SCENE = "hue_activate_scene"
 ATTR_GROUP_NAME = "group_name"
@@ -30,6 +30,7 @@ class HueBridge:
         self.allow_unreachable = allow_unreachable
         self.allow_groups = allow_groups
         self.available = True
+        self.authorized = False
         self.api = None
 
     @property
@@ -49,13 +50,7 @@ class HueBridge:
             # We are going to fail the config entry setup and initiate a new
             # linking procedure. When linking succeeds, it will remove the
             # old config entry.
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN,
-                    context={"source": config_entries.SOURCE_IMPORT},
-                    data={"host": host},
-                )
-            )
+            create_config_flow(hass, host)
             return False
 
         except CannotConnect:
@@ -82,6 +77,7 @@ class HueBridge:
             DOMAIN, SERVICE_HUE_SCENE, self.hue_activate_scene, schema=SCENE_SCHEMA
         )
 
+        self.authorized = True
         return True
 
     async def async_reset(self):

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -151,6 +151,17 @@ class HueBridge:
 
         await group.set_action(scene=scene.id)
 
+    async def handle_unauthorized_error(self):
+        """Create a new config flow when the authorization is no longer valid."""
+        if not self.authorized:
+            # we already created a new config flow, no need to do it again
+            return
+        LOGGER.error(
+            f"Unable to authorize to bridge {self.host}, setup the linking again."
+        )
+        self.authorized = False
+        create_config_flow(self.hass, self.host)
+
 
 async def get_bridge(hass, host, username=None):
     """Create a bridge object and verify authentication."""

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -157,7 +157,7 @@ class HueBridge:
             # we already created a new config flow, no need to do it again
             return
         LOGGER.error(
-            f"Unable to authorize to bridge {self.host}, setup the linking again."
+            "Unable to authorize to bridge %s, setup the linking again.", self.host
         )
         self.authorized = False
         create_config_flow(self.hass, self.host)

--- a/homeassistant/components/hue/helpers.py
+++ b/homeassistant/components/hue/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for Philips Hue."""
 from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
 from homeassistant.helpers.entity_registry import async_get_registry as get_ent_reg
+from homeassistant import config_entries
 
 from .const import DOMAIN
 
@@ -31,3 +32,14 @@ async def remove_devices(hass, config_entry, api_ids, current):
 
     for item_id in removed_items:
         del current[item_id]
+
+
+def create_config_flow(hass, host):
+    """Start a config flow."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={"host": host},
+        )
+    )

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -30,7 +30,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.util import color
 
-from .helpers import remove_devices, create_config_flow
+from .helpers import remove_devices
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
@@ -204,14 +204,7 @@ async def async_update_items(
         with async_timeout.timeout(4):
             await api.update()
     except aiohue.Unauthorized:
-        if not bridge.authorized:
-            # we already created a new config flow, no need to do it again
-            return
-        _LOGGER.error(
-            "Unable to authorize to bridge %s, setup the linking again.", bridge.host
-        )
-        bridge.authorized = False
-        create_config_flow(hass, bridge.host)
+        await bridge.handle_unauthorized_error()
         return
     except (asyncio.TimeoutError, aiohue.AiohueException) as err:
         _LOGGER.debug("Failed to fetch %s: %s", api_type, err)

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
-from .helpers import remove_devices, create_config_flow
+from .helpers import remove_devices
 
 CURRENT_SENSORS = "current_sensors"
 SENSOR_MANAGER_FORMAT = "{}_sensor_manager"
@@ -102,15 +102,7 @@ class SensorManager:
             with async_timeout.timeout(4):
                 await api.update()
         except Unauthorized:
-            if not self.bridge.authorized:
-                # we already created a new config flow, no need to do it again
-                return
-            _LOGGER.error(
-                "Unable to authorize to bridge %s, setup the linking again.",
-                self.bridge.host,
-            )
-            self.bridge.authorized = False
-            create_config_flow(self.hass, self.bridge.host)
+            await self.bridge.handle_unauthorized_error()
             return
         except (asyncio.TimeoutError, AiohueException) as err:
             _LOGGER.debug("Failed to fetch sensor: %s", err)

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import logging
 from time import monotonic
 
-from aiohue import AiohueException
+from aiohue import AiohueException, Unauthorized
 from aiohue.sensors import TYPE_ZLL_PRESENCE
 import async_timeout
 
@@ -13,7 +13,7 @@ from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
-from .helpers import remove_devices
+from .helpers import remove_devices, create_config_flow
 
 CURRENT_SENSORS = "current_sensors"
 SENSOR_MANAGER_FORMAT = "{}_sensor_manager"
@@ -80,6 +80,11 @@ class SensorManager:
 
         async def async_update_bridge(now):
             """Will update sensors from the bridge."""
+
+            # don't update when we are not authorized
+            if not self.bridge.authorized:
+                return
+
             await self.async_update_items()
 
             async_track_point_in_utc_time(
@@ -96,6 +101,17 @@ class SensorManager:
             start = monotonic()
             with async_timeout.timeout(4):
                 await api.update()
+        except Unauthorized:
+            if not self.bridge.authorized:
+                # we already created a new config flow, no need to do it again
+                return
+            _LOGGER.error(
+                "Unable to authorize to bridge %s, setup the linking again.",
+                self.bridge.host,
+            )
+            self.bridge.authorized = False
+            create_config_flow(self.hass, self.bridge.host)
+            return
         except (asyncio.TimeoutError, AiohueException) as err:
             _LOGGER.debug("Failed to fetch sensor: %s", err)
 
@@ -220,8 +236,10 @@ class GenericHueSensor:
     @property
     def available(self):
         """Return if sensor is available."""
-        return self.bridge.available and (
-            self.bridge.allow_unreachable or self.sensor.config["reachable"]
+        return (
+            self.bridge.available
+            and self.bridge.authorized
+            and (self.bridge.allow_unreachable or self.sensor.config["reachable"])
         )
 
     @property

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -605,7 +605,7 @@ async def test_update_unauthorized(hass, mock_bridge):
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 0
     assert len(hass.states.async_all()) == 0
-    assert mock_bridge.authorized is False
+    assert len(mock_bridge.handle_unauthorized_error.mock_calls) == 1
 
 
 async def test_light_turn_on_service(hass, mock_bridge):

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -599,13 +599,13 @@ async def test_update_timeout(hass, mock_bridge):
 
 
 async def test_update_unauthorized(hass, mock_bridge):
-    """Test bridge marked as not available if unauthorized during update."""
+    """Test bridge marked as not authorized if unauthorized during update."""
     mock_bridge.api.lights.update = Mock(side_effect=aiohue.Unauthorized)
     mock_bridge.api.groups.update = Mock(side_effect=aiohue.Unauthorized)
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 0
     assert len(hass.states.async_all()) == 0
-    assert mock_bridge.available is False
+    assert mock_bridge.authorized is False
 
 
 async def test_light_turn_on_service(hass, mock_bridge):

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -180,6 +180,7 @@ def mock_bridge(hass):
     """Mock a Hue bridge."""
     bridge = Mock(
         available=True,
+        authorized=True,
         allow_unreachable=False,
         allow_groups=False,
         api=Mock(),

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -436,9 +436,9 @@ async def test_update_timeout(hass, mock_bridge):
 
 
 async def test_update_unauthorized(hass, mock_bridge):
-    """Test bridge marked as not available if unauthorized during update."""
+    """Test bridge marked as not authorized if unauthorized during update."""
     mock_bridge.api.sensors.update = Mock(side_effect=aiohue.Unauthorized)
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 0
     assert len(hass.states.async_all()) == 0
-    assert mock_bridge.available is False
+    assert mock_bridge.authorized is False

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -256,6 +256,7 @@ def create_mock_bridge():
     """Create a mock Hue bridge."""
     bridge = Mock(
         available=True,
+        authorized=True,
         allow_unreachable=False,
         allow_groups=False,
         api=Mock(),


### PR DESCRIPTION
## Description:
When the authentication is not longer valid we start a new config flow.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
