### PR TITLE
Add support for Heat Mode detection for ecobee Heat Pumps

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -267,7 +267,7 @@ class Thermostat(ClimateDevice):
         self._last_active_hvac_mode = HVAC_MODE_AUTO
 
         self._operation_list = []
-        if self.thermostat["settings"]["heatStages"]:
+        if self.thermostat["settings"]["heatStages"] or self.thermostat["settings"]["hasHeatPump"]:
             self._operation_list.append(HVAC_MODE_HEAT)
         if self.thermostat["settings"]["coolStages"]:
             self._operation_list.append(HVAC_MODE_COOL)

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -267,7 +267,10 @@ class Thermostat(ClimateDevice):
         self._last_active_hvac_mode = HVAC_MODE_AUTO
 
         self._operation_list = []
-        if self.thermostat["settings"]["heatStages"] or self.thermostat["settings"]["hasHeatPump"]:
+        if (
+            self.thermostat["settings"]["heatStages"]
+            or self.thermostat["settings"]["hasHeatPump"]
+        ):
             self._operation_list.append(HVAC_MODE_HEAT)
         if self.thermostat["settings"]["coolStages"]:
             self._operation_list.append(HVAC_MODE_COOL)


### PR DESCRIPTION
Since the ecobee component started to dynamically set the supported HVAC modes based on querying the device a few releases ago, users with Heat Pumps noticed that the Heat mode was no longer offered as an option by HA. Some of us did not actually notice until the summer was over :). This commit fixes that.

For heatpumps, ecobee returns:
'coolStages': 1, 
'heatStages': 0,
'hasHeatPump': True,

Fix tested on HA 100.1 and 100.3

Fixes https://github.com/home-assistant/home-assistant/issues/26547

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
