### PR TITLE
Remove mypy from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,17 +15,3 @@ repos:
           - flake8-docstrings==1.3.1
           - pydocstyle==4.0.0
         files: ^(homeassistant|script|tests)/.+\.py$
-# Using a local "system" mypy instead of the mypy hook, because its
-# results depend on what is installed. And the mypy hook runs in a
-# virtualenv of its own, meaning we'd need to install and maintain
-# another set of our dependencies there... no. Use the "system" one
-# and reuse the environment that is set up anyway already instead.
--   repo: local
-    hooks:
-    -   id: mypy
-        name: mypy
-        entry: mypy
-        language: system
-        types: [python]
-        require_serial: true
-        files: ^homeassistant/.+\.py$

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -185,5 +185,5 @@ stages:
           pre-commit install-hooks
     - script: |
         . venv/bin/activate
-        pre-commit run mypy --all-files
+        mypy homeassistant
       displayName: 'Run mypy'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,4 +7,4 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo "Installing development dependencies..."
-python3 -m pip install tox colorlog pre-commit $(grep mypy requirements_test.txt)
+python3 -m pip install tox colorlog pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,4 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-    pre-commit run mypy {posargs: --all-files}
+    mypy homeassistant


### PR DESCRIPTION

## Description:

We should only run mypy in consistent environments, i.e. ones containing
our full dependency set. Running it without that produces inconsistent
results, and we don't currently expect one to be active when committing
because arranging that for example for GitHub Desktop is not something
we want to inflict on contributors.


**Related issue (if applicable):** fixes #28283

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
