### PR TITLE
SSDP matching improvements

### DIFF
--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -6,11 +6,11 @@
   "requirements": [
     "pydeconz==64"
   ],
-  "ssdp": {
-    "manufacturer": [
-      "Royal Philips Electronics"
-    ]
-  },
+  "ssdp": [
+    {
+      "manufacturer": "Royal Philips Electronics"
+    }
+  ],
   "dependencies": [],
   "codeowners": [
     "@kane610"

--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -6,11 +6,11 @@
   "requirements": [
     "pyheos==0.6.0"
   ],
-  "ssdp": {
-    "st": [
-      "urn:schemas-denon-com:device:ACT-Denon:1"
-    ]
-  },
+  "ssdp": [
+    {
+      "st": "urn:schemas-denon-com:device:ACT-Denon:1"
+    }
+  ],
   "dependencies": [],
   "codeowners": [
     "@andrewsayre"

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -6,11 +6,11 @@
   "requirements": [
     "aiohue==1.9.2"
   ],
-  "ssdp": {
-    "manufacturer": [
-      "Royal Philips Electronics"
-    ]
-  },
+  "ssdp": [
+    {
+      "manufacturer": "Royal Philips Electronics"
+    }
+  ],
   "homekit": {
     "models": [
       "BSB002"

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -7,10 +7,10 @@
     "pysonos==0.0.24"
   ],
   "dependencies": [],
-  "ssdp": {
-    "st": [
-      "urn:schemas-upnp-org:device:ZonePlayer:1"
-    ]
-  },
+  "ssdp": [
+    {
+      "st": "urn:schemas-upnp-org:device:ZonePlayer:1"
+    }
+  ],
   "codeowners": []
 }

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -6,11 +6,11 @@
   "requirements": [
     "pywemo==0.4.34"
   ],
-  "ssdp": {
-    "manufacturer": [
-      "Belkin International Inc."
-    ]
-  },
+  "ssdp": [
+    {
+      "manufacturer": "Belkin International Inc."
+    }
+  ],
   "homekit": {
     "models": [
       "Wemo"

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -8,37 +8,27 @@ To update, run python3 -m script.hassfest
 SSDP = {
     "deconz": [
         {
-            "manufacturer": [
-                "Royal Philips Electronics"
-            ]
+            "manufacturer": "Royal Philips Electronics"
         }
     ],
     "heos": [
         {
-            "st": [
-                "urn:schemas-denon-com:device:ACT-Denon:1"
-            ]
+            "st": "urn:schemas-denon-com:device:ACT-Denon:1"
         }
     ],
     "hue": [
         {
-            "manufacturer": [
-                "Royal Philips Electronics"
-            ]
+            "manufacturer": "Royal Philips Electronics"
         }
     ],
     "sonos": [
         {
-            "st": [
-                "urn:schemas-upnp-org:device:ZonePlayer:1"
-            ]
+            "st": "urn:schemas-upnp-org:device:ZonePlayer:1"
         }
     ],
     "wemo": [
         {
-            "manufacturer": [
-                "Belkin International Inc."
-            ]
+            "manufacturer": "Belkin International Inc."
         }
     ]
 }

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -6,22 +6,39 @@ To update, run python3 -m script.hassfest
 # fmt: off
 
 SSDP = {
-    "device_type": {},
-    "manufacturer": {
-        "Belkin International Inc.": [
-            "wemo"
-        ],
-        "Royal Philips Electronics": [
-            "deconz",
-            "hue"
-        ]
-    },
-    "st": {
-        "urn:schemas-denon-com:device:ACT-Denon:1": [
-            "heos"
-        ],
-        "urn:schemas-upnp-org:device:ZonePlayer:1": [
-            "sonos"
-        ]
-    }
+    "deconz": [
+        {
+            "manufacturer": [
+                "Royal Philips Electronics"
+            ]
+        }
+    ],
+    "heos": [
+        {
+            "st": [
+                "urn:schemas-denon-com:device:ACT-Denon:1"
+            ]
+        }
+    ],
+    "hue": [
+        {
+            "manufacturer": [
+                "Royal Philips Electronics"
+            ]
+        }
+    ],
+    "sonos": [
+        {
+            "st": [
+                "urn:schemas-upnp-org:device:ZonePlayer:1"
+            ]
+        }
+    ],
+    "wemo": [
+        {
+            "manufacturer": [
+                "Belkin International Inc."
+            ]
+        }
+    ]
 }

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -14,11 +14,7 @@ MANIFEST_SCHEMA = vol.Schema(
         vol.Optional("config_flow"): bool,
         vol.Optional("zeroconf"): [str],
         vol.Optional("ssdp"): vol.Schema(
-            {
-                vol.Optional("st"): [str],
-                vol.Optional("manufacturer"): [str],
-                vol.Optional("device_type"): [str],
-            }
+            vol.All([vol.All(vol.Schema({}, extra=vol.ALLOW_EXTRA), vol.Length(min=1))])
         ),
         vol.Optional("homekit"): vol.Schema({vol.Optional("models"): [str]}),
         vol.Required("documentation"): str,

--- a/script/hassfest/ssdp.py
+++ b/script/hassfest/ssdp.py
@@ -24,11 +24,8 @@ def sort_dict(value):
 
 def generate_and_validate(integrations: Dict[str, Integration]):
     """Validate and generate ssdp data."""
-    data = {
-        "st": defaultdict(list),
-        "manufacturer": defaultdict(list),
-        "device_type": defaultdict(list),
-    }
+
+    data = defaultdict(list)
 
     for domain in sorted(integrations):
         integration = integrations[domain]
@@ -56,14 +53,8 @@ def generate_and_validate(integrations: Dict[str, Integration]):
             )
             continue
 
-        for key in "st", "manufacturer", "device_type":
-            if key not in ssdp:
-                continue
+        data[domain].append(sort_dict(ssdp))
 
-            for value in ssdp[key]:
-                data[key][value].append(domain)
-
-    data = sort_dict({key: sort_dict(value) for key, value in data.items()})
     return BASE.format(json.dumps(data, indent=4))
 
 

--- a/script/hassfest/ssdp.py
+++ b/script/hassfest/ssdp.py
@@ -53,7 +53,8 @@ def generate_and_validate(integrations: Dict[str, Integration]):
             )
             continue
 
-        data[domain].append(sort_dict(ssdp))
+        for matcher in ssdp:
+            data[domain].append(sort_dict(matcher))
 
     return BASE.format(json.dumps(data, indent=4))
 

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -17,7 +17,7 @@ async def test_scan_match_st(hass):
 
     with patch(
         "netdisco.ssdp.scan", return_value=[Mock(st="mock-st", location=None)]
-    ), patch.dict(gn_ssdp.SSDP["st"], {"mock-st": ["mock-domain"]}), patch.object(
+    ), patch.dict(gn_ssdp.SSDP, {"mock-domain": [{"st": "mock-st"}]}), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
         await scanner.async_scan(None)
@@ -27,14 +27,15 @@ async def test_scan_match_st(hass):
     assert mock_init.mock_calls[0][2]["context"] == {"source": "ssdp"}
 
 
-async def test_scan_match_manufacturer(hass, aioclient_mock):
-    """Test matching based on ST."""
+@pytest.mark.parametrize("key", ("manufacturer", "deviceType"))
+async def test_scan_match_upnp_devicedesc(hass, aioclient_mock, key):
+    """Test matching based on UPnP device description data."""
     aioclient_mock.get(
         "http://1.1.1.1",
-        text="""
+        text=f"""
 <root>
   <device>
-    <manufacturer>Paulus</manufacturer>
+    <{key}>Paulus</{key}>
   </device>
 </root>
     """,
@@ -44,9 +45,7 @@ async def test_scan_match_manufacturer(hass, aioclient_mock):
     with patch(
         "netdisco.ssdp.scan",
         return_value=[Mock(st="mock-st", location="http://1.1.1.1")],
-    ), patch.dict(
-        gn_ssdp.SSDP["manufacturer"], {"Paulus": ["mock-domain"]}
-    ), patch.object(
+    ), patch.dict(gn_ssdp.SSDP, {"mock-domain": [{key: "Paulus"}]}), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
         await scanner.async_scan(None)
@@ -56,11 +55,11 @@ async def test_scan_match_manufacturer(hass, aioclient_mock):
     assert mock_init.mock_calls[0][2]["context"] == {"source": "ssdp"}
 
 
-async def test_scan_match_device_type(hass, aioclient_mock):
-    """Test matching based on ST."""
+async def test_scan_not_all_present(hass, aioclient_mock):
+    """Test match fails if some specified attributes are not present."""
     aioclient_mock.get(
         "http://1.1.1.1",
-        text="""
+        text=f"""
 <root>
   <device>
     <deviceType>Paulus</deviceType>
@@ -74,15 +73,43 @@ async def test_scan_match_device_type(hass, aioclient_mock):
         "netdisco.ssdp.scan",
         return_value=[Mock(st="mock-st", location="http://1.1.1.1")],
     ), patch.dict(
-        gn_ssdp.SSDP["device_type"], {"Paulus": ["mock-domain"]}
+        gn_ssdp.SSDP,
+        {"mock-domain": [{"deviceType": "Paulus", "manufacturer": "Paulus"}]},
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
         await scanner.async_scan(None)
 
-    assert len(mock_init.mock_calls) == 1
-    assert mock_init.mock_calls[0][1][0] == "mock-domain"
-    assert mock_init.mock_calls[0][2]["context"] == {"source": "ssdp"}
+    assert not mock_init.mock_calls
+
+
+async def test_scan_not_all_match(hass, aioclient_mock):
+    """Test match fails if some specified attribute values differ."""
+    aioclient_mock.get(
+        "http://1.1.1.1",
+        text=f"""
+<root>
+  <device>
+    <deviceType>Paulus</deviceType>
+    <manufacturer>Paulus</manufacturer>
+  </device>
+</root>
+    """,
+    )
+    scanner = ssdp.Scanner(hass)
+
+    with patch(
+        "netdisco.ssdp.scan",
+        return_value=[Mock(st="mock-st", location="http://1.1.1.1")],
+    ), patch.dict(
+        gn_ssdp.SSDP,
+        {"mock-domain": [{"deviceType": "Paulus", "manufacturer": "Not-Paulus"}]},
+    ), patch.object(
+        hass.config_entries.flow, "async_init", return_value=mock_coro()
+    ) as mock_init:
+        await scanner.async_scan(None)
+
+    assert not mock_init.mock_calls
 
 
 @pytest.mark.parametrize("exc", [asyncio.TimeoutError, aiohttp.ClientError])


### PR DESCRIPTION
## Breaking Change:

`ssdp` in manifest.json has changed; it is now a list of dicts, and as we now match using the UPnP device description fields directly, `device_type` has to be renamed to `deviceType`. Not sure if custom integrations support this stuff in the first place, but if they do, they need to adjust accordingly. No included integrations use it at the moment, nor are they broken by this change.

## Description:

Per discussion in https://github.com/home-assistant/home-assistant/pull/28214#discussion_r339291851

- support multiple match groups per domain
- require matches on all, not any item in a group
- support matching on all UPnP device description data

Matching on all UPnP device description data is consistent with providing all of it, ditto the `ssdp` data structure in manifest.json to the corresponding provided discovery_info, see #28197

**Related issue (if applicable):** #28214

**Pull request with documentation for developer docs:** https://github.com/home-assistant/developers.home-assistant/pull/341

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
