### PR TITLE
Fix flaky Samsung TV tests

### DIFF
--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -2,6 +2,7 @@
 import asyncio
 from asynctest import mock
 from datetime import timedelta
+import logging
 import pytest
 from samsungctl import exceptions
 from tests.common import MockDependency, async_fire_time_changed
@@ -263,6 +264,7 @@ async def test_send_key_autodetect_websocket(hass, remote):
 
 async def test_send_key_autodetect_websocket_exception(hass, caplog):
     """Test for send key with autodetection of protocol."""
+    caplog.set_level(logging.DEBUG)
     with patch(
         "samsungctl.Remote", side_effect=[exceptions.AccessDenied("Boom"), mock.DEFAULT]
     ) as remote, patch("homeassistant.components.samsungtv.media_player.socket"):
@@ -458,6 +460,7 @@ async def test_turn_off_legacy(hass, remote):
 
 async def test_turn_off_os_error(hass, remote, caplog):
     """Test for turn_off with OSError."""
+    caplog.set_level(logging.DEBUG)
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.close = mock.Mock(side_effect=OSError("BOOM"))
     assert await hass.services.async_call(


### PR DESCRIPTION
## Breaking Change:
None

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Fix 2 flaky tests which assert on debug log messages.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
