### PR TITLE
Implement Alexa.PlaybackStateReporter Interface for alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -12,9 +12,11 @@ from homeassistant.const import (
     STATE_LOCKED,
     STATE_OFF,
     STATE_ON,
+    STATE_PAUSED,
+    STATE_PLAYING,
     STATE_UNAVAILABLE,
-    STATE_UNLOCKED,
     STATE_UNKNOWN,
+    STATE_UNLOCKED,
 )
 import homeassistant.components.climate.const as climate
 from homeassistant.components.alarm_control_panel import ATTR_CODE_FORMAT, FORMAT_NUMBER
@@ -1078,3 +1080,39 @@ class AlexaDoorbellEventSource(AlexaCapability):
     def capability_proactively_reported(self):
         """Return True for proactively reported capability."""
         return True
+
+
+class AlexaPlaybackStateReporter(AlexaCapability):
+    """Implements Alexa.PlaybackStateReporter.
+
+    https://developer.amazon.com/docs/device-apis/alexa-playbackstatereporter.html
+    """
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa.PlaybackStateReporter"
+
+    def properties_supported(self):
+        """Return what properties this entity supports."""
+        return [{"name": "playbackState"}]
+
+    def properties_proactively_reported(self):
+        """Return True if properties asynchronously reported."""
+        return True
+
+    def properties_retrievable(self):
+        """Return True if properties can be retrieved."""
+        return True
+
+    def get_property(self, name):
+        """Read and return a property."""
+        if name != "playbackState":
+            raise UnsupportedProperty(name)
+
+        playback_state = self.entity.state
+        if playback_state == STATE_PLAYING:
+            return {"state": "PLAYING"}
+        if playback_state == STATE_PAUSED:
+            return {"state": "PAUSED"}
+
+        return {"state": "STOPPED"}

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -46,6 +46,7 @@ from .capabilities import (
     AlexaMotionSensor,
     AlexaPercentageController,
     AlexaPlaybackController,
+    AlexaPlaybackStateReporter,
     AlexaPowerController,
     AlexaPowerLevelController,
     AlexaRangeController,
@@ -418,6 +419,7 @@ class MediaPlayerCapabilities(AlexaEntity):
         )
         if supported & playback_features:
             yield AlexaPlaybackController(self.entity)
+            yield AlexaPlaybackStateReporter(self.entity)
 
         if supported & media_player.SUPPORT_SELECT_SOURCE:
             yield AlexaInputController(self.entity)

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -17,6 +17,11 @@ from homeassistant.const import (
 from homeassistant.components.climate import const as climate
 from homeassistant.components.alexa import smart_home
 from homeassistant.components.alexa.errors import UnsupportedProperty
+from homeassistant.components.media_player.const import (
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_STOP,
+)
 from tests.common import async_mock_service
 
 from . import (
@@ -629,3 +634,22 @@ async def test_report_alarm_control_panel_state(hass):
 
     properties = await reported_properties(hass, "alarm_control_panel.disarmed")
     properties.assert_equal("Alexa.SecurityPanelController", "armState", "DISARMED")
+
+
+async def test_report_playback_state(hass):
+    """Test PlaybackStateReporter implements playbackState property."""
+    hass.states.async_set(
+        "media_player.test",
+        "off",
+        {
+            "friendly_name": "Test media player",
+            "supported_features": SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_STOP,
+            "volume_level": 0.75,
+        },
+    )
+
+    properties = await reported_properties(hass, "media_player.test")
+
+    properties.assert_equal(
+        "Alexa.PlaybackStateReporter", "playbackState", {"state": "STOPPED"}
+    )

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -733,6 +733,7 @@ async def test_media_player(hass):
         "Alexa.Speaker",
         "Alexa.StepSpeaker",
         "Alexa.PlaybackController",
+        "Alexa.PlaybackStateReporter",
         "Alexa.EndpointHealth",
         "Alexa.ChannelController",
     )
@@ -947,6 +948,7 @@ async def test_media_player_power(hass):
         "Alexa.Speaker",
         "Alexa.StepSpeaker",
         "Alexa.PlaybackController",
+        "Alexa.PlaybackStateReporter",
         "Alexa.EndpointHealth",
         "Alexa.ChannelController",
     )


### PR DESCRIPTION
## Description:
Implements the `Alexa.PlaybackStateReporter` and `playbackState` property for `StateReport` and `ChangeReports`. 

Applies to all `media_player` entities that support playback features.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
