### PR TITLE
Add file list to attributes of folder sensor

### DIFF
--- a/homeassistant/components/folder/sensor.py
+++ b/homeassistant/components/folder/sensor.py
@@ -64,10 +64,12 @@ class Folder(Entity):
         self._size = None
         self._name = os.path.split(os.path.split(folder_path)[0])[1]
         self._unit_of_measurement = "MB"
+        self._file_list = None
 
     def update(self):
         """Update the sensor."""
         files_list = get_files_list(self._folder_path, self._filter_term)
+        self._file_list = files_list
         self._number_of_files = len(files_list)
         self._size = get_size(files_list)
 
@@ -96,6 +98,7 @@ class Folder(Entity):
             "filter": self._filter_term,
             "number_of_files": self._number_of_files,
             "bytes": self._size,
+            "file_list": self._file_list,
         }
         return attr
 


### PR DESCRIPTION
## Description:

Add list of files in folder to the attributes of the sensor. It can e.g. used by the lovelace slideshow card https://community.home-assistant.io/t/lovelace-slideshow-card/70907.

Pull request with documentation for home-assistant.io (if applicable): home-assistant/home-assistant.io#11044

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html