### PR TITLE
Add bandit, use to catch known vulnerable XML parsing

### DIFF
--- a/.pre-commit-config-all.yaml
+++ b/.pre-commit-config-all.yaml
@@ -33,7 +33,7 @@ repos:
         args:
           - --quiet
           - --format=custom
-          - --tests=B313,B314,B315,B316,B317,B318,B319,B320
+          - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script|tests)/.+\.py$
 # Using a local "system" mypy instead of the mypy hook, because its
 # results depend on what is installed. And the mypy hook runs in a

--- a/.pre-commit-config-all.yaml
+++ b/.pre-commit-config-all.yaml
@@ -26,6 +26,15 @@ repos:
           - flake8-docstrings==1.5.0
           - pydocstyle==4.0.1
         files: ^(homeassistant|script|tests)/.+\.py$
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.6.2
+    hooks:
+      - id: bandit
+        args:
+          - --quiet
+          - --format=custom
+          - --tests=B313,B314,B315,B316,B317,B318,B319,B320
+        files: ^(homeassistant|script|tests)/.+\.py$
 # Using a local "system" mypy instead of the mypy hook, because its
 # results depend on what is installed. And the mypy hook runs in a
 # virtualenv of its own, meaning we'd need to install and maintain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,12 @@ repos:
           - flake8-docstrings==1.5.0
           - pydocstyle==4.0.1
         files: ^(homeassistant|script|tests)/.+\.py$
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.6.2
+    hooks:
+      - id: bandit
+        args:
+          - --quiet
+          - --format=custom
+          - --tests=B313,B314,B315,B316,B317,B318,B319,B320
+        files: ^(homeassistant|script|tests)/.+\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,5 +29,5 @@ repos:
         args:
           - --quiet
           - --format=custom
-          - --tests=B313,B314,B315,B316,B317,B318,B319,B320
+          - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script|tests)/.+\.py$

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -50,6 +50,10 @@ stages:
         . venv/bin/activate
         pre-commit run flake8 --all-files
       displayName: 'Run flake8'
+    - script: |
+        . venv/bin/activate
+        pre-commit run bandit --all-files
+      displayName: 'Run bandit'
   - job: 'Validate'
     pool:
       vmImage: 'ubuntu-latest'

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -3,9 +3,9 @@ import asyncio
 from datetime import timedelta
 import logging
 from urllib.parse import urlparse
-from xml.etree import ElementTree
 
 import aiohttp
+from defusedxml import ElementTree
 from netdisco import ssdp, util
 
 from homeassistant.helpers.event import async_track_time_interval

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -3,6 +3,7 @@
   "name": "SSDP",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
   "requirements": [
+    "defusedxml==0.6.0",
     "netdisco==2.6.0"
   ],
   "dependencies": [

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -9,6 +9,7 @@ bcrypt==3.1.7
 certifi>=2019.9.11
 contextvars==2.4;python_version<"3.7"
 cryptography==2.8
+defusedxml==0.6.0
 distro==1.4.0
 hass-nabucasa==0.29
 home-assistant-frontend==20191115.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -402,6 +402,7 @@ datapoint==0.4.3
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns
 # homeassistant.components.ohmconnect
+# homeassistant.components.ssdp
 defusedxml==0.6.0
 
 # homeassistant.components.deluge

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -137,6 +137,7 @@ datadog==0.15.0
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns
 # homeassistant.components.ohmconnect
+# homeassistant.components.ssdp
 defusedxml==0.6.0
 
 # homeassistant.components.directv

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,6 @@
 # Automatically generated from .pre-commit-config-all.yaml by gen_requirements_all.py, do not edit
 
+bandit==1.6.2
 black==19.10b0
 flake8-docstrings==1.5.0
 flake8==3.7.9

--- a/tests/bandit.yaml
+++ b/tests/bandit.yaml
@@ -1,0 +1,11 @@
+# https://bandit.readthedocs.io/en/latest/config.html
+
+tests:
+  - B313
+  - B314
+  - B315
+  - B316
+  - B317
+  - B318
+  - B319
+  - B320

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -52,7 +52,7 @@ class TestEmulatedHue(unittest.TestCase):
 
     def test_description_xml(self):
         """Test the description."""
-        import xml.etree.ElementTree as ET
+        import defusedxml.ElementTree as ET
 
         result = requests.get(BRIDGE_URL_BASE.format("/description.xml"), timeout=5)
 

--- a/tests/components/rss_feed_template/test_init.py
+++ b/tests/components/rss_feed_template/test_init.py
@@ -1,7 +1,7 @@
 """The tests for the rss_feed_api component."""
 import asyncio
-from xml.etree import ElementTree
 
+from defusedxml import ElementTree
 import pytest
 
 from homeassistant.setup import async_setup_component

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ commands =
     python -m script.gen_requirements_all validate
     python -m script.hassfest validate
     pre-commit run flake8 {posargs: --all-files}
+    pre-commit run bandit {posargs: --all-files}
 
 [testenv:typing]
 deps =


### PR DESCRIPTION

## Description:

https://bandit.readthedocs.io/

Bandit has quite a few useful security related checks. This introduces it, and configures to use known vulnerable XML parsing use only for now. We can add more checks in the future.

Note that in its current state the build will expectedly fail, this is in order to demonstrate the found issues.

**Related issue (if applicable):** #28302 (vulnerable etree usage sidetrack)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
