### PR TITLE
Don't use deprecated encoding to json.loads

### DIFF
--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -92,7 +92,7 @@ class HomeTemplate(Home):
 
     def init_home(self, json_path=HOME_JSON):
         """Init template with json."""
-        self.init_json_state = json.loads(load_fixture(HOME_JSON), encoding="UTF-8")
+        self.init_json_state = json.loads(load_fixture(HOME_JSON))
         self.update_home(json_state=self.init_json_state, clearConfig=True)
         return self
 


### PR DESCRIPTION
## Description:

Will be removed in 3.9, ignored in earlier supported versions.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
