### PR TITLE
allow multiple heaters per incomfort gateway

### DIFF
--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -44,12 +44,13 @@ async def async_setup(hass, hass_config):
     )
 
     try:
-        heater = incomfort_data["heater"] = list(await client.heaters)[0]
+        heaters = incomfort_data["heaters"] = list(await client.heaters)
     except ClientResponseError as err:
         _LOGGER.warning("Setup failed, check your configuration, message is: %s", err)
         return False
 
-    await heater.update()
+    for heater in heaters:
+        await heater.update()
 
     for platform in ["water_heater", "binary_sensor", "sensor", "climate"]:
         hass.async_create_task(

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -11,9 +11,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if discovery_info is None:
         return
 
-    async_add_entities(
-        [IncomfortFailed(hass.data[DOMAIN]["client"], hass.data[DOMAIN]["heater"])]
-    )
+    client = hass.data[DOMAIN]["client"]
+    heaters = hass.data[DOMAIN]["heaters"]
+
+    async_add_entities([IncomfortFailed(client, h) for h in heaters])
 
 
 class IncomfortFailed(IncomfortChild, BinarySensorDevice):

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -17,9 +17,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         return
 
     client = hass.data[DOMAIN]["client"]
-    heater = hass.data[DOMAIN]["heater"]
+    heaters = hass.data[DOMAIN]["heaters"]
 
-    async_add_entities([InComfortClimate(client, heater, r) for r in heater.rooms])
+    async_add_entities(
+        [InComfortClimate(client, h, r) for h in heaters for r in h.rooms]
+    )
 
 
 class InComfortClimate(IncomfortChild, ClimateDevice):

--- a/homeassistant/components/incomfort/manifest.json
+++ b/homeassistant/components/incomfort/manifest.json
@@ -3,7 +3,7 @@
   "name": "Intergas InComfort/Intouch Lan2RF gateway",
   "documentation": "https://www.home-assistant.io/integrations/incomfort",
   "requirements": [
-    "incomfort-client==0.3.5"
+    "incomfort-client==0.4.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -29,14 +29,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         return
 
     client = hass.data[DOMAIN]["client"]
-    heater = hass.data[DOMAIN]["heater"]
+    heaters = hass.data[DOMAIN]["heaters"]
 
     async_add_entities(
-        [
-            IncomfortPressure(client, heater, INCOMFORT_PRESSURE),
-            IncomfortTemperature(client, heater, INCOMFORT_HEATER_TEMP),
-            IncomfortTemperature(client, heater, INCOMFORT_TAP_TEMP),
-        ]
+        [IncomfortPressure(client, h, INCOMFORT_PRESSURE) for h in heaters]
+        + [IncomfortTemperature(client, h, INCOMFORT_HEATER_TEMP) for h in heaters]
+        + [IncomfortTemperature(client, h, INCOMFORT_TAP_TEMP) for h in heaters]
     )
 
 

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -22,9 +22,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         return
 
     client = hass.data[DOMAIN]["client"]
-    heater = hass.data[DOMAIN]["heater"]
+    heaters = hass.data[DOMAIN]["heaters"]
 
-    async_add_entities([IncomfortWaterHeater(client, heater)])
+    async_add_entities([IncomfortWaterHeater(client, h) for h in heaters])
 
 
 class IncomfortWaterHeater(IncomfortEntity, WaterHeaterDevice):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -694,7 +694,7 @@ iglo==1.2.7
 ihcsdk==2.3.0
 
 # homeassistant.components.incomfort
-incomfort-client==0.3.5
+incomfort-client==0.4.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3


### PR DESCRIPTION
## Breaking Change:

None known.

## Description:
Adds all heaters to HA, and not just the first - requires a client bump. from 0.3.5 to 0.4.0, see: https://github.com/zxdavb/incomfort-client/compare/v0.3.5...v0.4.0

**Related issue (if applicable):** fixes #28318

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A (unchanged)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
