### PR TITLE
Rate is a separate word

### DIFF
--- a/homeassistant/components/demo/stt.py
+++ b/homeassistant/components/demo/stt.py
@@ -5,9 +5,9 @@ from aiohttp import StreamReader
 
 from homeassistant.components.stt import Provider, SpeechMetadata, SpeechResult
 from homeassistant.components.stt.const import (
-    AudioBitrates,
+    AudioBitRates,
     AudioFormats,
-    AudioSamplerates,
+    AudioSampleRates,
     AudioCodecs,
     SpeechResultState,
 )
@@ -39,14 +39,14 @@ class DemoProvider(Provider):
         return [AudioCodecs.PCM]
 
     @property
-    def supported_bitrates(self) -> List[AudioBitrates]:
-        """Return a list of supported bitrates."""
-        return [AudioBitrates.BITRATE_16]
+    def supported_bit_rates(self) -> List[AudioBitRates]:
+        """Return a list of supported bit rates."""
+        return [AudioBitRates.BITRATE_16]
 
     @property
-    def supported_samplerates(self) -> List[AudioSamplerates]:
-        """Return a list of supported samplerates."""
-        return [AudioSamplerates.SAMPLERATE_16000, AudioSamplerates.SAMPLERATE_44100]
+    def supported_sample_rates(self) -> List[AudioSampleRates]:
+        """Return a list of supported sample rates."""
+        return [AudioSampleRates.SAMPLERATE_16000, AudioSampleRates.SAMPLERATE_44100]
 
     async def async_process_audio_stream(
         self, metadata: SpeechMetadata, stream: StreamReader

--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -21,10 +21,10 @@ from homeassistant.setup import async_prepare_setup_platform
 
 from .const import (
     DOMAIN,
-    AudioBitrates,
+    AudioBitRates,
     AudioCodecs,
     AudioFormats,
-    AudioSamplerates,
+    AudioSampleRates,
     SpeechResultState,
 )
 
@@ -76,8 +76,8 @@ class SpeechMetadata:
     language: str = attr.ib()
     format: AudioFormats = attr.ib()
     codec: AudioCodecs = attr.ib()
-    bitrate: AudioBitrates = attr.ib(converter=int)
-    samplerate: AudioSamplerates = attr.ib(converter=int)
+    bit_rate: AudioBitRates = attr.ib(converter=int)
+    sample_rate: AudioSampleRates = attr.ib(converter=int)
 
 
 @attr.s
@@ -111,13 +111,13 @@ class Provider(ABC):
 
     @property
     @abstractmethod
-    def supported_bitrates(self) -> List[AudioBitrates]:
-        """Return a list of supported bitrates."""
+    def supported_bit_rates(self) -> List[AudioBitRates]:
+        """Return a list of supported bit_rates."""
 
     @property
     @abstractmethod
-    def supported_samplerates(self) -> List[AudioSamplerates]:
-        """Return a list of supported samplerates."""
+    def supported_sample_rates(self) -> List[AudioSampleRates]:
+        """Return a list of supported sample_rates."""
 
     @abstractmethod
     async def async_process_audio_stream(
@@ -135,8 +135,8 @@ class Provider(ABC):
             metadata.language not in self.supported_languages
             or metadata.format not in self.supported_formats
             or metadata.codec not in self.supported_codecs
-            or metadata.bitrate not in self.supported_bitrates
-            or metadata.samplerate not in self.supported_samplerates
+            or metadata.bit_rate not in self.supported_bit_rates
+            or metadata.sample_rate not in self.supported_sample_rates
         ):
             return False
         return True
@@ -211,7 +211,7 @@ class SpeechToTextView(HomeAssistantView):
                 "languages": stt_provider.supported_languages,
                 "formats": stt_provider.supported_formats,
                 "codecs": stt_provider.supported_codecs,
-                "samplerates": stt_provider.supported_samplerates,
-                "bitrates": stt_provider.supported_bitrates,
+                "sample_rates": stt_provider.supported_sample_rates,
+                "bit_rates": stt_provider.supported_bit_rates,
             }
         )

--- a/homeassistant/components/stt/const.py
+++ b/homeassistant/components/stt/const.py
@@ -18,8 +18,8 @@ class AudioFormats(str, Enum):
     OGG = "ogg"
 
 
-class AudioBitrates(int, Enum):
-    """Supported Audio bitrates."""
+class AudioBitRates(int, Enum):
+    """Supported Audio bit_rates."""
 
     BITRATE_8 = 8
     BITRATE_16 = 16
@@ -27,8 +27,8 @@ class AudioBitrates(int, Enum):
     BITRATE_32 = 32
 
 
-class AudioSamplerates(int, Enum):
-    """Supported Audio samplerates."""
+class AudioSampleRates(int, Enum):
+    """Supported Audio sample_rates."""
 
     SAMPLERATE_8000 = 8000
     SAMPLERATE_11000 = 11000

--- a/tests/components/demo/test_stt.py
+++ b/tests/components/demo/test_stt.py
@@ -23,8 +23,8 @@ async def test_demo_settings(hass_client):
     assert response.status == 200
     assert response_data == {
         "languages": ["en", "de"],
-        "bitrates": [16],
-        "samplerates": [16000, 44100],
+        "bit_rates": [16],
+        "sample_rates": [16000, 44100],
         "formats": ["wav"],
         "codecs": ["pcm"],
     }
@@ -45,7 +45,7 @@ async def test_demo_speech_wrong_metadata(hass_client):
     response = await client.post(
         "/api/stt/demo",
         headers={
-            "X-Speech-Content": "format=wav; codec=pcm; samplerate=8000; bitrate=16; language=de"
+            "X-Speech-Content": "format=wav; codec=pcm; sample_rate=8000; bit_rate=16; language=de"
         },
         data=b"Test",
     )
@@ -59,7 +59,7 @@ async def test_demo_speech(hass_client):
     response = await client.post(
         "/api/stt/demo",
         headers={
-            "X-Speech-Content": "format=wav; codec=pcm; samplerate=16000; bitrate=16; language=de"
+            "X-Speech-Content": "format=wav; codec=pcm; sample_rate=16000; bit_rate=16; language=de"
         },
         data=b"Test",
     )


### PR DESCRIPTION
## Description:
Accidentally merged the STT integration with typos. This fixes it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
