### PR TITLE
Support alexa SMARTPLUG display category based on switch outlet device_class

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -269,6 +269,10 @@ class SwitchCapabilities(AlexaEntity):
 
     def default_display_categories(self):
         """Return the display categories for this entity."""
+        device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
+        if device_class == switch.DEVICE_CLASS_OUTLET:
+            return [DisplayCategory.SMARTPLUG]
+
         return [DisplayCategory.SWITCH]
 
     def interfaces(self):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -167,6 +167,23 @@ async def test_switch(hass, events):
     properties.assert_equal("Alexa.PowerController", "powerState", "ON")
 
 
+async def test_outlet(hass, events):
+    """Test switch with device class outlet discovery."""
+    device = (
+        "switch.test",
+        "on",
+        {"friendly_name": "Test switch", "device_class": "outlet"},
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "switch#test"
+    assert appliance["displayCategories"][0] == "SMARTPLUG"
+    assert appliance["friendlyName"] == "Test switch"
+    assert_endpoint_capabilities(
+        appliance, "Alexa.PowerController", "Alexa.EndpointHealth"
+    )
+
+
 async def test_light(hass):
     """Test light discovery."""
     device = ("light.test_1", "on", {"friendly_name": "Test light 1"})


### PR DESCRIPTION
## Description:
Returns the default display category based on switch device_class. Defaults to switch, to support existing entities or entities without device_class attribute.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
