### PR TITLE
Add soundtouch attributes exposing multiroom zone info

### DIFF
--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -369,7 +369,13 @@ class SoundTouchDevice(MediaPlayerDevice):
             _LOGGER.info(
                 "Removing slaves from zone with master %s", self._device.config.name
             )
-            self._device.remove_zone_slave([slave.device for slave in slaves])
+            # SoundTouch API seems to have a bug and won't remove slaves if there are
+            # more than one in the payload. Therefore we have to loop over all slaves
+            # and remove them individually
+            for slave in slaves:
+                # make sure to not try to remove the master (aka current device)
+                if slave.entity_id != self.entity_id:
+                    self._device.remove_zone_slave([slave.device])
 
     def add_zone_slave(self, slaves):
         """

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -448,7 +448,7 @@ class SoundTouchDevice(MediaPlayerDevice):
         )
 
     def _get_instance_by_ip(self, ip_address):
-        """Search and return a SoundTouchDevice instace by it's IP address."""
+        """Search and return a SoundTouchDevice instance by it's IP address."""
         for instance in self.hass.data[DATA_SOUNDTOUCH]:
             if instance and instance.config["host"] == ip_address:
                 return instance

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -322,8 +322,8 @@ async def test_playing_media(mocked_status, mocked_volume, hass, one_device):
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.state == STATE_PLAYING
@@ -340,8 +340,8 @@ async def test_playing_unknown_media(mocked_status, mocked_volume, hass, one_dev
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.state == STATE_PLAYING
@@ -353,8 +353,8 @@ async def test_playing_radio(mocked_status, mocked_volume, hass, one_device):
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.state == STATE_PLAYING
@@ -367,8 +367,8 @@ async def test_get_volume_level(mocked_status, mocked_volume, hass, one_device):
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.attributes["volume_level"] == 0.12
@@ -380,8 +380,8 @@ async def test_get_state_off(mocked_status, mocked_volume, hass, one_device):
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.state == STATE_OFF
@@ -393,8 +393,8 @@ async def test_get_state_pause(mocked_status, mocked_volume, hass, one_device):
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.state == STATE_PAUSED
@@ -406,8 +406,8 @@ async def test_is_muted(mocked_status, mocked_volume, hass, one_device):
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.attributes["is_volume_muted"]
@@ -418,8 +418,8 @@ async def test_media_commands(mocked_status, mocked_volume, hass, one_device):
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.attributes["supported_features"] == 18365
@@ -433,13 +433,13 @@ async def test_should_turn_off(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player", "turn_off", {"entity_id": "media_player.soundtouch_1"}, True,
     )
-    assert mocked_status.call_count == 2
+    assert mocked_status.call_count == 3
     assert mocked_power_off.call_count == 1
 
 
@@ -452,13 +452,13 @@ async def test_should_turn_on(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player", "turn_on", {"entity_id": "media_player.soundtouch_1"}, True,
     )
-    assert mocked_status.call_count == 2
+    assert mocked_status.call_count == 3
     assert mocked_power_on.call_count == 1
 
 
@@ -470,13 +470,13 @@ async def test_volume_up(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player", "volume_up", {"entity_id": "media_player.soundtouch_1"}, True,
     )
-    assert mocked_volume.call_count == 2
+    assert mocked_volume.call_count == 3
     assert mocked_volume_up.call_count == 1
 
 
@@ -488,13 +488,13 @@ async def test_volume_down(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player", "volume_down", {"entity_id": "media_player.soundtouch_1"}, True,
     )
-    assert mocked_volume.call_count == 2
+    assert mocked_volume.call_count == 3
     assert mocked_volume_down.call_count == 1
 
 
@@ -506,8 +506,8 @@ async def test_set_volume_level(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player",
@@ -515,7 +515,7 @@ async def test_set_volume_level(
         {"entity_id": "media_player.soundtouch_1", "volume_level": 0.17},
         True,
     )
-    assert mocked_volume.call_count == 2
+    assert mocked_volume.call_count == 3
     mocked_set_volume.assert_called_with(17)
 
 
@@ -525,8 +525,8 @@ async def test_mute(mocked_mute, mocked_status, mocked_volume, hass, one_device)
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player",
@@ -534,7 +534,7 @@ async def test_mute(mocked_mute, mocked_status, mocked_volume, hass, one_device)
         {"entity_id": "media_player.soundtouch_1", "is_volume_muted": True},
         True,
     )
-    assert mocked_volume.call_count == 2
+    assert mocked_volume.call_count == 3
     assert mocked_mute.call_count == 1
 
 
@@ -544,13 +544,13 @@ async def test_play(mocked_play, mocked_status, mocked_volume, hass, one_device)
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player", "media_play", {"entity_id": "media_player.soundtouch_1"}, True,
     )
-    assert mocked_status.call_count == 2
+    assert mocked_status.call_count == 3
     assert mocked_play.call_count == 1
 
 
@@ -560,13 +560,13 @@ async def test_pause(mocked_pause, mocked_status, mocked_volume, hass, one_devic
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player", "media_pause", {"entity_id": "media_player.soundtouch_1"}, True,
     )
-    assert mocked_status.call_count == 2
+    assert mocked_status.call_count == 3
     assert mocked_pause.call_count == 1
 
 
@@ -578,8 +578,8 @@ async def test_play_pause(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player",
@@ -587,7 +587,7 @@ async def test_play_pause(
         {"entity_id": "media_player.soundtouch_1"},
         True,
     )
-    assert mocked_status.call_count == 2
+    assert mocked_status.call_count == 3
     assert mocked_play_pause.call_count == 1
 
 
@@ -605,8 +605,8 @@ async def test_next_previous_track(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player",
@@ -614,7 +614,7 @@ async def test_next_previous_track(
         {"entity_id": "media_player.soundtouch_1"},
         True,
     )
-    assert mocked_status.call_count == 2
+    assert mocked_status.call_count == 3
     assert mocked_next_track.call_count == 1
 
     await hass.services.async_call(
@@ -623,7 +623,7 @@ async def test_next_previous_track(
         {"entity_id": "media_player.soundtouch_1"},
         True,
     )
-    assert mocked_status.call_count == 3
+    assert mocked_status.call_count == 4
     assert mocked_previous_track.call_count == 1
 
 
@@ -636,8 +636,8 @@ async def test_play_media(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player",
@@ -674,8 +674,8 @@ async def test_play_media_url(
     await setup_soundtouch(hass, DEVICE_1_CONFIG)
 
     assert one_device.call_count == 1
-    assert mocked_status.call_count == 1
-    assert mocked_volume.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
 
     await hass.services.async_call(
         "media_player",
@@ -699,8 +699,8 @@ async def test_play_everywhere(
     await setup_soundtouch(hass, [DEVICE_1_CONFIG, DEVICE_2_CONFIG])
 
     assert mocked_device.call_count == 2
-    assert mocked_status.call_count == 2
-    assert mocked_volume.call_count == 2
+    assert mocked_status.call_count == 4
+    assert mocked_volume.call_count == 4
 
     # one master, one slave => create zone
     await hass.services.async_call(
@@ -744,8 +744,8 @@ async def test_create_zone(
     await setup_soundtouch(hass, [DEVICE_1_CONFIG, DEVICE_2_CONFIG])
 
     assert mocked_device.call_count == 2
-    assert mocked_status.call_count == 2
-    assert mocked_volume.call_count == 2
+    assert mocked_status.call_count == 4
+    assert mocked_volume.call_count == 4
 
     # one master, one slave => create zone
     await hass.services.async_call(
@@ -787,8 +787,8 @@ async def test_remove_zone_slave(
     await setup_soundtouch(hass, [DEVICE_1_CONFIG, DEVICE_2_CONFIG])
 
     assert mocked_device.call_count == 2
-    assert mocked_status.call_count == 2
-    assert mocked_volume.call_count == 2
+    assert mocked_status.call_count == 4
+    assert mocked_volume.call_count == 4
 
     # remove one slave
     await hass.services.async_call(
@@ -830,8 +830,8 @@ async def test_add_zone_slave(
     await setup_soundtouch(hass, [DEVICE_1_CONFIG, DEVICE_2_CONFIG])
 
     assert mocked_device.call_count == 2
-    assert mocked_status.call_count == 2
-    assert mocked_volume.call_count == 2
+    assert mocked_status.call_count == 4
+    assert mocked_volume.call_count == 4
 
     # add one slave
     await hass.services.async_call(
@@ -865,20 +865,14 @@ async def test_add_zone_slave(
 
 
 @patch("libsoundtouch.device.SoundTouchDevice.create_zone")
-@patch("libsoundtouch.device.SoundTouchDevice.volume")
-@patch("libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusPlaying)
 async def test_zone_attributes(
-    mocked_status, mocked_volume, mocked_create_zone, hass, two_zones,
+    mocked_create_zone, mocked_status, mocked_volume, hass, two_zones,
 ):
     """Test play everywhere."""
-    mocked_soundtouch_device = two_zones
-    assert await async_setup_component(
-        hass, "media_player", {"media_player": [DEVICE_1_CONFIG, DEVICE_2_CONFIG]}
-    )
-    await hass.async_block_till_done()
-    await hass.async_start()
+    mocked_device = two_zones
+    await setup_soundtouch(hass, [DEVICE_1_CONFIG, DEVICE_2_CONFIG])
 
-    assert mocked_soundtouch_device.call_count == 2
+    assert mocked_device.call_count == 2
     assert mocked_status.call_count == 4
     assert mocked_volume.call_count == 4
 


### PR DESCRIPTION
## Description:
this fixes an issues for a custom media_player component which has support for multiroom audio controls. Other media_player components like SONOS already expose the multiroom group info and kinda defined some sort of "standard" other components followed. This PR is adding the missing zone/group attributes for the lovelace component to work properly, which is the smallest change required to get the lovelace component working. I could have added new services as well, in order to be compatible to other media_player components, but as long as there is no actual officially defined standard in HA itself I refrained from adding breaking changes.

**Related issue (if applicable):** 
Related PR that will add multiroom group/ungroup support for the `mini-media-player` lovelace component kalkih/mini-media-player#165
Related issue of that component kalkih/mini-media-player#155

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
will create the according PR once I got feedback if this change is welcome or not

## Example entry for `configuration.yaml` (if applicable):
-

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
Not needed since functionality doesn't change. There are only additional state attributes now.

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
