### PR TITLE
Fix inability to transition between specific presets in Venstar component

### DIFF
--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -247,6 +247,7 @@ class VenstarThermostat(ClimateDevice):
             return PRESET_AWAY
         if self._client.schedule == 0:
             return HOLD_MODE_TEMPERATURE
+        return PRESET_NONE
 
     @property
     def preset_modes(self):
@@ -332,13 +333,11 @@ class VenstarThermostat(ClimateDevice):
         if preset_mode == PRESET_AWAY:
             success = self._client.set_away(self._client.AWAY_AWAY)
         elif preset_mode == HOLD_MODE_TEMPERATURE:
-            success = self._client.set_schedule(0)
+            success = self._client.set_away(self._client.AWAY_HOME)
+            success = success and self._client.set_schedule(0)
         elif preset_mode == PRESET_NONE:
-            success = False
-            if self._client.away:
-                success = self._client.set_away(self._client.AWAY_HOME)
-            if self._client.schedule == 0:
-                success = success and self._client.set_schedule(1)
+            success = self._client.set_away(self._client.AWAY_HOME)
+            success = success and self._client.set_schedule(1)
         else:
             _LOGGER.error("Unknown hold mode: %s", preset_mode)
             success = False


### PR DESCRIPTION
## Description:
This change addresses a bug where one is unable to change directly between the away and temperature hold presets, as temperature hold cannot be enabled on a Venstar thermostat if away mode is active.

Furthermore, this change removes redundant state checks as the set_away and set_schedule calls are idempotent in the venstarcolortouch library. 

See https://github.com/hpeyerl/venstar_colortouch/blob/master/src/venstarcolortouch/venstarcolortouch.py#L275.

## Checklist:
  - [X ] The code change is tested and works locally.
  - [X ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X ] There is no commented out code in this PR.
  - [X ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [NA ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [NA] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
