### PR TITLE
Use generic way to get the tmp directory for vicare

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -2,6 +2,7 @@
 import logging
 
 import voluptuous as vol
+import tempfile
 from PyViCare.PyViCareDevice import Device
 
 import homeassistant.helpers.config_validation as cv
@@ -36,7 +37,7 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Create the ViCare component."""
     conf = config[DOMAIN]
-    params = {"token_file": "/tmp/vicare_token.save"}
+    params = {"token_file": tempfile.gettempdir() + "/vicare_token.save"}
     if conf.get(CONF_CIRCUIT) is not None:
         params["circuit"] = conf[CONF_CIRCUIT]
 


### PR DESCRIPTION
## Description:

please consider to use more generic way to get the `tmp` directory then the hardcoded `/tmp`
on some platform `tmp` is not in `/tmp` path

For Python that would be the tempfile module - it has functions to get the temporary directory

so instead of
```python
params = {"token_file": "/tmp/vicare_token.save"}
```

we should use
```python
params = {"token_file": tempfile.gettempdir() + "/vicare_token.save"}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
