### PR TITLE
Rename rest_command request to response, add exc_info for exceptions

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -102,14 +102,18 @@ async def async_setup(hass, config):
                     )
 
                 if response.status < 400:
-                    _LOGGER.info("Success call %s.", response.url)
+                    _LOGGER.info(
+                        "Success. Url: %s. Status code: %d.",
+                        response.url,
+                        response.status,
+                    )
                 else:
                     _LOGGER.warning(
-                        "Error %d on call %s.", response.status, response.url
+                        "Error. Url: %s. Status code %d.", response.url, response.status
                     )
 
             except asyncio.TimeoutError:
-                _LOGGER.warning("Timeout call %s.", response.url)
+                _LOGGER.warning("Timeout call %s.", response.url, exc_info=1)
 
             except aiohttp.ClientError:
                 _LOGGER.error("Client error %s.", request_url, exc_info=1)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -4,7 +4,6 @@ import logging
 
 import aiohttp
 from aiohttp import hdrs
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -96,21 +95,26 @@ async def async_setup(hass, config):
 
             request_url = template_url.async_render(variables=service.data)
             try:
-                with async_timeout.timeout(timeout):
-                    response = await getattr(websession, method)(
-                        request_url, data=payload, auth=auth, headers=headers
-                    )
+                async with getattr(websession, method)(
+                    request_url,
+                    data=payload,
+                    auth=auth,
+                    headers=headers,
+                    timeout=timeout,
+                ) as response:
 
-                if response.status < 400:
-                    _LOGGER.info(
-                        "Success. Url: %s. Status code: %d.",
-                        response.url,
-                        response.status,
-                    )
-                else:
-                    _LOGGER.warning(
-                        "Error. Url: %s. Status code %d.", response.url, response.status
-                    )
+                    if response.status < 400:
+                        _LOGGER.info(
+                            "Success. Url: %s. Status code: %d.",
+                            response.url,
+                            response.status,
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "Error. Url: %s. Status code %d.",
+                            response.url,
+                            response.status,
+                        )
 
             except asyncio.TimeoutError:
                 _LOGGER.warning("Timeout call %s.", response.url, exc_info=1)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -8,13 +8,13 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_TIMEOUT,
-    CONF_USERNAME,
-    CONF_PASSWORD,
-    CONF_URL,
-    CONF_PAYLOAD,
-    CONF_METHOD,
     CONF_HEADERS,
+    CONF_METHOD,
+    CONF_PASSWORD,
+    CONF_PAYLOAD,
+    CONF_TIMEOUT,
+    CONF_URL,
+    CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -97,17 +97,19 @@ async def async_setup(hass, config):
             request_url = template_url.async_render(variables=service.data)
             try:
                 with async_timeout.timeout(timeout):
-                    request = await getattr(websession, method)(
+                    response = await getattr(websession, method)(
                         request_url, data=payload, auth=auth, headers=headers
                     )
 
-                if request.status < 400:
-                    _LOGGER.info("Success call %s.", request.url)
+                if response.status < 400:
+                    _LOGGER.info("Success call %s.", response.url)
                 else:
-                    _LOGGER.warning("Error %d on call %s.", request.status, request.url)
+                    _LOGGER.warning(
+                        "Error %d on call %s.", response.status, response.url
+                    )
 
             except asyncio.TimeoutError:
-                _LOGGER.warning("Timeout call %s.", request.url)
+                _LOGGER.warning("Timeout call %s.", response.url)
 
             except aiohttp.ClientError:
                 _LOGGER.error("Client error %s.", request_url)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -112,7 +112,7 @@ async def async_setup(hass, config):
                 _LOGGER.warning("Timeout call %s.", response.url)
 
             except aiohttp.ClientError:
-                _LOGGER.error("Client error %s.", request_url)
+                _LOGGER.error("Client error %s.", request_url, exc_info=1)
 
         # register services
         hass.services.async_register(DOMAIN, name, async_service_handler)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -104,7 +104,7 @@ async def async_setup(hass, config):
                 ) as response:
 
                     if response.status < 400:
-                        _LOGGER.info(
+                        _LOGGER.debug(
                             "Success. Url: %s. Status code: %d.",
                             response.url,
                             response.status,


### PR DESCRIPTION
## Breaking Change: N/A

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

- Renamed request to response, because it was misleading.
- Imports reordered using `isort`
- Added exception info using `exc_info=1` 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
