### PR TITLE
Connect rfxtrx to a device over a tcp connection

### DIFF
--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -3,7 +3,7 @@
   "name": "Rfxtrx",
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "requirements": [
-    "pyRFXtrx==0.23"
+    "pyRFXtrx==0.24"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1066,7 +1066,7 @@ pyHS100==0.3.5
 pyMetno==0.4.6
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.23
+pyRFXtrx==0.24
 
 # homeassistant.components.switchmate
 # pySwitchmate==0.4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -364,7 +364,7 @@ pyHS100==0.3.5
 pyMetno==0.4.6
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.23
+pyRFXtrx==0.24
 
 # homeassistant.components.nextbus
 py_nextbusnext==0.1.4


### PR DESCRIPTION
## Breaking Change:

Added ability to connect to rfxtrx over TCP. The previous "device" config needs to be changed to port for local USB connection. If you want to connect to a device via TCP use host and port. See the documentation for more details. 

## Description:

Allow RFXtrx device to be connected to over TCP. Allowing a user to connect the device to another linux host in their house and run ser2net to expose it.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11026

## Example entry for `configuration.yaml` (if applicable):
```yaml
rfxtrx:
  port: PATH_TO_SERIAL_DEVICE
```
OR
```yaml
rfxtrx:
  host: tcp host
  port: tcp port
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
