### PR TITLE
Add support for supportedOperations to Alexa.PlaybackController

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 import homeassistant.components.climate.const as climate
+import homeassistant.components.media_player.const as media_player
 from homeassistant.components.alarm_control_panel import ATTR_CODE_FORMAT, FORMAT_NUMBER
 from homeassistant.components import light, fan, cover
 import homeassistant.util.color as color_util
@@ -110,6 +111,11 @@ class AlexaCapability:
         """Return the Configuration object."""
         return []
 
+    @staticmethod
+    def supported_operations():
+        """Return the supportedOperations object."""
+        return []
+
     def serialize_discovery(self):
         """Serialize according to the Discovery API."""
         result = {"type": "AlexaInterface", "interface": self.name(), "version": "3"}
@@ -149,6 +155,10 @@ class AlexaCapability:
         instance = self.instance
         if instance is not None:
             result["instance"] = instance
+
+        supported_operations = self.supported_operations()
+        if supported_operations:
+            result["supportedOperations"] = supported_operations
 
         return result
 
@@ -483,6 +493,28 @@ class AlexaPlaybackController(AlexaCapability):
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.PlaybackController"
+
+    def supported_operations(self):
+        """Return the supportedOperations object.
+
+        Supported Operations: FastForward, Next, Pause, Play, Previous, Rewind, StartOver, Stop
+        """
+        supported_features = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+
+        operations = {
+            media_player.SUPPORT_NEXT_TRACK: "Next",
+            media_player.SUPPORT_PAUSE: "Pause",
+            media_player.SUPPORT_PLAY: "Play",
+            media_player.SUPPORT_PREVIOUS_TRACK: "Previous",
+            media_player.SUPPORT_STOP: "Stop",
+        }
+
+        supported_operations = []
+        for operation in operations:
+            if operation & supported_features:
+                supported_operations.append(operations[operation])
+
+        return supported_operations
 
 
 class AlexaInputController(AlexaCapability):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -10,6 +10,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SEEK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
     SUPPORT_TURN_OFF,
@@ -726,7 +727,7 @@ async def test_media_player(hass):
     assert appliance["displayCategories"][0] == "TV"
     assert appliance["friendlyName"] == "Test media player"
 
-    assert_endpoint_capabilities(
+    capabilities = assert_endpoint_capabilities(
         appliance,
         "Alexa.InputController",
         "Alexa.PowerController",
@@ -736,6 +737,13 @@ async def test_media_player(hass):
         "Alexa.EndpointHealth",
         "Alexa.ChannelController",
     )
+
+    playback_capability = get_capability(capabilities, "Alexa.PlaybackController")
+    assert playback_capability is not None
+    supported_operations = playback_capability["supportedOperations"]
+    operations = ["Play", "Pause", "Stop", "Next", "Previous"]
+    for operation in operations:
+        assert operation in supported_operations
 
     await assert_power_controller_works(
         "media_player#test", "media_player.turn_on", "media_player.turn_off", hass

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -10,7 +10,6 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SEEK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
     SUPPORT_TURN_OFF,


### PR DESCRIPTION
## Description:
Adds support for the `supportedOperations` object for the `Alexa.PlaybackController`. 
Exposes the supported `media_player` operations based on the entities supported features. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
