### PR TITLE
Use dict[key] for required config keys

### DIFF
--- a/homeassistant/components/xiaomi_miio/device_tracker.py
+++ b/homeassistant/components/xiaomi_miio/device_tracker.py
@@ -26,8 +26,8 @@ def get_scanner(hass, config):
     from miio import WifiRepeater, DeviceException
 
     scanner = None
-    host = config[DOMAIN].get(CONF_HOST)
-    token = config[DOMAIN].get(CONF_TOKEN)
+    host = config[DOMAIN][CONF_HOST]
+    token = config[DOMAIN][CONF_TOKEN]
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
 

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -436,7 +436,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     host = config[CONF_HOST]
     token = config[CONF_TOKEN]
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
     model = config.get(CONF_MODEL)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -434,9 +434,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
+    token = config[CONF_TOKEN]
     name = config.get(CONF_NAME)
-    token = config.get(CONF_TOKEN)
     model = config.get(CONF_MODEL)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -123,7 +123,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     host = config[CONF_HOST]
     token = config[CONF_TOKEN]
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
     model = config.get(CONF_MODEL)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -121,9 +121,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
+    token = config[CONF_TOKEN]
     name = config.get(CONF_NAME)
-    token = config.get(CONF_TOKEN)
     model = config.get(CONF_MODEL)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/remote.py
+++ b/homeassistant/components/xiaomi_miio/remote.py
@@ -75,8 +75,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Xiaomi IR Remote (Chuangmi IR) platform."""
     from miio import ChuangmiIr, DeviceException
 
-    host = config.get(CONF_HOST)
-    token = config.get(CONF_TOKEN)
+    host = config[CONF_HOST]
+    token = config[CONF_TOKEN]
 
     # Create handler
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -44,7 +44,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     host = config[CONF_HOST]
     token = config[CONF_TOKEN]
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
 

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -42,9 +42,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
+    token = config[CONF_TOKEN]
     name = config.get(CONF_NAME)
-    token = config.get(CONF_TOKEN)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
 

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -107,9 +107,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
+    token = config[CONF_TOKEN]
     name = config.get(CONF_NAME)
-    token = config.get(CONF_TOKEN)
     model = config.get(CONF_MODEL)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -109,7 +109,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     host = config[CONF_HOST]
     token = config[CONF_TOKEN]
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
     model = config.get(CONF_MODEL)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -184,7 +184,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     host = config[CONF_HOST]
     token = config[CONF_TOKEN]
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     # Create handler
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -182,9 +182,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
+    token = config[CONF_TOKEN]
     name = config.get(CONF_NAME)
-    token = config.get(CONF_TOKEN)
 
     # Create handler
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])


### PR DESCRIPTION
## Description:

Code clean up: Use dict[key] for required config keys.

**Related issue (if applicable):** None.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
