### PR TITLE
Add charset to imap component.

### DIFF
--- a/homeassistant/components/imap/sensor.py
+++ b/homeassistant/components/imap/sensor.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_SERVER = "server"
 CONF_FOLDER = "folder"
 CONF_SEARCH = "search"
+CONF_CHARSET = "charset"
 
 DEFAULT_PORT = 993
 
@@ -35,6 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_SERVER): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_CHARSET, default="utf-8"): cv.string,
         vol.Optional(CONF_FOLDER, default="INBOX"): cv.string,
         vol.Optional(CONF_SEARCH, default="UnSeen UnDeleted"): cv.string,
     }
@@ -49,6 +51,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         config.get(CONF_PASSWORD),
         config.get(CONF_SERVER),
         config.get(CONF_PORT),
+        config.get(CONF_CHARSET),
         config.get(CONF_FOLDER),
         config.get(CONF_SEARCH),
     )
@@ -62,13 +65,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class ImapSensor(Entity):
     """Representation of an IMAP sensor."""
 
-    def __init__(self, name, user, password, server, port, folder, search):
+    def __init__(self, name, user, password, server, port, charset, folder, search):
         """Initialize the sensor."""
         self._name = name or user
         self._user = user
         self._password = password
         self._server = server
         self._port = port
+        self._charset = charset
         self._folder = folder
         self._email_count = None
         self._search = search
@@ -150,7 +154,9 @@ class ImapSensor(Entity):
         """Check the number of found emails."""
         if self._connection:
             await self._connection.noop()
-            result, lines = await self._connection.search(self._search)
+            result, lines = await self._connection.search(
+                self._search, charset=self._charset
+            )
 
             if result == "OK":
                 self._email_count = len(lines[0].split())


### PR DESCRIPTION
## Description:

The imap component did not work with office 365 because of the wrong charset.
The default charset is UTF-8 in the imap component, Office 365 does not support this.

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: imap
    server: outlook.office365.com
    port: 993
    username: email@address.com
    password: password
    charset: US-ASCII
```
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

PR #10967
