### PR TITLE
Expose set auto mode for all Dyson fans

### DIFF
--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -151,14 +151,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         service_handle,
         schema=DYSON_SET_NIGHT_MODE_SCHEMA,
     )
-    if has_purecool_devices:
-        hass.services.register(
-            DYSON_DOMAIN,
-            SERVICE_SET_AUTO_MODE,
-            service_handle,
-            schema=SET_AUTO_MODE_SCHEMA,
-        )
 
+    hass.services.register(
+        DYSON_DOMAIN,
+        SERVICE_SET_AUTO_MODE,
+        service_handle,
+        schema=SET_AUTO_MODE_SCHEMA,
+    )
+    if has_purecool_devices:
         hass.services.register(
             DYSON_DOMAIN, SERVICE_SET_ANGLE, service_handle, schema=SET_ANGLE_SCHEMA
         )


### PR DESCRIPTION
Set auto mode should be exposed to all dyson fans (e.g. **Pure Cool Link** and **Pure Hot+Cool Link**) instead of only **Pure Cool**, as it is support in all of the models (i.e. similar to the set night mode).

For documentations: This is a special case where the documentation did in fact correctly noted that it should be supported by all fan models (for night mode and set auto mode it **does not** states that it is `(only for DP04 and TP04)`, which is true but the implementation placed it within the conditional block.

## Breaking Change:
No

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):**

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
