### PR TITLE
Always run flake8 through pre-commit, and with doctests

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,7 +33,7 @@
     {
       "label": "Flake8",
       "type": "shell",
-      "command": "flake8 homeassistant tests",
+      "command": "pre-commit run flake8 --all-files",
       "group": {
         "kind": "test",
         "isDefault": true

--- a/script/lazytox.py
+++ b/script/lazytox.py
@@ -120,7 +120,7 @@ async def pylint(files):
 
 async def flake8(files):
     """Exec flake8."""
-    _, log = await async_exec("flake8", *files)
+    _, log = await async_exec("pre-commit", "run", "flake8", "--files", *files)
     res = []
     for line in log.splitlines():
         line = line.split(":")

--- a/script/lazytox.py
+++ b/script/lazytox.py
@@ -120,7 +120,7 @@ async def pylint(files):
 
 async def flake8(files):
     """Exec flake8."""
-    _, log = await async_exec("flake8", "--doctests", *files)
+    _, log = await async_exec("flake8", *files)
     res = []
     for line in log.splitlines():
         line = line.split(":")

--- a/script/lint
+++ b/script/lint
@@ -15,7 +15,7 @@ printf "%s\n" $files
 echo "================"
 echo "LINT with flake8"
 echo "================"
-flake8 --doctests $files
+flake8 $files
 echo "================"
 echo "LINT with pylint"
 echo "================"

--- a/script/lint
+++ b/script/lint
@@ -15,7 +15,7 @@ printf "%s\n" $files
 echo "================"
 echo "LINT with flake8"
 echo "================"
-flake8 $files
+pre-commit run flake8 --files $files
 echo "================"
 echo "LINT with pylint"
 echo "================"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ norecursedirs = .git testing_config
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+doctests = True
 # To work with Black
 max-line-length = 88
 # E501: line too long


### PR DESCRIPTION
## Description:

- make all flake8 invocations go through pre-commit
- enable doctests in all invocations

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
