### PR TITLE
Fix Airly asyncio timeout error

### DIFF
--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -10,6 +10,7 @@ from airly.exceptions import AirlyError
 
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import Config, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import Throttle
 
@@ -44,6 +45,9 @@ async def async_setup_entry(hass, config_entry):
     airly = AirlyData(websession, api_key, latitude, longitude)
 
     await airly.async_update()
+    
+    if not airly.data:
+        raise ConfigEntryNotReady()
 
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][DATA_CLIENT] = {}

--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -1,12 +1,12 @@
 """The Airly component."""
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
-import async_timeout
 from aiohttp.client_exceptions import ClientConnectorError
 from airly import Airly
 from airly.exceptions import AirlyError
+import async_timeout
 
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import Config, HomeAssistant

--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass, config_entry):
     airly = AirlyData(websession, api_key, latitude, longitude)
 
     await airly.async_update()
-    
+
     if not airly.data:
         raise ConfigEntryNotReady()
 
@@ -108,11 +108,8 @@ class AirlyData:
             self.data[ATTR_API_CAQI_DESCRIPTION] = index["description"]
             self.data[ATTR_API_ADVICE] = index["advice"]
             _LOGGER.debug("Data retrieved from Airly")
-        except (
-            ValueError,
-            AirlyError,
-            asyncio.TimeoutError,
-            ClientConnectorError,
-        ) as error:
+        except asyncio.TimeoutError:
+            _LOGGER.error("Asyncio Timeout Error")
+        except (ValueError, AirlyError, ClientConnectorError) as error:
             _LOGGER.error(error)
             self.data = {}

--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -85,7 +85,7 @@ class AirlyData:
         """Update Airly data."""
 
         try:
-            with async_timeout.timeout(10):
+            with async_timeout.timeout(20):
                 measurements = self.airly.create_measurements_session_point(
                     self.latitude, self.longitude
                 )


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Standard 10 seconds asyncio timeout is too short at HA startup and the platform is not initialized on some systems. This PR adds `ConfigEntryNotReady` when this happens, increases asyncio timeout to 20 seconds and improves asyncio timeout error handling.

**Related issue (if applicable):** fixes #28379

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
