### PR TITLE
Use server-specific unique_ids for Plex media_players

### DIFF
--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -94,9 +94,10 @@ class PlexServer:
 
     def refresh_entity(self, machine_identifier, device, session):
         """Forward refresh dispatch to media_player."""
+        unique_id = f"{self.machine_identifier}:{machine_identifier}"
         dispatcher_send(
             self._hass,
-            PLEX_UPDATE_MEDIA_PLAYER_SIGNAL.format(machine_identifier),
+            PLEX_UPDATE_MEDIA_PLAYER_SIGNAL.format(unique_id),
             device,
             session,
         )


### PR DESCRIPTION
## Description:
As reported [here](https://community.home-assistant.io/t/plex-updates-via-web-socket/70243/8) Plex clients can report the same `machineIdentifier` to different Plex servers. This changes the `unique_id` to be server-specific and migrates the IDs for existing entities in the registry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
