### PR TITLE
Add support for Somfy Garage door Rollixo IO DiscreteGarageOpenerIOComponent in Tahoma component

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -47,6 +47,7 @@ TAHOMA_TYPES = {
     "io:VerticalExteriorAwningIOComponent": "cover",
     "io:WindowOpenerVeluxIOComponent": "cover",
     "io:GarageOpenerIOComponent": "cover",
+    "io:DiscreteGarageOpenerIOComponent": "cover",
     "rtds:RTDSContactSensor": "sensor",
     "rtds:RTDSMotionSensor": "sensor",
     "rtds:RTDSSmokeSensor": "smoke",

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -37,6 +37,7 @@ TAHOMA_DEVICE_CLASSES = {
     "io:VerticalExteriorAwningIOComponent": DEVICE_CLASS_AWNING,
     "io:WindowOpenerVeluxIOComponent": DEVICE_CLASS_WINDOW,
     "io:GarageOpenerIOComponent": DEVICE_CLASS_GARAGE,
+    "io:DiscreteGarageOpenerIOComponent": DEVICE_CLASS_GARAGE,
     "rts:BlindRTSComponent": DEVICE_CLASS_BLIND,
     "rts:CurtainRTSComponent": DEVICE_CLASS_CURTAIN,
     "rts:DualCurtainRTSComponent": DEVICE_CLASS_CURTAIN,


### PR DESCRIPTION
Add support for Somfy Garage door Rollixo IO DiscreteGarageOpenerIOComponent in Tahoma component.

## Description:
This is a fix for an issue I filed about my Somfy Garage door Rollixo IO not showing up in Home Assistant with the Tahoma integrations.
Adding two lines of code allow the garage door to be seen by Home Assistant's Tahoma component.

**Related issue:** fixes #27801



## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. 
*There are no existing tests for the Tahoma component*
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

