### PR TITLE
101.2

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -23,13 +23,11 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-from .const import ATTRIBUTION, DOMAIN
+from .const import ATTRIBUTION, DOMAIN, DEFAULT_CACHEDB
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_POLLING = "polling"
-
-DEFAULT_CACHEDB = "./abodepy_cache.pickle"
 
 SERVICE_SETTINGS = "change_setting"
 SERVICE_CAPTURE_IMAGE = "capture_image"

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import DOMAIN  # pylint: disable=W0611
+from .const import DOMAIN, DEFAULT_CACHEDB  # pylint: disable=W0611
 
 CONF_POLLING = "polling"
 
@@ -42,9 +42,12 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
         polling = user_input.get(CONF_POLLING, False)
+        cache = self.hass.config.path(DEFAULT_CACHEDB)
 
         try:
-            await self.hass.async_add_executor_job(Abode, username, password, True)
+            await self.hass.async_add_executor_job(
+                Abode, username, password, True, True, True, cache
+            )
 
         except (AbodeException, ConnectTimeout, HTTPError) as ex:
             _LOGGER.error("Unable to connect to Abode: %s", str(ex))

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -1,3 +1,5 @@
 """Constants for the Abode Security System component."""
 DOMAIN = "abode"
 ATTRIBUTION = "Data provided by goabode.com"
+
+DEFAULT_CACHEDB = "abodepy_cache.pickle"

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -180,13 +180,9 @@ class KNXLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        if self.device.supports_brightness:
-            return self.device.current_brightness
-        if (
-            self.device.supports_color or self.device.supports_rgbw
-        ) and self.device.current_color:
-            return max(self.device.current_color)
-        return None
+        if not self.device.supports_brightness:
+            return None
+        return self.device.current_brightness
 
     @property
     def hs_color(self):

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -94,9 +94,10 @@ class PlexServer:
 
     def refresh_entity(self, machine_identifier, device, session):
         """Forward refresh dispatch to media_player."""
+        unique_id = f"{self.machine_identifier}:{machine_identifier}"
         dispatcher_send(
             self._hass,
-            PLEX_UPDATE_MEDIA_PLAYER_SIGNAL.format(machine_identifier),
+            PLEX_UPDATE_MEDIA_PLAYER_SIGNAL.format(unique_id),
             device,
             session,
         )

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 101
-PATCH_VERSION = "1"
+PATCH_VERSION = "2"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 6, 1)

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -48,8 +48,12 @@ async def async_get_integration_with_requirements(
             hass, integration.domain, integration.requirements
         )
 
-    for dependency in integration.dependencies:
-        await async_get_integration_with_requirements(hass, dependency)
+    deps = integration.dependencies + (integration.after_dependencies or [])
+
+    if deps:
+        await asyncio.gather(
+            *[async_get_integration_with_requirements(hass, dep) for dep in deps]
+        )
 
     return integration
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -118,9 +118,16 @@ async def test_get_integration_with_requirements(hass):
     mock_integration(
         hass,
         MockModule(
+            "test_component_after_dep", requirements=["test-comp-after-dep==1.0.0"]
+        ),
+    )
+    mock_integration(
+        hass,
+        MockModule(
             "test_component",
             requirements=["test-comp==1.0.0"],
             dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
         ),
     )
 
@@ -136,13 +143,15 @@ async def test_get_integration_with_requirements(hass):
         assert integration
         assert integration.domain == "test_component"
 
-    assert len(mock_is_installed.mock_calls) == 2
+    assert len(mock_is_installed.mock_calls) == 3
     assert mock_is_installed.mock_calls[0][1][0] == "test-comp==1.0.0"
     assert mock_is_installed.mock_calls[1][1][0] == "test-comp-dep==1.0.0"
+    assert mock_is_installed.mock_calls[2][1][0] == "test-comp-after-dep==1.0.0"
 
-    assert len(mock_inst.mock_calls) == 2
+    assert len(mock_inst.mock_calls) == 3
     assert mock_inst.mock_calls[0][1][0] == "test-comp==1.0.0"
     assert mock_inst.mock_calls[1][1][0] == "test-comp-dep==1.0.0"
+    assert mock_inst.mock_calls[2][1][0] == "test-comp-after-dep==1.0.0"
 
 
 async def test_install_with_wheels_index(hass):


### PR DESCRIPTION
- Prevent TypeError when KNX RGB(W) light value contains None ([@phispi] - [#28358]) ([knx docs])
- Change Abode cache file path, add cache path to config flow ([@MisterWil] - [#28389]) ([abode docs])
- SNMP switch fix integer support ([@rfpronk] - [#28425]) ([snmp docs])
- Use server-specific unique_ids for Plex media_players ([@jjlawren] - [#28447]) ([plex docs])
- Also install after_deps ([@balloob] - [#28453])

[#28358]: https://github.com/home-assistant/home-assistant/pull/28358
[#28389]: https://github.com/home-assistant/home-assistant/pull/28389
[#28425]: https://github.com/home-assistant/home-assistant/pull/28425
[#28447]: https://github.com/home-assistant/home-assistant/pull/28447
[#28453]: https://github.com/home-assistant/home-assistant/pull/28453
[@MisterWil]: https://github.com/MisterWil
[@balloob]: https://github.com/balloob
[@jjlawren]: https://github.com/jjlawren
[@phispi]: https://github.com/phispi
[@rfpronk]: https://github.com/rfpronk
[abode docs]: https://www.home-assistant.io/integrations/abode/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[plex docs]: https://www.home-assistant.io/integrations/plex/
[snmp docs]: https://www.home-assistant.io/integrations/snmp/