### PR TITLE
Bump pre-commit to 1.20.0

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,7 +10,7 @@ flake8-docstrings==1.5.0
 flake8==3.7.8
 mock-open==1.3.1
 mypy==0.740
-pre-commit==1.18.3
+pre-commit==1.20.0
 pydocstyle==4.0.1
 pylint==2.4.3
 astroid==2.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -11,7 +11,7 @@ flake8-docstrings==1.5.0
 flake8==3.7.8
 mock-open==1.3.1
 mypy==0.740
-pre-commit==1.18.3
+pre-commit==1.20.0
 pydocstyle==4.0.1
 pylint==2.4.3
 astroid==2.3.2


### PR DESCRIPTION
## Description:

Bump `pre-commit` from `1.18.3` to `1.20.0`

Changelog `1.19.0`: <https://github.com/pre-commit/pre-commit/blob/master/CHANGELOG.md#1190---2019-10-26>
Changelog `1.20.0`: <https://github.com/pre-commit/pre-commit/blob/master/CHANGELOG.md#1200---2019-10-28>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
