### PR TITLE
Bump env_canada to 0.0.27

### DIFF
--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -3,7 +3,7 @@
   "name": "Environment Canada",
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
   "requirements": [
-    "env_canada==0.0.25"
+    "env_canada==0.0.27"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -456,7 +456,7 @@ enocean==0.50
 enturclient==0.2.0
 
 # homeassistant.components.environment_canada
-env_canada==0.0.25
+env_canada==0.0.27
 
 # homeassistant.components.envirophat
 # envirophat==0.0.6


### PR DESCRIPTION
## Description:

Bumps `env_canada` library to 0.0.27. Resolves issue with HTTPS certificate failures noted at https://community.home-assistant.io/t/support-for-environment-canada-platforms/126241/73.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.