### PR TITLE
Change Abode cache file path, add cache path to config flow

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_POLLING = "polling"
 
-DEFAULT_CACHEDB = "./abodepy_cache.pickle"
+DEFAULT_CACHEDB = ".abodepy.pickle"
 
 SERVICE_SETTINGS = "change_setting"
 SERVICE_CAPTURE_IMAGE = "capture_image"

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_POLLING = "polling"
 
-DEFAULT_CACHEDB = ".abodepy.pickle"
+DEFAULT_CACHEDB = "abodepy_cache.pickle"
 
 SERVICE_SETTINGS = "change_setting"
 SERVICE_CAPTURE_IMAGE = "capture_image"

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -23,13 +23,11 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-from .const import ATTRIBUTION, DOMAIN
+from .const import ATTRIBUTION, DOMAIN, DEFAULT_CACHEDB
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_POLLING = "polling"
-
-DEFAULT_CACHEDB = "abodepy_cache.pickle"
 
 SERVICE_SETTINGS = "change_setting"
 SERVICE_CAPTURE_IMAGE = "capture_image"

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import DOMAIN  # pylint: disable=W0611
+from .const import DOMAIN, DEFAULT_CACHEDB # pylint: disable=W0611
 
 CONF_POLLING = "polling"
 
@@ -42,9 +42,10 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
         polling = user_input.get(CONF_POLLING, False)
+        cache = hass.config.path(DEFAULT_CACHEDB)
 
         try:
-            await self.hass.async_add_executor_job(Abode, username, password, True)
+            await self.hass.async_add_executor_job(Abode, username, password, True, True, True, cache)
 
         except (AbodeException, ConnectTimeout, HTTPError) as ex:
             _LOGGER.error("Unable to connect to Abode: %s", str(ex))

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -42,7 +42,7 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
         polling = user_input.get(CONF_POLLING, False)
-        cache = hass.config.path(DEFAULT_CACHEDB)
+        cache = self.hass.config.path(DEFAULT_CACHEDB)
 
         try:
             await self.hass.async_add_executor_job(Abode, username, password, True, True, True, cache)

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import DOMAIN, DEFAULT_CACHEDB # pylint: disable=W0611
+from .const import DOMAIN, DEFAULT_CACHEDB  # pylint: disable=W0611
 
 CONF_POLLING = "polling"
 
@@ -45,7 +45,9 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         cache = self.hass.config.path(DEFAULT_CACHEDB)
 
         try:
-            await self.hass.async_add_executor_job(Abode, username, password, True, True, True, cache)
+            await self.hass.async_add_executor_job(
+                Abode, username, password, True, True, True, cache
+            )
 
         except (AbodeException, ConnectTimeout, HTTPError) as ex:
             _LOGGER.error("Unable to connect to Abode: %s", str(ex))

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -1,3 +1,5 @@
 """Constants for the Abode Security System component."""
 DOMAIN = "abode"
 ATTRIBUTION = "Data provided by goabode.com"
+
+DEFAULT_CACHEDB = "abodepy_cache.pickle"


### PR DESCRIPTION
## Description:
Fixes a permission denied issue by passing in a cache path in the config flow. This commit also removes the CWD path `./` in the defined cache/pickle file location to match how several other components define their pickle file locations: [feedreader](https://github.com/home-assistant/home-assistant/blob/e176f16141f4f08bf42e5fa49cb973b025aa0ae4/homeassistant/components/feedreader/__init__.py#L48) [logi_circle](https://github.com/home-assistant/home-assistant/blob/05ecc5a1355c7af11b5d310470a6171528dc7a2b/homeassistant/components/logi_circle/const.py#L8) [ring](https://github.com/home-assistant/home-assistant/blob/05ecc5a1355c7af11b5d310470a6171528dc7a2b/homeassistant/components/ring/__init__.py#L25) [mopar](https://github.com/home-assistant/home-assistant/blob/1e27e2827d7ec200e8b9fc123d61502d5b1d625e/homeassistant/components/mopar/__init__.py#L27)

**Related issue (if applicable):** fixes #28242

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]