### PR TITLE
Fix frontend dependencies for lovelace, history and config

### DIFF
--- a/homeassistant/components/config/manifest.json
+++ b/homeassistant/components/config/manifest.json
@@ -4,6 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/config",
   "requirements": [],
   "dependencies": [
+    "frontend",
     "http"
   ],
   "codeowners": [

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -9,7 +9,6 @@
     "api",
     "auth",
     "http",
-    "lovelace",
     "onboarding",
     "system_log",
     "websocket_api"

--- a/homeassistant/components/history/manifest.json
+++ b/homeassistant/components/history/manifest.json
@@ -4,6 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/history",
   "requirements": [],
   "dependencies": [
+    "frontend",
     "http",
     "recorder"
   ],

--- a/homeassistant/components/lovelace/manifest.json
+++ b/homeassistant/components/lovelace/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/lovelace",
   "requirements": [],
   "dependencies": [
-    "frontend",
+    "frontend"
   ],
   "codeowners": [
     "@home-assistant/frontend"

--- a/homeassistant/components/lovelace/manifest.json
+++ b/homeassistant/components/lovelace/manifest.json
@@ -3,7 +3,9 @@
   "name": "Lovelace",
   "documentation": "https://www.home-assistant.io/integrations/lovelace",
   "requirements": [],
-  "dependencies": [],
+  "dependencies": [
+    "frontend",
+  ],
   "codeowners": [
     "@home-assistant/frontend"
   ]


### PR DESCRIPTION
## Description: Fixing dependencies

On a fresh install, the components 'lovelace', 'history' and 'config' are giving issues (ModuleNotFoundError: No module named 'hass_frontend') due to the frontend component is not loaded yet, before these three components (see #28198). Adding a dependency 'frontend' for the 'lovelace', 'history' and 'config' component will fix this. For the frontend component, the dependency 'lovelace' is removed, otherwise they depend on eachother. 

**Related issue:** fixes #28198 Related #28203 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
