### PR TITLE
Prevent TypeError when KNX RGB(W) light value contains None

### DIFF
--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -181,20 +181,9 @@ class KNXLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        if self.device.supports_brightness:
-            return self.device.current_brightness
-        if (
-            self.device.supports_color or self.device.supports_rgbw
-        ) and self.device.current_color:
-            rgb, white = self.device.current_color
-            values = []
-            if rgb is not None:
-                values.extend(rgb)
-            if white is not None:
-                values.append(white)
-            if values:
-                return max(values)
-        return None
+        if not self.device.supports_brightness:
+            return None
+        return self.device.current_brightness
 
     @property
     def hs_color(self):

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -186,12 +186,12 @@ class KNXLight(Light):
         if (
             self.device.supports_color or self.device.supports_rgbw
         ) and self.device.current_color:
-            rgb, w = self.device.current_color
+            rgb, white = self.device.current_color
             values = []
             if rgb is not None:
                 values.extend(rgb)
-            if w is not None:
-                values.append(w)
+            if white is not None:
+                values.append(white)
             if values:
                 return max(values)
         return None

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -186,7 +186,14 @@ class KNXLight(Light):
         if (
             self.device.supports_color or self.device.supports_rgbw
         ) and self.device.current_color:
-            return max(self.device.current_color)
+            rgb, w = self.device.current_color
+            values = []
+            if rgb is not None:
+                values.extend(rgb)
+            if w is not None:
+                values.append(w)
+            if values:
+                return max(values)
         return None
 
     @property


### PR DESCRIPTION
## Description:

I have a homeassistant setup steering KNX RGB LEDs (not RGBW). It works smoothly as long as I only enable `address` and `state_address` in `configuration.yaml`. As soon as I add `color_address` (with or without `color_state_address`) I get a `TypeError` in the log and the light can't be turn on or off anymore.

The problem is:
```
  File "/home/philipp/opt/python-env/homeassistant/lib/python3.7/site-packages/homeassistant/components/knx/light.py", line 189, in brightness
    return max(self.device.current_color)
TypeError: '>' not supported between instances of 'NoneType' and 'NoneType'
```

Later the error changed to:
```
TypeError: '>' not supported between instances of 'NoneType' and 'tuple'
```
The actual value of `self.device.current_color` was `((0, 0, 0), None)`

The used homeassistant version was 0.100.3.

A quick fix is to replace the line `return max(self.device.current_color)` by `return None` or catch the TypeError and return `None`. That worked for me and I could turn the LED light on and off and could change color.

With this pull request I suggest a solution that tries to mimic the current max(...) behavior but takes possible None values into account. However it assumes that `self.device.current_color` has one of the formats `None, None`, `(int, int, int), None` or `(int, int, int), int` as returned by `xknx/devices/light.py`of package `xknx`.

Issue #18620 could be related.