### PR TITLE
Fix sensor device in the Abode component

### DIFF
--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -29,19 +29,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a sensor for an Abode device."""
-
     data = hass.data[DOMAIN]
+    entities = []
 
-    devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
-        if CONST.TEMP_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
-            devices.append(AbodeSensor(data, device, CONST.TEMP_STATUS_KEY))
-        if CONST.HUMI_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
-            devices.append(AbodeSensor(data, device, CONST.HUMI_STATUS_KEY))
-        if CONST.LUX_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
-            devices.append(AbodeSensor(data, device, CONST.LUX_STATUS_KEY))
+        for sensor_type in SENSOR_TYPES:
+            if sensor_type not in device.get_value(CONST.STATUSES_KEY):
+                continue
+            entities.append(AbodeSensor(data, device, sensor_type))
 
-    async_add_entities(devices)
+    async_add_entities(entities)
 
 
 class AbodeSensor(AbodeDevice):
@@ -69,7 +66,7 @@ class AbodeSensor(AbodeDevice):
     @property
     def unique_id(self):
         """Return a unique ID to use for this device."""
-        return self._device.device_uuid + self._sensor_type
+        return f"{self._device.device_uuid}-{self._sensor_type}"
 
     @property
     def state(self):

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -63,6 +63,11 @@ class AbodeSensor(AbodeDevice):
         return self._device_class
 
     @property
+    def unique_id(self):
+        """Return a unique ID to use for this device."""
+        return self._device.device_uuid + self._sensor_type
+
+    @property
     def state(self):
         """Return the state of the sensor."""
         if self._sensor_type == "temp":

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -34,8 +34,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
-        if CONST.TEMP_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
-            devices.append(AbodeSensor(data, device, CONST.TEMP_STATUS_KEY))
+        if "temp" in device.get_value(CONST.STATUSES_KEY):
+            devices.append(AbodeSensor(data, device, "temp"))
         if CONST.HUMI_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
             devices.append(AbodeSensor(data, device, CONST.HUMI_STATUS_KEY))
         if CONST.LUX_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -34,8 +34,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
-        for sensor_type in SENSOR_TYPES:
-            devices.append(AbodeSensor(data, device, sensor_type))
+        if CONST.TEMP_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
+            devices.append(AbodeSensor(data, device, CONST.TEMP_STATUS_KEY))
+        if CONST.HUMI_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
+            devices.append(AbodeSensor(data, device, CONST.HUMI_STATUS_KEY))
+        if CONST.LUX_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
+            devices.append(AbodeSensor(data, device, CONST.LUX_STATUS_KEY))
 
     async_add_entities(devices)
 

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -16,9 +16,9 @@ _LOGGER = logging.getLogger(__name__)
 
 # Sensor types: Name, icon
 SENSOR_TYPES = {
-    "temp": ["Temperature", DEVICE_CLASS_TEMPERATURE],
-    "humidity": ["Humidity", DEVICE_CLASS_HUMIDITY],
-    "lux": ["Lux", DEVICE_CLASS_ILLUMINANCE],
+    CONST.TEMP_STATUS_KEY: ["Temperature", DEVICE_CLASS_TEMPERATURE],
+    CONST.HUMI_STATUS_KEY: ["Humidity", DEVICE_CLASS_HUMIDITY],
+    CONST.LUX_STATUS_KEY: ["Lux", DEVICE_CLASS_ILLUMINANCE],
 }
 
 
@@ -34,8 +34,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
-        if "temp" in device.get_value(CONST.STATUSES_KEY):
-            devices.append(AbodeSensor(data, device, "temp"))
+        if CONST.TEMP_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
+            devices.append(AbodeSensor(data, device, CONST.TEMP_STATUS_KEY))
         if CONST.HUMI_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):
             devices.append(AbodeSensor(data, device, CONST.HUMI_STATUS_KEY))
         if CONST.LUX_STATUS_KEY in device.get_value(CONST.STATUSES_KEY):


### PR DESCRIPTION
## Description:
Add `unique_id` property to sensor.py which adds `sensor_type` as a differentiator to `unique_id`. This is needed since occupancy, multi and temperature/humidity/lux sensors from Abode are added as three separate entities in Home Assistant (temperature, humidity and lux) but have the same uuid from Abode (since it's considered one device in Abode). Also added some checks to see if certain sensor attributes exist in the Abode device JSON before adding the device to Home Assistant since there are three different Abode devices that are considered "sensor", one of which does not report humidity.

**Related issue (if applicable):** fixes #24346 and fixes #28481. Also fixes [#45 from abodepy](https://github.com/MisterWil/abodepy/issues/45).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]