### PR TITLE
Explicitly include "Alexa" Interface in discovery response

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -215,6 +215,20 @@ class AlexaCapability:
         return friendly_names
 
 
+class Alexa(AlexaCapability):
+    """Implements Alexa Interface.
+
+    Although endpoints implement this interface implicitly,
+    The API suggests you should explicitly include this interface.
+
+    https://developer.amazon.com/docs/device-apis/alexa-interface.html
+    """
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa"
+
+
 class AlexaEndpointHealth(AlexaCapability):
     """Implements Alexa.EndpointHealth.
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -33,6 +33,7 @@ from homeassistant.components import (
 
 from .const import CONF_DESCRIPTION, CONF_DISPLAY_CATEGORIES
 from .capabilities import (
+    Alexa,
     AlexaBrightnessController,
     AlexaChannelController,
     AlexaColorController,
@@ -261,6 +262,7 @@ class GenericCapabilities(AlexaEntity):
         return [
             AlexaPowerController(self.entity),
             AlexaEndpointHealth(self.hass, self.entity),
+            Alexa(self.hass),
         ]
 
 
@@ -277,6 +279,7 @@ class SwitchCapabilities(AlexaEntity):
         return [
             AlexaPowerController(self.entity),
             AlexaEndpointHealth(self.hass, self.entity),
+            Alexa(self.hass),
         ]
 
 
@@ -299,6 +302,7 @@ class ClimateCapabilities(AlexaEntity):
         yield AlexaThermostatController(self.hass, self.entity)
         yield AlexaTemperatureSensor(self.hass, self.entity)
         yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)
 
 
 @ENTITY_ADAPTERS.register(cover.DOMAIN)
@@ -316,6 +320,7 @@ class CoverCapabilities(AlexaEntity):
         if supported & cover.SUPPORT_SET_POSITION:
             yield AlexaPercentageController(self.entity)
         yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)
 
 
 @ENTITY_ADAPTERS.register(light.DOMAIN)
@@ -338,6 +343,7 @@ class LightCapabilities(AlexaEntity):
         if supported & light.SUPPORT_COLOR_TEMP:
             yield AlexaColorTemperatureController(self.entity)
         yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)
 
 
 @ENTITY_ADAPTERS.register(fan.DOMAIN)
@@ -369,6 +375,7 @@ class FanCapabilities(AlexaEntity):
             )
 
         yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)
 
 
 @ENTITY_ADAPTERS.register(lock.DOMAIN)
@@ -384,6 +391,7 @@ class LockCapabilities(AlexaEntity):
         return [
             AlexaLockController(self.entity),
             AlexaEndpointHealth(self.hass, self.entity),
+            Alexa(self.hass),
         ]
 
 
@@ -401,7 +409,6 @@ class MediaPlayerCapabilities(AlexaEntity):
 
     def interfaces(self):
         """Yield the supported interfaces."""
-        yield AlexaEndpointHealth(self.hass, self.entity)
         yield AlexaPowerController(self.entity)
 
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
@@ -435,6 +442,9 @@ class MediaPlayerCapabilities(AlexaEntity):
         if supported & media_player.const.SUPPORT_PLAY_MEDIA:
             yield AlexaChannelController(self.entity)
 
+        yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)
+
 
 @ENTITY_ADAPTERS.register(scene.DOMAIN)
 class SceneCapabilities(AlexaEntity):
@@ -453,7 +463,10 @@ class SceneCapabilities(AlexaEntity):
 
     def interfaces(self):
         """Yield the supported interfaces."""
-        return [AlexaSceneController(self.entity, supports_deactivation=False)]
+        return [
+            AlexaSceneController(self.entity, supports_deactivation=False),
+            Alexa(self.hass),
+        ]
 
 
 @ENTITY_ADAPTERS.register(script.DOMAIN)
@@ -467,7 +480,10 @@ class ScriptCapabilities(AlexaEntity):
     def interfaces(self):
         """Yield the supported interfaces."""
         can_cancel = bool(self.entity.attributes.get("can_cancel"))
-        return [AlexaSceneController(self.entity, supports_deactivation=can_cancel)]
+        return [
+            AlexaSceneController(self.entity, supports_deactivation=can_cancel),
+            Alexa(self.hass),
+        ]
 
 
 @ENTITY_ADAPTERS.register(sensor.DOMAIN)
@@ -486,6 +502,7 @@ class SensorCapabilities(AlexaEntity):
         if attrs.get(ATTR_UNIT_OF_MEASUREMENT) in (TEMP_FAHRENHEIT, TEMP_CELSIUS):
             yield AlexaTemperatureSensor(self.hass, self.entity)
             yield AlexaEndpointHealth(self.hass, self.entity)
+            yield Alexa(self.hass)
 
 
 @ENTITY_ADAPTERS.register(binary_sensor.DOMAIN)
@@ -517,6 +534,7 @@ class BinarySensorCapabilities(AlexaEntity):
                 yield AlexaDoorbellEventSource(self.entity)
 
         yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)
 
     def get_type(self):
         """Return the type of binary sensor."""
@@ -540,3 +558,4 @@ class AlarmControlPanelCapabilities(AlexaEntity):
         if not self.entity.attributes.get("code_arm_required"):
             yield AlexaSecurityPanelController(self.hass, self.entity)
             yield AlexaEndpointHealth(self.hass, self.entity)
+            yield Alexa(self.hass)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1035,6 +1035,7 @@ async def test_media_player_seek(hass):
 
     assert_endpoint_capabilities(
         appliance,
+        "Alexa",
         "Alexa.EndpointHealth",
         "Alexa.PowerController",
         "Alexa.SeekController",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -157,7 +157,7 @@ async def test_switch(hass, events):
     assert appliance["displayCategories"][0] == "SWITCH"
     assert appliance["friendlyName"] == "Test switch"
     assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     await assert_power_controller_works(
@@ -177,7 +177,7 @@ async def test_light(hass):
     assert appliance["displayCategories"][0] == "LIGHT"
     assert appliance["friendlyName"] == "Test light 1"
     assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     await assert_power_controller_works(
@@ -203,6 +203,7 @@ async def test_dimmable_light(hass):
         "Alexa.BrightnessController",
         "Alexa.PowerController",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     properties = await reported_properties(hass, "light#test_2")
@@ -245,6 +246,7 @@ async def test_color_light(hass):
         "Alexa.ColorController",
         "Alexa.ColorTemperatureController",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     # IncreaseColorTemperature and DecreaseColorTemperature have their own
@@ -260,8 +262,11 @@ async def test_script(hass):
     assert appliance["displayCategories"][0] == "ACTIVITY_TRIGGER"
     assert appliance["friendlyName"] == "Test script"
 
-    (capability,) = assert_endpoint_capabilities(appliance, "Alexa.SceneController")
-    assert not capability["supportsDeactivation"]
+    capabilities = assert_endpoint_capabilities(
+        appliance, "Alexa.SceneController", "Alexa"
+    )
+    scene_capability = get_capability(capabilities, "Alexa.SceneController")
+    assert not scene_capability["supportsDeactivation"]
 
     await assert_scene_controller_works("script#test", "script.turn_on", None, hass)
 
@@ -276,8 +281,11 @@ async def test_cancelable_script(hass):
     appliance = await discovery_test(device, hass)
 
     assert appliance["endpointId"] == "script#test_2"
-    (capability,) = assert_endpoint_capabilities(appliance, "Alexa.SceneController")
-    assert capability["supportsDeactivation"]
+    capabilities = assert_endpoint_capabilities(
+        appliance, "Alexa.SceneController", "Alexa"
+    )
+    scene_capability = get_capability(capabilities, "Alexa.SceneController")
+    assert scene_capability["supportsDeactivation"]
 
     await assert_scene_controller_works(
         "script#test_2", "script.turn_on", "script.turn_off", hass
@@ -293,7 +301,7 @@ async def test_input_boolean(hass):
     assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test input boolean"
     assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     await assert_power_controller_works(
@@ -310,8 +318,11 @@ async def test_scene(hass):
     assert appliance["displayCategories"][0] == "SCENE_TRIGGER"
     assert appliance["friendlyName"] == "Test scene"
 
-    (capability,) = assert_endpoint_capabilities(appliance, "Alexa.SceneController")
-    assert not capability["supportsDeactivation"]
+    capabilities = assert_endpoint_capabilities(
+        appliance, "Alexa.SceneController", "Alexa"
+    )
+    scene_capability = get_capability(capabilities, "Alexa.SceneController")
+    assert not scene_capability["supportsDeactivation"]
 
     await assert_scene_controller_works("scene#test", "scene.turn_on", None, hass)
 
@@ -325,7 +336,7 @@ async def test_fan(hass):
     assert appliance["displayCategories"][0] == "FAN"
     assert appliance["friendlyName"] == "Test fan 1"
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     power_capability = get_capability(capabilities, "Alexa.PowerController")
@@ -361,6 +372,7 @@ async def test_variable_fan(hass):
         "Alexa.PowerLevelController",
         "Alexa.RangeController",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     range_capability = get_capability(capabilities, "Alexa.RangeController")
@@ -444,6 +456,7 @@ async def test_oscillating_fan(hass):
         "Alexa.RangeController",
         "Alexa.ToggleController",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     toggle_capability = get_capability(capabilities, "Alexa.ToggleController")
@@ -508,6 +521,7 @@ async def test_direction_fan(hass):
         "Alexa.RangeController",
         "Alexa.ModeController",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     mode_capability = get_capability(capabilities, "Alexa.ModeController")
@@ -601,6 +615,7 @@ async def test_fan_range(hass):
         "Alexa.PowerLevelController",
         "Alexa.RangeController",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     range_capability = get_capability(capabilities, "Alexa.RangeController")
@@ -678,7 +693,7 @@ async def test_lock(hass):
     assert appliance["displayCategories"][0] == "SMARTLOCK"
     assert appliance["friendlyName"] == "Test lock"
     assert_endpoint_capabilities(
-        appliance, "Alexa.LockController", "Alexa.EndpointHealth"
+        appliance, "Alexa.LockController", "Alexa.EndpointHealth", "Alexa"
     )
 
     _, msg = await assert_request_calls_service(
@@ -729,6 +744,7 @@ async def test_media_player(hass):
 
     capabilities = assert_endpoint_capabilities(
         appliance,
+        "Alexa",
         "Alexa.ChannelController",
         "Alexa.EndpointHealth",
         "Alexa.InputController",
@@ -951,6 +967,7 @@ async def test_media_player_power(hass):
 
     assert_endpoint_capabilities(
         appliance,
+        "Alexa",
         "Alexa.ChannelController",
         "Alexa.EndpointHealth",
         "Alexa.InputController",
@@ -1121,7 +1138,7 @@ async def test_alert(hass):
     assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test alert"
     assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     await assert_power_controller_works(
@@ -1138,7 +1155,7 @@ async def test_automation(hass):
     assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test automation"
     assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     await assert_power_controller_works(
@@ -1155,7 +1172,7 @@ async def test_group(hass):
     assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test group"
     assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     await assert_power_controller_works(
@@ -1181,6 +1198,7 @@ async def test_cover(hass):
         "Alexa.PercentageController",
         "Alexa.PowerController",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     await assert_power_controller_works(
@@ -1269,7 +1287,7 @@ async def test_temp_sensor(hass):
     assert appliance["friendlyName"] == "Test Temp Sensor"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.TemperatureSensor", "Alexa.EndpointHealth"
+        appliance, "Alexa.TemperatureSensor", "Alexa.EndpointHealth", "Alexa"
     )
 
     temp_sensor_capability = get_capability(capabilities, "Alexa.TemperatureSensor")
@@ -1298,7 +1316,7 @@ async def test_contact_sensor(hass):
     assert appliance["friendlyName"] == "Test Contact Sensor"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.ContactSensor", "Alexa.EndpointHealth"
+        appliance, "Alexa.ContactSensor", "Alexa.EndpointHealth", "Alexa"
     )
 
     contact_sensor_capability = get_capability(capabilities, "Alexa.ContactSensor")
@@ -1327,7 +1345,7 @@ async def test_motion_sensor(hass):
     assert appliance["friendlyName"] == "Test Motion Sensor"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.MotionSensor", "Alexa.EndpointHealth"
+        appliance, "Alexa.MotionSensor", "Alexa.EndpointHealth", "Alexa"
     )
 
     motion_sensor_capability = get_capability(capabilities, "Alexa.MotionSensor")
@@ -1354,7 +1372,7 @@ async def test_doorbell_sensor(hass):
     assert appliance["friendlyName"] == "Test Doorbell Sensor"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.DoorbellEventSource", "Alexa.EndpointHealth"
+        appliance, "Alexa.DoorbellEventSource", "Alexa.EndpointHealth", "Alexa"
     )
 
     doorbell_capability = get_capability(capabilities, "Alexa.DoorbellEventSource")
@@ -1404,6 +1422,7 @@ async def test_thermostat(hass):
         "Alexa.ThermostatController",
         "Alexa.TemperatureSensor",
         "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     properties = await reported_properties(hass, "climate#test_thermostat")
@@ -1800,7 +1819,7 @@ async def test_entity_config(hass):
     assert appliance["friendlyName"] == "Config name"
     assert appliance["description"] == "Config description via Home Assistant"
     assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
     )
 
     scene = msg["payload"]["endpoints"][1]
@@ -1917,7 +1936,7 @@ async def test_alarm_control_panel_disarmed(hass):
     assert appliance["displayCategories"][0] == "SECURITY_PANEL"
     assert appliance["friendlyName"] == "Test Alarm Control Panel 1"
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.SecurityPanelController", "Alexa.EndpointHealth"
+        appliance, "Alexa.SecurityPanelController", "Alexa.EndpointHealth", "Alexa"
     )
     security_panel_capability = get_capability(
         capabilities, "Alexa.SecurityPanelController"
@@ -1984,7 +2003,7 @@ async def test_alarm_control_panel_armed(hass):
     assert appliance["displayCategories"][0] == "SECURITY_PANEL"
     assert appliance["friendlyName"] == "Test Alarm Control Panel 2"
     assert_endpoint_capabilities(
-        appliance, "Alexa.SecurityPanelController", "Alexa.EndpointHealth"
+        appliance, "Alexa.SecurityPanelController", "Alexa.EndpointHealth", "Alexa"
     )
 
     properties = await reported_properties(hass, "alarm_control_panel#test_2")

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -800,7 +800,7 @@ async def test_list_alexa_entities(hass, hass_ws_client, setup_api, mock_cloud_l
     assert response["result"][0] == {
         "entity_id": "light.kitchen",
         "display_categories": ["LIGHT"],
-        "interfaces": ["Alexa.PowerController", "Alexa.EndpointHealth"],
+        "interfaces": ["Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"],
     }
 
 


### PR DESCRIPTION
## Description:
According to the Alexa API Documentation. The "base" `Alexa` Interface should be explicitly included in the capabilities list for each endpoint. 

> Although endpoints implement this interface implicitly, you should explicitly include this interface and the supported version in your discovery response.
https://developer.amazon.com/docs/device-apis/alexa-interface.html

This PR makes sure that happens. 


```json
{
    "type": "AlexaInterface",
    "interface": "Alexa",
    "version": "3"
}
```

**Notes:**
- Confirmed through documentation and reviewing sample code provided by Alexa Docs that this is recommended. 
- No negative effects were ever known without it, but ultimately my OCD to follow API guidelines kicked in and decided to implement it. 
- Thought about implementing this a few ways:
  - manually hard coding it into each capabilities object
  - having the `AlexaCapability` base class expose it.
  - Ultimately decided to just create a new subclass `Alexa`, and add it to each entity.
- Updated all Tests that check capabilities to check for this interface.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
