### PR TITLE
Change ps4 state off to state standby

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     CONF_REGION,
     CONF_TOKEN,
     STATE_IDLE,
-    STATE_OFF,
+    STATE_STANDBY,
     STATE_PLAYING,
 )
 from homeassistant.helpers import device_registry, entity_registry
@@ -201,8 +201,8 @@ class PS4Device(MediaPlayerDevice):
                     if self._state != STATE_IDLE:
                         self.idle()
             else:
-                if self._state != STATE_OFF:
-                    self.state_off()
+                if self._state != STATE_STANDBY:
+                    self.state_standby()
 
         elif self._retry > DEFAULT_RETRIES:
             self.state_unknown()
@@ -230,10 +230,10 @@ class PS4Device(MediaPlayerDevice):
         self._state = STATE_IDLE
         self.schedule_update()
 
-    def state_off(self):
+    def state_standby(self):
         """Set states for state off."""
         self.reset_title()
-        self._state = STATE_OFF
+        self._state = STATE_STANDBY
         self.schedule_update()
 
     def state_unknown(self):

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -231,7 +231,7 @@ class PS4Device(MediaPlayerDevice):
         self.schedule_update()
 
     def state_standby(self):
-        """Set states for state off."""
+        """Set states for state standby."""
         self.reset_title()
         self._state = STATE_STANDBY
         self.schedule_update()

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     CONF_REGION,
     CONF_TOKEN,
     STATE_IDLE,
-    STATE_OFF,
+    STATE_STANDBY,
     STATE_PLAYING,
     STATE_UNKNOWN,
 )
@@ -46,7 +46,7 @@ MOCK_HOST_NAME = "Fake PS4"
 MOCK_HOST_ID = "A0000A0AA000"
 MOCK_HOST_VERSION = "09879011"
 MOCK_HOST_TYPE = "PS4"
-MOCK_STATUS_STANDBY = "Server Standby"
+MOCK_STATUS_REST = "Server Standby"
 MOCK_STATUS_ON = "Ok"
 MOCK_STANDBY_CODE = 620
 MOCK_ON_CODE = 200
@@ -100,13 +100,13 @@ MOCK_STATUS_IDLE = {
     "system-version": MOCK_HOST_VERSION,
 }
 
-MOCK_STATUS_OFF = {
+MOCK_STATUS_STANDBY = {
     "host-type": MOCK_HOST_TYPE,
     "host-ip": MOCK_HOST,
     "host-request-port": MOCK_TCP_PORT,
     "host-id": MOCK_HOST_ID,
     "host-name": MOCK_HOST_NAME,
-    "status": MOCK_STATUS_STANDBY,
+    "status": MOCK_STATUS_REST,
     "status_code": MOCK_STANDBY_CODE,
     "device-discovery-protocol-version": MOCK_DDP_VERSION,
     "system-version": MOCK_HOST_VERSION,
@@ -183,14 +183,14 @@ async def test_media_player_is_setup_correctly_with_entry(hass):
     assert mock_state == STATE_UNKNOWN
 
 
-async def test_state_off_is_set(hass):
-    """Test that state is set to off."""
+async def test_state_standby_is_set(hass):
+    """Test that state is set to standby."""
     mock_entity_id = await setup_mock_component(hass)
 
     with patch(MOCK_SAVE, side_effect=MagicMock()):
-        await mock_ddp_response(hass, MOCK_STATUS_OFF)
+        await mock_ddp_response(hass, MOCK_STATUS_STANDBY)
 
-    assert hass.states.get(mock_entity_id).state == STATE_OFF
+    assert hass.states.get(mock_entity_id).state == STATE_STANDBY
 
 
 async def test_state_playing_is_set(hass):
@@ -290,13 +290,13 @@ async def test_media_attributes_are_loaded(hass):
 async def test_device_info_is_set_from_status_correctly(hass):
     """Test that device info is set correctly from status update."""
     mock_d_registry = mock_device_registry(hass)
-    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_OFF):
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_STANDBY):
         mock_entity_id = await setup_mock_component(hass)
 
     await hass.async_block_till_done()
 
     # Reformat mock status-sw_version for assertion.
-    mock_version = MOCK_STATUS_OFF["system-version"]
+    mock_version = MOCK_STATUS_STANDBY["system-version"]
     mock_version = mock_version[1:4]
     mock_version = "{}.{}".format(mock_version[0], mock_version[1:])
 
@@ -306,7 +306,7 @@ async def test_device_info_is_set_from_status_correctly(hass):
     mock_entry = mock_d_registry.async_get_device(
         identifiers={(DOMAIN, MOCK_HOST_ID)}, connections={()}
     )
-    assert mock_state == STATE_OFF
+    assert mock_state == STATE_STANDBY
 
     assert len(mock_d_entries) == 1
     assert mock_entry.name == MOCK_HOST_NAME


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

State Off is now State Standby. Affects user defined scripts, automations, etc.

## Description:
Similar changes as Roku integration #28148
Currently, if service media_player.select_source is called when entity is in standby mode, PS4 will be turned on first and then will change source. This PR would allow this feature to be accessible from the UI, as the select source dropdown is not available if using state off.  State standby is also the more accurate state.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
