### PR TITLE
Align attribute naming between light and switch for HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -28,8 +28,8 @@ from .hap import HomematicipHAP
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_ENERGY_COUNTER = "energy_counter_kwh"
-ATTR_POWER_CONSUMPTION = "power_consumption"
+ATTR_TODAY_ENERGY_KWH = "today_energy_kwh"
+ATTR_CURRENT_POWER_W = "current_power_w"
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -95,11 +95,11 @@ class HomematicipLightMeasuring(HomematicipLight):
         """Return the state attributes of the generic device."""
         state_attr = super().device_state_attributes
 
-        current_power_consumption = self._device.currentPowerConsumption
-        if current_power_consumption > 0.05:
-            state_attr[ATTR_POWER_CONSUMPTION] = round(current_power_consumption, 2)
+        current_power_w = self._device.currentPowerConsumption
+        if current_power_w > 0.05:
+            state_attr[ATTR_CURRENT_POWER_W] = round(current_power_w, 2)
 
-        state_attr[ATTR_ENERGY_COUNTER] = round(self._device.energyCounter, 2)
+        state_attr[ATTR_TODAY_ENERGY_KWH] = round(self._device.energyCounter, 2)
 
         return state_attr
 

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -3,8 +3,8 @@ from homematicip.base.enums import RGBColorState
 
 from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.components.homematicip_cloud.light import (
-    ATTR_ENERGY_COUNTER,
-    ATTR_POWER_CONSUMPTION,
+    ATTR_CURRENT_POWER_W,
+    ATTR_TODAY_ENERGY_KWH,
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -209,8 +209,8 @@ async def test_hmip_light_measuring(hass, default_mock_hap):
     await async_manipulate_test_data(hass, hmip_device, "currentPowerConsumption", 50)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_ON
-    assert ha_state.attributes[ATTR_POWER_CONSUMPTION] == 50
-    assert ha_state.attributes[ATTR_ENERGY_COUNTER] == 6.33
+    assert ha_state.attributes[ATTR_CURRENT_POWER_W] == 50
+    assert ha_state.attributes[ATTR_TODAY_ENERGY_KWH] == 6.33
 
     await hass.services.async_call(
         "light", "turn_off", {"entity_id": entity_id}, blocking=True


### PR DESCRIPTION
## Breaking Change:
The attribute naming between Homematic IP `HmIP-BSM`  (light) and `HmIP-FSM/HmIP-PSM` (switch) was diffrent and in case of light not correct. Thats why the the attributes for `HmIP-BSM` are renamed:
- energy_counter_kwh --> today_energy_kwh
- power_consumption --> current_power_w

Please check your automations, scrips, scenes, etc., if you are using the old attributes in templates, and replace them with the new ones.

## Description:
Align attribute naming between light and switch for HomematicIP Cloud

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
