### PR TITLE
Handle Huawei LTE timeouts

### DIFF
--- a/homeassistant/components/huawei_lte/.translations/en.json
+++ b/homeassistant/components/huawei_lte/.translations/en.json
@@ -5,6 +5,7 @@
         },
         "error": {
             "connection_failed": "Connection failed",
+            "connection_timeout": "Connection timeout",
             "incorrect_password": "Incorrect password",
             "incorrect_username": "Incorrect username",
             "incorrect_username_or_password": "Incorrect username or password",

--- a/homeassistant/components/huawei_lte/const.py
+++ b/homeassistant/components/huawei_lte/const.py
@@ -10,6 +10,8 @@ UPDATE_OPTIONS_SIGNAL = f"{DOMAIN}_options_update"
 UNIT_BYTES = "B"
 UNIT_SECONDS = "s"
 
+CONNECTION_TIMEOUT = 10
+
 KEY_DEVICE_BASIC_INFORMATION = "device_basic_information"
 KEY_DEVICE_INFORMATION = "device_information"
 KEY_DEVICE_SIGNAL = "device_signal"

--- a/homeassistant/components/huawei_lte/strings.json
+++ b/homeassistant/components/huawei_lte/strings.json
@@ -11,6 +11,7 @@
             "invalid_url": "Invalid URL",
             "login_attempts_exceeded": "Maximum login attempts exceeded, please try again later",
             "response_error": "Unknown error from device",
+            "connection_timeout": "Connection timeout",
             "unknown_connection_error": "Unknown error connecting to device"
         },
         "step": {


### PR DESCRIPTION
## Description:

Add default timeout and handle timeouts.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
