### PR TITLE
Upgrade paho-mqtt to 1.5.0

### DIFF
--- a/homeassistant/components/mqtt/manifest.json
+++ b/homeassistant/components/mqtt/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/mqtt",
   "requirements": [
     "hbmqtt==0.9.5",
-    "paho-mqtt==1.4.0"
+    "paho-mqtt==1.5.0"
   ],
   "dependencies": [
     "http"

--- a/homeassistant/components/shiftr/manifest.json
+++ b/homeassistant/components/shiftr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shiftr",
   "documentation": "https://www.home-assistant.io/integrations/shiftr",
   "requirements": [
-    "paho-mqtt==1.4.0"
+    "paho-mqtt==1.5.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -933,7 +933,7 @@ orvibo==1.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.4.0
+paho-mqtt==1.5.0
 
 # homeassistant.components.panasonic_bluray
 panacotta==0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -324,7 +324,7 @@ oauth2client==4.0.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.4.0
+paho-mqtt==1.5.0
 
 # homeassistant.components.aruba
 # homeassistant.components.cisco_ios


### PR DESCRIPTION
## Description:
Changelog: https://github.com/eclipse/paho.mqtt.python/blob/master/ChangeLog.txt

## Example entry for `configuration.yaml` (if applicable):
```yaml
shiftr:
  username: !secret shiftr_user
  password: !secret shiftr_password
```

Shiftr.io output: https://twitter.com/fabaff/status/1190205181096529920

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.