### PR TITLE
Also install after_deps

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -48,8 +48,12 @@ async def async_get_integration_with_requirements(
             hass, integration.domain, integration.requirements
         )
 
-    for dependency in integration.dependencies:
-        await async_get_integration_with_requirements(hass, dependency)
+    deps = integration.dependencies + (integration.after_dependencies or [])
+
+    if deps:
+        await asyncio.gather(
+            *[async_get_integration_with_requirements(hass, dep) for dep in deps]
+        )
 
     return integration
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -118,9 +118,16 @@ async def test_get_integration_with_requirements(hass):
     mock_integration(
         hass,
         MockModule(
+            "test_component_after_dep", requirements=["test-comp-after-dep==1.0.0"]
+        ),
+    )
+    mock_integration(
+        hass,
+        MockModule(
             "test_component",
             requirements=["test-comp==1.0.0"],
             dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
         ),
     )
 
@@ -136,13 +143,15 @@ async def test_get_integration_with_requirements(hass):
         assert integration
         assert integration.domain == "test_component"
 
-    assert len(mock_is_installed.mock_calls) == 2
+    assert len(mock_is_installed.mock_calls) == 3
     assert mock_is_installed.mock_calls[0][1][0] == "test-comp==1.0.0"
     assert mock_is_installed.mock_calls[1][1][0] == "test-comp-dep==1.0.0"
+    assert mock_is_installed.mock_calls[2][1][0] == "test-comp-after-dep==1.0.0"
 
-    assert len(mock_inst.mock_calls) == 2
+    assert len(mock_inst.mock_calls) == 3
     assert mock_inst.mock_calls[0][1][0] == "test-comp==1.0.0"
     assert mock_inst.mock_calls[1][1][0] == "test-comp-dep==1.0.0"
+    assert mock_inst.mock_calls[2][1][0] == "test-comp-after-dep==1.0.0"
 
 
 async def test_install_with_wheels_index(hass):


### PR DESCRIPTION
## Description:
When making sure requirements are installed, also make sure they are installed for the dependencies mentioned in the `after_dependencies` 

**Related issue (if applicable):** fixes #28439

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
