### PR TITLE
Add source constants for all config entry discovery sources

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -20,9 +20,11 @@ from homeassistant.helpers.event import Event
 _LOGGER = logging.getLogger(__name__)
 _UNDEF: dict = {}
 
-SOURCE_USER = "user"
 SOURCE_DISCOVERY = "discovery"
 SOURCE_IMPORT = "import"
+SOURCE_SSDP = "ssdp"
+SOURCE_USER = "user"
+SOURCE_ZEROCONF = "zeroconf"
 
 HANDLERS = Registry()
 
@@ -50,7 +52,7 @@ ENTRY_STATE_FAILED_UNLOAD = "failed_unload"
 UNRECOVERABLE_STATES = (ENTRY_STATE_MIGRATION_ERROR, ENTRY_STATE_FAILED_UNLOAD)
 
 DISCOVERY_NOTIFICATION_ID = "config_entry_discovery"
-DISCOVERY_SOURCES = ("ssdp", "zeroconf", SOURCE_DISCOVERY, SOURCE_IMPORT)
+DISCOVERY_SOURCES = (SOURCE_SSDP, SOURCE_ZEROCONF, SOURCE_DISCOVERY, SOURCE_IMPORT)
 
 EVENT_FLOW_DISCOVERED = "config_entry_discovered"
 


### PR DESCRIPTION
## Description:

While developing a new integration, I noticed there where no discovery source constants for Zeroconf in the config entry discovery sources. This is a quick and tiny PR to address that, making things more consistent.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
