### PR TITLE
Add dump config service to HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -263,9 +263,13 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         anonymize = service.data[ATTR_ANONYMIZE]
 
         for hap in hass.data[DOMAIN].values():
-            config_file = (
-                f"{config_path}/{config_file_prefix}_{hap.config_entry.title}.json"
-            )
+            hap_sgtin = hap.config_entry.title
+
+            if anonymize:
+                hap_sgtin = hap_sgtin[-4:]
+
+            config_file = f"{config_path}/{config_file_prefix}_{hap_sgtin}.json"
+
             json_state = await hap.home.download_configuration()
             json_state = handle_config(json_state, anonymize)
             open(config_file, mode="w", encoding="utf8").write(json_state)

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -2,6 +2,7 @@
 import logging
 
 from homematicip.aio.group import AsyncHeatingGroup
+from homematicip.base.helpers import handle_config
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -26,17 +27,23 @@ from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_ACCESSPOINT_ID = "accesspoint_id"
+ATTR_ANONYMIZE = "anonymize"
 ATTR_CLIMATE_PROFILE_INDEX = "climate_profile_index"
+ATTR_CONFIG_OUTPUT_FILE_PREFIX = "config_output_file_prefix"
+ATTR_CONFIG_OUTPUT_PATH = "config_output_path"
 ATTR_DURATION = "duration"
 ATTR_ENDTIME = "endtime"
 ATTR_TEMPERATURE = "temperature"
-ATTR_ACCESSPOINT_ID = "accesspoint_id"
+
+DEFAULT_CONFIG_FILE_PREFIX = "hmip-config"
 
 SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION = "activate_eco_mode_with_duration"
 SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD = "activate_eco_mode_with_period"
 SERVICE_ACTIVATE_VACATION = "activate_vacation"
 SERVICE_DEACTIVATE_ECO_MODE = "deactivate_eco_mode"
 SERVICE_DEACTIVATE_VACATION = "deactivate_vacation"
+SERVICE_DUMP_HAP_CONFIG = "dump_hap_config"
 SERVICE_SET_ACTIVE_CLIMATE_PROFILE = "set_active_climate_profile"
 
 CONFIG_SCHEMA = vol.Schema(
@@ -93,6 +100,14 @@ SCHEMA_SET_ACTIVE_CLIMATE_PROFILE = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): comp_entity_ids,
         vol.Required(ATTR_CLIMATE_PROFILE_INDEX): cv.positive_int,
+    }
+)
+
+SCHEMA_DUMP_HAP_CONFIG = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_OUTPUT_PATH, default=""): cv.string,
+        vol.Required(ATTR_CONFIG_OUTPUT_FILE_PREFIX, default=""): cv.string,
+        vol.Required(ATTR_ANONYMIZE, default=True): cv.boolean,
     }
 )
 
@@ -237,6 +252,29 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         SERVICE_SET_ACTIVE_CLIMATE_PROFILE,
         _set_active_climate_profile,
         schema=SCHEMA_SET_ACTIVE_CLIMATE_PROFILE,
+    )
+
+    async def _async_dump_hap_config(service):
+        """Service to dump the configuration of a Homematic IP Access Point."""
+        config_path = service.data[ATTR_CONFIG_OUTPUT_PATH] or hass.config.config_dir
+        config_file_prefix = (
+            service.data[ATTR_CONFIG_OUTPUT_FILE_PREFIX] or DEFAULT_CONFIG_FILE_PREFIX
+        )
+        anonymize = service.data[ATTR_ANONYMIZE]
+
+        for hap in hass.data[DOMAIN].values():
+            config_file = (
+                f"{config_path}/{config_file_prefix}_{hap.config_entry.title}.json"
+            )
+            json_state = await hap.home.download_configuration()
+            json_state = handle_config(json_state, anonymize)
+            open(config_file, mode="w", encoding="utf8").write(json_state)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DUMP_HAP_CONFIG,
+        _async_dump_hap_config,
+        schema=SCHEMA_DUMP_HAP_CONFIG,
     )
 
     def _get_home(hapid: str):

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -57,4 +57,15 @@ set_active_climate_profile:
       description: The index of the climate profile (1 based)
       example: 1
 
-
+dump_hap_config:
+  description: Dump the configuration of the Homematic IP Access Point(s).
+  fields:
+    config_output_path:
+      description: (Default is 'Your home-assistant config directory') Path where to store the config.
+      example: '/config'
+    config_output_file_prefix:
+      description: (Default is 'hmip-config') Name of the config file. The SGTIN of the AP will always be appended.
+      example: 'hmip-config'
+    anonymize:
+      description: (Default is True) Should the Configuration be anonymized?
+      example: True

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -155,13 +155,11 @@ async def test_unload_entry(hass):
 async def test_hmip_dump_hap_config_services(hass, mock_hap_with_service):
     """Test dump configuration services."""
 
-    with patch(
-        "homeassistant.components.homematicip_cloud.open", return_value=Mock()
-    ) as open_mock:
+    with patch("pathlib.Path.write_text", return_value=Mock()) as write_mock:
         await hass.services.async_call(
             "homematicip_cloud", "dump_hap_config", {"anonymize": True}, blocking=True
         )
         home = mock_hap_with_service.home
         assert home.mock_calls[-1][0] == "download_configuration"
         assert len(home.mock_calls) == 8  # pylint: disable=W0212
-        assert len(open_mock.mock_calls) == 1
+        assert len(write_mock.mock_calls) > 0

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -1,13 +1,11 @@
 """Test HomematicIP Cloud setup process."""
 
-import os
 from unittest.mock import patch
 
 from homeassistant.components import homematicip_cloud as hmipc
-from homeassistant.components.homematicip_cloud import DEFAULT_CONFIG_FILE_PREFIX
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import Mock, MockConfigEntry, mock_coro
 
 
 async def test_config_with_accesspoint_passed_to_config_entry(hass):
@@ -156,18 +154,14 @@ async def test_unload_entry(hass):
 
 async def test_hmip_dump_hap_config_services(hass, mock_hap_with_service):
     """Test dump configuration services."""
-    config_file = f"{hass.config.config_dir}/{DEFAULT_CONFIG_FILE_PREFIX}"
-    try:
+
+    with patch(
+        "homeassistant.components.homematicip_cloud.open", return_value=Mock()
+    ) as open_mock:
         await hass.services.async_call(
             "homematicip_cloud", "dump_hap_config", {"anonymize": True}, blocking=True
         )
         home = mock_hap_with_service.home
         assert home.mock_calls[-1][0] == "download_configuration"
         assert len(home.mock_calls) == 8  # pylint: disable=W0212
-
-        assert os.path.isfile(config_file)
-        file_content = open(config_file, "r").readlines()
-        assert file_content
-    finally:
-        os.remove(config_file)
-        assert not os.path.isfile(config_file)
+        assert len(open_mock.mock_calls) == 2

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -164,4 +164,4 @@ async def test_hmip_dump_hap_config_services(hass, mock_hap_with_service):
         home = mock_hap_with_service.home
         assert home.mock_calls[-1][0] == "download_configuration"
         assert len(home.mock_calls) == 8  # pylint: disable=W0212
-        assert len(open_mock.mock_calls) == 2
+        assert len(open_mock.mock_calls) == 1


### PR DESCRIPTION
# Description:
This PR adds a service to dump the homematic ip cloud configurarion to a local file.
This can be used for self documention, or to support the development of the unterlying homematicip library.

The current process is really  unhandy for normal users.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10999


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
