### PR TITLE
Read raw bytes instead of text when reading ssdp

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -136,13 +136,13 @@ class Scanner:
         session = self.hass.helpers.aiohttp_client.async_get_clientsession()
         try:
             resp = await session.get(xml_location, timeout=5)
-            xml = await resp.text()
+            xml = await resp.read()
 
             # Samsung Smart TV sometimes returns an empty document the
             # first time. Retry once.
             if not xml:
                 resp = await session.get(xml_location, timeout=5)
-                xml = await resp.text()
+                xml = await resp.read()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             _LOGGER.debug("Error fetching %s: %s", xml_location, err)
             return {}


### PR DESCRIPTION
## Description:
The xml will contain processing instruction on charset, so we should not make any charset assumptions before that.

**Related issue (if applicable):** fixes #28267

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
