### PR TITLE
Allow setting an MQTT fan to a custom-named speed.

### DIFF
--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -278,6 +278,8 @@ class MqttFan(
                 self._speed = SPEED_HIGH
             elif payload == self._payload["SPEED_OFF"]:
                 self._speed = SPEED_OFF
+            elif payload in self._config[CONF_SPEED_LIST]:
+                self._speed = payload
             self.async_write_ha_state()
 
         if self._topic[CONF_SPEED_STATE_TOPIC] is not None:


### PR DESCRIPTION
This changeset allows an MQTT fan to a speed other then off, low, medium, or high as long as the custom speed is listed in the configured or discovered speed list. This is required for support of devices such as the Wink fan control via Zigbee2mqtt.

#
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) :** home-assistant/home-assistant.io#11065

## Example entry for `configuration.yaml` (if applicable):
```yaml
fan:
  - platform: mqtt
    speeds: 
      - 'smart'
      - 'custom'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)