### PR TITLE
Refactor Tradfri observation method

### DIFF
--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -105,7 +105,9 @@ class TradfriBaseClass(Entity):
     def _observe_update(self, device):
         """Receive new state data for this device."""
         self._refresh(device)
-        self.async_schedule_update_ha_state()
+
+        # Force refresh to handle bug where the GUI is not updated
+        self.async_schedule_update_ha_state(force_refresh=True)
 
     def _refresh(self, device):
         """Refresh the device data."""

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -35,7 +35,7 @@ class TradfriBaseClass(Entity):
         self.async_schedule_update_ha_state()
 
         _LOGGER.warning(
-            f"Observation failed for {self._name}, trying again",
+            "Observation failed for %s trying again",
             self._name,
             exc_info=error,
         )

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -46,11 +46,11 @@ class TradfriBaseClass(Entity):
     def _async_start_observe(self, exc=None):
         """Start observation of device."""
         if exc:
-            if type(exc) == AttributeError:
+            if isinstance(exc, AttributeError):
                 message = (
                     f"Caught an exception with {self._name}. Restarting observation."
                 )
-            elif type(exc) == RequestTimedOut:
+            elif isinstance(exc, RequestTimedOut):
                 message = f"Time out error with {self._name}. Restarting observation."
             else:
                 message = f"Undefined error with {self._name}. Restarting observation."
@@ -76,8 +76,8 @@ class TradfriBaseClass(Entity):
             for i in range(1, retries + 1):
                 try:
                     return api(*args, **kwargs)
-                except PytradfriError as e:
-                    _LOGGER.debug("Retrying Tradfri {} due to {}".format(i, e))
+                except PytradfriError as err:
+                    _LOGGER.debug("Retrying Tradfri % due to %" % (i, err))
                     if i == retries:
                         _LOGGER.warning("Request timeout")
                         raise

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TradfriBaseClass(Entity):
-    """Base class for IKEA TRADFRIRequestTimedOut.
+    """Base class for IKEA TRADFRI.
 
     All devices and groups should ultimately inherit from this class.
     """

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -35,9 +35,7 @@ class TradfriBaseClass(Entity):
         self.async_schedule_update_ha_state()
 
         _LOGGER.warning(
-            "Observation failed for %s trying again",
-            self._name,
-            exc_info=error,
+            "Observation failed for %s trying again", self._name, exc_info=error
         )
         # Wait one second before trying again
         asyncio.sleep(1)

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -30,11 +30,11 @@ class TradfriBaseClass(Entity):
 
         self._refresh(device)
 
-    def _restart(self, message):
+    def _restart(self, message, exc):
         """Log error and restart observation of device."""
-        self.async_schedule_update_ha_state()
+        self.async_schedule_update_ha_state(force_refresh=True)
 
-        _LOGGER.warning(message)
+        _LOGGER.warning(message, exc_info=exc)
         # Wait one half second before trying again
         asyncio.sleep(0.5)
         self._async_start_observe()
@@ -46,18 +46,14 @@ class TradfriBaseClass(Entity):
         if exc:
             if type(exc) == AttributeError:
                 message = (
-                    f"Caught an exception with {self._name} due to {exc}. Restarting observation."
+                    f"Caught an exception with {self._name}. Restarting observation."
                 )
             elif type(exc) == RequestTimedOut:
-                message = (
-                    f"Time out error with {self._name} due to {exc}. Restarting observation."
-                )
+                message = f"Time out error with {self._name}. Restarting observation."
             else:
-                message = (
-                    f"Undefined error with {self._name} due to {exc}. Restarting observation."
-                )
+                message = f"Undefined error with {self._name}. Restarting observation."
 
-            self._restart(message)
+            self._restart(message, exc)
             return False
 
         cmd = self._device.observe(


### PR DESCRIPTION
## Description:
This is the last step of #26863, where the Tradfri component is being refactored. In this PR, I'm trying to address the comments of @balloob made in #26864. Not sure I fully understand them so please bear with me.

After some testing (tracebacks in posts below), I believe what is happening is that the gateway is flooded with traffic, Home Assistant becomes unresponsive waiting for the responses and the GUI stops updating. This is raised by a aiocoap `TimeoutError`.

When the same thing happens for groups, which uses a different method to observe the state, an `AttributeError` is rasied.

In this PR, we continue to handle errors by restarting the observations. I've. however, try to become more specific catching the errors.

I would like for the component to be a bit chatty in debug mode to be able to gather logs from people reporting problems.


**Related issue (if applicable):** relates to #14386 #27119

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
