### PR TITLE
Bump pymyq to 2.0.1

### DIFF
--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -3,7 +3,7 @@
   "name": "Myq",
   "documentation": "https://www.home-assistant.io/integrations/myq",
   "requirements": [
-    "pymyq==2.0.0"
+    "pymyq==2.0.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1331,7 +1331,7 @@ pymsteams==0.1.12
 pymusiccast==0.1.6
 
 # homeassistant.components.myq
-pymyq==2.0.0
+pymyq==2.0.1
 
 # homeassistant.components.mysensors
 pymysensors==0.18.0


### PR DESCRIPTION
##  Description:

This PR bumps `pymyq` to 2.0.1.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/28337

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: myq
    username: !secret chamberlain_myq_username
    password: !secret chamberlain_myq_password
    type: chamberlain
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
