### PR TITLE
Fix issue with multiple Netatmo home coach devices

### DIFF
--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/integrations/netatmo",
   "requirements": [
-    "pyatmo==2.3.2"
+    "pyatmo==2.3.3"
   ],
   "dependencies": [
     "webhook"

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -213,7 +213,7 @@ class NetatmoSensor(Entity):
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._module_type = module["type"]
         self._module_id = module_info["id"]
-        self._unique_id = f"{self._module_id}-{self.type}-{self._module_type}"
+        self._unique_id = f"{self._module_id}-{self.type}"
 
     @property
     def name(self):

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -148,7 +148,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             all_module_infos = data.get_module_infos()
             all_module_names = [e["module_name"] for e in all_module_infos.values()]
             module_names = config.get(CONF_MODULES, all_module_names)
-            _dev = []
+            entities = []
             for module_name in module_names:
                 if module_name not in all_module_names:
                     _LOGGER.info("Module %s not found", module_name)
@@ -163,18 +163,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                         module["module_name"],
                         data.station_data.moduleById(mid=module["id"]),
                     )
-                    _dev.append(NetatmoSensor(data, module, condition.lower()))
-            return _dev
+                    entities.append(NetatmoSensor(data, module, condition.lower()))
+            return entities
 
         def _retry(_data):
             try:
-                _dev = find_devices(_data)
+                entities = find_devices(_data)
             except requests.exceptions.Timeout:
                 return call_later(
                     hass, NETATMO_UPDATE_INTERVAL, lambda _: _retry(_data)
                 )
-            if _dev:
-                add_entities(_dev, True)
+            if entities:
+                add_entities(entities, True)
 
         for data_class in [pyatmo.WeatherStationData, pyatmo.HomeCoachData]:
             try:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1090,7 +1090,7 @@ pyalarmdotcom==0.3.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==2.3.2
+pyatmo==2.3.3
 
 # homeassistant.components.atome
 pyatome==0.1.1


### PR DESCRIPTION
## Breaking Change:

none

## Description:
When more than one home coach device was available it was not guaranteed that it could be used within Home Assistant due to the way the individual modules were called (by name instead of id). The entity names might change for home coach devices. This was fixed upstream and is reflected in this change.

This includes an upgrade of `pyatmo` to 2.3.3.

~~Waiting for https://github.com/jabesq/netatmo-api-python/pull/88 to get merged and a new release of pyatmo.~~

**Related issue (if applicable):** fixes #27845

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
