### PR TITLE
Replace Netatmo CO2 sensor icon

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -62,7 +62,7 @@ SENSOR_TYPES = {
         "mdi:thermometer",
         DEVICE_CLASS_TEMPERATURE,
     ],
-    "co2": ["CO2", "ppm", "mdi:cloud", None],
+    "co2": ["CO2", "ppm", "mdi:periodic-table-co2", None],
     "pressure": ["Pressure", "mbar", "mdi:gauge", None],
     "noise": ["Noise", "dB", "mdi:volume-high", None],
     "humidity": ["Humidity", "%", "mdi:water-percent", DEVICE_CLASS_HUMIDITY],


### PR DESCRIPTION
#28078  Description:

Replaces the Netatmo CO2 sensor "mdi:cloud" icon with "mdi:periodic-table-co2" which is used by other platforms.

![image](https://user-images.githubusercontent.com/18193/68106184-aac30300-fe95-11e9-887f-86dbc6fb2da5.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
