### PR TITLE
List inputs in Alexa.InputController

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -118,6 +118,11 @@ class AlexaCapability:
         """Return the supportedOperations object."""
         return []
 
+    @staticmethod
+    def inputs():
+        """Applicable to InputController interface."""
+        return None
+
     def serialize_discovery(self):
         """Serialize according to the Discovery API."""
         result = {"type": "AlexaInterface", "interface": self.name(), "version": "3"}
@@ -148,6 +153,11 @@ class AlexaCapability:
         capability_resources = self.serialize_capability_resources()
         if capability_resources:
             result["capabilityResources"] = capability_resources
+
+        # pylint: disable=assignment-from-none
+        inputs = self.inputs()
+        if inputs is not None:
+            result["inputs"] = inputs
 
         configuration = self.configuration()
         if configuration:
@@ -528,6 +538,12 @@ class AlexaInputController(AlexaCapability):
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.InputController"
+
+    def inputs(self):
+        """Return sources available on this entity."""
+        source_list = self.entity.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST)
+        if source_list:
+            return [{"name": source} for source in source_list]
 
 
 class AlexaTemperatureSensor(AlexaCapability):


### PR DESCRIPTION
## Description:
Field `inputs` is mandatory for `Alexa.InputController` in discovery

https://developer.amazon.com/de/docs/device-apis/alexa-inputcontroller.html#discovery

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
