### PR TITLE
Cleanup Device Registry on Z-Wave Node Removal

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -491,7 +491,7 @@ async def async_setup_entry(hass, config_entry):
                 continue
 
             entity = hass.data[DATA_DEVICES][key]
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Removing Entity - value: %s - entity_id: %s", key, entity.entity_id
             )
             hass.add_job(entity.node_removed())
@@ -508,7 +508,7 @@ async def async_setup_entry(hass, config_entry):
         identifier, name = node_device_id_and_name(node)
         device = dev_reg.async_get_device(identifiers={identifier}, connections=set())
         if device is not None:
-            _LOGGER.info("Removing Device - %s - %s", device.id, name)
+            _LOGGER.debug("Removing Device - %s - %s", device.id, name)
             dev_reg.async_remove_device(device.id)
 
     def network_ready():

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -13,7 +13,9 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_component import DEFAULT_SCAN_INTERVAL
 from homeassistant.helpers.entity_platform import EntityPlatform
-from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.helpers.entity_registry import (
+    async_get_registry as async_get_entity_registry,
+)
 from homeassistant.helpers.device_registry import (
     async_get_registry as async_get_device_registry,
 )
@@ -379,7 +381,7 @@ async def async_setup_entry(hass, config_entry):
     hass.data[DATA_DEVICES] = {}
     hass.data[DATA_ENTITY_VALUES] = []
 
-    registry = await async_get_registry(hass)
+    registry = await async_get_entity_registry(hass)
 
     wsapi.async_load_websocket_api(hass)
 
@@ -1222,7 +1224,7 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
         self._name = _value_name(self.values.primary)
         if update_ids:
             # Update entity ID.
-            ent_reg = await async_get_registry(self.hass)
+            ent_reg = await async_get_entity_registry(self.hass)
             new_entity_id = ent_reg.async_generate_entity_id(
                 self.platform.domain,
                 self._name,


### PR DESCRIPTION
## Description:
Currently when a Z-Wave node is removed the entities are removed from the entity registry, but the device remains in the entity registry. This PR adds an extra step to the node_removed function to remove the device from the device registry as well.

Also fixes a traceback seen on some systems when cleaning up the entity registry on node removal.

**Related issue (if applicable):** fixes #26017

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
