### PR TITLE
Fix opentherm_gw config flow migration

### DIFF
--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -31,6 +31,11 @@ from .const import CONF_FLOOR_TEMP, CONF_PRECISION, DATA_GATEWAYS, DATA_OPENTHER
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_OPTIONS = {
+    CONF_FLOOR_TEMP: False,
+    CONF_PRECISION: 0,
+}
+
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
 
@@ -54,8 +59,9 @@ class OpenThermClimate(ClimateDevice):
         """Initialize the device."""
         self._gateway = gw_dev
         self.friendly_name = gw_dev.name
+        options = options or DEFAULT_OPTIONS
         self.floor_temp = options[CONF_FLOOR_TEMP]
-        self.temp_precision = options.get(CONF_PRECISION)
+        self.temp_precision = options[CONF_PRECISION]
         self._current_operation = None
         self._current_temperature = None
         self._hvac_mode = HVAC_MODE_HEAT
@@ -70,7 +76,7 @@ class OpenThermClimate(ClimateDevice):
     def update_options(self, entry):
         """Update climate entity options."""
         self.floor_temp = entry.options[CONF_FLOOR_TEMP]
-        self.temp_precision = entry.options.get(CONF_PRECISION)
+        self.temp_precision = entry.options[CONF_PRECISION]
         self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -31,10 +31,8 @@ from .const import CONF_FLOOR_TEMP, CONF_PRECISION, DATA_GATEWAYS, DATA_OPENTHER
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_OPTIONS = {
-    CONF_FLOOR_TEMP: False,
-    CONF_PRECISION: 0,
-}
+DEFAULT_FLOOR_TEMP = False
+DEFAULT_PRECISION = None
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
@@ -59,9 +57,8 @@ class OpenThermClimate(ClimateDevice):
         """Initialize the device."""
         self._gateway = gw_dev
         self.friendly_name = gw_dev.name
-        options = options or DEFAULT_OPTIONS
-        self.floor_temp = options[CONF_FLOOR_TEMP]
-        self.temp_precision = options[CONF_PRECISION]
+        self.floor_temp = options.get(CONF_FLOOR_TEMP, DEFAULT_FLOOR_TEMP)
+        self.temp_precision = options.get(CONF_PRECISION, DEFAULT_PRECISION)
         self._current_operation = None
         self._current_temperature = None
         self._hvac_mode = HVAC_MODE_HEAT


### PR DESCRIPTION
## Description:
The config flow migration for opentherm_gw lacked default options. This was not taken into account with the subsequent options flow PR, causing problems with the climate platform after migration.
This PR implements default options for the opentherm_gw climate platform.


**Related issue (if applicable):** fixes #28363 
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
