### PR TITLE
Add more iaqualink entity properties, fix timeout issues

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -214,12 +214,12 @@ class AqualinkEntity(Entity):
     @property
     def assumed_state(self) -> bool:
         """Return whether the state is based on actual reading from the device."""
-        return self.dev.system.last_run_success is False
+        return not self.dev.system.last_run_success
 
     @property
     def available(self) -> bool:
         """Return whether the device is available or not."""
-        return self.dev.system.online is True
+        return self.dev.system.online
 
     @property
     def device_info(self) -> Dict[str, Any]:

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -2,8 +2,8 @@
 import asyncio
 from functools import wraps
 import logging
+from typing import Any, Dict
 
-from aiohttp import ClientTimeout
 import voluptuous as vol
 
 from iaqualink import (
@@ -26,7 +26,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -85,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
     sensors = hass.data[DOMAIN][SENSOR_DOMAIN] = []
     switches = hass.data[DOMAIN][SWITCH_DOMAIN] = []
 
-    session = async_create_clientsession(hass, timeout=ClientTimeout(total=5))
+    session = async_get_clientsession(hass)
     aqualink = AqualinkClient(username, password, session)
     try:
         await aqualink.login()
@@ -210,3 +210,24 @@ class AqualinkEntity(Entity):
     def unique_id(self) -> str:
         """Return a unique identifier for this entity."""
         return f"{self.dev.system.serial}_{self.dev.name}"
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return whether the state is based on actual reading from the device."""
+        return self.dev.system.last_run_success is False
+
+    @property
+    def available(self) -> bool:
+        """Return whether the device is available or not."""
+        return self.dev.system.online is True
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        """Return the device info."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "model": self.dev.__class__.__name__.replace("Aqualink", ""),
+            "manufacturer": "Jandy",
+            "via_device": (DOMAIN, self.dev.system.serial),
+        }

--- a/homeassistant/components/iaqualink/manifest.json
+++ b/homeassistant/components/iaqualink/manifest.json
@@ -4,10 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/iaqualink/",
   "dependencies": [],
-  "codeowners": [
-    "@flz"
-  ],
-  "requirements": [
-    "iaqualink==0.2.9"
-  ]
+  "codeowners": ["@flz"],
+  "requirements": ["iaqualink==0.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -676,7 +676,7 @@ hydrawiser==0.1.1
 # i2csense==0.0.4
 
 # homeassistant.components.iaqualink
-iaqualink==0.2.9
+iaqualink==0.3.0
 
 # homeassistant.components.watson_tts
 ibm-watson==3.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -262,7 +262,7 @@ httplib2==0.10.3
 huawei-lte-api==1.4.3
 
 # homeassistant.components.iaqualink
-iaqualink==0.2.9
+iaqualink==0.3.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3


### PR DESCRIPTION
## Description:

* Update iaqualink-py to 0.3.0.
* Implement assumed_state, available and device_info.
* Remove the aiohttp timeout that was a workaround for bad locking logic in iaqualink-py.
* Use async_get_clientsession instead of async_create_clientsession.

**Related issue (if applicable):** fixes #27642 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
