### PR TITLE
Get the agent_user_id from the request context if available

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -281,7 +281,7 @@ class GoogleEntity:
             trait.might_2fa(domain, features, device_class) for trait in self.traits()
         )
 
-    async def sync_serialize(self):
+    async def sync_serialize(self, agent_user_id):
         """Serialize entity for a SYNC response.
 
         https://developers.google.com/actions/smarthome/create-app#actiondevicessync
@@ -317,7 +317,7 @@ class GoogleEntity:
                 "webhookId": self.config.local_sdk_webhook_id,
                 "httpPort": self.hass.config.api.port,
                 "httpSSL": self.hass.config.api.use_ssl,
-                "proxyDeviceId": self.config.agent_user_id,
+                "proxyDeviceId": agent_user_id,
             }
 
         for trt in traits:

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -79,18 +79,17 @@ async def async_devices_sync(hass, data, payload):
         EVENT_SYNC_RECEIVED, {"request_id": data.request_id}, context=data.context
     )
 
+    agent_user_id = data.config.agent_user_id or data.context.user_id
+
     devices = await asyncio.gather(
         *(
-            entity.sync_serialize()
+            entity.sync_serialize(agent_user_id)
             for entity in async_get_entities(hass, data.config)
             if entity.should_expose()
         )
     )
 
-    response = {
-        "agentUserId": data.config.agent_user_id or data.context.user_id,
-        "devices": devices,
-    }
+    response = {"agentUserId": agent_user_id, "devices": devices}
 
     return response
 

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -19,13 +19,13 @@ async def test_google_entity_sync_serialize_with_local_sdk(hass):
     )
     entity = helpers.GoogleEntity(hass, config, hass.states.get("light.ceiling_lights"))
 
-    serialized = await entity.sync_serialize()
+    serialized = await entity.sync_serialize(None)
     assert "otherDeviceIds" not in serialized
     assert "customData" not in serialized
 
     config.async_enable_local_sdk()
 
-    serialized = await entity.sync_serialize()
+    serialized = await entity.sync_serialize(None)
     assert serialized["otherDeviceIds"] == [{"deviceId": "light.ceiling_lights"}]
     assert serialized["customData"] == {
         "httpPort": 1234,

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -455,7 +455,7 @@ async def test_serialize_input_boolean(hass):
     state = State("input_boolean.bla", "on")
     # pylint: disable=protected-access
     entity = sh.GoogleEntity(hass, BASIC_CONFIG, state)
-    result = await entity.sync_serialize()
+    result = await entity.sync_serialize(None)
     assert result == {
         "id": "input_boolean.bla",
         "attributes": {},


### PR DESCRIPTION
## Description:
Allow proxyDeviceId to be grabbed from the sync request context. This is required for local installs and if cloud in the future would allow separate sync calls per login user.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
