### PR TITLE
Fix missing sonos import

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -8,6 +8,7 @@ import urllib
 
 import async_timeout
 import pysonos
+from pysonos import alarms
 from pysonos.exceptions import SoCoException, SoCoUPnPException
 import pysonos.snapshot
 
@@ -1163,7 +1164,7 @@ class SonosEntity(MediaPlayerDevice):
         """Set the alarm clock on the player."""
 
         alarm = None
-        for one_alarm in pysonos.alarms.get_alarms(self.soco):
+        for one_alarm in alarms.get_alarms(self.soco):
             # pylint: disable=protected-access
             if one_alarm._alarm_id == str(data[ATTR_ALARM_ID]):
                 alarm = one_alarm


### PR DESCRIPTION
## Description:
[PR 27938](https://github.com/home-assistant/home-assistant/pull/27938) tidied up the imports in media_player.py. An assumption was made about how the pysonos library exposes some of its interfaces which led to the regression reported in issue 28419.

This PR restores the missing import, and has been successfully locally tested by the person who reported the issue.

**Related issue (if applicable):** fixes [#28419](https://github.com/home-assistant/home-assistant/issues/28419)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
