### PR TITLE
Bump pysaj to v0.0.13 (fix for sensor date)

### DIFF
--- a/homeassistant/components/saj/manifest.json
+++ b/homeassistant/components/saj/manifest.json
@@ -3,7 +3,7 @@
   "name": "SAJ",
   "documentation": "https://www.home-assistant.io/integrations/saj",
   "requirements": [
-    "pysaj==0.0.12"
+    "pysaj==0.0.13"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1426,7 +1426,7 @@ pyrepetier==3.0.5
 pysabnzbd==1.1.0
 
 # homeassistant.components.saj
-pysaj==0.0.12
+pysaj==0.0.13
 
 # homeassistant.components.sony_projector
 pysdcp==1


### PR DESCRIPTION
## Description:
Bump pysaj to v0.0.13
This fixes an issue where the sensor last value date was not updated.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
