### PR TITLE
Add white_value support to light profiles

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -138,7 +138,7 @@ LIGHT_TURN_OFF_SCHEMA = {
 LIGHT_TOGGLE_SCHEMA = LIGHT_TURN_ON_SCHEMA
 
 PROFILE_SCHEMA = vol.Schema(
-    vol.ExactSequence((str, cv.small_float, cv.small_float, cv.byte))
+    vol.ExactSequence((str, cv.small_float, cv.small_float, cv.byte, cv.byte))
 )
 
 INTENT_SET = "HassLightSet"
@@ -159,6 +159,7 @@ def preprocess_turn_on_alternatives(params):
     if profile is not None:
         params.setdefault(ATTR_XY_COLOR, profile[:2])
         params.setdefault(ATTR_BRIGHTNESS, profile[2])
+        params.setdefault(ATTR_BRIGHTNESS, profile[3])
 
     color_name = params.pop(ATTR_COLOR_NAME, None)
     if color_name is not None:
@@ -382,8 +383,8 @@ class Profiles:
 
                     try:
                         for rec in reader:
-                            profile, color_x, color_y, brightness = PROFILE_SCHEMA(rec)
-                            profiles[profile] = (color_x, color_y, brightness)
+                            profile, color_x, color_y, brightness, white_value = PROFILE_SCHEMA(rec)
+                            profiles[profile] = (color_x, color_y, brightness, white_value)
                     except vol.MultipleInvalid as ex:
                         _LOGGER.error(
                             "Error parsing light profile from %s: %s", profile_path, ex

--- a/homeassistant/components/light/light_profiles.csv
+++ b/homeassistant/components/light/light_profiles.csv
@@ -1,5 +1,5 @@
-id,x,y,brightness
-relax,0.5119,0.4147,144
-concentrate,0.5119,0.4147,219
-energize,0.368,0.3686,203
-reading,0.4448,0.4066,240
+id,x,y,brightness, white_value
+relax,0.5119,0.4147,144,255
+concentrate,0.5119,0.4147,219,255
+energize,0.368,0.3686,203,255
+reading,0.4448,0.4066,240,255

--- a/homeassistant/components/light/light_profiles.csv
+++ b/homeassistant/components/light/light_profiles.csv
@@ -1,4 +1,4 @@
-id,x,y,brightness, white_value
+id,x,y,brightness,white_value
 relax,0.5119,0.4147,144,255
 concentrate,0.5119,0.4147,219,255
 energize,0.368,0.3686,203,255


### PR DESCRIPTION
## Description:

Certain 5 channel lights(Teckin SB50) appear to tie brightness to the RGB color channels causing brightness adjustments to have little effect on the actual brightness of the bulb although adjusting the white value achieves the desired effect.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
