### PR TITLE
Add a Services YAML for the Dominos integration

### DIFF
--- a/homeassistant/components/dominos/services.yaml
+++ b/homeassistant/components/dominos/services.yaml
@@ -1,0 +1,6 @@
+order:
+  description: Places a set of orders with Dominos Pizza.
+  fields:
+    order_entity_id:
+      description: The ID (as specified in the configuration) of an order to place. If provided as an array, all of the identified orders will be placed.
+      example: dominos.medium_pan


### PR DESCRIPTION
## Description:

**Related issue:** Addresses #27289

Documentation already exists for the Dominos integration at https://www.home-assistant.io/integrations/dominos —this adds the appropriate internal documentation to `services.yaml`.