### PR TITLE
Add Yr Weather sensor device classes

### DIFF
--- a/homeassistant/components/yr/sensor.py
+++ b/homeassistant/components/yr/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
+    PRESSURE_HPA,
     TEMP_CELSIUS,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/homeassistant/components/yr/sensor.py
+++ b/homeassistant/components/yr/sensor.py
@@ -44,7 +44,7 @@ SENSOR_TYPES = {
     "temperature": ["Temperature", TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
     "windSpeed": ["Wind speed", "m/s", None],
     "windGust": ["Wind gust", "m/s", None],
-    "pressure": ["Pressure", PRESSURE_HPA, None],
+    "pressure": ["Pressure", PRESSURE_HPA, DEVICE_CLASS_PRESSURE],
     "windDirection": ["Wind direction", "°", None],
     "humidity": ["Humidity", "%", DEVICE_CLASS_HUMIDITY],
     "fog": ["Fog", "%", None],
@@ -52,8 +52,11 @@ SENSOR_TYPES = {
     "lowClouds": ["Low clouds", "%", None],
     "mediumClouds": ["Medium clouds", "%", None],
     "highClouds": ["High clouds", "%", None],
-    "dewpointTemperature": ["Dewpoint temperature", TEMP_CELSIUS,
-                            DEVICE_CLASS_TEMPERATURE],
+    "dewpointTemperature": [
+        "Dewpoint temperature",
+        TEMP_CELSIUS,
+        DEVICE_CLASS_TEMPERATURE,
+    ],
 }
 
 CONF_FORECAST = "forecast"
@@ -150,6 +153,7 @@ class YrSensor(Entity):
     def device_class(self):
         """Return the device class of this entity, if any."""
         return self._device_class
+
 
 class YrData:
     """Get the latest data and updates the states."""

--- a/homeassistant/components/yr/sensor.py
+++ b/homeassistant/components/yr/sensor.py
@@ -19,6 +19,10 @@ from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     ATTR_ATTRIBUTION,
     CONF_NAME,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    TEMP_CELSIUS,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
@@ -34,20 +38,21 @@ ATTRIBUTION = (
 # https://api.met.no/license_data.html
 
 SENSOR_TYPES = {
-    "symbol": ["Symbol", None],
-    "precipitation": ["Precipitation", "mm"],
-    "temperature": ["Temperature", "°C"],
-    "windSpeed": ["Wind speed", "m/s"],
-    "windGust": ["Wind gust", "m/s"],
-    "pressure": ["Pressure", "hPa"],
-    "windDirection": ["Wind direction", "°"],
-    "humidity": ["Humidity", "%"],
-    "fog": ["Fog", "%"],
-    "cloudiness": ["Cloudiness", "%"],
-    "lowClouds": ["Low clouds", "%"],
-    "mediumClouds": ["Medium clouds", "%"],
-    "highClouds": ["High clouds", "%"],
-    "dewpointTemperature": ["Dewpoint temperature", "°C"],
+    "symbol": ["Symbol", None, None],
+    "precipitation": ["Precipitation", "mm", None],
+    "temperature": ["Temperature", TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
+    "windSpeed": ["Wind speed", "m/s", None],
+    "windGust": ["Wind gust", "m/s", None],
+    "pressure": ["Pressure", PRESSURE_HPA, None],
+    "windDirection": ["Wind direction", "°", None],
+    "humidity": ["Humidity", "%", DEVICE_CLASS_HUMIDITY],
+    "fog": ["Fog", "%", None],
+    "cloudiness": ["Cloudiness", "%", None],
+    "lowClouds": ["Low clouds", "%", None],
+    "mediumClouds": ["Medium clouds", "%", None],
+    "highClouds": ["High clouds", "%", None],
+    "dewpointTemperature": ["Dewpoint temperature", TEMP_CELSIUS,
+                            DEVICE_CLASS_TEMPERATURE],
 }
 
 CONF_FORECAST = "forecast"
@@ -103,6 +108,7 @@ class YrSensor(Entity):
         self.type = sensor_type
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
+        self._device_class = SENSOR_TYPES[self.type][2]
 
     @property
     def name(self):
@@ -139,6 +145,10 @@ class YrSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
+    @property
+    def device_class(self):
+        """Return the device class of this entity, if any."""
+        return self._device_class
 
 class YrData:
     """Get the latest data and updates the states."""


### PR DESCRIPTION
## Breaking Change:
None

## Description:
The yr weather monitoring component should set device classes for the sensors it reports.
This is usually not obvious but can be seen in the UI if humidity is monitored.  Instead of the correct humidty symbol (raindrop with '%'), a generic eye symbol is displayed.

In addition, I have referenced the unit constants where they exist.

This PR adds the device class to each sensor where a suitable one exists.
## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]