### PR TITLE
Add DIRECTORY and PLUGIN to kodi media types

### DIFF
--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -783,6 +783,10 @@ class KodiDevice(MediaPlayerDevice):
             return self.server.Player.Open({"item": {"channelid": int(media_id)}})
         if media_type == "PLAYLIST":
             return self.server.Player.Open({"item": {"playlistid": int(media_id)}})
+        if media_type == "DIRECTORY":
+            return self.server.Player.Open({"item": {"directory": str(media_id)}})
+        if media_type == "PLUGIN":
+            return self.server.Player.Open({"item": {"file": str(media_id)}})
 
         return self.server.Player.Open({"item": {"file": str(media_id)}})
 


### PR DESCRIPTION
## Description:

Add DIRECTORY and PLUGIN to media types supported by kodi component. This allows the use of smart playlists which need the media to be passed as DIRECTORY type.

Pull request with documentation for home-assistant.io (if applicable): home-assistant/home-assistant.io#11043

## Example service call:
```yaml
      - service: media_player.play_media
        data_template:
          entity_id: media_player.kodi
          media_content_type: >
            {% if (trigger.payload == "D9-34-77-15") %}
              DIRECTORY
            {% else %}
              PLUGIN
            {% endif %}
          media_content_id: >
            {% if (trigger.payload == "19-8D-DD-4E") %}
              plugin://plugin.video.youtube/play/?video_id=BfmwAhB5jyU
            {% elif (trigger.payload == "D9-34-77-15") %}
              special://profile/playlists/video/feuerwehrmann_sam.xsp
            {% else %}
              plugin://plugin.video.youtube/play/?video_id=oO_ibgO3IGk
            {% endif %}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html