### PR TITLE
Check for import errors before validating config

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -527,3 +527,11 @@ async def test_when_setup_already_loaded(hass):
     setup.async_when_setup(hass, "test", mock_callback)
     await hass.async_block_till_done()
     assert calls == ["test", "test"]
+
+
+async def test_setup_import_blows_up(hass):
+    """Test that we handle it correctly when importing integration blows up."""
+    with mock.patch(
+        "homeassistant.loader.Integration.get_component", side_effect=ValueError
+    ):
+        assert not await setup.async_setup_component(hass, "sun", {})


### PR DESCRIPTION
## Description:
Check if the integration imports cleanly as the first thing once we resolve dependencies and requirements and catch any type of error. Now it was getting imported as part of the config validation check, and that blew up and was not caught correctly.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
