### PR TITLE
Refactor the ecobee integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -177,7 +177,6 @@ omit =
     homeassistant/components/ecoal_boiler/*
     homeassistant/components/ecobee/__init__.py
     homeassistant/components/ecobee/binary_sensor.py
-    homeassistant/components/ecobee/climate.py
     homeassistant/components/ecobee/notify.py
     homeassistant/components/ecobee/sensor.py
     homeassistant/components/ecobee/weather.py

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -106,19 +106,14 @@ class EcobeeData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def update(self):
         """Get the latest data from ecobee.com."""
-        try:
-            _LOGGER.debug("Updating ecobee")
-            await self._hass.async_add_executor_job(self.ecobee.update)
-        except ExpiredTokenError:
-            _LOGGER.warning(
-                "Ecobee update failed; attempting to refresh expired tokens"
-            )
-            await self.refresh()
+        _LOGGER.debug("Updating ecobee")
+        if not await self.request(self.ecobee.update):
+            _LOGGER.error("Ecobee update failed")
 
     async def refresh(self) -> bool:
         """Refresh ecobee tokens and update config entry."""
         _LOGGER.debug("Refreshing ecobee tokens and updating config entry")
-        if await self._hass.async_add_executor_job(self.ecobee.refresh_tokens):
+        if await self.request(self.ecobee.refresh_tokens):
             self._hass.config_entries.async_update_entry(
                 self._entry,
                 data={

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -2,15 +2,15 @@
 import asyncio
 from datetime import timedelta
 import functools
-import voluptuous as vol
 
 from pyecobee import (
-    Ecobee,
     ECOBEE_API_KEY,
     ECOBEE_REFRESH_TOKEN,
+    Ecobee,
     ExpiredTokenError,
     InvalidTokenError,
 )
+import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_API_KEY

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -131,7 +131,7 @@ class EcobeeData:
         try:
             return await self._hass.async_add_executor_job(req)
         except ExpiredTokenError:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ecobee request failed due to expired token; refreshing and retrying"
             )
             if await self.refresh():

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -67,9 +67,7 @@ async def async_setup_entry(hass, entry):
         if not await data.refresh():
             return False
     except InvalidTokenError:
-        hass.components.persistent_notification.async_create(
-            ECOBEE_INVALID_TOKEN_MESSAGE, title=DOMAIN
-        )
+        _LOGGER.error(ECOBEE_INVALID_TOKEN_MESSAGE)
         return False
 
     await data.update()
@@ -141,9 +139,6 @@ class EcobeeData:
             )
         except InvalidTokenError:
             _LOGGER.error(ECOBEE_INVALID_TOKEN_MESSAGE)
-            self._hass.components.persistent_notification.async_create(
-                ECOBEE_INVALID_TOKEN_MESSAGE, title=DOMAIN
-            )
 
 
 async def async_unload_entry(hass, config_entry):

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -70,9 +70,7 @@ class EcobeeBinarySensor(BinarySensorDevice):
                 thermostat = self.data.ecobee.get_thermostat(self.index)
                 identifier = thermostat["identifier"]
                 try:
-                    model = (
-                        f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
-                    )
+                    model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]}"
                 except KeyError:
                     _LOGGER.error(
                         "Model number for ecobee thermostat %s not recognized. "

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -1,10 +1,12 @@
 """Support for Ecobee binary sensors."""
+from pyecobee.const import ECOBEE_MODEL_TO_NAME
+
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OCCUPANCY,
     BinarySensorDevice,
 )
 
-from .const import _LOGGER, DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER
+from .const import _LOGGER, DOMAIN, MANUFACTURER
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -669,7 +669,7 @@ class Thermostat(ClimateDevice):
     async def resume_program(self, resume_all: bool = False):
         """Resume the scheduled thermostat program."""
         _LOGGER.debug(
-            "Resuming the program on thermostat %s with resume_all %",
+            "Resuming the program on thermostat %s with resume_all %s",
             self.name,
             resume_all,
         )

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -308,9 +308,7 @@ class Thermostat(ClimateDevice):
     def device_info(self):
         """Return device information for the thermostat."""
         try:
-            model = (
-                f"{ECOBEE_MODEL_TO_NAME[self._thermostat['modelNumber']]} Thermostat"
-            )
+            model = f"{ECOBEE_MODEL_TO_NAME[self._thermostat['modelNumber']]}"
         except KeyError:
             _LOGGER.error(
                 "Model number for ecobee thermostat %s not recognized. "

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -1,6 +1,7 @@
 """Support for ecobee thermostats."""
 import collections
 
+from pyecobee.const import ECOBEE_MODEL_TO_NAME
 import voluptuous as vol
 
 from homeassistant.components.climate import ClimateDevice
@@ -36,28 +37,27 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.temperature import convert
 
-from .const import _LOGGER, DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER
+from .const import (
+    _LOGGER,
+    ATTR_COOL_TEMP,
+    ATTR_END_DATE,
+    ATTR_END_TIME,
+    ATTR_FAN_MIN_ON_TIME,
+    ATTR_FAN_MODE,
+    ATTR_HEAT_TEMP,
+    ATTR_RESUME_ALL,
+    ATTR_START_DATE,
+    ATTR_START_TIME,
+    ATTR_VACATION_NAME,
+    DEFAULT_RESUME_ALL,
+    DOMAIN,
+    MANUFACTURER,
+    PRESET_HOLD_INDEFINITE,
+    PRESET_HOLD_NEXT_TRANSITION,
+    PRESET_TEMPERATURE,
+    PRESET_VACATION,
+)
 from .util import ecobee_date, ecobee_time
-
-ATTR_COOL_TEMP = "cool_temp"
-ATTR_END_DATE = "end_date"
-ATTR_END_TIME = "end_time"
-ATTR_FAN_MIN_ON_TIME = "fan_min_on_time"
-ATTR_FAN_MODE = "fan_mode"
-ATTR_HEAT_TEMP = "heat_temp"
-ATTR_RESUME_ALL = "resume_all"
-ATTR_START_DATE = "start_date"
-ATTR_START_TIME = "start_time"
-ATTR_VACATION_NAME = "vacation_name"
-
-DEFAULT_RESUME_ALL = False
-PRESET_TEMPERATURE = "temp"
-PRESET_VACATION = "vacation"
-PRESET_HOLD_NEXT_TRANSITION = "next_transition"
-PRESET_HOLD_INDEFINITE = "indefinite"
-AWAY_MODE = "awayMode"
-PRESET_HOME = "home"
-PRESET_SLEEP = "sleep"
 
 # Order matters, because for reverse mapping we don't want to map HEAT to AUX
 ECOBEE_HVAC_TO_HASS = collections.OrderedDict(

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -617,15 +617,15 @@ class Thermostat(ClimateDevice):
         heat_temp_setpoint = (
             heat_temp
             if heat_temp is not None
-            else self._thermostat["runtime"]["desiredCool"] / 10.0
+            else self._thermostat["runtime"]["desiredHeat"] / 10.0
         )
 
         _LOGGER.debug(
             "Setting hold temperature on thermostat %s to "
             "heat_temp: %s, cool_temp: %s",
             self.name,
-            heat_temp_setpoint,
             cool_temp_setpoint,
+            heat_temp_setpoint,
         )
         await self._data.request(
             self._data.ecobee.set_hold_temp,

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -267,7 +267,7 @@ class Thermostat(ClimateDevice):
 
     def _create_operation_modes(self) -> list:
         """Create the operation modes for the thermostat; called in init."""
-        operation_modes = list()
+        operation_modes = []
         if self._thermostat["settings"]["heatStages"]:
             operation_modes.append(HVAC_MODE_HEAT)
         if self._thermostat["settings"]["coolStages"]:
@@ -279,7 +279,7 @@ class Thermostat(ClimateDevice):
 
     def _create_preset_modes(self) -> dict:
         """Create the preset modes for the thermostat; called in init."""
-        preset_modes = dict()
+        preset_modes = {}
         for comfort in self._thermostat["program"]["climates"]:
             preset_modes[comfort["climateRef"]] = comfort["name"]
         return preset_modes

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -1,4 +1,4 @@
-"""Support for Ecobee Thermostats."""
+"""Support for ecobee thermostats."""
 import collections
 
 import voluptuous as vol
@@ -28,9 +28,8 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    STATE_ON,
-    STATE_OFF,
     ATTR_TEMPERATURE,
+    STATE_OFF,
     STATE_ON,
     TEMP_FAHRENHEIT,
 )

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -9,24 +9,26 @@ DATA_ECOBEE_CONFIG = "ecobee_config"
 CONF_INDEX = "index"
 CONF_REFRESH_TOKEN = "refresh_token"
 
+ATTR_COOL_TEMP = "cool_temp"
+ATTR_END_DATE = "end_date"
+ATTR_END_TIME = "end_time"
+ATTR_FAN_MIN_ON_TIME = "fan_min_on_time"
+ATTR_FAN_MODE = "fan_mode"
+ATTR_HEAT_TEMP = "heat_temp"
+ATTR_RESUME_ALL = "resume_all"
+ATTR_START_DATE = "start_date"
+ATTR_START_TIME = "start_time"
+ATTR_VACATION_NAME = "vacation_name"
+DEFAULT_RESUME_ALL = False
+PRESET_HOLD_NEXT_TRANSITION = "next_transition"
+PRESET_HOLD_INDEFINITE = "indefinite"
+PRESET_TEMPERATURE = "temp"
+PRESET_VACATION = "vacation"
+
 ECOBEE_INVALID_TOKEN_MESSAGE = (
     "Your ecobee credentials have expired; "
     "please remove and re-add the integration to re-authenticate"
 )
-
-ECOBEE_MODEL_TO_NAME = {
-    "idtSmart": "ecobee Smart",
-    "idtEms": "ecobee Smart EMS",
-    "siSmart": "ecobee Si Smart",
-    "siEms": "ecobee Si EMS",
-    "athenaSmart": "ecobee3 Smart",
-    "athenaEms": "ecobee3 EMS",
-    "corSmart": "Carrier/Bryant Cor",
-    "nikeSmart": "ecobee3 lite Smart",
-    "nikeEms": "ecobee3 lite EMS",
-    "apolloSmart": "ecobee4 Smart",
-    "vulcanSmart": "ecobee4 Smart",
-}
 
 ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]
 

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -9,6 +9,11 @@ DATA_ECOBEE_CONFIG = "ecobee_config"
 CONF_INDEX = "index"
 CONF_REFRESH_TOKEN = "refresh_token"
 
+ECOBEE_INVALID_TOKEN_MESSAGE = (
+    "Your ecobee credentials have expired; "
+    "please remove and re-add the integration to re-authenticate"
+)
+
 ECOBEE_MODEL_TO_NAME = {
     "idtSmart": "ecobee Smart",
     "idtEms": "ecobee Smart EMS",

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -4,6 +4,6 @@
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/integrations/ecobee",
     "dependencies": [],
-    "requirements": ["python-ecobee-api==0.2.0"],
+    "requirements": ["python-ecobee-api==0.2.1"],
     "codeowners": ["@marthoc"]
 }

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -1,9 +1,9 @@
 {
-  "domain": "ecobee",
-  "name": "Ecobee",
-  "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/ecobee",
-  "dependencies": [],
-  "requirements": ["python-ecobee-api==0.1.4"],
-  "codeowners": ["@marthoc"]
+    "domain": "ecobee",
+    "name": "Ecobee",
+    "config_flow": true,
+    "documentation": "https://www.home-assistant.io/integrations/ecobee",
+    "dependencies": [],
+    "requirements": ["python-ecobee-api==0.2.0"],
+    "codeowners": ["@marthoc"]
 }

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -1,5 +1,10 @@
 """Support for Ecobee sensors."""
-from pyecobee.const import ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN
+from pyecobee.const import (
+    ECOBEE_MODEL_TO_NAME,
+    ECOBEE_STATE_CALIBRATING,
+    ECOBEE_STATE_UNKNOWN,
+    ECOBEE_VALUE_UNKNOWN,
+)
 
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
@@ -8,7 +13,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity import Entity
 
-from .const import _LOGGER, DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER
+from .const import _LOGGER, DOMAIN, MANUFACTURER
 
 SENSOR_TYPES = {
     "temperature": ["Temperature", TEMP_FAHRENHEIT],
@@ -112,7 +117,11 @@ class EcobeeSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self._state in [ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN, "unknown"]:
+        if self._state in [
+            ECOBEE_STATE_CALIBRATING,
+            ECOBEE_STATE_UNKNOWN,
+            ECOBEE_VALUE_UNKNOWN,
+        ]:
             return None
 
         if self.type == "temperature":

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -84,9 +84,7 @@ class EcobeeSensor(Entity):
                 thermostat = self.data.ecobee.get_thermostat(self.index)
                 identifier = thermostat["identifier"]
                 try:
-                    model = (
-                        f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
-                    )
+                    model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]}"
                 except KeyError:
                     _LOGGER.error(
                         "Model number for ecobee thermostat %s not recognized. "

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -67,7 +67,7 @@ class EcobeeWeather(WeatherEntity):
         """Return device information for the ecobee weather platform."""
         thermostat = self.data.ecobee.get_thermostat(self._index)
         try:
-            model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
+            model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]}"
         except KeyError:
             _LOGGER.error(
                 "Model number for ecobee thermostat %s not recognized. "

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -1,7 +1,7 @@
 """Support for displaying weather info from Ecobee API."""
 from datetime import datetime
 
-from pyecobee.const import ECOBEE_STATE_UNKNOWN
+from pyecobee.const import ECOBEE_MODEL_TO_NAME, ECOBEE_STATE_UNKNOWN
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
@@ -14,13 +14,7 @@ from homeassistant.components.weather import (
 )
 from homeassistant.const import TEMP_FAHRENHEIT
 
-from .const import (
-    _LOGGER,
-    DOMAIN,
-    ECOBEE_MODEL_TO_NAME,
-    ECOBEE_WEATHER_SYMBOL_TO_HASS,
-    MANUFACTURER,
-)
+from .const import _LOGGER, DOMAIN, ECOBEE_WEATHER_SYMBOL_TO_HASS, MANUFACTURER
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1554,7 +1554,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.2.0
+python-ecobee-api==0.2.1
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1554,7 +1554,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.4
+python-ecobee-api==0.2.0
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -525,7 +525,7 @@ pysonos==0.0.24
 pyspcwebgw==0.4.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.2.0
+python-ecobee-api==0.2.1
 
 # homeassistant.components.darksky
 python-forecastio==1.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -525,7 +525,7 @@ pysonos==0.0.24
 pyspcwebgw==0.4.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.4
+python-ecobee-api==0.2.0
 
 # homeassistant.components.darksky
 python-forecastio==1.4.0

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -1,288 +1,585 @@
-"""The test for the Ecobee thermostat module."""
-import unittest
-from unittest import mock
+"""Tests for the ecobee climate module."""
+from unittest.mock import Mock
 
-from homeassistant.components.ecobee import climate as ecobee
-import homeassistant.const as const
-from homeassistant.const import STATE_OFF
+from asynctest import CoroutineMock, patch
+import pyecobee
+from pyecobee.const import ECOBEE_MODEL_TO_NAME
+import pytest
 
+from homeassistant.components import climate, ecobee
+from homeassistant.components.ecobee.climate import Thermostat
+from homeassistant.const import STATE_OFF, STATE_ON, TEMP_FAHRENHEIT
 
-class TestEcobee(unittest.TestCase):
-    """Tests for Ecobee climate."""
+from tests.common import MockConfigEntry
 
-    def setUp(self):
-        """Set up test variables."""
-        vals = {
-            "name": "Ecobee",
-            "program": {
-                "climates": [
-                    {"name": "Climate1", "climateRef": "c1"},
-                    {"name": "Climate2", "climateRef": "c2"},
-                ],
-                "currentClimateRef": "c1",
+MOCK_API_RESPONSE = [
+    {
+        "identifier": "test-identifier-1",
+        "name": "Test Thermostat 1",
+        "modelNumber": "athenaSmart",
+        "settings": {
+            "hvacMode": "heat",
+            "coolStages": 1,
+            "heatStages": 2,
+            "fanMinOnTime": 5,
+            "heatCoolMinDelta": 50,
+            "holdAction": "indefinite",
+        },
+        "runtime": {
+            "connected": True,
+            "actualTemperature": 727,
+            "actualHumidity": 35,
+            "desiredHeat": 753,
+            "desiredCool": 734,
+            "desiredFanMode": "auto",
+        },
+        "events": [
+            {"type": "hold", "name": "hold", "running": True, "holdClimateRef": ""},
+            {
+                "type": "template",
+                "name": "_Default_",
+                "running": False,
+                "holdClimateRef": "",
             },
-            "runtime": {
-                "actualTemperature": 300,
-                "actualHumidity": 15,
-                "desiredHeat": 400,
-                "desiredCool": 200,
-                "desiredFanMode": "on",
-            },
-            "settings": {
-                "hvacMode": "auto",
-                "heatStages": 1,
-                "coolStages": 1,
-                "fanMinOnTime": 10,
-                "heatCoolMinDelta": 50,
-                "holdAction": "nextTransition",
-            },
-            "equipmentStatus": "fan",
-            "events": [
-                {
-                    "name": "Event1",
-                    "running": True,
-                    "type": "hold",
-                    "holdClimateRef": "away",
-                    "endDate": "2017-01-01 10:00:00",
-                    "startDate": "2017-02-02 11:00:00",
-                }
+        ],
+        "program": {
+            "climates": [
+                {"name": "Home", "climateRef": "home"},
+                {"name": "Away", "climateRef": "away"},
+                {"name": "Sleep", "climateRef": "sleep"},
             ],
-        }
+            "currentClimateRef": "home",
+        },
+        "equipmentStatus": "auxHeat2,fan",
+    },
+    {
+        "identifier": "test-identifier-2",
+        "name": "Test Thermostat 2",
+        "modelNumber": "badmodel",
+        "settings": {
+            "hvacMode": "auto",
+            "coolStages": 0,
+            "heatStages": 0,
+            "fanMinOnTime": 5,
+            "heatCoolMinDelta": 50,
+            "holdAction": "indefinite",
+        },
+        "runtime": {
+            "connected": True,
+            "actualTemperature": 727,
+            "actualHumidity": 35,
+            "desiredHeat": 753,
+            "desiredCool": 734,
+            "desiredFanMode": "auto",
+        },
+        "events": [
+            {"type": "hold", "name": "hold", "running": False, "holdClimateRef": ""},
+            {
+                "type": "vacation",
+                "name": "test-vacation",
+                "running": True,
+                "holdClimateRef": "",
+            },
+            {
+                "type": "template",
+                "name": "_Default_",
+                "running": False,
+                "holdClimateRef": "",
+            },
+        ],
+        "program": {
+            "climates": [
+                {"name": "Home", "climateRef": "home"},
+                {"name": "Away", "climateRef": "away"},
+                {"name": "Sleep", "climateRef": "sleep"},
+            ],
+            "currentClimateRef": "home",
+        },
+        "equipmentStatus": "auxHeat2",
+    },
+    {
+        "identifier": "test-identifier-3",
+        "name": "Test Thermostat 3",
+        "modelNumber": "athenaSmart",
+        "settings": {
+            "hvacMode": "cool",
+            "coolStages": 0,
+            "heatStages": 0,
+            "fanMinOnTime": 5,
+            "heatCoolMinDelta": 50,
+            "holdAction": "indefinite",
+        },
+        "runtime": {
+            "connected": True,
+            "actualTemperature": 727,
+            "actualHumidity": 35,
+            "desiredHeat": 753,
+            "desiredCool": 734,
+            "desiredFanMode": "auto",
+        },
+        "events": [
+            {"type": "autoAway", "name": "away", "running": True, "holdClimateRef": ""},
+            {
+                "type": "template",
+                "name": "_Default_",
+                "running": False,
+                "holdClimateRef": "",
+            },
+        ],
+        "program": {
+            "climates": [
+                {"name": "Home", "climateRef": "home"},
+                {"name": "Away", "climateRef": "away"},
+                {"name": "Sleep", "climateRef": "sleep"},
+            ],
+            "currentClimateRef": "home",
+        },
+        "equipmentStatus": "",
+    },
+    {
+        "identifier": "test-identifier-4",
+        "name": "Test Thermostat 4",
+        "modelNumber": "athenaSmart",
+        "settings": {
+            "hvacMode": "cool",
+            "coolStages": 0,
+            "heatStages": 0,
+            "fanMinOnTime": 5,
+            "heatCoolMinDelta": 50,
+            "holdAction": "indefinite",
+        },
+        "runtime": {
+            "connected": True,
+            "actualTemperature": 727,
+            "actualHumidity": 35,
+            "desiredHeat": 753,
+            "desiredCool": 734,
+            "desiredFanMode": "auto",
+        },
+        "events": [
+            {"type": "hold", "name": "Home", "running": True, "holdClimateRef": "home"},
+            {
+                "type": "template",
+                "name": "_Default_",
+                "running": False,
+                "holdClimateRef": "",
+            },
+        ],
+        "program": {
+            "climates": [
+                {"name": "Home", "climateRef": "home"},
+                {"name": "Away", "climateRef": "away"},
+                {"name": "Sleep", "climateRef": "sleep"},
+            ],
+            "currentClimateRef": "home",
+        },
+        "equipmentStatus": "humidifier",
+    },
+    {
+        "identifier": "test-identifier-5",
+        "name": "Test Thermostat 5",
+        "modelNumber": "athenaSmart",
+        "settings": {
+            "hvacMode": "cool",
+            "coolStages": 0,
+            "heatStages": 0,
+            "fanMinOnTime": 5,
+            "heatCoolMinDelta": 50,
+            "holdAction": "nextTransition",
+        },
+        "runtime": {
+            "connected": True,
+            "actualTemperature": 727,
+            "actualHumidity": 35,
+            "desiredHeat": 753,
+            "desiredCool": 734,
+            "desiredFanMode": "auto",
+        },
+        "events": [
+            {
+                "type": "sensor",
+                "name": "Living Room",
+                "running": True,
+                "holdClimateRef": "",
+            },
+            {
+                "type": "template",
+                "name": "_Default_",
+                "running": False,
+                "holdClimateRef": "",
+            },
+        ],
+        "program": {
+            "climates": [
+                {"name": "Home", "climateRef": "home"},
+                {"name": "Away", "climateRef": "away"},
+                {"name": "Sleep", "climateRef": "sleep"},
+            ],
+            "currentClimateRef": "sleep",
+        },
+        "equipmentStatus": "auxHeat2,fan",
+    },
+]
 
-        self.ecobee = mock.Mock()
-        self.ecobee.__getitem__ = mock.Mock(side_effect=vals.__getitem__)
-        self.ecobee.__setitem__ = mock.Mock(side_effect=vals.__setitem__)
 
-        self.data = mock.Mock()
-        self.data.ecobee.get_thermostat.return_value = self.ecobee
-        self.thermostat = ecobee.Thermostat(self.data, 1)
+@pytest.fixture
+def mock_account(hass):
+    """Mock an ecobee account object."""
+    account = ecobee.EcobeeData(
+        hass,
+        MockConfigEntry(domain=ecobee.DOMAIN),
+        api_key="dummy",
+        refresh_token="dummy",
+    )
 
-    def test_name(self):
-        """Test name property."""
-        assert "Ecobee" == self.thermostat.name
+    def mock_get_thermostat(index):
+        return account.ecobee.thermostats[index]
 
-    def test_current_temperature(self):
-        """Test current temperature."""
-        assert 30 == self.thermostat.current_temperature
-        self.ecobee["runtime"]["actualTemperature"] = 404
-        assert 40.4 == self.thermostat.current_temperature
+    account.ecobee = Mock(
+        thermostats=MOCK_API_RESPONSE,
+        get_thermostat=mock_get_thermostat,
+        spec=pyecobee.Ecobee,
+    )
 
-    def test_target_temperature_low(self):
-        """Test target low temperature."""
-        assert 40 == self.thermostat.target_temperature_low
-        self.ecobee["runtime"]["desiredHeat"] = 502
-        assert 50.2 == self.thermostat.target_temperature_low
+    return account
 
-    def test_target_temperature_high(self):
-        """Test target high temperature."""
-        assert 20 == self.thermostat.target_temperature_high
-        self.ecobee["runtime"]["desiredCool"] = 103
-        assert 10.3 == self.thermostat.target_temperature_high
 
-    def test_target_temperature(self):
-        """Test target temperature."""
-        assert self.thermostat.target_temperature is None
-        self.ecobee["settings"]["hvacMode"] = "heat"
-        assert 40 == self.thermostat.target_temperature
-        self.ecobee["settings"]["hvacMode"] = "cool"
-        assert 20 == self.thermostat.target_temperature
-        self.ecobee["settings"]["hvacMode"] = "auxHeatOnly"
-        assert 40 == self.thermostat.target_temperature
-        self.ecobee["settings"]["hvacMode"] = "off"
-        assert self.thermostat.target_temperature is None
+async def setup_climate(hass, mock_account):
+    """Load the ecobee climate platform with the mocked account."""
+    hass.config.components.add(ecobee.DOMAIN)
+    hass.data[ecobee.DOMAIN] = mock_account
+    config_entry = MockConfigEntry(domain=ecobee.DOMAIN)
+    await hass.config_entries.async_forward_entry_setup(config_entry, "climate")
 
-    def test_desired_fan_mode(self):
-        """Test desired fan mode property."""
-        assert "on" == self.thermostat.fan_mode
-        self.ecobee["runtime"]["desiredFanMode"] = "auto"
-        assert "auto" == self.thermostat.fan_mode
 
-    def test_fan(self):
-        """Test fan property."""
-        assert const.STATE_ON == self.thermostat.fan
-        self.ecobee["equipmentStatus"] = ""
-        assert STATE_OFF == self.thermostat.fan
-        self.ecobee["equipmentStatus"] = "heatPump, heatPump2"
-        assert STATE_OFF == self.thermostat.fan
+async def test_climate_platform_loads_correctly(hass, mock_account):
+    """Test that the climate platform loads with five climate entities."""
+    await setup_climate(hass, mock_account)
+    assert len(hass.states.async_all()) == 5
+    t_stat_1 = hass.states.get("climate.test_thermostat_1")
+    assert t_stat_1 is not None
+    t_stat_2 = hass.states.get("climate.test_thermostat_2")
+    assert t_stat_2 is not None
+    t_stat_3 = hass.states.get("climate.test_thermostat_3")
+    assert t_stat_3 is not None
+    t_stat_4 = hass.states.get("climate.test_thermostat_4")
+    assert t_stat_4 is not None
+    t_stat_5 = hass.states.get("climate.test_thermostat_5")
+    assert t_stat_5 is not None
 
-    def test_hvac_mode(self):
-        """Test current operation property."""
-        assert "auto" == self.thermostat.hvac_mode
-        self.ecobee["settings"]["hvacMode"] = "heat"
-        assert "heat" == self.thermostat.hvac_mode
-        self.ecobee["settings"]["hvacMode"] = "cool"
-        assert "cool" == self.thermostat.hvac_mode
-        self.ecobee["settings"]["hvacMode"] = "auxHeatOnly"
-        assert "heat" == self.thermostat.hvac_mode
-        self.ecobee["settings"]["hvacMode"] = "off"
-        assert "off" == self.thermostat.hvac_mode
 
-    def test_hvac_modes(self):
-        """Test operation list property."""
-        assert ["auto", "heat", "cool", "off"] == self.thermostat.hvac_modes
+async def test_simple_properties(mock_account):
+    """Test that a climate entity returns expected values for simple properties."""
+    t_stat = Thermostat(mock_account, 0)
+    assert t_stat.available is True
+    assert t_stat.supported_features == ecobee.climate.SUPPORT_FLAGS
+    assert t_stat.name == "Test Thermostat 1"
+    assert t_stat.unique_id == "test-identifier-1"
+    assert t_stat.temperature_unit == TEMP_FAHRENHEIT
+    assert t_stat.current_temperature == 72.7
+    assert t_stat.fan_mode == "auto"
+    assert t_stat.fan_modes == [climate.const.FAN_AUTO, climate.const.FAN_ON]
+    assert t_stat.preset_modes == ["Home", "Away", "Sleep"]
+    assert t_stat.hvac_mode == "heat"
+    assert t_stat.current_humidity == 35
+    assert t_stat.device_state_attributes == {
+        "fan": STATE_ON,
+        "climate_mode": "Home",
+        "equipment_running": "auxHeat2,fan",
+        "fan_min_on_time": 5,
+    }
+    assert t_stat.is_aux_heat is True
 
-    def test_hvac_mode2(self):
-        """Test operation mode property."""
-        assert "auto" == self.thermostat.hvac_mode
-        self.ecobee["settings"]["hvacMode"] = "heat"
-        assert "heat" == self.thermostat.hvac_mode
 
-    def test_device_state_attributes(self):
-        """Test device state attributes property."""
-        self.ecobee["equipmentStatus"] = "heatPump2"
-        assert {
-            "fan": "off",
-            "climate_mode": "Climate1",
-            "fan_min_on_time": 10,
-            "equipment_running": "heatPump2",
-        } == self.thermostat.device_state_attributes
+async def test_device_info_property(mock_account):
+    """Test the device_info property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.device_info == {
+        "identifiers": {("ecobee", "test-identifier-1")},
+        "name": "Test Thermostat 1",
+        "manufacturer": "ecobee",
+        "model": ECOBEE_MODEL_TO_NAME["athenaSmart"],
+    }
+    t_stat_2 = Thermostat(mock_account, 1)
+    assert t_stat_2.device_info is None
 
-        self.ecobee["equipmentStatus"] = "auxHeat2"
-        assert {
-            "fan": "off",
-            "climate_mode": "Climate1",
-            "fan_min_on_time": 10,
-            "equipment_running": "auxHeat2",
-        } == self.thermostat.device_state_attributes
-        self.ecobee["equipmentStatus"] = "compCool1"
-        assert {
-            "fan": "off",
-            "climate_mode": "Climate1",
-            "fan_min_on_time": 10,
-            "equipment_running": "compCool1",
-        } == self.thermostat.device_state_attributes
-        self.ecobee["equipmentStatus"] = ""
-        assert {
-            "fan": "off",
-            "climate_mode": "Climate1",
-            "fan_min_on_time": 10,
-            "equipment_running": "",
-        } == self.thermostat.device_state_attributes
 
-        self.ecobee["equipmentStatus"] = "Unknown"
-        assert {
-            "fan": "off",
-            "climate_mode": "Climate1",
-            "fan_min_on_time": 10,
-            "equipment_running": "Unknown",
-        } == self.thermostat.device_state_attributes
+async def test_target_temperature_low_property(mock_account):
+    """Test the target_temperature_low property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.target_temperature_low is None
+    t_stat_2 = Thermostat(mock_account, 1)
+    assert t_stat_2.target_temperature_low == 75.3
 
-        self.ecobee["program"]["currentClimateRef"] = "c2"
-        assert {
-            "fan": "off",
-            "climate_mode": "Climate2",
-            "fan_min_on_time": 10,
-            "equipment_running": "Unknown",
-        } == self.thermostat.device_state_attributes
 
-    def test_is_aux_heat_on(self):
-        """Test aux heat property."""
-        assert not self.thermostat.is_aux_heat
-        self.ecobee["equipmentStatus"] = "fan, auxHeat"
-        assert self.thermostat.is_aux_heat
+async def test_target_temperature_high_property(mock_account):
+    """Test the target_temperature_high property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.target_temperature_high is None
+    t_stat_2 = Thermostat(mock_account, 1)
+    assert t_stat_2.target_temperature_high == 73.4
 
-    def test_set_temperature(self):
-        """Test set temperature."""
-        # Auto -> Auto
-        self.data.reset_mock()
-        self.thermostat.set_temperature(target_temp_low=20, target_temp_high=30)
-        self.data.ecobee.set_hold_temp.assert_has_calls(
-            [mock.call(1, 30, 20, "nextTransition")]
+
+async def test_target_temperature_property(mock_account):
+    """Test the target_temperature property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.target_temperature == 75.3
+    t_stat_2 = Thermostat(mock_account, 2)
+    assert t_stat_2.target_temperature == 73.4
+    t_stat_3 = Thermostat(mock_account, 1)
+    assert t_stat_3.target_temperature is None
+
+
+async def test_fan_property(mock_account):
+    """Test the fan property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.fan == STATE_ON
+    t_stat_2 = Thermostat(mock_account, 1)
+    assert t_stat_2.fan == STATE_OFF
+
+
+async def test_preset_mode_property(mock_account):
+    """Test the preset mode property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.preset_mode == ecobee.const.PRESET_TEMPERATURE
+    t_stat_2 = Thermostat(mock_account, 3)
+    assert t_stat_2.preset_mode == "Home"
+    t_stat_3 = Thermostat(mock_account, 2)
+    assert t_stat_3.preset_mode == "away"
+    t_stat_4 = Thermostat(mock_account, 1)
+    assert t_stat_4.preset_mode == "vacation"
+    t_stat_5 = Thermostat(mock_account, 4)
+    assert t_stat_5.preset_mode == "Sleep"
+
+
+async def test_hvac_modes_property(mock_account):
+    """Test the hvac_modes property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.hvac_modes == [
+        climate.const.HVAC_MODE_AUTO,
+        climate.const.HVAC_MODE_HEAT,
+        climate.const.HVAC_MODE_COOL,
+        climate.const.HVAC_MODE_OFF,
+    ]
+    t_stat_2 = Thermostat(mock_account, 1)
+    assert t_stat_2.hvac_modes == [climate.const.HVAC_MODE_OFF]
+
+
+async def test_hvac_action_property(mock_account):
+    """Test the hvac_action property."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.hvac_action == climate.const.CURRENT_HVAC_HEAT
+
+    t_stat_2 = Thermostat(mock_account, 2)
+    assert t_stat_2.hvac_action == climate.const.CURRENT_HVAC_IDLE
+
+    t_stat_3 = Thermostat(mock_account, 3)
+    assert t_stat_3.hvac_action == climate.const.CURRENT_HVAC_IDLE
+
+
+async def test_set_preset_mode(mock_account):
+    """Test the async_set_preset_mode method."""
+    pass
+
+
+async def test_set_fan_mode(mock_account):
+    """Test the async_set_fan_mode method."""
+    with patch.object(mock_account.ecobee, "set_fan_mode") as mock_method:
+        t_stat = Thermostat(mock_account, 0)
+        await t_stat.async_set_fan_mode("dummy")
+        mock_method.assert_not_called()
+
+        await t_stat.async_set_fan_mode("auto")
+        mock_method.assert_called_with(0, "auto", 73.4, 75.3, "nextTransition")
+
+
+async def test_set_temperature(mock_account):
+    """Test the async_set_temperature method."""
+    pass
+
+
+async def test_set_humidity(mock_account):
+    """Test the async_set_humidity method."""
+    with patch.object(mock_account.ecobee, "set_humidity") as mock_method:
+        t_stat = Thermostat(mock_account, 0)
+
+        await t_stat.async_set_humidity(50)
+        mock_method.assert_called_with(0, 50)
+
+
+async def test_set_hvac_mode(mock_account):
+    """Test the async_set_hvac_mode method."""
+    with patch.object(mock_account.ecobee, "set_hvac_mode") as mock_method:
+        t_stat = Thermostat(mock_account, 0)
+
+        await t_stat.async_set_hvac_mode("dummy")
+        mock_method.assert_not_called()
+
+        await t_stat.async_set_hvac_mode("auto")
+        mock_method.assert_called_with(0, "auto")
+
+
+async def test_turn_on(hass, mock_account):
+    """Test the async_turn_on method."""
+    with patch.object(mock_account.ecobee, "set_hvac_mode") as mock_method:
+        await setup_climate(hass, mock_account)
+
+        await hass.services.async_call(
+            "climate",
+            "turn_on",
+            {"entity_id": "climate.test_thermostat_1"},
+            blocking=True,
+        )
+        mock_method.assert_called_with(0, "heat")
+
+
+async def test_turn_off(hass, mock_account):
+    """Test the async_turn_off method."""
+    with patch.object(mock_account.ecobee, "set_hvac_mode") as mock_method:
+        await setup_climate(hass, mock_account)
+
+        await hass.services.async_call(
+            "climate",
+            "turn_off",
+            {"entity_id": "climate.test_thermostat_1"},
+            blocking=True,
+        )
+        mock_method.assert_called_with(0, "off")
+
+
+async def test_update(mock_account):
+    """Test the async_update method."""
+    with patch.object(
+        mock_account, "update", new_callable=CoroutineMock
+    ) as mock_method:
+        t_stat = Thermostat(mock_account, 0)
+        await t_stat.async_update()
+        mock_method.assert_awaited()
+
+        t_stat._update_without_throttle = True
+        await t_stat.async_update()
+        mock_method.assert_awaited_with(no_throttle=True)
+
+
+async def test_set_auto_temp_hold(mock_account):
+    """Test the set_auto_temp_hold method."""
+    with patch.object(mock_account.ecobee, "set_hold_temp") as mock_method:
+        t_stat = Thermostat(mock_account, 0)
+
+        await t_stat.set_auto_temp_hold(None, None)
+        mock_method.assert_called_with(0, 73.4, 75.3, "nextTransition")
+
+        await t_stat.set_auto_temp_hold(75, 70)
+        mock_method.assert_called_with(0, 70, 75, "nextTransition")
+
+
+async def test_set_temp_hold(mock_account):
+    """Test the set_temp_hold method."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    with patch.object(
+        t_stat_1, "set_auto_temp_hold", new_callable=CoroutineMock
+    ) as mock_method:
+        await t_stat_1.set_temp_hold(75)
+        mock_method.assert_awaited_with(75, 75)
+
+    t_stat_2 = Thermostat(mock_account, 1)
+    with patch.object(
+        t_stat_2, "set_auto_temp_hold", new_callable=CoroutineMock
+    ) as mock_method:
+        await t_stat_2.set_temp_hold(75)
+        mock_method.assert_awaited_with(70, 80)
+
+
+async def test_set_fan_min_on_time(mock_account):
+    """Test the set_fan_min_on_time method."""
+    with patch.object(mock_account.ecobee, "set_fan_min_on_time") as mock_method:
+        t_stat = Thermostat(mock_account, 0)
+
+        await t_stat.set_fan_min_on_time(10)
+        mock_method.assert_called_with(0, 10)
+
+
+async def test_resume_program(mock_account):
+    """Test the resume_program method."""
+    with patch.object(mock_account.ecobee, "resume_program") as mock_method:
+        t_stat = Thermostat(mock_account, 0)
+
+        await t_stat.resume_program()
+        mock_method.assert_called_with(0, "false")
+
+        await t_stat.resume_program(resume_all=True)
+        mock_method.assert_called_with(0, "true")
+
+
+async def test_hold_preference(mock_account):
+    """Test the hold_preference method."""
+    t_stat_1 = Thermostat(mock_account, 0)
+    assert t_stat_1.hold_preference() == "nextTransition"
+
+    t_stat_2 = Thermostat(mock_account, 4)
+    assert t_stat_2.hold_preference() == "nextTransition"
+
+
+async def test_create_vacation(hass, mock_account):
+    """Test the create_vacation service."""
+    with patch.object(mock_account.ecobee, "create_vacation") as mock_method:
+        await setup_climate(hass, mock_account)
+
+        await hass.services.async_call(
+            "ecobee",
+            "create_vacation",
+            {
+                "entity_id": "climate.test_thermostat_1",
+                "vacation_name": "Skiing",
+                "cool_temp": 23,
+                "heat_temp": 25,
+            },
+            blocking=True,
+        )
+        mock_method.assert_called_with(
+            0, "Skiing", 73.4, 77.0, fan_mode="auto", fan_min_on_time=0
         )
 
-        # Auto -> Hold
-        self.data.reset_mock()
-        self.thermostat.set_temperature(temperature=20)
-        self.data.ecobee.set_hold_temp.assert_has_calls(
-            [mock.call(1, 25, 15, "nextTransition")]
+        await hass.services.async_call(
+            "ecobee",
+            "create_vacation",
+            {
+                "entity_id": "climate.test_thermostat_1",
+                "vacation_name": "Beach",
+                "cool_temp": 23,
+                "heat_temp": 25,
+                "start_date": "2019-11-19",
+                "start_time": "08:00:00",
+                "end_date": "2020-02-19",
+                "end_time": "10:00:00",
+                "fan_mode": "on",
+                "fan_min_on_time": 5,
+            },
+            blocking=True,
+        )
+        mock_method.assert_called_with(
+            0,
+            "Beach",
+            73.4,
+            77.0,
+            start_date="2019-11-19",
+            start_time="08:00:00",
+            end_date="2020-02-19",
+            end_time="10:00:00",
+            fan_mode="on",
+            fan_min_on_time=5,
         )
 
-        # Cool -> Hold
-        self.data.reset_mock()
-        self.ecobee["settings"]["hvacMode"] = "cool"
-        self.thermostat.set_temperature(temperature=20.5)
-        self.data.ecobee.set_hold_temp.assert_has_calls(
-            [mock.call(1, 20.5, 20.5, "nextTransition")]
+
+async def test_delete_vacation(hass, mock_account):
+    """Test the delete_vacation service."""
+    with patch.object(mock_account.ecobee, "delete_vacation") as mock_method:
+        await setup_climate(hass, mock_account)
+
+        await hass.services.async_call(
+            "ecobee",
+            "delete_vacation",
+            {"entity_id": "climate.test_thermostat_1", "vacation_name": "Skiing"},
+            blocking=True,
         )
-
-        # Heat -> Hold
-        self.data.reset_mock()
-        self.ecobee["settings"]["hvacMode"] = "heat"
-        self.thermostat.set_temperature(temperature=20)
-        self.data.ecobee.set_hold_temp.assert_has_calls(
-            [mock.call(1, 20, 20, "nextTransition")]
-        )
-
-        # Heat -> Auto
-        self.data.reset_mock()
-        self.ecobee["settings"]["hvacMode"] = "heat"
-        self.thermostat.set_temperature(target_temp_low=20, target_temp_high=30)
-        assert not self.data.ecobee.set_hold_temp.called
-
-    def test_set_hvac_mode(self):
-        """Test operation mode setter."""
-        self.data.reset_mock()
-        self.thermostat.set_hvac_mode("auto")
-        self.data.ecobee.set_hvac_mode.assert_has_calls([mock.call(1, "auto")])
-        self.data.reset_mock()
-        self.thermostat.set_hvac_mode("heat")
-        self.data.ecobee.set_hvac_mode.assert_has_calls([mock.call(1, "heat")])
-
-    def test_set_fan_min_on_time(self):
-        """Test fan min on time setter."""
-        self.data.reset_mock()
-        self.thermostat.set_fan_min_on_time(15)
-        self.data.ecobee.set_fan_min_on_time.assert_has_calls([mock.call(1, 15)])
-        self.data.reset_mock()
-        self.thermostat.set_fan_min_on_time(20)
-        self.data.ecobee.set_fan_min_on_time.assert_has_calls([mock.call(1, 20)])
-
-    def test_resume_program(self):
-        """Test resume program."""
-        # False
-        self.data.reset_mock()
-        self.thermostat.resume_program(False)
-        self.data.ecobee.resume_program.assert_has_calls([mock.call(1, "false")])
-        self.data.reset_mock()
-        self.thermostat.resume_program(None)
-        self.data.ecobee.resume_program.assert_has_calls([mock.call(1, "false")])
-        self.data.reset_mock()
-        self.thermostat.resume_program(0)
-        self.data.ecobee.resume_program.assert_has_calls([mock.call(1, "false")])
-
-        # True
-        self.data.reset_mock()
-        self.thermostat.resume_program(True)
-        self.data.ecobee.resume_program.assert_has_calls([mock.call(1, "true")])
-        self.data.reset_mock()
-        self.thermostat.resume_program(1)
-        self.data.ecobee.resume_program.assert_has_calls([mock.call(1, "true")])
-
-    def test_hold_preference(self):
-        """Test hold preference."""
-        assert "nextTransition" == self.thermostat.hold_preference()
-        for action in [
-            "useEndTime4hour",
-            "useEndTime2hour",
-            "nextPeriod",
-            "indefinite",
-            "askMe",
-        ]:
-            self.ecobee["settings"]["holdAction"] = action
-            assert "nextTransition" == self.thermostat.hold_preference()
-
-    def test_set_fan_mode_on(self):
-        """Test set fan mode to on."""
-        self.data.reset_mock()
-        self.thermostat.set_fan_mode("on")
-        self.data.ecobee.set_fan_mode.assert_has_calls(
-            [mock.call(1, "on", 20, 40, "nextTransition")]
-        )
-
-    def test_set_fan_mode_auto(self):
-        """Test set fan mode to auto."""
-        self.data.reset_mock()
-        self.thermostat.set_fan_mode("auto")
-        self.data.ecobee.set_fan_mode.assert_has_calls(
-            [mock.call(1, "auto", 20, 40, "nextTransition")]
-        )
+        mock_method.assert_called_with(0, "Skiing")


### PR DESCRIPTION
# Description:

This PR refactors the ecobee integration. It looks like a lot is going on, but the major change is the addition of a method to the data object that wraps calls to the API from the climate platform so that token errors generated by these calls can be caught, tokens refreshed, and the calls retried (I've added support for raising these errors from these calls to python-ecobee-api in a recent PR, so this cannot be merged until that PR is merged and a new version of that library is released by @nkgilley). A side effect of this refactor is that it will be straightforaward to convert this integration to async once the underlying library becomes async. Nothing in this PR creates a breaking change and the functionality will be transparent to the end-user.

Retrying failed calls used to be handled in python-ecobee-api, but this has created a (fortunately) uncommon bug in Home Assistant - currently, if a call fails because of expired tokens, the library automatically refreshes and retries. This wasn't a problem when HA used the ecobee.conf file to store configuration, as the new keys would get updated into that file by python-ecobee-api automatically and used on startup by HA. But, now that we have moved to config entries, we need to make sure that the only time the key is refreshed is by HA in the refresh() method, as that method also takes care of updating the config entry with the newly refreshed keys.

The climate platform has also been generally cleaned up to streamline the code and improve readability/maintainability, including the addition of debug logging to the class methods in order to aid resolving issues in the future. Constants have been moved to .const and imported rather than defined in climate.py. API-specific constants have been moved to python-ecobee-api and imported from there.

This PR is also a jumping off point to rewrite and expand tests for the ecobee integration, which I will do in this PR once reviewers are happy with how the refactored code looks.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
