### PR TITLE
pre-commit: ship default and full configs

### DIFF
--- a/.pre-commit-config-all.yaml
+++ b/.pre-commit-config-all.yaml
@@ -1,0 +1,42 @@
+# This configuration includes the full set of hooks we use. In
+# addition to the defaults (see .pre-commit-config.yaml), this
+# includes hooks that require our development and test dependencies
+# installed and the virtualenv containing them active by the time
+# pre-commit runs to produce correct results.
+#
+# If this is not a problem for your workflow, using this config is
+# recommended, install it with
+#     pre-commit install --config .pre-commit-config-all.yaml
+# Otherwise, see the default .pre-commit-config.yaml for a lighter one.
+
+repos:
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    -   id: black
+        args:
+          - --safe
+          - --quiet
+        files: ^((homeassistant|script|tests)/.+)?[^/]+\.py$
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.8
+    hooks:
+    -   id: flake8
+        additional_dependencies:
+          - flake8-docstrings==1.3.1
+          - pydocstyle==4.0.0
+        files: ^(homeassistant|script|tests)/.+\.py$
+# Using a local "system" mypy instead of the mypy hook, because its
+# results depend on what is installed. And the mypy hook runs in a
+# virtualenv of its own, meaning we'd need to install and maintain
+# another set of our dependencies there... no. Use the "system" one
+# and reuse the environment that is set up anyway already instead.
+-   repo: local
+    hooks:
+    -   id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        require_serial: true
+        files: ^homeassistant/.+\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
+# This configuration includes the default, minimal set of hooks to be
+# run on all commits. It requires no specific setup and one can just
+# start using pre-commit with it.
+#
+# See .pre-commit-config-all.yaml for a more complete one that comes
+# with a better coverage at the cost of some specific setup needed.
+
 repos:
 -   repo: https://github.com/psf/black
     rev: 19.10b0
@@ -15,17 +22,3 @@ repos:
           - flake8-docstrings==1.3.1
           - pydocstyle==4.0.0
         files: ^(homeassistant|script|tests)/.+\.py$
-# Using a local "system" mypy instead of the mypy hook, because its
-# results depend on what is installed. And the mypy hook runs in a
-# virtualenv of its own, meaning we'd need to install and maintain
-# another set of our dependencies there... no. Use the "system" one
-# and reuse the environment that is set up anyway already instead.
--   repo: local
-    hooks:
-    -   id: mypy
-        name: mypy
-        entry: mypy
-        language: system
-        types: [python]
-        require_serial: true
-        files: ^homeassistant/.+\.py$

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -45,7 +45,7 @@ stages:
 
           . venv/bin/activate
           pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
-          pre-commit install-hooks
+          pre-commit install-hooks --config .pre-commit-config-all.yaml
     - script: |
         . venv/bin/activate
         pre-commit run flake8 --all-files
@@ -84,7 +84,7 @@ stages:
 
           . venv/bin/activate
           pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
-          pre-commit install-hooks
+          pre-commit install-hooks --config .pre-commit-config-all.yaml
     - script: |
         . venv/bin/activate
         pre-commit run black --all-files
@@ -182,8 +182,8 @@ stages:
 
           . venv/bin/activate
           pip install -e . -r requirements_test.txt -c homeassistant/package_constraints.txt
-          pre-commit install-hooks
+          pre-commit install-hooks --config .pre-commit-config-all.yaml
     - script: |
         . venv/bin/activate
-        pre-commit run mypy --all-files
+        pre-commit run --config .pre-commit-config-all.yaml mypy --all-files
       displayName: 'Run mypy'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 
-# When updating this file, update .pre-commit-config.yaml too
+# When updating this file, update .pre-commit-config*.yaml too
 asynctest==0.13.0
 black==19.10b0
 codecov==2.0.15

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -3,7 +3,7 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 
-# When updating this file, update .pre-commit-config.yaml too
+# When updating this file, update .pre-commit-config*.yaml too
 asynctest==0.13.0
 black==19.10b0
 codecov==2.0.15

--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,4 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-    pre-commit run mypy {posargs: --all-files}
+    pre-commit run --config .pre-commit-config-all.yaml mypy {posargs: --all-files}


### PR DESCRIPTION
## Description:

Yet another option for tackling mypy in pre-commit. This is my current favorite. I think we should adopt this one instead of #28405, and also add at least pylint here in the future (leaving that out for now, though).

For now, the only difference between the two is mypy.

It's a bummer that we need to duplicate stuff in the default config in the "all" one, filed RFE about that: https://github.com/pre-commit/pre-commit/issues/1203

**Related issue (if applicable):** fixes #28283 fixes https://github.com/home-assistant/home-assistant/pull/28405

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
