### PR TITLE
Fix Abode capture_image and trigger_quick_action services

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -89,7 +89,7 @@ class AbodeSystem:
 
         self.abode = abode
         self.polling = polling
-        self.devices = []
+        self.entities = []
         self.logout_listener = None
 
 
@@ -179,27 +179,27 @@ def setup_hass_services(hass):
         """Capture a new image."""
         entity_ids = call.data.get(ATTR_ENTITY_ID)
 
-        target_devices = [
-            device
-            for device in hass.data[DOMAIN].devices
-            if device.entity_id in entity_ids
+        target_entities = [
+            entity
+            for entity in hass.data[DOMAIN].entities
+            if entity.entity_id in entity_ids
         ]
 
-        for device in target_devices:
-            device.capture()
+        for entity in target_entities:
+            entity.capture()
 
     def trigger_quick_action(call):
         """Trigger a quick action."""
         entity_ids = call.data.get(ATTR_ENTITY_ID, None)
 
-        target_devices = [
-            device
-            for device in hass.data[DOMAIN].devices
-            if device.entity_id in entity_ids
+        target_entities = [
+            entity
+            for entity in hass.data[DOMAIN].entities
+            if entity.entity_id in entity_ids
         ]
 
-        for device in target_devices:
-            device.trigger()
+        for entity in target_entities:
+            entity.trigger()
 
     hass.services.register(
         DOMAIN, SERVICE_SETTINGS, change_setting, schema=CHANGE_SETTING_SCHEMA

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -187,22 +187,28 @@ def setup_hass_services(hass):
         entity_ids = call.data.get(ATTR_ENTITY_ID)
 
         target_entities = [
-            entity for entity in hass.data[DOMAIN].entity_ids if entity in entity_ids
+            entity_id
+            for entity_id in hass.data[DOMAIN].entity_ids
+            if entity_id in entity_ids
         ]
 
-        for entity in target_entities:
-            dispatcher_send(hass, SIGNAL_CAPTURE_IMAGE)
+        for entity_id in target_entities:
+            signal = SIGNAL_CAPTURE_IMAGE.format(entity_id)
+            dispatcher_send(hass, signal)
 
     def trigger_quick_action(call):
         """Trigger a quick action."""
         entity_ids = call.data.get(ATTR_ENTITY_ID, None)
 
         target_entities = [
-            entity for entity in hass.data[DOMAIN].entity_ids if entity in entity_ids
+            entity_id
+            for entity_id in hass.data[DOMAIN].entity_ids
+            if entity_id in entity_ids
         ]
 
-        for entity in target_entities:
-            dispatcher_send(hass, SIGNAL_TRIGGER_QUICK_ACTION)
+        for entity_id in target_entities:
+            signal = SIGNAL_TRIGGER_QUICK_ACTION.format(entity_id)
+            dispatcher_send(hass, signal)
 
     hass.services.register(
         DOMAIN, SERVICE_SETTINGS, change_setting, schema=CHANGE_SETTING_SCHEMA

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -23,12 +23,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up an alarm control panel for an Abode device."""
+    """Set up Abode alarm control panel device."""
     data = hass.data[DOMAIN]
-
-    async_add_entities(
-        [AbodeAlarm(data, await hass.async_add_executor_job(data.abode.get_alarm))]
-    )
+    entity = [AbodeAlarm(data, await hass.async_add_executor_job(data.abode.get_alarm))]
+    data.entities.extend(entity)
+    async_add_entities(entity)
 
 
 class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -25,9 +25,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode alarm control panel device."""
     data = hass.data[DOMAIN]
-    entity = [AbodeAlarm(data, await hass.async_add_executor_job(data.abode.get_alarm))]
-    data.entities.extend(entity)
-    async_add_entities(entity)
+    async_add_entities(
+        [AbodeAlarm(data, await hass.async_add_executor_job(data.abode.get_alarm))]
+    )
 
 
 class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -62,10 +62,6 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
 class AbodeQuickActionBinarySensor(AbodeAutomation, BinarySensorDevice):
     """A binary sensor implementation for Abode quick action automations."""
 
-    def __init__(self, data, automation, event):
-        """Initialize the Abode quick action."""
-        AbodeAutomation.__init__(self, data, automation, event)
-
     async def async_added_to_hass(self):
         """Subscribe Abode events."""
         await super().async_added_to_hass()

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -18,7 +18,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up a sensor for an Abode device."""
+    """Set up Abode binary sensor devices."""
     data = hass.data[DOMAIN]
 
     device_types = [
@@ -29,19 +29,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         CONST.TYPE_OPENING,
     ]
 
-    devices = []
+    entities = []
 
     for device in data.abode.get_devices(generic_type=device_types):
-        devices.append(AbodeBinarySensor(data, device))
+        entities.append(AbodeBinarySensor(data, device))
 
     for automation in data.abode.get_automations(generic_type=CONST.TYPE_QUICK_ACTION):
-        devices.append(
+        entities.append(
             AbodeQuickActionBinarySensor(
                 data, automation, TIMELINE.AUTOMATION_EDIT_GROUP
             )
         )
 
-    async_add_entities(devices)
+    data.entities.extend(entities)
+    async_add_entities(entities)
 
 
 class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -65,12 +65,12 @@ class AbodeQuickActionBinarySensor(AbodeAutomation, BinarySensorDevice):
     def __init__(self, data, automation, event):
         """Initialize the Abode quick action."""
         AbodeAutomation.__init__(self, data, automation, event)
-        BinarySensorDevice.__init__(self)
 
     async def async_added_to_hass(self):
         """Subscribe Abode events."""
         await super().async_added_to_hass()
-        async_dispatcher_connect(self.hass, SIGNAL_TRIGGER_QUICK_ACTION, self.trigger)
+        signal = SIGNAL_TRIGGER_QUICK_ACTION.format(self.entity_id)
+        async_dispatcher_connect(self.hass, signal, self.trigger)
 
     def trigger(self):
         """Trigger a quick automation."""

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -5,9 +5,10 @@ import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import AbodeAutomation, AbodeDevice
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_TRIGGER_QUICK_ACTION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +42,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             )
         )
 
-    data.entities.extend(entities)
     async_add_entities(entities)
 
 
@@ -61,6 +61,16 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):
 
 class AbodeQuickActionBinarySensor(AbodeAutomation, BinarySensorDevice):
     """A binary sensor implementation for Abode quick action automations."""
+
+    def __init__(self, data, automation, event):
+        """Initialize the Abode quick action."""
+        AbodeAutomation.__init__(self, data, automation, event)
+        BinarySensorDevice.__init__(self)
+
+    async def async_added_to_hass(self):
+        """Subscribe Abode events."""
+        await super().async_added_to_hass()
+        async_dispatcher_connect(self.hass, SIGNAL_TRIGGER_QUICK_ACTION, self.trigger)
 
     def trigger(self):
         """Trigger a quick automation."""

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -23,15 +23,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up a camera for an Abode device."""
-
+    """Set up Abode camera devices."""
     data = hass.data[DOMAIN]
 
-    devices = []
-    for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA):
-        devices.append(AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE))
+    entities = []
 
-    async_add_entities(devices)
+    for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA):
+        entities.append(AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE))
+
+    data.entities.extend(entities)
+    async_add_entities(entities)
 
 
 class AbodeCamera(AbodeDevice, Camera):

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -55,7 +55,8 @@ class AbodeCamera(AbodeDevice, Camera):
             self._capture_callback,
         )
 
-        async_dispatcher_connect(self.hass, SIGNAL_CAPTURE_IMAGE, self.capture)
+        signal = SIGNAL_CAPTURE_IMAGE.format(self.entity_id)
+        async_dispatcher_connect(self.hass, signal, self.capture)
 
     def capture(self):
         """Request a new image capture."""

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -7,10 +7,11 @@ import abodepy.helpers.timeline as TIMELINE
 import requests
 
 from homeassistant.components.camera import Camera
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import Throttle
 
 from . import AbodeDevice
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_CAPTURE_IMAGE
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=90)
 
@@ -31,7 +32,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA):
         entities.append(AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE))
 
-    data.entities.extend(entities)
     async_add_entities(entities)
 
 
@@ -54,6 +54,8 @@ class AbodeCamera(AbodeDevice, Camera):
             self._event,
             self._capture_callback,
         )
+
+        async_dispatcher_connect(self.hass, SIGNAL_CAPTURE_IMAGE, self.capture)
 
     def capture(self):
         """Request a new image capture."""

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -3,3 +3,6 @@ DOMAIN = "abode"
 ATTRIBUTION = "Data provided by goabode.com"
 
 DEFAULT_CACHEDB = "abodepy_cache.pickle"
+
+SIGNAL_CAPTURE_IMAGE = "abode_camera_capture"
+SIGNAL_TRIGGER_QUICK_ACTION = "abode_trigger_quick_action"

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -4,5 +4,5 @@ ATTRIBUTION = "Data provided by goabode.com"
 
 DEFAULT_CACHEDB = "abodepy_cache.pickle"
 
-SIGNAL_CAPTURE_IMAGE = "abode_camera_capture"
-SIGNAL_TRIGGER_QUICK_ACTION = "abode_trigger_quick_action"
+SIGNAL_CAPTURE_IMAGE = "abode_camera_capture_{}"
+SIGNAL_TRIGGER_QUICK_ACTION = "abode_trigger_quick_action_{}"

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -18,14 +18,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode cover devices."""
-
     data = hass.data[DOMAIN]
 
-    devices = []
-    for device in data.abode.get_devices(generic_type=CONST.TYPE_COVER):
-        devices.append(AbodeCover(data, device))
+    entities = []
 
-    async_add_entities(devices)
+    for device in data.abode.get_devices(generic_type=CONST.TYPE_COVER):
+        entities.append(AbodeCover(data, device))
+
+    data.entities.extend(entities)
+    async_add_entities(entities)
 
 
 class AbodeCover(AbodeDevice, CoverDevice):

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -25,7 +25,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device in data.abode.get_devices(generic_type=CONST.TYPE_COVER):
         entities.append(AbodeCover(data, device))
 
-    data.entities.extend(entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -33,12 +33,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode light devices."""
     data = hass.data[DOMAIN]
 
-    devices = []
+    entities = []
 
     for device in data.abode.get_devices(generic_type=CONST.TYPE_LIGHT):
-        devices.append(AbodeLight(data, device))
+        entities.append(AbodeLight(data, device))
 
-    async_add_entities(devices)
+    data.entities.extend(entities)
+    async_add_entities(entities)
 
 
 class AbodeLight(AbodeDevice, Light):

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -38,7 +38,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device in data.abode.get_devices(generic_type=CONST.TYPE_LIGHT):
         entities.append(AbodeLight(data, device))
 
-    data.entities.extend(entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -25,7 +25,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device in data.abode.get_devices(generic_type=CONST.TYPE_LOCK):
         entities.append(AbodeLock(data, device))
 
-    data.entities.extend(entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -18,14 +18,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode lock devices."""
-
     data = hass.data[DOMAIN]
 
-    devices = []
-    for device in data.abode.get_devices(generic_type=CONST.TYPE_LOCK):
-        devices.append(AbodeLock(data, device))
+    entities = []
 
-    async_add_entities(devices)
+    for device in data.abode.get_devices(generic_type=CONST.TYPE_LOCK):
+        entities.append(AbodeLock(data, device))
+
+    data.entities.extend(entities)
+    async_add_entities(entities)
 
 
 class AbodeLock(AbodeDevice, LockDevice):

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/abode",
   "requirements": [
-    "abodepy==0.16.6"
+    "abodepy==0.16.7"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -39,7 +39,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 continue
             entities.append(AbodeSensor(data, device, sensor_type))
 
-    data.entities.extend(entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -28,8 +28,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up a sensor for an Abode device."""
+    """Set up Abode sensor devices."""
     data = hass.data[DOMAIN]
+
     entities = []
 
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
@@ -38,6 +39,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 continue
             entities.append(AbodeSensor(data, device, sensor_type))
 
+    data.entities.extend(entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -21,17 +21,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode switch devices."""
     data = hass.data[DOMAIN]
 
-    devices = []
+    entities = []
 
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SWITCH):
-        devices.append(AbodeSwitch(data, device))
+        entities.append(AbodeSwitch(data, device))
 
     for automation in data.abode.get_automations(generic_type=CONST.TYPE_AUTOMATION):
-        devices.append(
+        entities.append(
             AbodeAutomationSwitch(data, automation, TIMELINE.AUTOMATION_EDIT_GROUP)
         )
 
-    async_add_entities(devices)
+    data.entities.extend(entities)
+    async_add_entities(entities)
 
 
 class AbodeSwitch(AbodeDevice, SwitchDevice):

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -31,7 +31,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             AbodeAutomationSwitch(data, automation, TIMELINE.AUTOMATION_EDIT_GROUP)
         )
 
-    data.entities.extend(entities)
     async_add_entities(entities)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -106,7 +106,7 @@ WazeRouteCalculator==0.10
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.6
+abodepy==0.16.7
 
 # homeassistant.components.mcp23017
 adafruit-blinka==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -47,7 +47,7 @@ RtmAPI==0.7.2
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.6
+abodepy==0.16.7
 
 # homeassistant.components.androidtv
 adb-shell==0.0.7


### PR DESCRIPTION
## Description:
Two changes caused `capture_image` and `trigger_quick_action` services to stop working. The first is when I implemented config entries for Abode, I deleted `data.devices.extend(devices)` from the old `setup_platform` and forgot to add it back into the new `async_setup_entry`. This was extending the `devices` list of the `AbodeSystem` class which was being used for the `capture_image` and `trigger_quick_action` services. Secondly, there was a change to abodepy that resulted in the `capture` method to stop working which I created an [issue](https://github.com/MisterWil/abodepy/issues/58) for.

I still need to determine why the change to abodepy was made so I can either change it back to how it was or add some additional code to abodepy if the different Abode cameras are using different URLs for the put request.

**Abodepy 0.16.7 is published. This PR is ready to be merged after review.**

Changes made with this PR include:
- Cleaned up some doc strings for consistency.
- Renamed `device` or `devices` to `entity` or `entities` where applicable (code clean up).
- Added `data.entities.extend(entities)` to each module.

Considerations:
- If there is a list being stored for the Abode domain when `async_add_entities(entity)` is called, we could just utilize that list for the services methods instead of creating a new `self.entities` list for the `AbodeSystem` class.

**Related issue (if applicable):** fixes broken Abode services (no issues created yet)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
