### PR TITLE
Bump avea to 1.4

### DIFF
--- a/homeassistant/components/avea/manifest.json
+++ b/homeassistant/components/avea/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/avea",
   "dependencies": [],
   "codeowners": ["@pattyland"],
-  "requirements": ["avea==1.2.8"]
+  "requirements": ["avea==1.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -246,7 +246,7 @@ aurorapy==0.2.6
 av==6.1.2
 
 # homeassistant.components.avea
-avea==1.2.8
+avea==1.4
 
 # homeassistant.components.avion
 # avion==0.10


### PR DESCRIPTION
Description:
Bump avea to 1.4

https://pypi.org/project/avea/#history

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
