### PR TITLE
Add Alexa.ModeController to cover entities, adds open/close utterances!

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -944,15 +944,20 @@ class AlexaModeController(AlexaCapability):
                     {
                         "value": f"{cover.ATTR_POSITION}.{STATE_OPEN}",
                         "friendly_names": [
-                            {"type": Catalog.LABEL_TEXT, "value": STATE_OPEN},
+                            {"type": Catalog.LABEL_TEXT, "value": "open"},
                             {"type": Catalog.LABEL_TEXT, "value": "opened"},
+                            {"type": Catalog.LABEL_TEXT, "value": "raise"},
+                            {"type": Catalog.LABEL_TEXT, "value": "raised"},
                         ],
                     },
                     {
                         "value": f"{cover.ATTR_POSITION}.{STATE_CLOSED}",
                         "friendly_names": [
-                            {"type": Catalog.LABEL_TEXT, "value": STATE_CLOSED},
                             {"type": Catalog.LABEL_TEXT, "value": "close"},
+                            {"type": Catalog.LABEL_TEXT, "value": "closed"},
+                            {"type": Catalog.LABEL_TEXT, "value": "shut"},
+                            {"type": Catalog.LABEL_TEXT, "value": "lower"},
+                            {"type": Catalog.LABEL_TEXT, "value": "lowered"},
                         ],
                     },
                 ],

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -9,9 +9,11 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_CLOSED,
     STATE_LOCKED,
     STATE_OFF,
     STATE_ON,
+    STATE_OPEN,
     STATE_PAUSED,
     STATE_PLAYING,
     STATE_UNAVAILABLE,
@@ -887,6 +889,9 @@ class AlexaModeController(AlexaCapability):
         if self.instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
             return self.entity.attributes.get(fan.ATTR_DIRECTION)
 
+        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+            return self.entity.attributes.get(cover.ATTR_POSITION)
+
         return None
 
     def configuration(self):
@@ -900,6 +905,12 @@ class AlexaModeController(AlexaCapability):
         if self.instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
             capability_resources = [
                 {"type": Catalog.LABEL_ASSET, "value": Catalog.SETTING_DIRECTION}
+            ]
+
+        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+            capability_resources = [
+                {"type": Catalog.LABEL_ASSET, "value": Catalog.SETTING_MODE},
+                {"type": Catalog.LABEL_ASSET, "value": Catalog.SETTING_PRESET},
             ]
 
         return capability_resources
@@ -921,6 +932,27 @@ class AlexaModeController(AlexaCapability):
                         "value": f"{fan.ATTR_DIRECTION}.{fan.DIRECTION_REVERSE}",
                         "friendly_names": [
                             {"type": Catalog.LABEL_TEXT, "value": fan.DIRECTION_REVERSE}
+                        ],
+                    },
+                ],
+            }
+
+        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+            mode_resources = {
+                "ordered": False,
+                "resources": [
+                    {
+                        "value": f"{cover.ATTR_POSITION}.{STATE_OPEN}",
+                        "friendly_names": [
+                            {"type": Catalog.LABEL_TEXT, "value": STATE_OPEN},
+                            {"type": Catalog.LABEL_TEXT, "value": "opened"},
+                        ],
+                    },
+                    {
+                        "value": f"{cover.ATTR_POSITION}.{STATE_CLOSED}",
+                        "friendly_names": [
+                            {"type": Catalog.LABEL_TEXT, "value": STATE_CLOSED},
+                            {"type": Catalog.LABEL_TEXT, "value": "close"},
                         ],
                     },
                 ],

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -306,7 +306,10 @@ class CoverCapabilities(AlexaEntity):
 
     def default_display_categories(self):
         """Return the display categories for this entity."""
-        return [DisplayCategory.DOOR]
+        device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
+        if device_class in (cover.DEVICE_CLASS_GARAGE, cover.DEVICE_CLASS_DOOR):
+            return [DisplayCategory.DOOR]
+        return [DisplayCategory.OTHER]
 
     def interfaces(self):
         """Yield the supported interfaces."""
@@ -314,6 +317,10 @@ class CoverCapabilities(AlexaEntity):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & cover.SUPPORT_SET_POSITION:
             yield AlexaPercentageController(self.entity)
+        if supported & (cover.SUPPORT_CLOSE | cover.SUPPORT_OPEN):
+            yield AlexaModeController(
+                self.entity, instance=f"{cover.DOMAIN}.{cover.ATTR_POSITION}"
+            )
         yield AlexaEndpointHealth(self.hass, self.entity)
 
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -9,7 +9,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
-    STATE_ALARM_DISARMED,
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_ARM_NIGHT,
@@ -28,6 +27,9 @@ from homeassistant.const import (
     SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
+    STATE_ALARM_DISARMED,
+    STATE_CLOSED,
+    STATE_OPEN,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
@@ -955,23 +957,42 @@ async def async_api_set_mode(hass, config, directive, context):
     domain = entity.domain
     service = None
     data = {ATTR_ENTITY_ID: entity.entity_id}
-    mode = directive.payload["mode"]
+    capability_mode = directive.payload["mode"]
 
-    if domain != fan.DOMAIN:
+    if domain not in (fan.DOMAIN, cover.DOMAIN):
         msg = "Entity does not support directive"
         raise AlexaInvalidDirectiveError(msg)
 
     if instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
-        mode, direction = mode.split(".")
-        if direction in [fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD]:
+        mode, setting = capability_mode.split(".")
+        if setting in [fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD]:
             service = fan.SERVICE_SET_DIRECTION
-            data[fan.ATTR_DIRECTION] = direction
+            data[fan.ATTR_DIRECTION] = setting
+
+    if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        mode, setting = capability_mode.split(".")
+
+        if setting == STATE_CLOSED:
+            service = cover.SERVICE_CLOSE_COVER
+
+        if setting == STATE_OPEN:
+            service = cover.SERVICE_OPEN_COVER
 
     await hass.services.async_call(
         domain, service, data, blocking=False, context=context
     )
 
-    return directive.response()
+    response = directive.response()
+    response.add_context_property(
+        {
+            "namespace": "Alexa.ModeController",
+            "instance": instance,
+            "name": "mode",
+            "value": capability_mode,
+        }
+    )
+
+    return response
 
 
 @HANDLERS.register(("Alexa.ModeController", "AdjustMode"))

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -978,6 +978,15 @@ async def async_api_set_mode(hass, config, directive, context):
         if setting == STATE_OPEN:
             service = cover.SERVICE_OPEN_COVER
 
+    if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        mode, position = mode.split(".")
+
+        if position == STATE_CLOSED:
+            service = cover.SERVICE_CLOSE_COVER
+
+        if position == STATE_OPEN:
+            service = cover.SERVICE_OPEN_COVER
+
     await hass.services.async_call(
         domain, service, data, blocking=False, context=context
     )

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -965,7 +965,7 @@ async def async_api_set_mode(hass, config, directive, context):
 
     if instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
         _, direction = capability_mode.split(".")
-        if direction in [fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD]:
+        if direction in (fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD):
             service = fan.SERVICE_SET_DIRECTION
             data[fan.ATTR_DIRECTION] = direction
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -964,13 +964,13 @@ async def async_api_set_mode(hass, config, directive, context):
         raise AlexaInvalidDirectiveError(msg)
 
     if instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
-        mode, setting = capability_mode.split(".")
+        _, setting = capability_mode.split(".")
         if setting in [fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD]:
             service = fan.SERVICE_SET_DIRECTION
             data[fan.ATTR_DIRECTION] = setting
 
     if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
-        mode, setting = capability_mode.split(".")
+        _, setting = capability_mode.split(".")
 
         if setting == STATE_CLOSED:
             service = cover.SERVICE_CLOSE_COVER
@@ -979,7 +979,7 @@ async def async_api_set_mode(hass, config, directive, context):
             service = cover.SERVICE_OPEN_COVER
 
     if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
-        mode, position = mode.split(".")
+        _, position = capability_mode.split(".")
 
         if position == STATE_CLOSED:
             service = cover.SERVICE_CLOSE_COVER

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -970,15 +970,6 @@ async def async_api_set_mode(hass, config, directive, context):
             data[fan.ATTR_DIRECTION] = setting
 
     if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
-        _, setting = capability_mode.split(".")
-
-        if setting == STATE_CLOSED:
-            service = cover.SERVICE_CLOSE_COVER
-
-        if setting == STATE_OPEN:
-            service = cover.SERVICE_OPEN_COVER
-
-    if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
         _, position = capability_mode.split(".")
 
         if position == STATE_CLOSED:

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -964,10 +964,10 @@ async def async_api_set_mode(hass, config, directive, context):
         raise AlexaInvalidDirectiveError(msg)
 
     if instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
-        _, setting = capability_mode.split(".")
-        if setting in [fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD]:
+        _, direction = capability_mode.split(".")
+        if direction in [fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD]:
             service = fan.SERVICE_SET_DIRECTION
-            data[fan.ATTR_DIRECTION] = setting
+            data[fan.ATTR_DIRECTION] = direction
 
     if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
         _, position = capability_mode.split(".")

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -547,7 +547,7 @@ async def test_direction_fan(hass):
         },
     } in supported_modes
 
-    call, _ = await assert_request_calls_service(
+    call, msg = await assert_request_calls_service(
         "Alexa.ModeController",
         "SetMode",
         "fan#test_4",
@@ -557,6 +557,25 @@ async def test_direction_fan(hass):
         instance="fan.direction",
     )
     assert call.data["direction"] == "reverse"
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "mode"
+    assert properties["namespace"] == "Alexa.ModeController"
+    assert properties["value"] == "direction.reverse"
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.ModeController",
+        "SetMode",
+        "fan#test_4",
+        "fan.set_direction",
+        hass,
+        payload={"mode": "direction.forward"},
+        instance="fan.direction",
+    )
+    assert call.data["direction"] == "forward"
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "mode"
+    assert properties["namespace"] == "Alexa.ModeController"
+    assert properties["value"] == "direction.forward"
 
     # Test for AdjustMode instance=None Error coverage
     with pytest.raises(AssertionError):
@@ -1057,11 +1076,12 @@ async def test_cover(hass):
     appliance = await discovery_test(device, hass)
 
     assert appliance["endpointId"] == "cover#test"
-    assert appliance["displayCategories"][0] == "DOOR"
+    assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test cover"
 
     assert_endpoint_capabilities(
         appliance,
+        "Alexa.ModeController",
         "Alexa.PercentageController",
         "Alexa.PowerController",
         "Alexa.EndpointHealth",
@@ -1943,3 +1963,93 @@ async def test_mode_unsupported_domain(hass):
     assert msg["header"]["name"] == "ErrorResponse"
     assert msg["header"]["namespace"] == "Alexa"
     assert msg["payload"]["type"] == "INVALID_DIRECTIVE"
+
+
+async def test_cover_position(hass):
+    """Test cover position mode discovery."""
+    device = (
+        "cover.test",
+        "off",
+        {"friendly_name": "Test cover", "supported_features": 255, "position": 30},
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "cover#test"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test cover"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.ModeController",
+        "Alexa.PercentageController",
+        "Alexa.PowerController",
+        "Alexa.EndpointHealth",
+    )
+
+    mode_capability = get_capability(capabilities, "Alexa.ModeController")
+    assert mode_capability is not None
+    assert mode_capability["instance"] == "cover.position"
+
+    properties = mode_capability["properties"]
+    assert properties["nonControllable"] is False
+    assert {"name": "mode"} in properties["supported"]
+
+    capability_resources = mode_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "asset",
+        "value": {"assetId": "Alexa.Setting.Mode"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = mode_capability["configuration"]
+    assert configuration is not None
+    assert configuration["ordered"] is False
+
+    supported_modes = configuration["supportedModes"]
+    assert supported_modes is not None
+    assert {
+        "value": "position.open",
+        "modeResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "open", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "opened", "locale": "en-US"}},
+            ]
+        },
+    } in supported_modes
+    assert {
+        "value": "position.closed",
+        "modeResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "closed", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "close", "locale": "en-US"}},
+            ]
+        },
+    } in supported_modes
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.ModeController",
+        "SetMode",
+        "cover#test",
+        "cover.close_cover",
+        hass,
+        payload={"mode": "position.closed"},
+        instance="cover.position",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "mode"
+    assert properties["namespace"] == "Alexa.ModeController"
+    assert properties["value"] == "position.closed"
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.ModeController",
+        "SetMode",
+        "cover#test",
+        "cover.open_cover",
+        hass,
+        payload={"mode": "position.open"},
+        instance="cover.position",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "mode"
+    assert properties["namespace"] == "Alexa.ModeController"
+    assert properties["value"] == "position.open"

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2013,6 +2013,8 @@ async def test_cover_position(hass):
             "friendlyNames": [
                 {"@type": "text", "value": {"text": "open", "locale": "en-US"}},
                 {"@type": "text", "value": {"text": "opened", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "raise", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "raised", "locale": "en-US"}},
             ]
         },
     } in supported_modes
@@ -2020,8 +2022,11 @@ async def test_cover_position(hass):
         "value": "position.closed",
         "modeResources": {
             "friendlyNames": [
-                {"@type": "text", "value": {"text": "closed", "locale": "en-US"}},
                 {"@type": "text", "value": {"text": "close", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "closed", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "shut", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "lower", "locale": "en-US"}},
+                {"@type": "text", "value": {"text": "lowered", "locale": "en-US"}},
             ]
         },
     } in supported_modes


### PR DESCRIPTION
## Description:
Adds the elusive `open` and `close` utterances that are missing from the Alexa Smart Home API to cover entities! 
Finally can open and close covers without instead of using `on`/`off` or custom skills. Takes advantage of the custom names for `modeResources`. 

`open`, `opened`, `raise`, `raised`
`close`, `closed`, `lower`, `lowered`, `shut`

Directives for the `modeController` work best in the following format:
> Alexa, set {DEVICE NAME} to {MODE NAME}.

The following short phrases work:
> Alexa, set garage door to closed
> Alexa, shades to close
> Alexa, blinds to open

The following also works, but could never get `open` to work. 
> Alexa, shut the living room shades

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
