### PR TITLE
Fix feedreader handling unrecognized published date

### DIFF
--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -139,9 +139,10 @@ class FeedManager:
 
     def _update_and_fire_entry(self, entry):
         """Update last_entry_timestamp and fire entry."""
-        # We are lucky, `published_parsed` data available, let's make use of
-        # it to publish only new available entries since the last run
-        if "published_parsed" in entry.keys():
+        # Check if the entry has a published date.
+        if "published_parsed" in entry.keys() and entry.published_parsed:
+            # We are lucky, `published_parsed` data available, let's make use of
+            # it to publish only new available entries since the last run
             self._has_published_parsed = True
             self._last_entry_timestamp = max(
                 entry.published_parsed, self._last_entry_timestamp

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -163,6 +163,12 @@ class TestFeedreaderComponent(unittest.TestCase):
         manager, events = self.setup_manager(feed_data)
         assert len(events) == 3
 
+    def test_feed_with_unrecognized_publication_date(self):
+        """Test simple feed with entry with unrecognized publication date."""
+        feed_data = load_fixture("feedreader4.xml")
+        manager, events = self.setup_manager(feed_data)
+        assert len(events) == 1
+
     def test_feed_invalid_data(self):
         """Test feed with invalid data."""
         feed_data = "INVALID DATA"

--- a/tests/fixtures/feedreader4.xml
+++ b/tests/fixtures/feedreader4.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 26 Oct 2019 12:00:00 +1000 </lastBuildDate>
+        <pubDate>Mon, 26 Oct 2019 15:00:00 +1000</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Title 1</title>
+            <description>Description 1</description>
+            <link>http://www.example.com/link/1</link>
+            <guid isPermaLink="false">GUID 1</guid>
+            <pubDate>26.10.2019 - 12:06:24</pubDate>
+        </item>
+
+    </channel>
+</rss>


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
If a published date is supplied in a feed but the date format is unrecognized then the feedreader fails to process feed entries properly.
This fix checks not only if the feed entry does have a `published_parsed` key, but also if the field actually contains a value.

**Related issue (if applicable):** fixes #27694

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
feedreader:
  urls:
    - https://bit-titan.net/rss.php?rss=all&uid=5817&pk=c1bdbdcc66f69b53b4fa8ead04500d3a
  scan_interval:
    minutes: 1
  max_entries: 50
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
