### PR TITLE
Add unifiled config_flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -756,7 +756,9 @@ omit =
     homeassistant/components/uber/sensor.py
     homeassistant/components/ubus/device_tracker.py
     homeassistant/components/ue_smart_radio/media_player.py
-    homeassistant/components/unifiled/*
+    homeassistant/components/unifiled/__init__.py
+    homeassistant/components/unifiled/light.py
+    homeassistant/components/unifiled/const.py
     homeassistant/components/upcloud/*
     homeassistant/components/upnp/*
     homeassistant/components/upc_connect/*

--- a/homeassistant/components/unifiled/.translations/en.json
+++ b/homeassistant/components/unifiled/.translations/en.json
@@ -1,0 +1,24 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Controller is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect, please try again",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password",
+                    "port": "Port",
+                    "username": "Username"
+                },
+                "title": "Connect to the Unifi LED controller"
+            }
+        },
+        "title": "Unifi LED"
+    }
+}

--- a/homeassistant/components/unifiled/__init__.py
+++ b/homeassistant/components/unifiled/__init__.py
@@ -2,7 +2,9 @@
 import logging
 
 from unifiled import unifiled
+
 from homeassistant.exceptions import PlatformNotReady
+
 from .const import KEY_API
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/unifiled/__init__.py
+++ b/homeassistant/components/unifiled/__init__.py
@@ -1,1 +1,14 @@
 """Unifi LED Lights integration."""
+
+
+async def async_setup(hass, config):
+    """Set up the unifiled integration."""
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up a config entry for unifiled."""
+
+    hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, "light"))
+
+    return True

--- a/homeassistant/components/unifiled/__init__.py
+++ b/homeassistant/components/unifiled/__init__.py
@@ -29,9 +29,10 @@ async def async_setup_entry(hass, entry):
         _LOGGER.error("Could not connect to unifiled controller")
         raise PlatformNotReady()
 
-    # hass.data[DOMAIN][LEDAPI] = api
     hass.data.setdefault(KEY_API, {})[entry.entry_id] = api
 
-    hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, "light"))
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "light")
+    )
 
     return True

--- a/homeassistant/components/unifiled/__init__.py
+++ b/homeassistant/components/unifiled/__init__.py
@@ -1,4 +1,11 @@
 """Unifi LED Lights integration."""
+import logging
+
+from unifiled import unifiled
+from homeassistant.exceptions import PlatformNotReady
+from .const import KEY_API
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass, config):
@@ -8,6 +15,22 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up a config entry for unifiled."""
+
+    # Assign configuration variables.
+    host = entry.data["host"]
+    port = entry.data["port"]
+    username = entry.data["username"]
+    password = entry.data["password"]
+
+    api = unifiled(host, port, username=username, password=password)
+
+    # Verify that passed in configuration works
+    if not api.getloginstate():
+        _LOGGER.error("Could not connect to unifiled controller")
+        raise PlatformNotReady()
+
+    # hass.data[DOMAIN][LEDAPI] = api
+    hass.data.setdefault(KEY_API, {})[entry.entry_id] = api
 
     hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, "light"))
 

--- a/homeassistant/components/unifiled/config_flow.py
+++ b/homeassistant/components/unifiled/config_flow.py
@@ -50,9 +50,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=info["title"], data=user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors

--- a/homeassistant/components/unifiled/config_flow.py
+++ b/homeassistant/components/unifiled/config_flow.py
@@ -10,19 +10,21 @@ from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema({"host": str, "port": str, "username": str, "password": str})
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("host"): str,
+        vol.Required("port"): str,
+        vol.Required("username"): str,
+        vol.Required("password"): str,
+    }
+)
 
 
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect."""
 
     try:
-        unifiled(
-            data["host"],
-            data["port"],
-            username=data["username"],
-            password=data["password"],
-        )
+        unifiled(data["host"], data["port"], data["username"], data["password"])
         return {"title": data["host"]}
     except Exception as ex:  # pylint: disable=broad-except
         _LOGGER.error(ex)

--- a/homeassistant/components/unifiled/config_flow.py
+++ b/homeassistant/components/unifiled/config_flow.py
@@ -1,0 +1,64 @@
+"""Config flow for unifiled integration."""
+import logging
+
+from unifiled import unifiled
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema({"host": str, "port": str, "username": str, "password": str})
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect."""
+
+    try:
+        unifiled(
+            data["host"],
+            data["port"],
+            username=data["username"],
+            password=data["password"],
+        )
+        return {"title": data["host"]}
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOGGER.error(ex)
+        raise CannotConnect()
+
+
+class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for unifiled."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/unifiled/config_flow.py
+++ b/homeassistant/components/unifiled/config_flow.py
@@ -23,7 +23,9 @@ DATA_SCHEMA = vol.Schema(
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect."""
 
-    api = unifiled(data["host"], data["port"], data["username"], data["password"])
+    api = await hass.async_add_executor_job(
+        unifiled, data["host"], data["port"], data["username"], data["password"]
+    )
 
     if not api.getloginstate():
         _LOGGER.error("Could not connect to unifiled controller")

--- a/homeassistant/components/unifiled/const.py
+++ b/homeassistant/components/unifiled/const.py
@@ -1,3 +1,4 @@
 """Constants for the unifiledtemp integration."""
 
 DOMAIN = "unifiled"
+KEY_API = "unifiled_api"

--- a/homeassistant/components/unifiled/const.py
+++ b/homeassistant/components/unifiled/const.py
@@ -1,0 +1,3 @@
+"""Constants for the unifiledtemp integration."""
+
+DOMAIN = "unifiled"

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -11,19 +11,6 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Unifi LED platform."""
 
-    # Assign configuration variables.
-    # host = config_entry.data["host"]
-    # port = config_entry.data["port"]
-    # username = config_entry.data["username"]
-    # password = config_entry.data["password"]
-
-    # api = unifiled(host, port, username=username, password=password)
-
-    # Verify that passed in configuration works
-    # if not api.getloginstate():
-    #    _LOGGER.error("Could not connect to unifiled controller")
-    #    raise PlatformNotReady()
-
     api = hass.data[KEY_API][config_entry.entry_id]
 
     async_add_devices(UnifiLedLight(light, api) for light in api.getlights())

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -2,48 +2,32 @@
 import logging
 
 from unifiled import unifiled
-import voluptuous as vol
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    PLATFORM_SCHEMA,
-    SUPPORT_BRIGHTNESS,
-    Light,
-)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
+from homeassistant.exceptions import PlatformNotReady
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-# Validation of the user's configuration
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_PORT, default=20443): vol.All(cv.port, cv.string),
-    }
-)
 
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Unifi LED platform."""
 
     # Assign configuration variables.
-    # The configuration check takes care they are present.
-    host = config[CONF_HOST]
-    port = config[CONF_PORT]
-    username = config[CONF_USERNAME]
-    password = config[CONF_PASSWORD]
+    _ip = config_entry.data["host"]
+    _port = config_entry.data["port"]
+    _username = config_entry.data["username"]
+    _password = config_entry.data["password"]
 
-    api = unifiled(host, port, username=username, password=password)
+    api = unifiled(_ip, _port, username=_username, password=_password)
 
     # Verify that passed in configuration works
     if not api.getloginstate():
         _LOGGER.error("Could not connect to unifiled controller")
-        return
+        raise PlatformNotReady()
 
-    add_entities(UnifiLedLight(light, api) for light in api.getlights())
+    async_add_devices(UnifiLedLight(light, api) for light in api.getlights())
 
 
 class UnifiLedLight(Light):
@@ -55,7 +39,8 @@ class UnifiLedLight(Light):
         self._api = api
         self._light = light
         self._name = light["name"]
-        self._unique_id = light["id"]
+        self._unifiledid = light["id"]
+        self._unique_id = "light." + light["id"]
         self._state = light["status"]["output"]
         self._available = light["isOnline"]
         self._brightness = self._api.convertfrom100to255(light["status"]["led"])
@@ -77,6 +62,17 @@ class UnifiLedLight(Light):
         return self._brightness
 
     @property
+    def device_info(self):
+        """Return the device info of this light."""
+        return {
+            "identifiers": {(DOMAIN, self._unique_id)},
+            "name": self._name,
+            "manufacturer": "Ubiquiti Networks",
+            "model": self._light["info"]["model"],
+            "sw_version": self._light["info"]["version"],
+        }
+
+    @property
     def unique_id(self):
         """Return the unique id of this light."""
         return self._unique_id
@@ -94,19 +90,19 @@ class UnifiLedLight(Light):
     def turn_on(self, **kwargs):
         """Instruct the light to turn on."""
         self._api.setdevicebrightness(
-            self._unique_id,
+            self._unifiledid,
             str(self._api.convertfrom255to100(kwargs.get(ATTR_BRIGHTNESS, 255))),
         )
-        self._api.setdeviceoutput(self._unique_id, 1)
+        self._api.setdeviceoutput(self._unifiledid, 1)
 
     def turn_off(self, **kwargs):
         """Instruct the light to turn off."""
-        self._api.setdeviceoutput(self._unique_id, 0)
+        self._api.setdeviceoutput(self._unifiledid, 0)
 
     def update(self):
         """Update the light states."""
-        self._state = self._api.getlightstate(self._unique_id)
+        self._state = self._api.getlightstate(self._unifiledid)
         self._brightness = self._api.convertfrom100to255(
-            self._api.getlightbrightness(self._unique_id)
+            self._api.getlightbrightness(self._unifiledid)
         )
-        self._available = self._api.getlightavailable(self._unique_id)
+        self._available = self._api.getlightavailable(self._unifiledid)

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -1,12 +1,9 @@
 """Support for Unifi Led lights."""
 import logging
 
-from unifiled import unifiled
-
 from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
-from homeassistant.exceptions import PlatformNotReady
 
-from .const import DOMAIN
+from .const import DOMAIN, KEY_API
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,17 +12,19 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Unifi LED platform."""
 
     # Assign configuration variables.
-    host = config_entry.data["host"]
-    port = config_entry.data["port"]
-    username = config_entry.data["username"]
-    password = config_entry.data["password"]
+    # host = config_entry.data["host"]
+    # port = config_entry.data["port"]
+    # username = config_entry.data["username"]
+    # password = config_entry.data["password"]
 
-    api = unifiled(host, port, username=username, password=password)
+    # api = unifiled(host, port, username=username, password=password)
 
     # Verify that passed in configuration works
-    if not api.getloginstate():
-        _LOGGER.error("Could not connect to unifiled controller")
-        raise PlatformNotReady()
+    # if not api.getloginstate():
+    #    _LOGGER.error("Could not connect to unifiled controller")
+    #    raise PlatformNotReady()
+
+    api = hass.data[KEY_API][config_entry.entry_id]
 
     async_add_devices(UnifiLedLight(light, api) for light in api.getlights())
 

--- a/homeassistant/components/unifiled/light.py
+++ b/homeassistant/components/unifiled/light.py
@@ -15,12 +15,12 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Unifi LED platform."""
 
     # Assign configuration variables.
-    _ip = config_entry.data["host"]
-    _port = config_entry.data["port"]
-    _username = config_entry.data["username"]
-    _password = config_entry.data["password"]
+    host = config_entry.data["host"]
+    port = config_entry.data["port"]
+    username = config_entry.data["username"]
+    password = config_entry.data["password"]
 
-    api = unifiled(_ip, _port, username=_username, password=_password)
+    api = unifiled(host, port, username=username, password=password)
 
     # Verify that passed in configuration works
     if not api.getloginstate():
@@ -39,8 +39,7 @@ class UnifiLedLight(Light):
         self._api = api
         self._light = light
         self._name = light["name"]
-        self._unifiledid = light["id"]
-        self._unique_id = "light." + light["id"]
+        self._unique_id = light["id"]
         self._state = light["status"]["output"]
         self._available = light["isOnline"]
         self._brightness = self._api.convertfrom100to255(light["status"]["led"])
@@ -90,19 +89,19 @@ class UnifiLedLight(Light):
     def turn_on(self, **kwargs):
         """Instruct the light to turn on."""
         self._api.setdevicebrightness(
-            self._unifiledid,
+            self._unique_id,
             str(self._api.convertfrom255to100(kwargs.get(ATTR_BRIGHTNESS, 255))),
         )
-        self._api.setdeviceoutput(self._unifiledid, 1)
+        self._api.setdeviceoutput(self._unique_id, 1)
 
     def turn_off(self, **kwargs):
         """Instruct the light to turn off."""
-        self._api.setdeviceoutput(self._unifiledid, 0)
+        self._api.setdeviceoutput(self._unique_id, 0)
 
     def update(self):
         """Update the light states."""
-        self._state = self._api.getlightstate(self._unifiledid)
+        self._state = self._api.getlightstate(self._unique_id)
         self._brightness = self._api.convertfrom100to255(
-            self._api.getlightbrightness(self._unifiledid)
+            self._api.getlightbrightness(self._unique_id)
         )
-        self._available = self._api.getlightavailable(self._unifiledid)
+        self._available = self._api.getlightavailable(self._unique_id)

--- a/homeassistant/components/unifiled/manifest.json
+++ b/homeassistant/components/unifiled/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/unifiled",
   "dependencies": [],
   "codeowners": ["@florisvdk"],
-  "requirements": ["unifiled==0.16"]
+  "requirements": ["unifiled==0.16"],
+  "config_flow": true
 }

--- a/homeassistant/components/unifiled/manifest.json
+++ b/homeassistant/components/unifiled/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/unifiled",
   "dependencies": [],
   "codeowners": ["@florisvdk"],
-  "requirements": ["unifiled==0.11"]
+  "requirements": ["unifiled==0.16"]
 }

--- a/homeassistant/components/unifiled/strings.json
+++ b/homeassistant/components/unifiled/strings.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "title": "Unifi LED",
+    "step": {
+      "user": {
+        "title": "Connect to the Unifi LED controller",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "username": "Username",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Controller is already configured"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -89,6 +89,7 @@ FLOWS = [
     "twentemilieu",
     "twilio",
     "unifi",
+    "unifiled",
     "upnp",
     "velbus",
     "vesync",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1993,7 +1993,7 @@ twentemilieu==0.2.0
 twilio==6.32.0
 
 # homeassistant.components.unifiled
-unifiled==0.11
+unifiled==0.16
 
 # homeassistant.components.upcloud
 upcloud-api==0.4.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -636,6 +636,9 @@ twentemilieu==0.2.0
 # homeassistant.components.twilio
 twilio==6.32.0
 
+# homeassistant.components.unifiled
+unifiled==0.16
+
 # homeassistant.components.huawei_lte
 url-normalize==1.4.1
 

--- a/tests/components/unifiled/__init__.py
+++ b/tests/components/unifiled/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the unifiled integration."""

--- a/tests/components/unifiled/test_config_flow.py
+++ b/tests/components/unifiled/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.unifiled.config_flow.validate_input",
+        "homeassistant.components.unifiled.config_flow.unifiled",
         return_value=mock_coro({"title": "Test Title"}),
     ), patch(
         "homeassistant.components.unifiled.async_setup", return_value=mock_coro(True)
@@ -37,7 +37,7 @@ async def test_form(hass):
         )
 
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "Test Title"
+    assert result2["title"] == "1.1.1.1"
     assert result2["data"] == {
         "host": "1.1.1.1",
         "port": "20443",

--- a/tests/components/unifiled/test_config_flow.py
+++ b/tests/components/unifiled/test_config_flow.py
@@ -56,7 +56,7 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "homeassistant.components.unifiled.config_flow.validate_input",
+        "homeassistant.components.unifiled.config_flow.unifiled",
         side_effect=InvalidAuth,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -80,7 +80,7 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.unifiled.config_flow.validate_input",
+        "homeassistant.components.unifiled.config_flow.unifiled",
         side_effect=CannotConnect,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/unifiled/test_config_flow.py
+++ b/tests/components/unifiled/test_config_flow.py
@@ -1,0 +1,97 @@
+"""Test the unifiled config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.unifiled.const import DOMAIN
+from homeassistant.components.unifiled.config_flow import CannotConnect, InvalidAuth
+
+from tests.common import mock_coro
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.unifiled.config_flow.validate_input",
+        return_value=mock_coro({"title": "Test Title"}),
+    ), patch(
+        "homeassistant.components.unifiled.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, patch(
+        "homeassistant.components.unifiled.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "port": "20443",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Test Title"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "port": "20443",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.unifiled.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "port": "20443",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.unifiled.config_flow.validate_input",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "port": "20443",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/unifiled/test_config_flow.py
+++ b/tests/components/unifiled/test_config_flow.py
@@ -18,9 +18,6 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.unifiled.config_flow.unifiled",
-        return_value=mock_coro(True),
-    ), patch(
         "homeassistant.components.unifiled.config_flow.unifiled.getloginstate",
         return_value=mock_coro(True),
     ), patch(

--- a/tests/components/unifiled/test_config_flow.py
+++ b/tests/components/unifiled/test_config_flow.py
@@ -2,8 +2,8 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries, setup
-from homeassistant.components.unifiled.const import DOMAIN
 from homeassistant.components.unifiled.config_flow import CannotConnect
+from homeassistant.components.unifiled.const import DOMAIN
 
 from tests.common import mock_coro
 

--- a/tests/components/unifiled/test_config_flow.py
+++ b/tests/components/unifiled/test_config_flow.py
@@ -49,6 +49,47 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_form_login_failed(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.unifiled.config_flow.unifiled.getloginstate",
+        return_value=mock_coro(False),
+    ), patch(
+        "homeassistant.components.unifiled.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, patch(
+        "homeassistant.components.unifiled.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "port": "20443",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "1.1.1.1"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "port": "20443",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_form_cannot_connect(hass):
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Breaking Change:
No longer using the config file for settings.

## Description:
Convert the unifiled integration to use the config flow.
The docs are not updated yet because i still have an open pull request from the creation of the integration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io/pull/11218)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
