### PR TITLE
Fix broken deconz trigger

### DIFF
--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -235,6 +235,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
     event_id = deconz_event.serial
 
     event_config = {
+        event.CONF_PLATFORM: "event",
         event.CONF_EVENT_TYPE: CONF_DECONZ_EVENT,
         event.CONF_EVENT_DATA: {CONF_UNIQUE_ID: event_id, CONF_EVENT: trigger},
     }


### PR DESCRIPTION
## Description:
Fix broken deconz trigger

**Related issue (if applicable):** fixes #28173

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
