### PR TITLE
Checking state before actually sending a new state change

### DIFF
--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -158,13 +158,15 @@ class PjLinkDevice(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn projector off."""
-        with self.projector() as projector:
-            projector.set_power("off")
+        if self._pwstate == STATE_ON:
+            with self.projector() as projector:
+                projector.set_power("off")
 
     def turn_on(self):
         """Turn projector on."""
-        with self.projector() as projector:
-            projector.set_power("on")
+        if self._pwstate == STATE_OFF:
+            with self.projector() as projector:
+                projector.set_power("on")
 
     def mute_volume(self, mute):
         """Mute (true) of unmute (false) media player."""


### PR DESCRIPTION
## Description:

Added a check to check the current state of the projector before sending it new state. Some projectors (for instance NEC) will return an error if you attempt to turn off an already turned off projector.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]