### PR TITLE
Use friendly app names for Fire TV sources

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -581,7 +581,6 @@ class FireTVDevice(ADBDevice):
         If the source starts with a '!', then it will close the app instead of
         opening it.
         """
-        _LOGGER.critical("select_source(%s)", source)
         if isinstance(source, str):
             if not source.startswith("!"):
                 self.aftv.launch_app(self._app_name_to_id.get(source, source))

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -290,7 +290,7 @@ class ADBDevice(MediaPlayerDevice):
         self._app_id_to_name = APPS.copy()
         self._app_id_to_name.update(apps)
         self._app_name_to_id = {
-            value: key for (key, value) in self._app_id_to_name.items()
+            value: key for key, value in self._app_id_to_name.items()
         }
         self._keys = KEYS
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -287,8 +287,11 @@ class ADBDevice(MediaPlayerDevice):
         """Initialize the Android TV / Fire TV device."""
         self.aftv = aftv
         self._name = name
-        self._apps = APPS.copy()
-        self._apps.update(apps)
+        self._app_id_to_name = APPS.copy()
+        self._app_id_to_name.update(apps)
+        self._app_name_to_id = {
+            value: key for (key, value) in self._app_id_to_name.items()
+        }
         self._keys = KEYS
 
         self._device_properties = self.aftv.device_properties
@@ -328,7 +331,7 @@ class ADBDevice(MediaPlayerDevice):
     @property
     def app_name(self):
         """Return the friendly name of the current app."""
-        return self._apps.get(self._current_app, self._current_app)
+        return self._app_id_to_name.get(self._current_app, self._current_app)
 
     @property
     def available(self):
@@ -518,7 +521,7 @@ class FireTVDevice(ADBDevice):
         super().__init__(aftv, name, apps, turn_on_command, turn_off_command)
 
         self._get_sources = get_sources
-        self._running_apps = None
+        self._sources = None
 
     @adb_decorator(override_available=True)
     def update(self):
@@ -538,23 +541,28 @@ class FireTVDevice(ADBDevice):
             return
 
         # Get the `state`, `current_app`, and `running_apps`.
-        state, self._current_app, self._running_apps = self.aftv.update(
-            self._get_sources
-        )
+        state, self._current_app, running_apps = self.aftv.update(self._get_sources)
 
         self._state = ANDROIDTV_STATES.get(state)
         if self._state is None:
             self._available = False
 
+        if running_apps:
+            self._sources = [
+                self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
+            ]
+        else:
+            self._sources = None
+
     @property
     def source(self):
         """Return the current app."""
-        return self._current_app
+        return self._app_id_to_name.get(self._current_app, self._current_app)
 
     @property
     def source_list(self):
         """Return a list of running apps."""
-        return self._running_apps
+        return self._sources
 
     @property
     def supported_features(self):
@@ -573,8 +581,10 @@ class FireTVDevice(ADBDevice):
         If the source starts with a '!', then it will close the app instead of
         opening it.
         """
+        _LOGGER.critical("select_source(%s)", source)
         if isinstance(source, str):
             if not source.startswith("!"):
-                self.aftv.launch_app(source)
+                self.aftv.launch_app(self._app_name_to_id.get(source, source))
             else:
-                self.aftv.stop_app(source[1:].lstrip())
+                source_ = source[1:].lstrip()
+                self.aftv.stop_app(self._app_name_to_id.get(source_, source_))

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -140,3 +140,15 @@ def isfile(filepath):
 
 PATCH_ISFILE = patch("os.path.isfile", isfile)
 PATCH_ACCESS = patch("os.access", return_value=True)
+
+
+def patch_firetv_update(state, current_app, running_apps):
+    """Patch the `FireTV.update()` method."""
+    return patch(
+        "androidtv.firetv.FireTV.update",
+        return_value=(state, current_app, running_apps),
+    )
+
+
+PATCH_LAUNCH_APP = patch("androidtv.firetv.FireTV.launch_app")
+PATCH_STOP_APP = patch("androidtv.firetv.FireTV.stop_app")

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -9,12 +9,12 @@ from homeassistant.components.androidtv.media_player import (
     CONF_APPS,
 )
 from homeassistant.components.media_player.const import (
-    ATTR_INPUT_SOURCE,
+    # ATTR_INPUT_SOURCE,
     DOMAIN,
-    SERVICE_SELECT_SOURCE,
+    # SERVICE_SELECT_SOURCE,
 )
 from homeassistant.const import (
-    ATTR_ENTITY_ID,
+    # ATTR_ENTITY_ID,
     CONF_DEVICE_CLASS,
     CONF_HOST,
     CONF_NAME,
@@ -321,45 +321,51 @@ async def test_firetv_sources(hass):
         assert state.attributes["source_list"] == ["com.app.test2", "TEST 1"]
 
     with patchers.PATCH_LAUNCH_APP as launch_app:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test1"},
-        )
+        # await hass.services.async_call(
+        #     DOMAIN,
+        #     SERVICE_SELECT_SOURCE,
+        #     {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test1"},
+        # )
+        hass.data["androidtv"]["127.0.0.1:5555"].select_source("com.app.test1")
         launch_app.assert_called_with("com.app.test1")
 
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "TEST 1"},
-        )
+        # await hass.services.async_call(
+        #     DOMAIN,
+        #     SERVICE_SELECT_SOURCE,
+        #     {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "TEST 1"},
+        # )
+        hass.data["androidtv"]["127.0.0.1:5555"].select_source("TEST 1")
         launch_app.assert_called_with("com.app.test1")
 
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test2"},
-        )
+        # await hass.services.async_call(
+        #     DOMAIN,
+        #     SERVICE_SELECT_SOURCE,
+        #     {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test2"},
+        # )
+        hass.data["androidtv"]["127.0.0.1:5555"].select_source("com.app.test2")
         launch_app.assert_called_with("com.app.test2")
 
     with patchers.PATCH_STOP_APP as stop_app:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test1"},
-        )
+        # await hass.services.async_call(
+        #     DOMAIN,
+        #     SERVICE_SELECT_SOURCE,
+        #     {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test1"},
+        # )
+        hass.data["androidtv"]["127.0.0.1:5555"].select_source("!com.app.test1")
         stop_app.assert_called_with("com.app.test1")
 
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "TEST 1"},
-        )
+        # await hass.services.async_call(
+        #     DOMAIN,
+        #     SERVICE_SELECT_SOURCE,
+        #     {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "TEST 1"},
+        # )
+        hass.data["androidtv"]["127.0.0.1:5555"].select_source("!TEST 1")
         stop_app.assert_called_with("com.app.test1")
 
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test2"},
-        )
+        # await hass.services.async_call(
+        #     DOMAIN,
+        #     SERVICE_SELECT_SOURCE,
+        #     {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "com.app.test2"},
+        # )
+        hass.data["androidtv"]["127.0.0.1:5555"].select_source("!com.app.test2")
         stop_app.assert_called_with("com.app.test2")


### PR DESCRIPTION
## Breaking Change:

The `source` and `sources_list` attributes for Fire TV devices will use friendly app names instead of app IDs (e.g., "Netflix" instead of "com.netflix.ninja"). If you are using these attributes in automations, sensors, etc., you will need to update them. 

* If you are currently checking that the `source` attribute of a Fire TV device is a particular app ID, you have two options:
  - Check the `app_id` attribute instead
  - Replace that app ID with the friendly name for the app. 
* If you are currently checking the `sources_list` attribute, then you will need to check for friendly app names instead of app IDs. 

You can still use app IDs for the `media_player.select_source` service. 

## Description:

Use friendly app names instead of app IDs for the sources for Fire TV devices (e.g., "Netflix" instead of "com.netflix.ninja"). 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
