### PR TITLE
Add services description for ness alarm

### DIFF
--- a/homeassistant/components/ness_alarm/services.yaml
+++ b/homeassistant/components/ness_alarm/services.yaml
@@ -1,0 +1,19 @@
+# Describes the format for available ness alarm services
+
+aux:
+  description: Trigger an aux output.
+  fields:
+    output_id:
+      description: The aux output you wish to change. A number from 1-4.
+      example: 1
+    state:
+      description: The On/Off State, represented as true/false. Default is true. If P14xE 8E is enabled then a value of true will pulse output x for the time specified in P14(x+4)E.
+      example: true
+      default: true
+
+panic:
+  description: Trigger a panic
+  fields:
+    code:
+      description: The user code to use to trigger the panic.
+      example: 1234


### PR DESCRIPTION
## Description:
Add service description for ness alarm integration

**Related issue (if applicable):** #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Screenshots
![ness_alarm1](https://user-images.githubusercontent.com/127828/67815761-1e38cf00-faa8-11e9-8445-021d67131388.png)
![ness_alarm2](https://user-images.githubusercontent.com/127828/67815771-22fd8300-faa8-11e9-81aa-625df2888f06.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
