### PR TITLE
New Standby Codes for Pioneer AVR

### DIFF
--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -169,6 +169,8 @@ class PioneerDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the device."""
+        if self._pwstate == "PWR2":
+            return STATE_OFF
         if self._pwstate == "PWR1":
             return STATE_OFF
         if self._pwstate == "PWR0":


### PR DESCRIPTION
## Description:

Added different Power Code Responses for other Pioneer AVR Models

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]