### PR TITLE
WIP: Add additional dependencies for owntracks

### DIFF
--- a/homeassistant/components/owntracks/manifest.json
+++ b/homeassistant/components/owntracks/manifest.json
@@ -4,7 +4,10 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/owntracks",
   "requirements": [
-    "PyNaCl==1.3.0"
+    "PyNaCl==1.3.0",
+    "paho-mqtt==1.5.0",
+    "hbmqtt==0.9.5"
+
   ],
   "dependencies": [
     "webhook"


### PR DESCRIPTION
Owntracks requires additional dependencies.

## Breaking Change:
With an update from 0.99.2 to 0.101.0 the owntracks module started throwing errors about missing dependencies.

## Description:
This PR adds the dependencies to the manifests.json.

**Related issue (if applicable):**
fixes #28388

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
