### PR TITLE
Bump youtube_dl to 2019.10.29

### DIFF
--- a/homeassistant/components/media_extractor/manifest.json
+++ b/homeassistant/components/media_extractor/manifest.json
@@ -3,7 +3,7 @@
   "name": "Media extractor",
   "documentation": "https://www.home-assistant.io/integrations/media_extractor",
   "requirements": [
-    "youtube_dl==2019.10.22"
+    "youtube_dl==2019.10.29"
   ],
   "dependencies": [
     "media_player"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2030,7 +2030,7 @@ yeelight==0.5.0
 yeelightsunflower==0.0.10
 
 # homeassistant.components.media_extractor
-youtube_dl==2019.10.22
+youtube_dl==2019.10.29
 
 # homeassistant.components.zengge
 zengge==0.2


### PR DESCRIPTION
## Description:

Bump `youtube_dl` to `2019.10.29`

Changelog: <https://github.com/ytdl-org/youtube-dl/releases/tag/2019.10.29>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_extractor:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
