### PR TITLE
Allow generic camera streams to use authentication info

### DIFF
--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -2,7 +2,7 @@
   "domain": "generic",
   "name": "Generic",
   "documentation": "https://www.home-assistant.io/integrations/generic",
-  "requirements": [],
+  "requirements": ["furl==2.1.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -527,6 +527,9 @@ freesms==0.1.2
 # homeassistant.components.fritzdect
 fritzhome==1.0.4
 
+# homeassistant.components.generic
+furl==2.1.0
+
 # homeassistant.components.google_translate
 gTTS-token==1.1.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -184,6 +184,9 @@ feedparser-homeassistant==5.2.2.dev1
 # homeassistant.components.foobot
 foobot_async==0.3.1
 
+# homeassistant.components.generic
+furl==2.1.0
+
 # homeassistant.components.google_translate
 gTTS-token==1.1.3
 

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -39,6 +39,55 @@ def test_fetching_url(aioclient_mock, hass, hass_client):
 
 
 @asyncio.coroutine
+def test_auth_in_stream(aioclient_mock, hass, hass_client):
+    """Test that auth is embedded in the stream source."""
+    camera = yield from async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "still_image_url": "http://example.com",
+                "username": "user",
+                "password": "pass",
+                "stream_source": "http://example.com:554/cam",
+                "auth_in_stream": True,
+            }
+        },
+    )
+
+    camera = hass.data["camera"].get_entity("camera.config_test")
+
+    source = yield from camera.stream_source()
+    assert source == "http://user:pass@example.com:554/cam"
+
+
+@asyncio.coroutine
+def test_no_auth_in_stream(aioclient_mock, hass, hass_client):
+    """Test that auth is not embedded in the stream source."""
+    camera = yield from async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "still_image_url": "http://example.com",
+                "username": "user",
+                "password": "pass",
+                "stream_source": "http://example.com:554/cam",
+            }
+        },
+    )
+
+    camera = hass.data["camera"].get_entity("camera.config_test")
+
+    source = yield from camera.stream_source()
+    assert source == "http://example.com:554/cam"
+
+
+@asyncio.coroutine
 def test_fetching_without_verify_ssl(aioclient_mock, hass, hass_client):
     """Test that it fetches the given url when ssl verify is off."""
     aioclient_mock.get("https://example.com", text="hello world")


### PR DESCRIPTION
## Description:

The Generic Camera component can have a `stream_source` url configured, but it currently does not take authentication into account. A way around it is to include the authentication info in the URL, but that means repeating information, and also that the url is best placed in `secrets.yaml`, which can be an unnecessary complication.
This PR adds the `auth_in_stream` parameter, which, if set to true, will add the authentication information from the `username` and `password` parameters, and embed them in the stream source url.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: generic
    name: Test
    still_image_url: http://194.218.96.92/jpg/image.jpg
    stream_source: "rtsp://192.168.1.21:554/"
    username: user
    password: super secret passw0rd
    auth_in_stream: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
