### PR TITLE
Fix amazon dependency conflicts

### DIFF
--- a/homeassistant/components/amazon_polly/manifest.json
+++ b/homeassistant/components/amazon_polly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Amazon polly",
   "documentation": "https://www.home-assistant.io/integrations/amazon_polly",
   "requirements": [
-    "boto3==1.9.233"
+    "boto3==1.9.252"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/aws/manifest.json
+++ b/homeassistant/components/aws/manifest.json
@@ -3,7 +3,7 @@
   "name": "Aws",
   "documentation": "https://www.home-assistant.io/integrations/aws",
   "requirements": [
-    "aiobotocore==0.10.2"
+    "aiobotocore==0.10.4"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/route53/manifest.json
+++ b/homeassistant/components/route53/manifest.json
@@ -3,7 +3,7 @@
   "name": "Route53",
   "documentation": "https://www.home-assistant.io/integrations/route53",
   "requirements": [
-    "boto3==1.9.233",
+    "boto3==1.9.252",
     "ipify==1.0.0"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -306,10 +306,8 @@ blockchain==1.4.4
 # homeassistant.components.bom
 bomradarloop==0.1.3
 
-# homeassistant.components.route53
-boto3==1.9.233
-
 # homeassistant.components.amazon_polly
+# homeassistant.components.route53
 boto3==1.9.252
 
 # homeassistant.components.braviatv

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -133,7 +133,7 @@ aioasuswrt==1.1.21
 aioautomatic==0.6.5
 
 # homeassistant.components.aws
-aiobotocore==0.10.2
+aiobotocore==0.10.4
 
 # homeassistant.components.dnsip
 aiodns==2.0.0
@@ -306,9 +306,11 @@ blockchain==1.4.4
 # homeassistant.components.bom
 bomradarloop==0.1.3
 
-# homeassistant.components.amazon_polly
 # homeassistant.components.route53
 boto3==1.9.233
+
+# homeassistant.components.amazon_polly
+boto3==1.9.252
 
 # homeassistant.components.braviatv
 braviarc-homeassistant==0.3.7.dev0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -68,7 +68,7 @@ aioasuswrt==1.1.21
 aioautomatic==0.6.5
 
 # homeassistant.components.aws
-aiobotocore==0.10.2
+aiobotocore==0.10.4
 
 # homeassistant.components.esphome
 aioesphomeapi==2.4.2


### PR DESCRIPTION
## Description:
The amazon components have intermingled dependencies a few layers deep which aren't picked up by the automation scripts. In the 0.100 release boto3 was changed for the amazon_polly component which broke aws.

All is good in the world now.  This should probably go into a beta to make sure it gets a bit of testing as I'm not able to test aws or route53. amazon_polly tests okay.

**Related issue (if applicable):** fixes #27418 

# Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
