### PR TITLE
Don't set entity_id  in ZHA entities

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -39,7 +39,7 @@ class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
         self._unique_id = unique_id
         ieeetail = "".join([f"{o:02x}" for o in zha_device.ieee[:4]])
         ch_names = [ch.cluster.ep_attribute for ch in channels]
-        ch_names = "/".join(sorted(ch_names))
+        ch_names = ", ".join(sorted(ch_names))
         self._name = f"{zha_device.name} {ieeetail} {ch_names}"
         self._state = None
         self._device_state_attributes = {}

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -9,7 +9,6 @@ from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.util import slugify
 
 from .core.const import (
     ATTR_MANUFACTURER,
@@ -38,17 +37,10 @@ class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
         self._force_update = False
         self._should_poll = False
         self._unique_id = unique_id
-        if not skip_entity_id:
-            ieee = zha_device.ieee
-            ieeetail = "".join([f"{o:02x}" for o in ieee[:4]])
-            self.entity_id = "{}.{}_{}_{}_{}{}".format(
-                self._domain,
-                slugify(zha_device.manufacturer),
-                slugify(zha_device.model),
-                ieeetail,
-                channels[0].cluster.endpoint.endpoint_id,
-                kwargs.get(ENTITY_SUFFIX, ""),
-            )
+        ieeetail = "".join([f"{o:02x}" for o in zha_device.ieee[:4]])
+        ch_names = [ch.cluster.ep_attribute for ch in channels]
+        ch_names = "/".join(sorted(ch_names))
+        self._name = f"{zha_device.name} {ieeetail} {ch_names}"
         self._state = None
         self._device_state_attributes = {}
         self._zha_device = zha_device
@@ -63,7 +55,7 @@ class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
     @property
     def name(self):
         """Return Entity's default name."""
-        return self.zha_device.name
+        return self._name
 
     @property
     def unique_id(self) -> str:

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -170,12 +170,12 @@ async def find_entity_id(domain, zha_device, hass):
     ieeetail = "".join([f"{o:02x}" for o in zha_device.ieee[:4]])
     head = f"{domain}." + slugify(f"{zha_device.name} {ieeetail}")
 
-    entities = hass.states.async_entity_ids(domain)
+    enitiy_ids = hass.states.async_entity_ids(domain)
     await hass.async_block_till_done()
 
-    for entity in entities:
-        if entity.startswith(head):
-            return entity
+    for entity_id in enitiy_ids:
+        if entity_id.startswith(head):
+            return entity_id
     return None
 
 

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -161,23 +161,22 @@ async def async_setup_entry(hass, config_entry):
     return True
 
 
-def make_entity_id(domain, device, cluster, use_suffix=True):
-    """Make the entity id for the entity under testing.
+async def find_entity_id(domain, zha_device, hass):
+    """Find the entity id under the testing.
 
     This is used to get the entity id in order to get the state from the state
     machine so that we can test state changes.
     """
-    ieee = device.ieee
-    ieeetail = "".join([f"{o:02x}" for o in ieee[:4]])
-    entity_id = "{}.{}_{}_{}_{}{}".format(
-        domain,
-        slugify(device.manufacturer),
-        slugify(device.model),
-        ieeetail,
-        cluster.endpoint.endpoint_id,
-        ("", "_{}".format(cluster.cluster_id))[use_suffix],
-    )
-    return entity_id
+    ieeetail = "".join([f"{o:02x}" for o in zha_device.ieee[:4]])
+    head = f"{domain}." + slugify(f"{zha_device.name} {ieeetail}")
+
+    entities = hass.states.async_entity_ids(domain)
+    await hass.async_block_till_done()
+
+    for entity in entities:
+        if entity.startswith(head):
+            return entity
+    return None
 
 
 async def async_enable_traffic(hass, zha_gateway, zha_devices):
@@ -188,7 +187,7 @@ async def async_enable_traffic(hass, zha_gateway, zha_devices):
 
 
 async def async_test_device_join(
-    hass, zha_gateway, cluster_id, domain, device_type=None
+    hass, zha_gateway, cluster_id, entity_id, device_type=None
 ):
     """Test a newly joining device.
 
@@ -205,20 +204,14 @@ async def async_test_device_join(
             "zigpy.zcl.Cluster.bind",
             return_value=mock_coro([zcl_f.Status.SUCCESS, zcl_f.Status.SUCCESS]),
         ):
-            zigpy_device = await async_init_zigpy_device(
+            await async_init_zigpy_device(
                 hass,
                 [cluster_id, zigpy.zcl.clusters.general.Basic.cluster_id],
                 [],
                 device_type,
                 zha_gateway,
                 ieee="00:0d:6f:00:0a:90:69:f7",
-                manufacturer="FakeMan{}".format(cluster_id),
-                model="FakeMod{}".format(cluster_id),
                 is_new_join=True,
-            )
-            cluster = zigpy_device.endpoints.get(1).in_clusters[cluster_id]
-            entity_id = make_entity_id(
-                domain, zigpy_device, cluster, use_suffix=device_type is None
             )
             assert hass.states.get(entity_id) is not None
 

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -11,8 +11,8 @@ from .common import (
     async_enable_traffic,
     async_init_zigpy_device,
     async_test_device_join,
+    find_entity_id,
     make_attribute,
-    make_entity_id,
     make_zcl_header,
 )
 
@@ -27,6 +27,7 @@ async def test_binary_sensor(hass, config_entry, zha_gateway):
         [],
         None,
         zha_gateway,
+        ieee="00:0d:6f:11:9a:90:69:e6",
     )
 
     zigpy_device_occupancy = await async_init_zigpy_device(
@@ -46,15 +47,15 @@ async def test_binary_sensor(hass, config_entry, zha_gateway):
 
     # on off binary_sensor
     zone_cluster = zigpy_device_zone.endpoints.get(1).ias_zone
-    zone_entity_id = make_entity_id(DOMAIN, zigpy_device_zone, zone_cluster)
     zone_zha_device = zha_gateway.get_device(zigpy_device_zone.ieee)
+    zone_entity_id = await find_entity_id(DOMAIN, zone_zha_device, hass)
+    assert zone_entity_id is not None
 
     # occupancy binary_sensor
     occupancy_cluster = zigpy_device_occupancy.endpoints.get(1).occupancy
-    occupancy_entity_id = make_entity_id(
-        DOMAIN, zigpy_device_occupancy, occupancy_cluster
-    )
     occupancy_zha_device = zha_gateway.get_device(zigpy_device_occupancy.ieee)
+    occupancy_entity_id = await find_entity_id(DOMAIN, occupancy_zha_device, hass)
+    assert occupancy_entity_id is not None
 
     # test that the sensors exist and are in the unavailable state
     assert hass.states.get(zone_entity_id).state == STATE_UNAVAILABLE
@@ -76,7 +77,7 @@ async def test_binary_sensor(hass, config_entry, zha_gateway):
 
     # test new sensor join
     await async_test_device_join(
-        hass, zha_gateway, measurement.OccupancySensing.cluster_id, DOMAIN
+        hass, zha_gateway, measurement.OccupancySensing.cluster_id, occupancy_entity_id
     )
 
 

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -16,8 +16,8 @@ from .common import (
     async_enable_traffic,
     async_init_zigpy_device,
     async_test_device_join,
+    find_entity_id,
     make_attribute,
-    make_entity_id,
     make_zcl_header,
 )
 
@@ -47,8 +47,9 @@ async def test_device_tracker(hass, config_entry, zha_gateway):
     await hass.async_block_till_done()
 
     cluster = zigpy_device.endpoints.get(1).power
-    entity_id = make_entity_id(DOMAIN, zigpy_device, cluster, use_suffix=False)
     zha_device = zha_gateway.get_device(zigpy_device.ieee)
+    entity_id = await find_entity_id(DOMAIN, zha_device, hass)
+    assert entity_id is not None
 
     # test that the device tracker was created and that it is unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
@@ -90,6 +91,6 @@ async def test_device_tracker(hass, config_entry, zha_gateway):
         hass,
         zha_gateway,
         general.PowerConfiguration.cluster_id,
-        DOMAIN,
+        entity_id,
         SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE,
     )

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -20,8 +20,8 @@ from .common import (
     async_enable_traffic,
     async_init_zigpy_device,
     async_test_device_join,
+    find_entity_id,
     make_attribute,
-    make_entity_id,
     make_zcl_header,
 )
 
@@ -41,8 +41,9 @@ async def test_fan(hass, config_entry, zha_gateway):
     await hass.async_block_till_done()
 
     cluster = zigpy_device.endpoints.get(1).fan
-    entity_id = make_entity_id(DOMAIN, zigpy_device, cluster)
     zha_device = zha_gateway.get_device(zigpy_device.ieee)
+    entity_id = await find_entity_id(DOMAIN, zha_device, hass)
+    assert entity_id is not None
 
     # test that the fan was created and that it is unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
@@ -97,7 +98,7 @@ async def test_fan(hass, config_entry, zha_gateway):
         assert cluster.write_attributes.call_args == call({"fan_mode": 3})
 
     # test adding new fan to the network and HA
-    await async_test_device_join(hass, zha_gateway, hvac.Fan.cluster_id, DOMAIN)
+    await async_test_device_join(hass, zha_gateway, hvac.Fan.cluster_id, entity_id)
 
 
 async def async_turn_on(hass, entity_id, speed=None):

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -11,8 +11,8 @@ from homeassistant.const import STATE_LOCKED, STATE_UNAVAILABLE, STATE_UNLOCKED
 from .common import (
     async_enable_traffic,
     async_init_zigpy_device,
+    find_entity_id,
     make_attribute,
-    make_entity_id,
     make_zcl_header,
 )
 
@@ -39,8 +39,9 @@ async def test_lock(hass, config_entry, zha_gateway):
     await hass.async_block_till_done()
 
     cluster = zigpy_device.endpoints.get(1).door_lock
-    entity_id = make_entity_id(DOMAIN, zigpy_device, cluster)
     zha_device = zha_gateway.get_device(zigpy_device.ieee)
+    entity_id = await find_entity_id(DOMAIN, zha_device, hass)
+    assert entity_id is not None
 
     # test that the lock was created and that it is unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -12,8 +12,8 @@ from .common import (
     async_enable_traffic,
     async_init_zigpy_device,
     async_test_device_join,
+    find_entity_id,
     make_attribute,
-    make_entity_id,
     make_zcl_header,
 )
 
@@ -85,7 +85,7 @@ async def test_sensor(hass, config_entry, zha_gateway):
 
     # test joining a new temperature sensor to the network
     await async_test_device_join(
-        hass, zha_gateway, measurement.TemperatureMeasurement.cluster_id, DOMAIN
+        hass, zha_gateway, measurement.TemperatureMeasurement.cluster_id, entity_id
     )
 
 
@@ -110,7 +110,7 @@ async def async_build_devices(hass, zha_gateway, config_entry, cluster_ids):
             [],
             None,
             zha_gateway,
-            ieee="{}0:15:8d:00:02:32:4f:32".format(counter),
+            ieee="00:15:8d:00:02:32:4f:0{}".format(counter),
             manufacturer="Fake{}".format(cluster_id),
             model="FakeModel{}".format(cluster_id),
         )
@@ -126,10 +126,10 @@ async def async_build_devices(hass, zha_gateway, config_entry, cluster_ids):
         device_info = device_infos[cluster_id]
         zigpy_device = device_info["zigpy_device"]
         device_info["cluster"] = zigpy_device.endpoints.get(1).in_clusters[cluster_id]
-        device_info["entity_id"] = make_entity_id(
-            DOMAIN, zigpy_device, device_info["cluster"]
-        )
-        device_info["zha_device"] = zha_gateway.get_device(zigpy_device.ieee)
+        zha_device = zha_gateway.get_device(zigpy_device.ieee)
+        device_info["zha_device"] = zha_device
+        device_info["entity_id"] = await find_entity_id(DOMAIN, zha_device, hass)
+    await hass.async_block_till_done()
     return device_infos
 
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -11,8 +11,8 @@ from .common import (
     async_enable_traffic,
     async_init_zigpy_device,
     async_test_device_join,
+    find_entity_id,
     make_attribute,
-    make_entity_id,
     make_zcl_header,
 )
 
@@ -39,8 +39,9 @@ async def test_switch(hass, config_entry, zha_gateway):
     await hass.async_block_till_done()
 
     cluster = zigpy_device.endpoints.get(1).on_off
-    entity_id = make_entity_id(DOMAIN, zigpy_device, cluster)
     zha_device = zha_gateway.get_device(zigpy_device.ieee)
+    entity_id = await find_entity_id(DOMAIN, zha_device, hass)
+    assert entity_id is not None
 
     # test that the switch was created and that its state is unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
@@ -93,4 +94,4 @@ async def test_switch(hass, config_entry, zha_gateway):
         )
 
     # test joining a new switch to the network and HA
-    await async_test_device_join(hass, zha_gateway, general.OnOff.cluster_id, DOMAIN)
+    await async_test_device_join(hass, zha_gateway, general.OnOff.cluster_id, entity_id)


### PR DESCRIPTION
## Description:
Don't set `entity_id` in ZHA entities. Instead use `name` property and let HA handle entity ids.

In previous versions ZHA entities were issuing their own entity ids when a new device was joined. This was only useful for newly joined devices, as it allowed ZHA to "seed" the entity id, but after that "entity registry" was taking over it anyway. In this PR we take a more general approach and let HA handle the `entity_id` creation/handling.

This is not a breaking, because we keep the `unique_id` intact, thus all existing entities would retain their entity_id and friendly names. Only newly joined devices would be affected.


### The new style entity_ids and names:
![image](https://user-images.githubusercontent.com/5826160/67915607-f5790e00-fb69-11e9-9609-adb6a7b58354.png)

### The old style of entity_ids and names:
![image](https://user-images.githubusercontent.com/5826160/67915719-17729080-fb6a-11e9-848b-af0a6c9cb546.png)



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
