### PR TITLE
Flux log with debug instead of info

### DIFF
--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -310,7 +310,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
             await async_set_lights_xy(
                 self.hass, self._lights, x_val, y_val, brightness, self._transition
             )
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Lights updated to x:%s y:%s brightness:%s, %s%% "
                 "of %s cycle complete at %s",
                 x_val,
@@ -322,7 +322,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
             )
         elif self._mode == MODE_RGB:
             await async_set_lights_rgb(self.hass, self._lights, rgb, self._transition)
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Lights updated to rgb:%s, %s%% " "of %s cycle complete at %s",
                 rgb,
                 round(percentage_complete * 100),
@@ -335,7 +335,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
             await async_set_lights_temp(
                 self.hass, self._lights, mired, brightness, self._transition
             )
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Lights updated to mired:%s brightness:%s, %s%% "
                 "of %s cycle complete at %s",
                 mired,


### PR DESCRIPTION
## Breaking Change:

Nothing breaks

## Description:
Flux used to spam the log with debug messages that are labeled `INFO`. These messages are now labeled `DEBUG` and wont be shown by default.
Please reject this PR if there are good reasons to show these messages by default.

**Related issue (if applicable):** fixes #28332

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
