### PR TITLE
Add climate device actions

### DIFF
--- a/homeassistant/components/climate/device_action.py
+++ b/homeassistant/components/climate/device_action.py
@@ -1,0 +1,111 @@
+"""Provides device automations for Climate."""
+from typing import Optional, List
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DOMAIN,
+    CONF_TYPE,
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+)
+from homeassistant.core import HomeAssistant, Context
+from homeassistant.helpers import entity_registry
+import homeassistant.helpers.config_validation as cv
+from . import DOMAIN, const
+
+ACTION_TYPES = {"set_hvac_mode", "set_preset_mode"}
+
+SET_HVAC_MODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): "set_hvac_mode",
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+        vol.Required(const.ATTR_HVAC_MODE): vol.In(const.HVAC_MODES),
+    }
+)
+
+SET_PRESET_MODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): "set_preset_mode",
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+        vol.Required(const.ATTR_PRESET_MODE): str,
+    }
+)
+
+ACTION_SCHEMA = vol.Any(SET_HVAC_MODE_SCHEMA, SET_PRESET_MODE_SCHEMA)
+
+
+async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device actions for Climate devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    actions = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        state = hass.states.get(entry.entity_id)
+
+        # We need a state or else we can't populate the HVAC and preset modes.
+        if state is None:
+            continue
+
+        actions.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "set_hvac_mode",
+            }
+        )
+        actions.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "set_preset_mode",
+            }
+        )
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Optional[Context]
+) -> None:
+    """Execute a device action."""
+    config = ACTION_SCHEMA(config)
+
+    service_data = {ATTR_ENTITY_ID: config[CONF_ENTITY_ID]}
+
+    if config[CONF_TYPE] == "set_hvac_mode":
+        service = const.SERVICE_SET_HVAC_MODE
+        service_data[const.ATTR_HVAC_MODE] = config[const.ATTR_HVAC_MODE]
+    elif config[CONF_TYPE] == "set_preset_mode":
+        service = const.SERVICE_SET_PRESET_MODE
+        service_data[const.ATTR_PRESET_MODE] = config[const.ATTR_PRESET_MODE]
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, blocking=True, context=context
+    )
+
+
+async def async_get_action_capabilities(hass, config):
+    """List action capabilities."""
+    state = hass.states.get(config[CONF_ENTITY_ID])
+    action_type = config[CONF_TYPE]
+
+    fields = {}
+
+    if action_type == "set_hvac_mode":
+        hvac_modes = state.attributes[const.ATTR_HVAC_MODES] if state else []
+        fields[vol.Required(const.ATTR_HVAC_MODE)] = vol.In(hvac_modes)
+    elif action_type == "set_preset_mode":
+        if state:
+            preset_modes = state.attributes.get(const.ATTR_PRESET_MODES, [])
+        else:
+            preset_modes = []
+        fields[vol.Required(const.ATTR_PRESET_MODE)] = vol.In(preset_modes)
+
+    return {"extra_fields": vol.Schema(fields)}

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -1,0 +1,8 @@
+{
+  "device_automation": {
+    "action_type": {
+      "set_hvac_mode": "Change HVAC mode on {entity_name}",
+      "set_preset_mode": "Change preset on {entity_name}"
+    }
+  }
+}

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -1,0 +1,177 @@
+"""The tests for Climate device actions."""
+import pytest
+import voluptuous_serialize
+
+from homeassistant.components.climate import DOMAIN, const, device_action
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry, config_validation as cv
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_get_actions(hass, device_reg, entity_reg):
+    """Test we get the expected actions from a climate."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    hass.states.async_set("climate.test_5678", const.HVAC_MODE_COOL, {})
+    expected_actions = [
+        {
+            "domain": DOMAIN,
+            "type": "set_hvac_mode",
+            "device_id": device_entry.id,
+            "entity_id": "climate.test_5678",
+        },
+        {
+            "domain": DOMAIN,
+            "type": "set_preset_mode",
+            "device_id": device_entry.id,
+            "entity_id": "climate.test_5678",
+        },
+    ]
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    assert_lists_same(actions, expected_actions)
+
+
+async def test_action(hass):
+    """Test for actions."""
+    hass.states.async_set(
+        "climate.entity",
+        const.HVAC_MODE_COOL,
+        {
+            const.ATTR_HVAC_MODES: [const.HVAC_MODE_COOL, const.HVAC_MODE_OFF],
+            const.ATTR_PRESET_MODES: [const.PRESET_HOME, const.PRESET_AWAY],
+        },
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event_set_hvac_mode",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "climate.entity",
+                        "type": "set_hvac_mode",
+                        "hvac_mode": const.HVAC_MODE_OFF,
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event_set_preset_mode",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "climate.entity",
+                        "type": "set_preset_mode",
+                        "preset_mode": const.PRESET_AWAY,
+                    },
+                },
+            ]
+        },
+    )
+
+    set_hvac_mode_calls = async_mock_service(hass, "climate", "set_hvac_mode")
+    set_preset_mode_calls = async_mock_service(hass, "climate", "set_preset_mode")
+
+    hass.bus.async_fire("test_event_set_hvac_mode")
+    await hass.async_block_till_done()
+    assert len(set_hvac_mode_calls) == 1
+    assert len(set_preset_mode_calls) == 0
+
+    hass.bus.async_fire("test_event_set_preset_mode")
+    await hass.async_block_till_done()
+    assert len(set_hvac_mode_calls) == 1
+    assert len(set_preset_mode_calls) == 1
+
+
+async def test_capabilities(hass):
+    """Test getting capabilities."""
+    hass.states.async_set(
+        "climate.entity",
+        const.HVAC_MODE_COOL,
+        {
+            const.ATTR_HVAC_MODES: [const.HVAC_MODE_COOL, const.HVAC_MODE_OFF],
+            const.ATTR_PRESET_MODES: [const.PRESET_HOME, const.PRESET_AWAY],
+        },
+    )
+
+    # Set HVAC mode
+    capabilities = await device_action.async_get_action_capabilities(
+        hass,
+        {
+            "domain": DOMAIN,
+            "device_id": "abcdefgh",
+            "entity_id": "climate.entity",
+            "type": "set_hvac_mode",
+        },
+    )
+
+    assert capabilities and "extra_fields" in capabilities
+
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "hvac_mode",
+            "options": [("cool", "cool"), ("off", "off")],
+            "required": True,
+            "type": "select",
+        }
+    ]
+
+    # Set preset mode
+    capabilities = await device_action.async_get_action_capabilities(
+        hass,
+        {
+            "domain": DOMAIN,
+            "device_id": "abcdefgh",
+            "entity_id": "climate.entity",
+            "type": "set_preset_mode",
+        },
+    )
+
+    assert capabilities and "extra_fields" in capabilities
+
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "preset_mode",
+            "options": [("home", "home"), ("away", "away")],
+            "required": True,
+            "type": "select",
+        }
+    ]


### PR DESCRIPTION
## Description:
Add climate device actions to set HVAC and preset mode.

**Related issue (if applicable):** fixes #26985

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
