### PR TITLE
Jewish calendar config flow

### DIFF
--- a/homeassistant/components/jewish_calendar/.translations/en.json
+++ b/homeassistant/components/jewish_calendar/.translations/en.json
@@ -7,17 +7,17 @@
         "step": {
             "user": {
                 "data": {
-                    "candle_lighting_minutes_before_sunset": "Number of minutes before sunset for candle lighthing",
-                    "diaspora": "Is location outside of Israel",
-                    "havdalah_minutes_after_sunset": "Number of minutes after sunset for havdalah (0 - use the time for Tzet Hakochavim)",
-                    "language": "Show holidays and dates in english (latin) or hebrew",
-                    "latitude": "Override the default latitude value set by Home Assistant",
-                    "longitude": "Override the default longitude value set by Home Assistant",
-                    "name": "The name to be used for the sensors"
+                    "candle_lighting_minutes_before_sunset": "Minutes before sunset for candle lighthing",
+                    "diaspora": "Outside of Israel",
+                    "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah",
+                    "language": "Language for holidays and dates",
+                    "latitude": "Override default latitude",
+                    "longitude": "Override default longitude",
+                    "name": "Name to be used for sensors"
                 },
                 "title": "Jewish Calendar settings"
             }
         },
-        "title": "Jewish calendar"
+        "title": "Jewish Calendar"
     }
 }

--- a/homeassistant/components/jewish_calendar/.translations/en.json
+++ b/homeassistant/components/jewish_calendar/.translations/en.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {},
+        "step": {
+            "user": {
+                "data": {
+                    "candle_lighting_minutes_before_sunset": "Number of minutes before sunset for candle lighthing",
+                    "diaspora": "Is location outside of Israel",
+                    "havdalah_minutes_after_sunset": "Number of minutes after sunset for havdalah (0 - use the time for Tzet Hakochavim)",
+                    "language": "Show holidays and dates in english (latin) or hebrew",
+                    "latitude": "Override the default latitude value set by Home Assistant",
+                    "longitude": "Override the default longitude value set by Home Assistant",
+                    "name": "The name to be used for the sensors"
+                },
+                "title": "Jewish Calendar settings"
+            }
+        },
+        "title": "Jewish calendar"
+    }
+}

--- a/homeassistant/components/jewish_calendar/.translations/en.json
+++ b/homeassistant/components/jewish_calendar/.translations/en.json
@@ -7,11 +7,12 @@
         "data": {
           "name": "Name to be used for sensors",
           "diaspora": "Outside of Israel",
-          "language": "Language for holidays and dates",
+          "language": "Language for holidays and dates"
         }
+      }
     },
     "error": {
-      "name_exists": "Name already exists",
+      "name_exists": "Name already exists"
     },
     "abort": {
       "already_configured": "Device is already configured"

--- a/homeassistant/components/jewish_calendar/.translations/en.json
+++ b/homeassistant/components/jewish_calendar/.translations/en.json
@@ -1,23 +1,33 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {},
-        "step": {
-            "user": {
-                "data": {
-                    "candle_lighting_minutes_before_sunset": "Minutes before sunset for candle lighthing",
-                    "diaspora": "Outside of Israel",
-                    "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah",
-                    "language": "Language for holidays and dates",
-                    "latitude": "Override default latitude",
-                    "longitude": "Override default longitude",
-                    "name": "Name to be used for sensors"
-                },
-                "title": "Jewish Calendar settings"
-            }
-        },
-        "title": "Jewish Calendar"
+  "config": {
+    "title": "Jewish Calendar",
+    "step": {
+      "user": {
+        "title": "Jewish Calendar settings",
+        "data": {
+          "name": "Name to be used for sensors",
+          "diaspora": "Outside of Israel",
+          "language": "Language for holidays and dates",
+        }
+    },
+    "error": {
+      "name_exists": "Name already exists",
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure options for Jewish Calendar",
+        "data": {
+          "candle_lighting_minutes_before_sunset": "Minutes before sunset for candle lighthing",
+          "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah",
+          "latitude": "Override default latitude",
+          "longitude": "Override default longitude"
+        }
+      }
+    }
+  }
 }

--- a/homeassistant/components/jewish_calendar/.translations/en.json
+++ b/homeassistant/components/jewish_calendar/.translations/en.json
@@ -7,7 +7,11 @@
         "data": {
           "name": "Name to be used for sensors",
           "diaspora": "Outside of Israel",
-          "language": "Language for holidays and dates"
+          "language": "Language for holidays and dates",
+          "latitude": "Override default latitude",
+          "longitude": "Override default longitude",
+          "elevation": "Override default elevation",
+          "time_zone": "Override default time zone"
         }
       }
     },
@@ -24,9 +28,7 @@
         "title": "Configure options for Jewish Calendar",
         "data": {
           "candle_lighting_minutes_before_sunset": "Minutes before sunset for candle lighthing",
-          "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah",
-          "latitude": "Override default latitude",
-          "longitude": "Override default longitude"
+          "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah"
         }
       }
     }

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -92,12 +92,12 @@ async def async_setup_entry(hass, config_entry):
     language = config_entry.data[CONF_LANGUAGE]
     diaspora = config_entry.data[CONF_DIASPORA]
 
-    latitude = config_entry.data.pop(CONF_LATITUDE, hass.config.latitude)
-    longitude = config_entry.data.pop(CONF_LONGITUDE, hass.config.longitude)
-    candle_lighting_offset = config_entry.data.pop(
+    latitude = config_entry.data.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config_entry.data.get(CONF_LONGITUDE, hass.config.longitude)
+    candle_lighting_offset = config_entry.data.get(
         CONF_CANDLE_LIGHT_MINUTES, DEFAULT_CANDLE_LIGHT
     )
-    havdalah_offset = config_entry.data.pop(
+    havdalah_offset = config_entry.data.get(
         CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
     )
 

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -8,10 +8,10 @@ from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.helpers.discovery import async_load_platform
 import homeassistant.helpers.config_validation as cv
 
+from .const import DOMAIN
+
 
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "jewish_calendar"
 
 SENSOR_TYPES = {
     "binary": {
@@ -104,5 +104,15 @@ async def async_setup(hass, config):
     hass.async_create_task(
         async_load_platform(hass, "binary_sensor", DOMAIN, {}, config)
     )
+
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up a config entry for NEW_NAME."""
+    # TODO forward the entry for each platform that you want to set up.
+    # hass.async_create_task(
+    #     hass.config_entries.async_forward_entry_setup(entry, "media_player")
+    # )
 
     return True

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -92,16 +92,16 @@ async def async_setup_entry(hass, config_entry):
     language = config_entry.data[CONF_LANGUAGE]
     diaspora = config_entry.data[CONF_DIASPORA]
 
-    if not config_entry.options:
-        latitude = config_entry.data.pop(CONF_LATITUDE, hass.config.latitude)
-        longitude = config_entry.data.pop(CONF_LONGITUDE, hass.config.longitude)
-        candle_lighting_offset = config_entry.data.pop(
-            CONF_CANDLE_LIGHT_MINUTES, DEFAULT_CANDLE_LIGHT
-        )
-        havdalah_offset = config_entry.data.pop(
-            CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
-        )
+    latitude = config_entry.data.pop(CONF_LATITUDE, hass.config.latitude)
+    longitude = config_entry.data.pop(CONF_LONGITUDE, hass.config.longitude)
+    candle_lighting_offset = config_entry.data.pop(
+        CONF_CANDLE_LIGHT_MINUTES, DEFAULT_CANDLE_LIGHT
+    )
+    havdalah_offset = config_entry.data.pop(
+        CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
+    )
 
+    if not config_entry.options:
         options = {
             CONF_LATITUDE: latitude,
             CONF_LONGITUDE: longitude,

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -1,5 +1,6 @@
 """The jewish_calendar component."""
 from copy import deepcopy
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -105,6 +106,8 @@ async def async_setup_entry(hass, entry):
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
-    await hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    await hass.config_entries.async_forward_entry_unload(entry, "binary_sensor")
+    await asyncio.gather(
+        hass.config_entries.async_forward_entry_unload(entry, "sensor"),
+        hass.config_entries.async_forward_entry_unload(entry, "binary_sensor"),
+    )
     return True

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -1,9 +1,11 @@
 """The jewish_calendar component."""
+from copy import deepcopy
 import logging
 
 import voluptuous as vol
 import hdate
 
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 
 from .const import (
@@ -49,6 +51,17 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema(DATA_SCHEMA)}, extra=vol.ALLOW_EX
 
 async def async_setup(hass, config):
     """Set up the Jewish Calendar component."""
+    if DOMAIN not in config:
+        return True
+
+    conf = config[DOMAIN]
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=deepcopy(conf)
+        )
+    )
+
     return True
 
 

--- a/homeassistant/components/jewish_calendar/binary_sensor.py
+++ b/homeassistant/components/jewish_calendar/binary_sensor.py
@@ -11,11 +11,8 @@ from . import DOMAIN, SENSOR_TYPES
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Jewish Calendar binary sensor devices."""
-    if discovery_info is None:
-        return
-
     async_add_entities(
         [
             JewishCalendarBinarySensor(hass.data[DOMAIN], sensor, sensor_info)

--- a/homeassistant/components/jewish_calendar/binary_sensor.py
+++ b/homeassistant/components/jewish_calendar/binary_sensor.py
@@ -15,7 +15,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Jewish Calendar binary sensor devices."""
     async_add_entities(
         [
-            JewishCalendarBinarySensor(hass.data[DOMAIN], sensor, sensor_info)
+            JewishCalendarBinarySensor(
+                hass.data[DOMAIN][config_entry.entry_id], sensor, sensor_info
+            )
             for sensor, sensor_info in SENSOR_TYPES["binary"].items()
         ]
     )

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -30,6 +30,7 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                 title=user_input.get(CONF_NAME, DEFAULT_NAME),
                 data={
+                    CONF_NAME: user_input[CONF_NAME],
                     CONF_DIASPORA: user_input[CONF_DIASPORA],
                     CONF_LANGUAGE: user_input[CONF_LANGUAGE],
                     CONF_CANDLE_LIGHT_MINUTES: user_input[CONF_CANDLE_LIGHT_MINUTES],

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -62,7 +62,7 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
-            errors={},
+            errors=errors,
         )
 
     async def async_step_import(self, import_config):

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -59,7 +59,7 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
         if self._async_current_entries():
-            _LOGGER.warning("Only one configuration of Jewish calendar is allowed.")
+            _LOGGER.warning("Only one configuration of Jewish calendar is allowed")
             return self.async_abort(reason="single_instance_allowed")
 
         return await self.async_step_user(import_config)

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -15,14 +15,13 @@ from .const import (
     DEFAULT_HAVDALAH_OFFSET_MINUTES,
     DEFAULT_LANGUAGE,
     DEFAULT_NAME,
-    DOMAIN,
     DATA_SCHEMA,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class JewishCalendarConfigFlow(config_entries.ConfigFlow):
     """Handle a config flow for Jewish calendar."""
 
     VERSION = 1

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -1,9 +1,10 @@
 """Config flow for Jewish calendar integration."""
+import logging
+
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 
 from .const import (
-    DEFAULT_NAME,
     CONF_DIASPORA,
     CONF_LANGUAGE,
     CONF_CANDLE_LIGHT_MINUTES,
@@ -12,8 +13,10 @@ from .const import (
     DATA_SCHEMA,
 )
 
+_LOGGER = logging.getLogger(__name__)
 
-class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+
+class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Jewish calendar."""
 
     VERSION = 1
@@ -23,8 +26,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if user_input is not None:
             return self.async_create_entry(
-                title=user_input.get(CONF_NAME, DEFAULT_NAME),
+                title=user_input[CONF_NAME],
                 data={
+                    CONF_NAME: user_input[CONF_NAME],
                     CONF_DIASPORA: user_input[CONF_DIASPORA],
                     CONF_LANGUAGE: user_input[CONF_LANGUAGE],
                     CONF_CANDLE_LIGHT_MINUTES: user_input[CONF_CANDLE_LIGHT_MINUTES],
@@ -41,3 +45,11 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA, errors={})
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        if self._async_current_entries():
+            _LOGGER.warning("Only one configuration of Jewish calendar is allowed.")
+            return self.async_abort(reason="single_instance_allowed")
+
+        return await self.async_step_user(import_config)

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -10,6 +10,10 @@ from .const import (
     CONF_LANGUAGE,
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_CANDLE_LIGHT,
+    DEFAULT_DIASPORA,
+    DEFAULT_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_LANGUAGE,
     DEFAULT_NAME,
     DOMAIN,
     DATA_SCHEMA,
@@ -30,13 +34,15 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                 title=user_input.get(CONF_NAME, DEFAULT_NAME),
                 data={
-                    CONF_NAME: user_input[CONF_NAME],
-                    CONF_DIASPORA: user_input[CONF_DIASPORA],
-                    CONF_LANGUAGE: user_input[CONF_LANGUAGE],
-                    CONF_CANDLE_LIGHT_MINUTES: user_input[CONF_CANDLE_LIGHT_MINUTES],
-                    CONF_HAVDALAH_OFFSET_MINUTES: user_input[
-                        CONF_HAVDALAH_OFFSET_MINUTES
-                    ],
+                    CONF_NAME: user_input.get(CONF_NAME, DEFAULT_NAME),
+                    CONF_DIASPORA: user_input.get(CONF_DIASPORA, DEFAULT_DIASPORA),
+                    CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
+                    CONF_CANDLE_LIGHT_MINUTES: user_input.get(
+                        CONF_CANDLE_LIGHT_MINUTES, DEFAULT_CANDLE_LIGHT
+                    ),
+                    CONF_HAVDALAH_OFFSET_MINUTES: user_input.get(
+                        CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
+                    ),
                     CONF_LATITUDE: user_input.get(
                         CONF_LATITUDE, self.hass.config.latitude
                     ),

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -78,11 +78,11 @@ class JewishCalendarOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle Jewish Calendar options."""
 
     def __init__(self, config_entry):
-        """Initialize Transmission options flow."""
+        """Initialize Jewidh Calendar options flow."""
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
-        """Manage the Transmission options."""
+        """Manage the Jewish Calendar options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -15,13 +15,14 @@ from .const import (
     DEFAULT_HAVDALAH_OFFSET_MINUTES,
     DEFAULT_LANGUAGE,
     DEFAULT_NAME,
+    DOMAIN,
     DATA_SCHEMA,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class JewishCalendarConfigFlow(config_entries.ConfigFlow):
+class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Jewish calendar."""
 
     VERSION = 1

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -1,0 +1,63 @@
+"""Config flow for Jewish calendar integration."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant import core, config_entries, exceptions
+
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+# TODO adjust the data schema to the data that you need
+DATA_SCHEMA = vol.Schema({"host": str, "username": str, "password": str})
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    # TODO validate the data can be used to set up a connection.
+    # If you cannot connect:
+    # throw CannotConnect
+    # If the authentication is wrong:
+    # InvalidAuth
+
+    # Return some info we want to store in the config entry.
+    return {"title": "Name of the device"}
+
+
+class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Jewish calendar."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -1,31 +1,20 @@
 """Config flow for Jewish calendar integration."""
 import logging
 
-import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 
-from homeassistant import core, config_entries, exceptions
-
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import (
+    DEFAULT_NAME,
+    CONF_DIASPORA,
+    CONF_LANGUAGE,
+    CONF_CANDLE_LIGHT_MINUTES,
+    CONF_HAVDALAH_OFFSET_MINUTES,
+    DOMAIN,
+    DATA_SCHEMA,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-# TODO adjust the data schema to the data that you need
-DATA_SCHEMA = vol.Schema({"host": str, "username": str, "password": str})
-
-
-async def validate_input(hass: core.HomeAssistant, data):
-    """Validate the user input allows us to connect.
-
-    Data has the keys from DATA_SCHEMA with values provided by the user.
-    """
-    # TODO validate the data can be used to set up a connection.
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
-
-    # Return some info we want to store in the config entry.
-    return {"title": "Name of the device"}
 
 
 class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -39,13 +28,25 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             try:
-                info = await validate_input(self.hass, user_input)
-
-                return self.async_create_entry(title=info["title"], data=user_input)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                errors["base"] = "invalid_auth"
+                return self.async_create_entry(
+                    title=user_input.get(CONF_NAME, DEFAULT_NAME),
+                    data={
+                        CONF_DIASPORA: user_input[CONF_DIASPORA],
+                        CONF_LANGUAGE: user_input[CONF_LANGUAGE],
+                        CONF_CANDLE_LIGHT_MINUTES: user_input[
+                            CONF_CANDLE_LIGHT_MINUTES
+                        ],
+                        CONF_HAVDALAH_OFFSET_MINUTES: user_input[
+                            CONF_HAVDALAH_OFFSET_MINUTES
+                        ],
+                        CONF_LATITUDE: user_input.get(
+                            CONF_LATITUDE, self.hass.config.latitude
+                        ),
+                        CONF_LONGITUDE: user_input.get(
+                            CONF_LONGITUDE, self.hass.config.longitude
+                        ),
+                    },
+                )
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -53,11 +54,3 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(exceptions.HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Jewish calendar integration."""
 import logging
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
@@ -9,6 +10,7 @@ from .const import (
     CONF_LANGUAGE,
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_NAME,
     DOMAIN,
     DATA_SCHEMA,
 )
@@ -26,9 +28,8 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if user_input is not None:
             return self.async_create_entry(
-                title=user_input[CONF_NAME],
+                title=user_input.get(CONF_NAME, DEFAULT_NAME),
                 data={
-                    CONF_NAME: user_input[CONF_NAME],
                     CONF_DIASPORA: user_input[CONF_DIASPORA],
                     CONF_LANGUAGE: user_input[CONF_LANGUAGE],
                     CONF_CANDLE_LIGHT_MINUTES: user_input[CONF_CANDLE_LIGHT_MINUTES],
@@ -44,7 +45,9 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA, errors={})
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(DATA_SCHEMA), errors={}
+        )
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -4,6 +4,8 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 
 from .const import (
     CONF_DIASPORA,
@@ -16,7 +18,6 @@ from .const import (
     DEFAULT_LANGUAGE,
     DEFAULT_NAME,
     DOMAIN,
-    DATA_SCHEMA,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,32 +29,40 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return JewishCalendarOptionsFlowHandler(config_entry)
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
+        errors = {}
+
         if user_input is not None:
-            return self.async_create_entry(
-                title=user_input.get(CONF_NAME, DEFAULT_NAME),
-                data={
-                    CONF_NAME: user_input.get(CONF_NAME, DEFAULT_NAME),
-                    CONF_DIASPORA: user_input.get(CONF_DIASPORA, DEFAULT_DIASPORA),
-                    CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
-                    CONF_CANDLE_LIGHT_MINUTES: user_input.get(
-                        CONF_CANDLE_LIGHT_MINUTES, DEFAULT_CANDLE_LIGHT
-                    ),
-                    CONF_HAVDALAH_OFFSET_MINUTES: user_input.get(
-                        CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
-                    ),
-                    CONF_LATITUDE: user_input.get(
-                        CONF_LATITUDE, self.hass.config.latitude
-                    ),
-                    CONF_LONGITUDE: user_input.get(
-                        CONF_LONGITUDE, self.hass.config.longitude
-                    ),
-                },
-            )
+
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                    errors[CONF_NAME] = "name_exists"
+                    break
+
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
 
         return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(DATA_SCHEMA), errors={}
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+                    vol.Optional(CONF_DIASPORA, default=DEFAULT_DIASPORA): bool,
+                    vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
+                        ["hebrew", "english"]
+                    ),
+                }
+            ),
+            errors={},
         )
 
     async def async_step_import(self, import_config):
@@ -63,3 +72,46 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         return await self.async_step_user(import_config)
+
+
+class JewishCalendarOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Jewish Calendar options."""
+
+    def __init__(self, config_entry):
+        """Initialize Transmission options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Transmission options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = {
+            vol.Optional(
+                CONF_CANDLE_LIGHT_MINUTES,
+                default=self.config_entry.options.get(
+                    CONF_CANDLE_LIGHT_MINUTES, DEFAULT_CANDLE_LIGHT
+                ),
+            ): int,
+            # Default of 0 means use 8.5 degrees / 'three_stars' time.
+            vol.Optional(
+                CONF_HAVDALAH_OFFSET_MINUTES,
+                default=self.config_entry.options.get(
+                    CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
+                ),
+            ): int,
+            vol.Optional(
+                CONF_LATITUDE,
+                default=self.config_entry.options.get(
+                    CONF_LATITUDE, self.hass.config.latitude
+                ),
+            ): cv.latitude,
+            vol.Optional(
+                CONF_LONGITUDE,
+                default=self.config_entry.options.get(
+                    CONF_LONGITUDE, self.hass.config.longitude
+                ),
+            ): cv.longitude,
+        }
+
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -1,6 +1,4 @@
 """Config flow for Jewish calendar integration."""
-import logging
-
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 
@@ -14,8 +12,6 @@ from .const import (
     DATA_SCHEMA,
 )
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Jewish calendar."""
@@ -25,32 +21,23 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
-        errors = {}
         if user_input is not None:
-            try:
-                return self.async_create_entry(
-                    title=user_input.get(CONF_NAME, DEFAULT_NAME),
-                    data={
-                        CONF_DIASPORA: user_input[CONF_DIASPORA],
-                        CONF_LANGUAGE: user_input[CONF_LANGUAGE],
-                        CONF_CANDLE_LIGHT_MINUTES: user_input[
-                            CONF_CANDLE_LIGHT_MINUTES
-                        ],
-                        CONF_HAVDALAH_OFFSET_MINUTES: user_input[
-                            CONF_HAVDALAH_OFFSET_MINUTES
-                        ],
-                        CONF_LATITUDE: user_input.get(
-                            CONF_LATITUDE, self.hass.config.latitude
-                        ),
-                        CONF_LONGITUDE: user_input.get(
-                            CONF_LONGITUDE, self.hass.config.longitude
-                        ),
-                    },
-                )
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+            return self.async_create_entry(
+                title=user_input.get(CONF_NAME, DEFAULT_NAME),
+                data={
+                    CONF_DIASPORA: user_input[CONF_DIASPORA],
+                    CONF_LANGUAGE: user_input[CONF_LANGUAGE],
+                    CONF_CANDLE_LIGHT_MINUTES: user_input[CONF_CANDLE_LIGHT_MINUTES],
+                    CONF_HAVDALAH_OFFSET_MINUTES: user_input[
+                        CONF_HAVDALAH_OFFSET_MINUTES
+                    ],
+                    CONF_LATITUDE: user_input.get(
+                        CONF_LATITUDE, self.hass.config.latitude
+                    ),
+                    CONF_LONGITUDE: user_input.get(
+                        CONF_LONGITUDE, self.hass.config.longitude
+                    ),
+                },
+            )
 
-        return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
-        )
+        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA, errors={})

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -11,8 +11,6 @@ from homeassistant.const import (
     CONF_TIME_ZONE,
 )
 from homeassistant.core import callback
-from homeassistant import exceptions
-import homeassistant.helpers.config_validation as cv
 
 
 from .const import (

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -3,9 +3,17 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import (
+    CONF_ELEVATION,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    CONF_TIME_ZONE,
+)
 from homeassistant.core import callback
+from homeassistant import exceptions
 import homeassistant.helpers.config_validation as cv
+
 
 from .const import (
     CONF_DIASPORA,
@@ -20,7 +28,27 @@ from .const import (
     DOMAIN,
 )
 
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+        vol.Required(CONF_DIASPORA, default=DEFAULT_DIASPORA): bool,
+        vol.Required(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
+            ["hebrew", "english"]
+        ),
+        # Default is empty, unless user wants to override
+        vol.Optional(CONF_LATITUDE): float,
+        vol.Optional(CONF_LONGITUDE): float,
+        vol.Optional(CONF_ELEVATION): float,
+        vol.Optional(CONF_TIME_ZONE): str,
+    }
+)
+
 _LOGGER = logging.getLogger(__name__)
+
+
+async def validate_input(hass, data):
+    """Validate the user input."""
+    return {"title": data[CONF_NAME]}
 
 
 class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -40,37 +68,31 @@ class JewishCalendarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-
             for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if all(
+                    _value == entry.as_dict().get(_key)
+                    for _key, _value in user_input.items()
+                    if _key != CONF_NAME
+                ):
+                    return self.async_abort(reason="already_configured")
+
                 if entry.data[CONF_NAME] == user_input[CONF_NAME]:
                     errors[CONF_NAME] = "name_exists"
                     break
 
-            if not errors:
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
-                )
+            try:
+                info = await validate_input(self.hass, user_input)
+                return self.async_create_entry(title=info["title"], data=user_input)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-                    vol.Optional(CONF_DIASPORA, default=DEFAULT_DIASPORA): bool,
-                    vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
-                        ["hebrew", "english"]
-                    ),
-                }
-            ),
-            errors=errors,
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
-        if self._async_current_entries():
-            _LOGGER.warning("Only one configuration of Jewish calendar is allowed")
-            return self.async_abort(reason="single_instance_allowed")
-
         return await self.async_step_user(import_config)
 
 
@@ -78,7 +100,7 @@ class JewishCalendarOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle Jewish Calendar options."""
 
     def __init__(self, config_entry):
-        """Initialize Jewidh Calendar options flow."""
+        """Initialize Jewish Calendar options flow."""
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
@@ -100,18 +122,6 @@ class JewishCalendarOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
                 ),
             ): int,
-            vol.Optional(
-                CONF_LATITUDE,
-                default=self.config_entry.options.get(
-                    CONF_LATITUDE, self.hass.config.latitude
-                ),
-            ): cv.latitude,
-            vol.Optional(
-                CONF_LONGITUDE,
-                default=self.config_entry.options.get(
-                    CONF_LONGITUDE, self.hass.config.longitude
-                ),
-            ): cv.longitude,
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -18,10 +18,10 @@ DOMAIN = "jewish_calendar"
 DATA_SCHEMA = {
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
     vol.Optional(CONF_DIASPORA, default=False): bool,
-    vol.Inclusive(CONF_LATITUDE, "coordinates"): cv.latitude,
-    vol.Inclusive(CONF_LONGITUDE, "coordinates"): cv.longitude,
     vol.Optional(CONF_LANGUAGE, default="english"): vol.In(["hebrew", "english"]),
     vol.Optional(CONF_CANDLE_LIGHT_MINUTES, default=CANDLE_LIGHT_DEFAULT): int,
     # Default of 0 means use 8.5 degrees / 'three_stars' time.
     vol.Optional(CONF_HAVDALAH_OFFSET_MINUTES, default=0): int,
+    vol.Optional(CONF_LATITUDE): cv.latitude,
+    vol.Optional(CONF_LONGITUDE): cv.longitude,
 }

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -16,8 +16,8 @@ DEFAULT_NAME = "Jewish Calendar"
 DOMAIN = "jewish_calendar"
 
 DATA_SCHEMA = {
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_DIASPORA, default=False): cv.boolean,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+    vol.Optional(CONF_DIASPORA, default=False): bool,
     vol.Inclusive(CONF_LATITUDE, "coordinates"): cv.latitude,
     vol.Inclusive(CONF_LONGITUDE, "coordinates"): cv.longitude,
     vol.Optional(CONF_LANGUAGE, default="english"): vol.In(["hebrew", "english"]),

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -4,24 +4,30 @@ import voluptuous as vol
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
-CANDLE_LIGHT_DEFAULT = 18
-
 CONF_DIASPORA = "diaspora"
 CONF_LANGUAGE = "language"
 CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
 CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
 
 DEFAULT_NAME = "Jewish Calendar"
+DEFAULT_CANDLE_LIGHT = 18
+DEFAULT_DIASPORA = False
+DEFAULT_HAVDALAH_OFFSET_MINUTES = 0
+DEFAULT_LANGUAGE = "english"
 
 DOMAIN = "jewish_calendar"
 
 DATA_SCHEMA = {
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-    vol.Optional(CONF_DIASPORA, default=False): bool,
-    vol.Optional(CONF_LANGUAGE, default="english"): vol.In(["hebrew", "english"]),
-    vol.Optional(CONF_CANDLE_LIGHT_MINUTES, default=CANDLE_LIGHT_DEFAULT): int,
+    vol.Optional(CONF_DIASPORA, default=DEFAULT_DIASPORA): bool,
+    vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
+        ["hebrew", "english"]
+    ),
+    vol.Optional(CONF_CANDLE_LIGHT_MINUTES, default=DEFAULT_CANDLE_LIGHT): int,
     # Default of 0 means use 8.5 degrees / 'three_stars' time.
-    vol.Optional(CONF_HAVDALAH_OFFSET_MINUTES, default=0): int,
+    vol.Optional(
+        CONF_HAVDALAH_OFFSET_MINUTES, default=DEFAULT_HAVDALAH_OFFSET_MINUTES
+    ): int,
     vol.Optional(CONF_LATITUDE): cv.latitude,
     vol.Optional(CONF_LONGITUDE): cv.longitude,
 }

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -1,3 +1,27 @@
-"""Constants for the Jewish Calendar intergration."""
+"""Constants for the Jewish Calendar integration."""
+import voluptuous as vol
+
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+import homeassistant.helpers.config_validation as cv
+
+CANDLE_LIGHT_DEFAULT = 18
+
+CONF_DIASPORA = "diaspora"
+CONF_LANGUAGE = "language"
+CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
+CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
+
+DEFAULT_NAME = "Jewish Calendar"
 
 DOMAIN = "jewish_calendar"
+
+DATA_SCHEMA = {
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_DIASPORA, default=False): cv.boolean,
+    vol.Inclusive(CONF_LATITUDE, "coordinates"): cv.latitude,
+    vol.Inclusive(CONF_LONGITUDE, "coordinates"): cv.longitude,
+    vol.Optional(CONF_LANGUAGE, default="english"): vol.In(["hebrew", "english"]),
+    vol.Optional(CONF_CANDLE_LIGHT_MINUTES, default=CANDLE_LIGHT_DEFAULT): int,
+    # Default of 0 means use 8.5 degrees / 'three_stars' time.
+    vol.Optional(CONF_HAVDALAH_OFFSET_MINUTES, default=0): int,
+}

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Jewish Calendar intergration."""
+
+DOMAIN = "jewish_calendar"

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -1,9 +1,4 @@
 """Constants for the Jewish Calendar integration."""
-import voluptuous as vol
-
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
-import homeassistant.helpers.config_validation as cv
-
 CONF_DIASPORA = "diaspora"
 CONF_LANGUAGE = "language"
 CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
@@ -16,18 +11,3 @@ DEFAULT_HAVDALAH_OFFSET_MINUTES = 0
 DEFAULT_LANGUAGE = "english"
 
 DOMAIN = "jewish_calendar"
-
-DATA_SCHEMA = {
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-    vol.Optional(CONF_DIASPORA, default=DEFAULT_DIASPORA): bool,
-    vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
-        ["hebrew", "english"]
-    ),
-    vol.Optional(CONF_CANDLE_LIGHT_MINUTES, default=DEFAULT_CANDLE_LIGHT): int,
-    # Default of 0 means use 8.5 degrees / 'three_stars' time.
-    vol.Optional(
-        CONF_HAVDALAH_OFFSET_MINUTES, default=DEFAULT_HAVDALAH_OFFSET_MINUTES
-    ): int,
-    vol.Optional(CONF_LATITUDE): cv.latitude,
-    vol.Optional(CONF_LONGITUDE): cv.longitude,
-}

--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -8,5 +8,6 @@
   "dependencies": [],
   "codeowners": [
     "@tsvi"
-  ]
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -13,11 +13,8 @@ from . import DOMAIN, SENSOR_TYPES
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Jewish calendar sensor platform."""
-    if discovery_info is None:
-        return
-
     sensors = [
         JewishCalendarSensor(hass.data[DOMAIN], sensor, sensor_info)
         for sensor, sensor_info in SENSOR_TYPES["data"].items()

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -1,4 +1,4 @@
-"""Platform to retrieve Jewish calendar information for Home Assistant."""
+"""Support for Jewish calendar sensors."""
 import logging
 
 import hdate

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -16,11 +16,15 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Jewish calendar sensor platform."""
     sensors = [
-        JewishCalendarSensor(hass.data[DOMAIN], sensor, sensor_info)
+        JewishCalendarSensor(
+            hass.data[DOMAIN][config_entry.entry_id], sensor, sensor_info
+        )
         for sensor, sensor_info in SENSOR_TYPES["data"].items()
     ]
     sensors.extend(
-        JewishCalendarTimeSensor(hass.data[DOMAIN], sensor, sensor_info)
+        JewishCalendarTimeSensor(
+            hass.data[DOMAIN][config_entry.entry_id], sensor, sensor_info
+        )
         for sensor, sensor_info in SENSOR_TYPES["time"].items()
     )
 

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -1,17 +1,17 @@
 {
   "config": {
-    "title": "Jewish calendar",
+    "title": "Jewish Calendar",
     "step": {
       "user": {
         "title": "Jewish Calendar settings",
         "data": {
-          "name": "The name to be used for the sensors",
-          "diaspora": "Is location outside of Israel",
-          "language": "Show holidays and dates in english (latin) or hebrew",
-          "candle_lighting_minutes_before_sunset": "Number of minutes before sunset for candle lighthing",
-          "havdalah_minutes_after_sunset": "Number of minutes after sunset for havdalah (0 - use the time for Tzet Hakochavim)",
-          "latitude": "Override the default latitude value set by Home Assistant",
-          "longitude": "Override the default longitude value set by Home Assistant"
+          "name": "Name to be used for sensors",
+          "diaspora": "Outside of Israel",
+          "language": "Language for holidays and dates",
+          "candle_lighting_minutes_before_sunset": "Minutes before sunset for candle lighthing",
+          "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah",
+          "latitude": "Override default latitude",
+          "longitude": "Override default longitude"
         }
       }
     },

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -8,17 +8,26 @@
           "name": "Name to be used for sensors",
           "diaspora": "Outside of Israel",
           "language": "Language for holidays and dates",
+        }
+    },
+    "error": {
+      "name_exists": "Name already exists",
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure options for Jewish Calendar",
+        "data": {
           "candle_lighting_minutes_before_sunset": "Minutes before sunset for candle lighthing",
           "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah",
           "latitude": "Override default latitude",
           "longitude": "Override default longitude"
         }
       }
-    },
-    "error": {
-    },
-    "abort": {
-      "already_configured": "Device is already configured"
     }
   }
 }

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -3,16 +3,19 @@
     "title": "Jewish calendar",
     "step": {
       "user": {
-        "title": "Connect to the device",
+        "title": "Jewish Calendar settings",
         "data": {
-          "host": "Host"
+          "name": "The name to be used for the sensors",
+          "diaspora": "Is location outside of Israel",
+          "language": "Show holidays and dates in english (latin) or hebrew",
+          "candle_lighting_minutes_before_sunset": "Number of minutes before sunset for candle lighthing",
+          "havdalah_minutes_after_sunset": "Number of minutes after sunset for havdalah (0 - use the time for Tzet Hakochavim)",
+          "latitude": "Override the default latitude value set by Home Assistant",
+          "longitude": "Override the default longitude value set by Home Assistant"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect, please try again",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
     },
     "abort": {
       "already_configured": "Device is already configured"

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "title": "Jewish calendar",
+    "step": {
+      "user": {
+        "title": "Connect to the device",
+        "data": {
+          "host": "Host"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  }
+}

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -7,11 +7,12 @@
         "data": {
           "name": "Name to be used for sensors",
           "diaspora": "Outside of Israel",
-          "language": "Language for holidays and dates",
+          "language": "Language for holidays and dates"
         }
+      }
     },
     "error": {
-      "name_exists": "Name already exists",
+      "name_exists": "Name already exists"
     },
     "abort": {
       "already_configured": "Device is already configured"

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -7,7 +7,11 @@
         "data": {
           "name": "Name to be used for sensors",
           "diaspora": "Outside of Israel",
-          "language": "Language for holidays and dates"
+          "language": "Language for holidays and dates",
+          "latitude": "Override default latitude",
+          "longitude": "Override default longitude",
+          "elevation": "Override default elevation",
+          "time_zone": "Override default time zone"
         }
       }
     },
@@ -24,9 +28,7 @@
         "title": "Configure options for Jewish Calendar",
         "data": {
           "candle_lighting_minutes_before_sunset": "Minutes before sunset for candle lighthing",
-          "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah",
-          "latitude": "Override default latitude",
-          "longitude": "Override default longitude"
+          "havdalah_minutes_after_sunset": "Minutes after sunset for havdalah"
         }
       }
     }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -38,6 +38,7 @@ FLOWS = [
     "ipma",
     "iqvia",
     "izone",
+    "jewish_calendar",
     "life360",
     "lifx",
     "linky",

--- a/tests/components/jewish_calendar/__init__.py
+++ b/tests/components/jewish_calendar/__init__.py
@@ -31,7 +31,7 @@ def make_nyc_test_params(dtime, results, havdalah_offset=0):
         }
     return (
         dtime,
-        jcal_const.CANDLE_LIGHT_DEFAULT,
+        jcal_const.DEFAULT_CANDLE_LIGHT,
         havdalah_offset,
         True,
         "America/New_York",
@@ -51,7 +51,7 @@ def make_jerusalem_test_params(dtime, results, havdalah_offset=0):
         }
     return (
         dtime,
-        jcal_const.CANDLE_LIGHT_DEFAULT,
+        jcal_const.DEFAULT_CANDLE_LIGHT,
         havdalah_offset,
         False,
         "Asia/Jerusalem",

--- a/tests/components/jewish_calendar/__init__.py
+++ b/tests/components/jewish_calendar/__init__.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 from unittest.mock import patch
 
-from homeassistant.components import jewish_calendar
+import homeassistant.components.jewish_calendar.const as jcal_const
 import homeassistant.util.dt as dt_util
 
 
@@ -31,7 +31,7 @@ def make_nyc_test_params(dtime, results, havdalah_offset=0):
         }
     return (
         dtime,
-        jewish_calendar.CANDLE_LIGHT_DEFAULT,
+        jcal_const.CANDLE_LIGHT_DEFAULT,
         havdalah_offset,
         True,
         "America/New_York",
@@ -51,7 +51,7 @@ def make_jerusalem_test_params(dtime, results, havdalah_offset=0):
         }
     return (
         dtime,
-        jewish_calendar.CANDLE_LIGHT_DEFAULT,
+        jcal_const.CANDLE_LIGHT_DEFAULT,
         havdalah_offset,
         False,
         "Asia/Jerusalem",

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -17,9 +17,6 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.jewish_calendar.config_flow.validate_input",
-        return_value=mock_coro({"title": "Test Title"}),
-    ), patch(
         "homeassistant.components.jewish_calendar.async_setup",
         return_value=mock_coro(True),
     ) as mock_setup, patch(

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -25,19 +25,19 @@ async def test_form(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
+            {"name": "JCalendar", "diaspora": True, "language": "hebrew"},
         )
 
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "Test Title"
+    assert result2["title"] == "JCalendar"
     assert result2["data"] == {
-        "host": "1.1.1.1",
-        "username": "test-username",
-        "password": "test-password",
+        "name": "JCalendar",
+        "diaspora": True,
+        "language": "hebrew",
+        "candle_lighting_minutes_before_sunset": 18,
+        "havdalah_minutes_after_sunset": 0,
+        "latitude": 32.87336,
+        "longitude": -117.22743,
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -43,10 +43,6 @@ async def test_step_user(hass):
         "name": "JCalendar",
         "diaspora": True,
         "language": "hebrew",
-        "candle_lighting_minutes_before_sunset": 18,
-        "havdalah_minutes_after_sunset": 0,
-        "latitude": 32.87336,
-        "longitude": -117.22743,
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -94,8 +90,6 @@ async def test_step_import_with_options(hass):
     assert result["title"] == "test"
     assert result["data"] == {
         CONF_NAME: "test",
-        CONF_LANGUAGE: "english",
-        CONF_DIASPORA: False,
         CONF_CANDLE_LIGHT_MINUTES: 20,
         CONF_HAVDALAH_OFFSET_MINUTES: 50,
         CONF_LATITUDE: 31.76,

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -8,8 +8,6 @@ from homeassistant.components.jewish_calendar.const import (
     CONF_LANGUAGE,
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_HAVDALAH_OFFSET_MINUTES,
-    DEFAULT_CANDLE_LIGHT,
-    DEFAULT_HAVDALAH_OFFSET_MINUTES,
     DOMAIN,
 )
 from homeassistant.components.jewish_calendar import config_flow
@@ -57,7 +55,7 @@ async def test_step_user(hass):
 
 @pytest.mark.parametrize("diaspora", [True, False])
 @pytest.mark.parametrize("language", ["hebrew", "english"])
-async def test_step_import(hass, language, diaspora):
+async def test_step_import_no_options(hass, language, diaspora):
     """Test that the import step works."""
     conf = {
         DOMAIN: {CONF_NAME: "test", CONF_LANGUAGE: language, CONF_DIASPORA: diaspora}
@@ -73,8 +71,33 @@ async def test_step_import(hass, language, diaspora):
         CONF_NAME: "test",
         CONF_LANGUAGE: language,
         CONF_DIASPORA: diaspora,
-        CONF_CANDLE_LIGHT_MINUTES: DEFAULT_CANDLE_LIGHT,
-        CONF_HAVDALAH_OFFSET_MINUTES: DEFAULT_HAVDALAH_OFFSET_MINUTES,
-        CONF_LATITUDE: 32.87336,
-        CONF_LONGITUDE: -117.22743,
+    }
+
+
+async def test_step_import_with_options(hass):
+    """Test that the import step works."""
+    conf = {
+        DOMAIN: {
+            CONF_NAME: "test",
+            CONF_CANDLE_LIGHT_MINUTES: 20,
+            CONF_HAVDALAH_OFFSET_MINUTES: 50,
+            CONF_LATITUDE: 31.76,
+            CONF_LONGITUDE: 35.235,
+        }
+    }
+
+    flow = config_flow.JewishCalendarConfigFlow()
+    flow.hass = hass
+
+    result = await flow.async_step_import(import_config=conf[DOMAIN])
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "test"
+    assert result["data"] == {
+        CONF_NAME: "test",
+        CONF_LANGUAGE: "english",
+        CONF_DIASPORA: False,
+        CONF_CANDLE_LIGHT_MINUTES: 20,
+        CONF_HAVDALAH_OFFSET_MINUTES: 50,
+        CONF_LATITUDE: 31.76,
+        CONF_LONGITUDE: 35.235,
     }

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -1,0 +1,97 @@
+"""Test the Jewish calendar config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.jewish_calendar.const import DOMAIN
+from homeassistant.components.jewish_calendar.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+)
+
+from tests.common import mock_coro
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.jewish_calendar.config_flow.validate_input",
+        return_value=mock_coro({"title": "Test Title"}),
+    ), patch(
+        "homeassistant.components.jewish_calendar.async_setup",
+        return_value=mock_coro(True),
+    ) as mock_setup, patch(
+        "homeassistant.components.jewish_calendar.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Test Title"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.jewish_calendar.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.jewish_calendar.config_flow.validate_input",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -3,10 +3,6 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, setup
 from homeassistant.components.jewish_calendar.const import DOMAIN
-from homeassistant.components.jewish_calendar.config_flow import (
-    CannotConnect,
-    InvalidAuth,
-)
 
 from tests.common import mock_coro
 
@@ -49,49 +45,3 @@ async def test_form(hass):
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_invalid_auth(hass):
-    """Test we handle invalid auth."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.jewish_calendar.config_flow.validate_input",
-        side_effect=InvalidAuth,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "invalid_auth"}
-
-
-async def test_form_cannot_connect(hass):
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.jewish_calendar.config_flow.validate_input",
-        side_effect=CannotConnect,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Moving the Jewish calendar to config flow and adding support for multiple entries (this might be interesting to support times for different locations)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11176

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
