### PR TITLE
Fix KeyError in decora setup

### DIFF
--- a/homeassistant/components/decora/light.py
+++ b/homeassistant/components/decora/light.py
@@ -15,6 +15,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import CONF_API_KEY, CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util as util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     lights = []
     for address, device_config in config[CONF_DEVICES].items():
         device = {}
-        device["name"] = device_config[CONF_NAME]
+        try:
+            device["name"] = device_config[CONF_NAME]
+        except KeyError:
+            device["name"] = util.slugify(address)
         device["key"] = device_config[CONF_API_KEY]
         device["address"] = address
         light = DecoraLight(device)

--- a/homeassistant/components/decora/light.py
+++ b/homeassistant/components/decora/light.py
@@ -79,7 +79,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device["name"] = device_config[CONF_NAME]
         device["key"] = device_config[CONF_API_KEY]
         device["address"] = address
-        _LOGGER.warning(device["name"])
         light = DecoraLight(device)
         lights.append(light)
 


### PR DESCRIPTION
## Breaking Change: None

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Fix KeyError: 'name' in decora setup.

**Related issue (if applicable):** fixes #27643<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
`name` does not need to be specified, see [documentation example](https://www.home-assistant.io/integrations/decora/)
```yaml
light:
  - platform: decora
    devices:
      00:21:4D:00:00:01:
        api_key: 003026
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
see home-assistant/home-assistant.io#11028

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
