### PR TITLE
Bump pyEight library to 0.1.2 to update API URL

### DIFF
--- a/homeassistant/components/eight_sleep/manifest.json
+++ b/homeassistant/components/eight_sleep/manifest.json
@@ -3,7 +3,7 @@
   "name": "Eight sleep",
   "documentation": "https://www.home-assistant.io/integrations/eight_sleep",
   "requirements": [
-    "pyeight==0.1.1"
+    "pyeight==0.1.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1180,7 +1180,7 @@ pyeconet==0.0.11
 pyedimax==0.1
 
 # homeassistant.components.eight_sleep
-pyeight==0.1.1
+pyeight==0.1.2
 
 # homeassistant.components.emby
 pyemby==1.6


### PR DESCRIPTION
##  Description:
Update pyEight library version.  The API url has changed.

**Related issue (if applicable):** 
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
