### PR TITLE
Use defined device class constants for Homematic

### DIFF
--- a/homeassistant/components/homematic/binary_sensor.py
+++ b/homeassistant/components/homematic/binary_sensor.py
@@ -63,7 +63,7 @@ class HMBinarySensor(HMDevice, BinarySensorDevice):
         # If state is MOTION (Only RemoteMotion working)
         if self._state == "MOTION":
             return DEVICE_CLASS_MOTION
-        return SENSOR_TYPES_CLASS.get(self._hmdevice.__class__.__name__, None)
+        return SENSOR_TYPES_CLASS.get(self._hmdevice.__class__.__name__)
 
     def _init_data_struct(self):
         """Generate the data dictionary (self._data) from metadata."""

--- a/homeassistant/components/homematic/binary_sensor.py
+++ b/homeassistant/components/homematic/binary_sensor.py
@@ -1,26 +1,32 @@
 """Support for HomeMatic binary sensors."""
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_OPENING,
+    DEVICE_CLASS_PRESENCE,
+    DEVICE_CLASS_SMOKE,
+    BinarySensorDevice,
+)
 from homeassistant.components.homematic import ATTR_DISCOVERY_TYPE, DISCOVER_BATTERY
-from homeassistant.const import DEVICE_CLASS_BATTERY
 
 from . import ATTR_DISCOVER_DEVICES, HMDevice
 
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES_CLASS = {
-    "IPShutterContact": "opening",
-    "IPShutterContactSabotage": "opening",
-    "MaxShutterContact": "opening",
-    "Motion": "motion",
-    "MotionV2": "motion",
-    "PresenceIP": "motion",
+    "IPShutterContact": DEVICE_CLASS_OPENING,
+    "IPShutterContactSabotage": DEVICE_CLASS_OPENING,
+    "MaxShutterContact": DEVICE_CLASS_OPENING,
+    "Motion": DEVICE_CLASS_MOTION,
+    "MotionV2": DEVICE_CLASS_MOTION,
+    "PresenceIP": DEVICE_CLASS_PRESENCE,
     "Remote": None,
     "RemoteMotion": None,
-    "ShutterContact": "opening",
-    "Smoke": "smoke",
-    "SmokeV2": "smoke",
+    "ShutterContact": DEVICE_CLASS_OPENING,
+    "Smoke": DEVICE_CLASS_SMOKE,
+    "SmokeV2": DEVICE_CLASS_SMOKE,
     "TiltSensor": None,
     "WeatherSensor": None,
 }
@@ -56,7 +62,7 @@ class HMBinarySensor(HMDevice, BinarySensorDevice):
         """Return the class of this sensor from DEVICE_CLASSES."""
         # If state is MOTION (Only RemoteMotion working)
         if self._state == "MOTION":
-            return "motion"
+            return DEVICE_CLASS_MOTION
         return SENSOR_TYPES_CLASS.get(self._hmdevice.__class__.__name__, None)
 
     def _init_data_struct(self):

--- a/homeassistant/components/homematic/sensor.py
+++ b/homeassistant/components/homematic/sensor.py
@@ -1,7 +1,15 @@
 """Support for HomeMatic sensors."""
 import logging
 
-from homeassistant.const import ENERGY_WATT_HOUR, POWER_WATT, STATE_UNKNOWN
+from homeassistant.const import (
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+    ENERGY_WATT_HOUR,
+    POWER_WATT,
+    STATE_UNKNOWN,
+)
 
 from . import ATTR_DISCOVER_DEVICES, HMDevice
 
@@ -48,20 +56,20 @@ HM_UNIT_HA_CAST = {
     "VALUE": "#",
 }
 
-HM_ICON_HA_CAST = {
-    "WIND_SPEED": "mdi:weather-windy",
-    "HUMIDITY": "mdi:water-percent",
-    "TEMPERATURE": "mdi:thermometer",
-    "ACTUAL_TEMPERATURE": "mdi:thermometer",
-    "LUX": "mdi:weather-sunny",
-    "CURRENT_ILLUMINATION": "mdi:weather-sunny",
-    "AVERAGE_ILLUMINATION": "mdi:weather-sunny",
-    "LOWEST_ILLUMINATION": "mdi:weather-sunny",
-    "HIGHEST_ILLUMINATION": "mdi:weather-sunny",
-    "BRIGHTNESS": "mdi:invert-colors",
-    "POWER": "mdi:flash-red-eye",
-    "CURRENT": "mdi:flash-red-eye",
+HM_DEVICE_CLASS_HA_CAST = {
+    "HUMIDITY": DEVICE_CLASS_HUMIDITY,
+    "TEMPERATURE": DEVICE_CLASS_TEMPERATURE,
+    "ACTUAL_TEMPERATURE": DEVICE_CLASS_TEMPERATURE,
+    "LUX": DEVICE_CLASS_ILLUMINANCE,
+    "CURRENT_ILLUMINATION": DEVICE_CLASS_ILLUMINANCE,
+    "AVERAGE_ILLUMINATION": DEVICE_CLASS_ILLUMINANCE,
+    "LOWEST_ILLUMINATION": DEVICE_CLASS_ILLUMINANCE,
+    "HIGHEST_ILLUMINATION": DEVICE_CLASS_ILLUMINANCE,
+    "POWER": DEVICE_CLASS_POWER,
+    "CURRENT": DEVICE_CLASS_POWER,
 }
+
+HM_ICON_HA_CAST = {"WIND_SPEED": "mdi:weather-windy", "BRIGHTNESS": "mdi:invert-colors"}
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -95,6 +103,11 @@ class HMSensor(HMDevice):
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return HM_UNIT_HA_CAST.get(self._state, None)
+
+    @property
+    def device_class(self):
+        """Return the device class to use in the frontend, if any."""
+        return HM_DEVICE_CLASS_HA_CAST.get(self._state, None)
 
     @property
     def icon(self):

--- a/homeassistant/components/homematic/sensor.py
+++ b/homeassistant/components/homematic/sensor.py
@@ -107,7 +107,7 @@ class HMSensor(HMDevice):
     @property
     def device_class(self):
         """Return the device class to use in the frontend, if any."""
-        return HM_DEVICE_CLASS_HA_CAST.get(self._state, None)
+        return HM_DEVICE_CLASS_HA_CAST.get(self._state)
 
     @property
     def icon(self):

--- a/homeassistant/components/homematic/sensor.py
+++ b/homeassistant/components/homematic/sensor.py
@@ -94,7 +94,7 @@ class HMSensor(HMDevice):
         # Does a cast exist for this class?
         name = self._hmdevice.__class__.__name__
         if name in HM_STATE_HA_CAST:
-            return HM_STATE_HA_CAST[name].get(self._hm_get_state(), None)
+            return HM_STATE_HA_CAST[name].get(self._hm_get_state())
 
         # No cast, return original value
         return self._hm_get_state()
@@ -102,7 +102,7 @@ class HMSensor(HMDevice):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return HM_UNIT_HA_CAST.get(self._state, None)
+        return HM_UNIT_HA_CAST.get(self._state)
 
     @property
     def device_class(self):
@@ -112,7 +112,7 @@ class HMSensor(HMDevice):
     @property
     def icon(self):
         """Return the icon to use in the frontend, if any."""
-        return HM_ICON_HA_CAST.get(self._state, None)
+        return HM_ICON_HA_CAST.get(self._state)
 
     def _init_data_struct(self):
         """Generate a data dictionary (self._data) from metadata."""


### PR DESCRIPTION
## Description:
`sensor`: Replace strings with existing device_class constants.
`binary_sensor`: instead of using own icons, the predefined device classes are used where possible.
By this refactoring this, the used icons align with other integrations that use device classes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
