### PR TITLE
Add lock device triggers

### DIFF
--- a/homeassistant/components/lock/device_trigger.py
+++ b/homeassistant/components/lock/device_trigger.py
@@ -1,0 +1,90 @@
+"""Provides device automations for Lock."""
+from typing import List
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_DOMAIN,
+    CONF_TYPE,
+    CONF_PLATFORM,
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+)
+from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.components.automation import state, AutomationActionType
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from . import DOMAIN
+
+TRIGGER_TYPES = {"locked", "unlocked"}
+
+TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device triggers for Lock devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    triggers = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        # Add triggers for each entity that belongs to this integration
+        # TODO add your own triggers.
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "locked",
+            }
+        )
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "unlocked",
+            }
+        )
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+
+    if config[CONF_TYPE] == "locked":
+        from_state = STATE_UNLOCKED
+        to_state = STATE_LOCKED
+    else:
+        from_state = STATE_LOCKED
+        to_state = STATE_UNLOCKED
+
+    state_config = {
+        state.CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        state.CONF_FROM: from_state,
+        state.CONF_TO: to_state,
+    }
+    state_config = state.TRIGGER_SCHEMA(state_config)
+    return await state.async_attach_trigger(
+        hass, state_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/lock/device_trigger.py
+++ b/homeassistant/components/lock/device_trigger.py
@@ -39,7 +39,6 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
             continue
 
         # Add triggers for each entity that belongs to this integration
-        # TODO add your own triggers.
         triggers.append(
             {
                 CONF_PLATFORM: "device",

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -8,6 +8,10 @@
     "condition_type": {
       "is_locked": "{entity_name} is locked",
       "is_unlocked": "{entity_name} is unlocked"
+    },
+    "trigger_type": {
+      "locked": "{entity_name} locked",
+      "unlocked": "{entity_name} unlocked"
     }
   }
 }

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -1,0 +1,132 @@
+"""The tests for Lock device triggers."""
+import pytest
+
+from homeassistant.components.lock import DOMAIN
+from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock serivce."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_triggers(hass, device_reg, entity_reg):
+    """Test we get the expected triggers from a lock."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "locked",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "unlocked",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+    ]
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_if_fires_on_state_change(hass, calls):
+    """Test for turn_on and turn_off triggers firing."""
+    hass.states.async_set("lock.entity", STATE_UNLOCKED)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "lock.entity",
+                        "type": "locked",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "locked - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "lock.entity",
+                        "type": "unlocked",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "unlocked - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is turning on.
+    hass.states.async_set("lock.entity", STATE_LOCKED)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data[
+        "some"
+    ] == "locked - device - {} - unlocked - locked - None".format("lock.entity")
+
+    # Fake that the entity is turning off.
+    hass.states.async_set("lock.entity", STATE_UNLOCKED)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data[
+        "some"
+    ] == "unlocked - device - {} - locked - unlocked - None".format("lock.entity")


### PR DESCRIPTION
## Description:
Add device triggers to locks.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/27019

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
