### PR TITLE
WIP: Fix Yandex tts speechkit

### DIFF
--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -40,7 +40,7 @@ MAX_SPEED = 3
 
 CONF_CODEC = "codec"
 CONF_VOICE = "voice"
-CONF_EMOTION = "neutral"
+CONF_EMOTION = "emotion"
 CONF_SPEED = "speed"
 
 DEFAULT_LANG = "en-US"
@@ -116,10 +116,10 @@ class YandexSpeechKitProvider(Provider):
                     "speed": options.get(CONF_SPEED, self._speed),
                 }
 
-                bearer__format = "Api-Key {}".format(self._key)
+                bearer_format = "Api-Key {}".format(self._key)
                 request = await websession.post(
                     YANDEX_API_URL,
-                    headers={"authorization": bearer__format},
+                    headers={"authorization": bearer_format},
                     data=url_param,
                 )
 

--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -45,7 +45,7 @@ CONF_SPEED = "speed"
 
 DEFAULT_LANG = "en-US"
 DEFAULT_CODEC = "oggopus"
-DEFAULT_VOICE = "omazh"
+DEFAULT_VOICE = "alyss"
 DEFAULT_EMOTION = "neutral"
 DEFAULT_SPEED = 1
 

--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -30,7 +30,7 @@ SUPPORT_VOICES = [
     "alyss",
     "nick",
     "alena",
-    "filipp"
+    "filipp",
 ]
 
 SUPPORTED_EMOTION = ["good", "evil", "neutral"]
@@ -117,15 +117,19 @@ class YandexSpeechKitProvider(Provider):
                 }
 
                 bearer__format = "Api-Key {}".format(self._key)
-                request = await websession.post(YANDEX_API_URL,
-                                                headers={"authorization": bearer__format},
-                                                data=url_param
-                                                )
+                request = await websession.post(
+                    YANDEX_API_URL,
+                    headers={"authorization": bearer__format},
+                    data=url_param,
+                )
 
                 if request.status != 200:
                     error = await request.read()
                     _LOGGER.error(
-                        "Error %d on load URL %s. Response %s", request.status, request.url, error
+                        "Error %d on load URL %s. Response %s",
+                        request.status,
+                        request.url,
+                        error,
                     )
                     return (None, None)
                 data = await request.read()

--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -118,9 +118,9 @@ class YandexSpeechKitProvider(Provider):
 
                 bearer__format = "Api-Key {}".format(self._key)
                 request = await websession.post(YANDEX_API_URL,
-                                               headers={"authorization": bearer__format},
-                                               data=url_param
-                                               )
+                                                headers={"authorization": bearer__format},
+                                                data=url_param
+                                                )
 
                 if request.status != 200:
                     error = await request.read()

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -9,7 +9,7 @@ from homeassistant.components.media_player.const import (
     SERVICE_PLAY_MEDIA,
     DOMAIN as DOMAIN_MP,
 )
-from tests.common import get_test_home_assistant, assert_setup_component, mock_service
+from tests.common import post_test_home_assistant, assert_setup_component, mock_service
 
 from tests.components.tts.test_init import mutagen_mock  # noqa
 
@@ -19,8 +19,8 @@ class TestTTSYandexPlatform:
 
     def setup_method(self):
         """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self._base_url = "https://tts.voicetech.yandex.net/generate?"
+        self.hass = post_test_home_assistant()
+        self._base_url = "https://tts.api.cloud.yandex.net/speech/v1/tts:synthesize"
 
     def teardown_method(self):
         """Stop everything that was started."""
@@ -53,11 +53,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
 
@@ -83,11 +83,11 @@ class TestTTSYandexPlatform:
             "lang": "ru-RU",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
 
@@ -119,11 +119,11 @@ class TestTTSYandexPlatform:
             "lang": "ru-RU",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
 
@@ -151,11 +151,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, exc=asyncio.TimeoutError(), params=url_param
         )
 
@@ -181,11 +181,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=403, content=b"test", params=url_param
         )
 
@@ -210,11 +210,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "alyss",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
 
@@ -246,11 +246,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "evil",
             "speed": 1,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
 
@@ -282,11 +282,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": "0.1",
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
 
@@ -314,11 +314,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "neutral",
             "speed": 2,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
 
@@ -346,11 +346,11 @@ class TestTTSYandexPlatform:
             "lang": "en-US",
             "key": "1234567xx",
             "speaker": "zahar",
-            "format": "mp3",
+            "format": "oggopus",
             "emotion": "evil",
             "speed": 2,
         }
-        aioclient_mock.get(
+        aioclient_mock.post(
             self._base_url, status=200, content=b"test", params=url_param
         )
         config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -4,14 +4,12 @@ import os
 import shutil
 
 import homeassistant.components.tts as tts
-from homeassistant.setup import setup_component
 from homeassistant.components.media_player.const import (
     SERVICE_PLAY_MEDIA,
     DOMAIN as DOMAIN_MP,
 )
-from tests.common import post_test_home_assistant, assert_setup_component, mock_service
-
-from tests.components.tts.test_init import mutagen_mock  # noqa
+from homeassistant.setup import setup_component
+from tests.common import get_test_home_assistant, assert_setup_component, mock_service
 
 
 class TestTTSYandexPlatform:
@@ -19,7 +17,7 @@ class TestTTSYandexPlatform:
 
     def setup_method(self):
         """Set up things to be run when tests are started."""
-        self.hass = post_test_home_assistant()
+        self.hass = get_test_home_assistant()
         self._base_url = "https://tts.api.cloud.yandex.net/speech/v1/tts:synthesize"
 
     def teardown_method(self):

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -46,18 +46,16 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
-        )
+        aioclient_mock.post(self._base_url, status=200, data=request_param)
 
         config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}
 
@@ -76,18 +74,16 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "ru-RU",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
-        )
+        aioclient_mock.post(self._base_url, status=200, data=request_param)
 
         config = {
             tts.DOMAIN: {
@@ -112,18 +108,16 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "ru-RU",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
-        )
+        aioclient_mock.post(self._base_url, status=200, data=request_param)
 
         config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}
 
@@ -144,17 +138,17 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
         aioclient_mock.post(
-            self._base_url, status=200, exc=asyncio.TimeoutError(), params=url_param
+            self._base_url, status=200, exc=asyncio.TimeoutError(), data=request_param
         )
 
         config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}
@@ -174,18 +168,16 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.post(
-            self._base_url, status=403, content=b"test", params=url_param
-        )
+        aioclient_mock.post(self._base_url, status=403, data=request_param)
 
         config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}
 
@@ -203,7 +195,7 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
@@ -212,9 +204,7 @@ class TestTTSYandexPlatform:
             "emotion": "neutral",
             "speed": 1,
         }
-        aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
-        )
+        aioclient_mock.post(self._base_url, status=200, data=request_param)
 
         config = {
             tts.DOMAIN: {
@@ -239,18 +229,16 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "evil",
             "speed": 1,
         }
-        aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
-        )
+        aioclient_mock.post(self._base_url, status=200, data=request_param)
 
         config = {
             tts.DOMAIN: {
@@ -275,17 +263,17 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "neutral",
             "speed": "0.1",
         }
         aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
+            self._base_url, status=200, content=b"test", data=request_param
         )
 
         config = {
@@ -307,17 +295,17 @@ class TestTTSYandexPlatform:
         """Test service call say."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "neutral",
             "speed": 2,
         }
         aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
+            self._base_url, status=200, content=b"test", data=request_param
         )
 
         config = {
@@ -339,18 +327,16 @@ class TestTTSYandexPlatform:
         """Test service call say with options."""
         calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
-        url_param = {
+        request_param = {
             "text": "HomeAssistant",
             "lang": "en-US",
             "key": "1234567xx",
-            "speaker": "zahar",
+            "speaker": "alyss",
             "format": "oggopus",
             "emotion": "evil",
             "speed": 2,
         }
-        aioclient_mock.post(
-            self._base_url, status=200, content=b"test", params=url_param
-        )
+        aioclient_mock.post(self._base_url, status=200, data=request_param)
         config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}
 
         with assert_setup_component(1, tts.DOMAIN):


### PR DESCRIPTION
## Breaking Change:
Right now yandexx tts is broken due api endpoint shutdown see #28519 
I updated code to work with new API of yandex speechkit
User should recieve new api key to work

## Description:
Updated code accroding to new API description
Removed unsupported voices

**Related issue:** fixes #28519

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11106

## Example entry for `configuration.yaml` (if applicable):
```yaml
tts:
  - platform: yandextts
    api_key: *******
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
