### PR TITLE
Improve scene.create service

### DIFF
--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -55,7 +55,7 @@ def _convert_states(states):
 
 
 async def _part_of_config(hass, name):
-    """Determine if entity_id was manually configured, return True in an error occurs."""
+    """Determine whether entity_id was configured manually, return True if an error occurs."""
     try:
         conf = await conf_util.async_hass_config_yaml(hass)
     except HomeAssistantError as err:

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -143,13 +143,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         entity_id = f"{SCENE_DOMAIN}.{scene_config.name}"
         old = platform.entities.get(entity_id)
         if old is not None:
-            if old.from_yaml:
+            if not old.from_service:
                 _LOGGER.warning("The scene %s already exists", entity_id)
                 return
-
             await platform.async_remove_entity(entity_id)
-
-        async_add_entities([HomeAssistantScene(hass, scene_config, from_yaml=False)])
+        async_add_entities([HomeAssistantScene(hass, scene_config, from_service=True)])
 
     hass.services.async_register(
         SCENE_DOMAIN, SERVICE_CREATE, create_service, CREATE_SCENE_SCHEMA
@@ -177,12 +175,12 @@ def _process_scenes_config(hass, async_add_entities, config):
 class HomeAssistantScene(Scene):
     """A scene is a group of entities and the states we want them to be."""
 
-    def __init__(self, hass, scene_config, scene_id=None, from_yaml=True):
+    def __init__(self, hass, scene_config, scene_id=None, from_service=False):
         """Initialize the scene."""
         self._id = scene_id
         self.hass = hass
         self.scene_config = scene_config
-        self.from_yaml = from_yaml
+        self.from_service = from_service
 
     @property
     def name(self):

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -1,7 +1,22 @@
 """Test Home Assistant scenes."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.setup import async_setup_component
+
+CONFIGURED_SCENE = {"scene": {"name": "hallo_2", "entities": {"light.kitchen": "on"}}}
+
+
+@pytest.fixture(name="config")
+def mock_configured_scene():
+    """Mock a configured scene."""
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value=CONFIGURED_SCENE,
+    ), patch("homeassistant.config.find_config_file", return_value=""):
+        yield
 
 
 async def test_reload_config_service(hass):
@@ -53,10 +68,11 @@ async def test_apply_service(hass):
     assert state.attributes["brightness"] == 50
 
 
-async def test_create_service(hass, caplog):
+async def test_create_service(hass, caplog, config):
     """Test the create service."""
-    assert await async_setup_component(hass, "scene", {})
+    assert await async_setup_component(hass, "scene", CONFIGURED_SCENE)
     assert hass.states.get("scene.hallo") is None
+    assert hass.states.get("scene.hallo_2") is not None
 
     assert await hass.services.async_call(
         "scene",
@@ -81,12 +97,34 @@ async def test_create_service(hass, caplog):
         "create",
         {
             "scene_id": "hallo",
+            "entities": {"light.kitchen_light": {"state": "on", "brightness": 100}},
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    scene = hass.states.get("scene.hallo")
+    assert scene is not None
+    assert scene.domain == "scene"
+    assert scene.name == "hallo"
+    assert scene.state == "scening"
+    assert scene.attributes.get("entity_id") == ["light.kitchen_light"]
+
+    assert await hass.services.async_call(
+        "scene",
+        "create",
+        {
+            "scene_id": "hallo_2",
             "entities": {"light.bed_light": {"state": "on", "brightness": 50}},
         },
         blocking=True,
     )
-
     await hass.async_block_till_done()
-    assert "The scene scene.hallo already exists" in caplog.text
-    assert hass.states.get("scene.hallo") is not None
-    assert hass.states.get("scene.hallo_2") is None
+
+    assert "The scene scene.hallo_2 already exists" in caplog.text
+    scene = hass.states.get("scene.hallo_2")
+    assert scene is not None
+    assert scene.domain == "scene"
+    assert scene.name == "hallo_2"
+    assert scene.state == "scening"
+    assert scene.attributes.get("entity_id") == ["light.kitchen"]


### PR DESCRIPTION
## Breaking Change:
Nothing breaks because the scene.create service has not yet been released.

## Description:
This allows to overwrite scenes using `scene.create`. A scene is overwritten if it was previously created by `scene.create`. If the scene was configured by YAML, the service `scene.create` will cause a warning.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11099

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
