### PR TITLE
Implement Alexa.SeekController Interface for media_player in Alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1175,3 +1175,14 @@ class AlexaPlaybackStateReporter(AlexaCapability):
             return {"state": "PAUSED"}
 
         return {"state": "STOPPED"}
+
+
+class AlexaSeekController(AlexaCapability):
+    """Implements Alexa.SeekController.
+
+    https://developer.amazon.com/docs/device-apis/alexa-seekcontroller.html
+    """
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa.SeekController"

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -52,6 +52,7 @@ from .capabilities import (
     AlexaRangeController,
     AlexaSceneController,
     AlexaSecurityPanelController,
+    AlexaSeekController,
     AlexaSpeaker,
     AlexaStepSpeaker,
     AlexaTemperatureSensor,
@@ -424,6 +425,9 @@ class MediaPlayerCapabilities(AlexaEntity):
         if supported & playback_features:
             yield AlexaPlaybackController(self.entity)
             yield AlexaPlaybackStateReporter(self.entity)
+
+        if supported & media_player.const.SUPPORT_SEEK:
+            yield AlexaSeekController(self.entity)
 
         if supported & media_player.SUPPORT_SELECT_SOURCE:
             yield AlexaInputController(self.entity)

--- a/homeassistant/components/alexa/errors.py
+++ b/homeassistant/components/alexa/errors.py
@@ -111,3 +111,10 @@ class AlexaInvalidDirectiveError(AlexaError):
 
     namespace = "Alexa"
     error_type = "INVALID_DIRECTIVE"
+
+
+class AlexaVideoActionNotPermittedForContentError(AlexaError):
+    """Class to represent action not permitted for content errors."""
+
+    namespace = "Alexa.Video"
+    error_type = "ACTION_NOT_PERMITTED_FOR_CONTENT"

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -54,6 +54,7 @@ from .errors import (
     AlexaSecurityPanelUnauthorizedError,
     AlexaTempRangeError,
     AlexaUnsupportedThermostatModeError,
+    AlexaVideoActionNotPermittedForContentError,
 )
 from .state_report import async_enable_proactive_mode
 
@@ -1193,14 +1194,20 @@ async def async_api_seek(hass, config, directive, context):
     """Process a seek request."""
     entity = directive.entity
     position_delta = int(directive.payload["deltaPositionMilliseconds"])
-    current_position = int(entity.attributes.get(media_player.ATTR_MEDIA_POSITION))
 
-    # convert milliseconds to seconds for service media_seek.
-    position_delta = int(position_delta / 1000)
+    current_position = entity.attributes.get(media_player.ATTR_MEDIA_POSITION)
+    if not current_position:
+        msg = f"{entity} did not return the current media position."
+        raise AlexaVideoActionNotPermittedForContentError(msg)
 
-    seek_position = current_position + position_delta
+    seek_position = int(current_position) + int(position_delta / 1000)
+
     if seek_position < 0:
         seek_position = 0
+
+    media_duration = entity.attributes.get(media_player.ATTR_MEDIA_DURATION)
+    if media_duration and 0 < int(media_duration) < seek_position:
+        seek_position = media_duration
 
     data = {
         ATTR_ENTITY_ID: entity.entity_id,

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -712,7 +712,6 @@ async def test_media_player(hass):
             | SUPPORT_PLAY
             | SUPPORT_PLAY_MEDIA
             | SUPPORT_PREVIOUS_TRACK
-            | SUPPORT_SEEK
             | SUPPORT_SELECT_SOURCE
             | SUPPORT_STOP
             | SUPPORT_TURN_OFF
@@ -720,7 +719,6 @@ async def test_media_player(hass):
             | SUPPORT_VOLUME_MUTE
             | SUPPORT_VOLUME_SET,
             "volume_level": 0.75,
-            "media_position": 300,
         },
     )
     appliance = await discovery_test(device, hass)
@@ -737,7 +735,6 @@ async def test_media_player(hass):
         "Alexa.PlaybackController",
         "Alexa.PlaybackStateReporter",
         "Alexa.PowerController",
-        "Alexa.SeekController",
         "Alexa.Speaker",
         "Alexa.StepSpeaker",
     )
@@ -934,54 +931,6 @@ async def test_media_player(hass):
         payload={"channelCount": -1},
     )
 
-    # Test seek forward 30 seconds.
-    call, msg = await assert_request_calls_service(
-        "Alexa.SeekController",
-        "AdjustSeekPosition",
-        "media_player#test",
-        "media_player.media_seek",
-        hass,
-        response_type="StateReport",
-        payload={"deltaPositionMilliseconds": 30000},
-    )
-    assert call.data["seek_position"] == 330
-
-    assert "properties" in msg["event"]["payload"]
-    properties = msg["event"]["payload"]["properties"]
-    assert {"name": "positionMilliseconds", "value": 330000} in properties
-
-    # Test seek reverse 30 seconds.
-    call, msg = await assert_request_calls_service(
-        "Alexa.SeekController",
-        "AdjustSeekPosition",
-        "media_player#test",
-        "media_player.media_seek",
-        hass,
-        response_type="StateReport",
-        payload={"deltaPositionMilliseconds": -30000},
-    )
-    assert call.data["seek_position"] == 270
-
-    assert "properties" in msg["event"]["payload"]
-    properties = msg["event"]["payload"]["properties"]
-    assert {"name": "positionMilliseconds", "value": 270000} in properties
-
-    # Test seek more than current position result = 0.
-    call, msg = await assert_request_calls_service(
-        "Alexa.SeekController",
-        "AdjustSeekPosition",
-        "media_player#test",
-        "media_player.media_seek",
-        hass,
-        response_type="StateReport",
-        payload={"deltaPositionMilliseconds": -500000},
-    )
-    assert call.data["seek_position"] == 0
-
-    assert "properties" in msg["event"]["payload"]
-    properties = msg["event"]["payload"]["properties"]
-    assert {"name": "positionMilliseconds", "value": 0} in properties
-
 
 async def test_media_player_power(hass):
     """Test media player discovery with mapped on/off."""
@@ -1047,6 +996,120 @@ async def test_media_player_speaker(hass):
     assert appliance["endpointId"] == "media_player#test"
     assert appliance["displayCategories"][0] == "SPEAKER"
     assert appliance["friendlyName"] == "Test media player"
+
+
+async def test_media_player_seek(hass):
+    """Test media player seek capability."""
+    device = (
+        "media_player.test_seek",
+        "playing",
+        {
+            "friendly_name": "Test media player seek",
+            "supported_features": SUPPORT_SEEK,
+            "media_position": 300,  # 5min
+            "media_duration": 600,  # 10min
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "media_player#test_seek"
+    assert appliance["displayCategories"][0] == "TV"
+    assert appliance["friendlyName"] == "Test media player seek"
+
+    assert_endpoint_capabilities(
+        appliance,
+        "Alexa.EndpointHealth",
+        "Alexa.PowerController",
+        "Alexa.SeekController",
+    )
+
+    # Test seek forward 30 seconds.
+    call, msg = await assert_request_calls_service(
+        "Alexa.SeekController",
+        "AdjustSeekPosition",
+        "media_player#test_seek",
+        "media_player.media_seek",
+        hass,
+        response_type="StateReport",
+        payload={"deltaPositionMilliseconds": 30000},
+    )
+    assert call.data["seek_position"] == 330
+    assert "properties" in msg["event"]["payload"]
+    properties = msg["event"]["payload"]["properties"]
+    assert {"name": "positionMilliseconds", "value": 330000} in properties
+
+    # Test seek reverse 30 seconds.
+    call, msg = await assert_request_calls_service(
+        "Alexa.SeekController",
+        "AdjustSeekPosition",
+        "media_player#test_seek",
+        "media_player.media_seek",
+        hass,
+        response_type="StateReport",
+        payload={"deltaPositionMilliseconds": -30000},
+    )
+    assert call.data["seek_position"] == 270
+    assert "properties" in msg["event"]["payload"]
+    properties = msg["event"]["payload"]["properties"]
+    assert {"name": "positionMilliseconds", "value": 270000} in properties
+
+    # Test seek backwards more than current position (5 min.) result = 0.
+    call, msg = await assert_request_calls_service(
+        "Alexa.SeekController",
+        "AdjustSeekPosition",
+        "media_player#test_seek",
+        "media_player.media_seek",
+        hass,
+        response_type="StateReport",
+        payload={"deltaPositionMilliseconds": -500000},
+    )
+    assert call.data["seek_position"] == 0
+    assert "properties" in msg["event"]["payload"]
+    properties = msg["event"]["payload"]["properties"]
+    assert {"name": "positionMilliseconds", "value": 0} in properties
+
+    # Test seek forward more than current duration (10 min.) result = 600 sec.
+    call, msg = await assert_request_calls_service(
+        "Alexa.SeekController",
+        "AdjustSeekPosition",
+        "media_player#test_seek",
+        "media_player.media_seek",
+        hass,
+        response_type="StateReport",
+        payload={"deltaPositionMilliseconds": 800000},
+    )
+    assert call.data["seek_position"] == 600
+    assert "properties" in msg["event"]["payload"]
+    properties = msg["event"]["payload"]["properties"]
+    assert {"name": "positionMilliseconds", "value": 600000} in properties
+
+
+async def test_media_player_seek_error(hass):
+    """Test media player seek capability for media_position Error."""
+    device = (
+        "media_player.test_seek",
+        "playing",
+        {"friendly_name": "Test media player seek", "supported_features": SUPPORT_SEEK},
+    )
+    await discovery_test(device, hass)
+
+    # Test for media_position error.
+    with pytest.raises(AssertionError):
+        call, msg = await assert_request_calls_service(
+            "Alexa.SeekController",
+            "AdjustSeekPosition",
+            "media_player#test_seek",
+            "media_player.media_seek",
+            hass,
+            response_type="StateReport",
+            payload={"deltaPositionMilliseconds": 30000},
+        )
+
+        assert "event" in msg
+        msg = msg["event"]
+        assert msg["header"]["name"] == "ErrorResponse"
+        assert msg["header"]["namespace"] == "Alexa.Video"
+        assert msg["payload"]["type"] == "ACTION_NOT_PERMITTED_FOR_CONTENT"
 
 
 async def test_alert(hass):


### PR DESCRIPTION
## Description:
Implements `Alexa.SeekController` Interface for `media_player` entities that support `SUPPORT_SEEK`. 

> User: Alexa, skip 30 seconds on device
> User: Alexa, go back 10 seconds on device

**Notes**
 - There is not a standard format for `media_player.media_seek` service `seek_position` parameter except for a comment suggesting it should be in seconds. Therefore It's up to the integration to handle this from the service in seconds.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
