### PR TITLE
Add device actions to vacuum

### DIFF
--- a/homeassistant/components/vacuum/device_action.py
+++ b/homeassistant/components/vacuum/device_action.py
@@ -1,0 +1,72 @@
+"""Provides device automations for Vacuum."""
+from typing import Optional, List
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DOMAIN,
+    CONF_TYPE,
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+)
+from homeassistant.core import HomeAssistant, Context
+from homeassistant.helpers import entity_registry
+import homeassistant.helpers.config_validation as cv
+from . import DOMAIN, SERVICE_START, SERVICE_RETURN_TO_BASE
+
+ACTION_TYPES = {"clean", "dock"}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+    }
+)
+
+
+async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device actions for Vacuum devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    actions = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        actions.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "clean",
+            }
+        )
+        actions.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "dock",
+            }
+        )
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Optional[Context]
+) -> None:
+    """Execute a device action."""
+    config = ACTION_SCHEMA(config)
+
+    service_data = {ATTR_ENTITY_ID: config[CONF_ENTITY_ID]}
+
+    if config[CONF_TYPE] == "clean":
+        service = SERVICE_START
+    elif config[CONF_TYPE] == "dock":
+        service = SERVICE_RETURN_TO_BASE
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, blocking=True, context=context
+    )

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -1,0 +1,8 @@
+{
+  "device_automation": {
+    "action_type": {
+      "clean": "Let {entity_name} clean",
+      "dock": "Let {entity_name} return to the dock"
+    }
+  }
+}

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -1,0 +1,98 @@
+"""The tests for Vacuum device actions."""
+import pytest
+
+from homeassistant.components.vacuum import DOMAIN
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_get_actions(hass, device_reg, entity_reg):
+    """Test we get the expected actions from a vacuum."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_actions = [
+        {
+            "domain": DOMAIN,
+            "type": "clean",
+            "device_id": device_entry.id,
+            "entity_id": "vacuum.test_5678",
+        },
+        {
+            "domain": DOMAIN,
+            "type": "dock",
+            "device_id": device_entry.id,
+            "entity_id": "vacuum.test_5678",
+        },
+    ]
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    assert_lists_same(actions, expected_actions)
+
+
+async def test_action(hass):
+    """Test for turn_on and turn_off actions."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_dock"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "vacuum.entity",
+                        "type": "dock",
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_clean"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "vacuum.entity",
+                        "type": "clean",
+                    },
+                },
+            ]
+        },
+    )
+
+    dock_calls = async_mock_service(hass, "vacuum", "return_to_base")
+    clean_calls = async_mock_service(hass, "vacuum", "start")
+
+    hass.bus.async_fire("test_event_dock")
+    await hass.async_block_till_done()
+    assert len(dock_calls) == 1
+    assert len(clean_calls) == 0
+
+    hass.bus.async_fire("test_event_clean")
+    await hass.async_block_till_done()
+    assert len(dock_calls) == 1
+    assert len(clean_calls) == 1


### PR DESCRIPTION
## Description:
Add device actions to vacuum integration.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/26992

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
