### PR TITLE
Handle iaqualink failures better

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -4,6 +4,7 @@ from functools import wraps
 import logging
 from typing import Any, Dict
 
+import aiohttp.client_exceptions
 import voluptuous as vol
 
 from iaqualink import (
@@ -26,6 +27,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -90,8 +92,14 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
     try:
         await aqualink.login()
     except AqualinkLoginException as login_exception:
-        _LOGGER.error("Exception raised while attempting to login: %s", login_exception)
+        _LOGGER.error("Failed to login: %s", login_exception)
         return False
+    except (
+        asyncio.TimeoutError,
+        aiohttp.client_exceptions.ClientConnectorError,
+    ) as aio_exception:
+        _LOGGER.warning("Exception raised while attempting to login: %s", aio_exception)
+        raise ConfigEntryNotReady
 
     systems = await aqualink.get_systems()
     systems = list(systems.values())
@@ -133,7 +141,16 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
 
     async def _async_systems_update(now):
         """Refresh internal state for all systems."""
+        prev = systems[0].last_run_success
+
         await systems[0].update()
+        success = systems[0].last_run_success
+
+        if not success and prev:
+            _LOGGER.warning("Failed to refresh iAqualink state")
+        elif success and not prev:
+            _LOGGER.warning("Reconnected to iAqualink")
+
         async_dispatcher_send(hass, DOMAIN)
 
     async_track_time_interval(hass, _async_systems_update, UPDATE_INTERVAL)


### PR DESCRIPTION
## Description:

These changes better handle failure during component initialization and subsequent updates. This brings the behavior in line with the integration quality scale.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
