### PR TITLE
Improve coverage of input_datetime/reproduce_state

### DIFF
--- a/homeassistant/components/input_datetime/reproduce_state.py
+++ b/homeassistant/components/input_datetime/reproduce_state.py
@@ -31,18 +31,12 @@ def is_valid_datetime(string: str) -> bool:
 
 def is_valid_date(string: str) -> bool:
     """Test if string dt is a valid date."""
-    try:
-        return dt_util.parse_date(string) is not None
-    except ValueError:
-        return False
+    return dt_util.parse_date(string) is not None
 
 
 def is_valid_time(string: str) -> bool:
     """Test if string dt is a valid time."""
-    try:
-        return dt_util.parse_time(string) is not None
-    except ValueError:
-        return False
+    return dt_util.parse_time(string) is not None
 
 
 async def _async_reproduce_state(

--- a/tests/components/input_datetime/test_reproduce_state.py
+++ b/tests/components/input_datetime/test_reproduce_state.py
@@ -36,7 +36,11 @@ async def test_reproducing_states(hass, caplog):
 
     # Test invalid state is handled
     await hass.helpers.state.async_reproduce_state(
-        [State("input_datetime.entity_datetime", "not_supported")], blocking=True
+        [
+            State("input_datetime.entity_datetime", "not_supported"),
+            State("input_datetime.entity_datetime", "2010-25-10 01:20:00"),
+        ],
+        blocking=True,
     )
 
     assert "not_supported" in caplog.text

--- a/tests/components/input_datetime/test_reproduce_state.py
+++ b/tests/components/input_datetime/test_reproduce_state.py
@@ -38,12 +38,17 @@ async def test_reproducing_states(hass, caplog):
     await hass.helpers.state.async_reproduce_state(
         [
             State("input_datetime.entity_datetime", "not_supported"),
-            State("input_datetime.entity_datetime", "2010-25-10 01:20:00"),
+            State("input_datetime.entity_datetime", "not-valid-date"),
+            State("input_datetime.entity_datetime", "not:valid:time"),
+            State("input_datetime.entity_datetime", "1234-56-78 90:12:34"),
         ],
         blocking=True,
     )
 
     assert "not_supported" in caplog.text
+    assert "not-valid-date" in caplog.text
+    assert "not:valid:time" in caplog.text
+    assert "1234-56-78 90:12:34" in caplog.text
     assert len(datetime_calls) == 0
 
     # Make sure correct services are called


### PR DESCRIPTION
## Breaking Change:
Nothing breaks

## Description:
The coverage didn't work when I submitted the previous pull request. So I did not notice that the coverage was less than 100%. This PR increases the coverage to 100%.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
