### PR TITLE
Change keys for Samsung TV next and prev track command

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -316,11 +316,11 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def media_next_track(self):
         """Send next track command."""
-        self.send_key("KEY_FF")
+        self.send_key("KEY_CHUP")
 
     def media_previous_track(self):
         """Send the previous track command."""
-        self.send_key("KEY_REWIND")
+        self.send_key("KEY_CHDOWN")
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Support changing a channel."""

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -532,7 +532,7 @@ async def test_media_next_track(hass, remote):
     )
     # key and update called
     assert remote.control.call_count == 2
-    assert remote.control.call_args_list == [call("KEY_FF"), call("KEY")]
+    assert remote.control.call_args_list == [call("KEY_CHUP"), call("KEY")]
 
 
 async def test_media_previous_track(hass, remote):
@@ -543,7 +543,7 @@ async def test_media_previous_track(hass, remote):
     )
     # key and update called
     assert remote.control.call_count == 2
-    assert remote.control.call_args_list == [call("KEY_REWIND"), call("KEY")]
+    assert remote.control.call_args_list == [call("KEY_CHDOWN"), call("KEY")]
 
 
 async def test_turn_on_with_mac(hass, remote, wakeonlan):


### PR DESCRIPTION
## Breaking Change:

The behaviour for next and previous track commands for samsung TVs were changed.
Before the change the samsung tv component reacted to the two above commands sending the KEY_FF and KEY_REWIND commands. While watching TV programs those two commands do nothing.
After the change the entity sends the KEY_CHUP and KEY_CHDOWN commands instead, thus allowing the user to change channel using the media player standard lovelace interface.
The user doesn't need to change anything in the configuration.

## Description:

The best solution would be to send the right command based on the status of the TV (just like in the LG webos component) but unluckily looks like there is no way to detect what the TV currently showing.
Since there is no next/prev command in the media player but only next/prev track one has to deal with this.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
