### PR TITLE
Do not fail pre-commit if mypy is not available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,17 +15,18 @@ repos:
           - flake8-docstrings==1.3.1
           - pydocstyle==4.0.0
         files: ^(homeassistant|script|tests)/.+\.py$
-# Using a local "system" mypy instead of the mypy hook, because its
-# results depend on what is installed. And the mypy hook runs in a
+# Using a locally set up mypy instead of the "real" mypy hook, because
+# mypy's results depend on what is installed. The "real" one runs in a
 # virtualenv of its own, meaning we'd need to install and maintain
-# another set of our dependencies there... no. Use the "system" one
-# and reuse the environment that is set up anyway already instead.
+# another set of our dependencies there... no. Use a wrapper script
+# that launches the one installed in the currently active environment
+# that is set up as desired instead.
 -   repo: local
     hooks:
     -   id: mypy
-        name: mypy
-        entry: mypy
-        language: system
+        name: mypy (if available)
+        entry: script/mypy_wrapper.py
+        language: script
         types: [python]
         require_serial: true
         files: ^homeassistant/.+\.py$

--- a/script/mypy_wrapper.py
+++ b/script/mypy_wrapper.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+"""
+Wrapper script for mypy to exit without error when it's not available.
+
+For use in pre-commit.
+"""
+
+import sys
+
+if __name__ == "__main__":
+    try:
+        from mypy.__main__ import console_entry
+    except ImportError:
+        print("mypy is not available, skipping it")
+        sys.exit(0)
+    sys.exit(console_entry())


### PR DESCRIPTION
## Description:

Closes https://github.com/home-assistant/home-assistant/issues/28283

**Related issue (if applicable):** fixes #28283

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
