### PR TITLE
0.101.3

### DIFF
--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -31,6 +31,8 @@ DEFAULT_SCAN_INTERVAL = timedelta(minutes=10)
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up configured Airly."""
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][DATA_CLIENT] = {}
     return True
 
 
@@ -49,8 +51,6 @@ async def async_setup_entry(hass, config_entry):
     if not airly.data:
         raise ConfigEntryNotReady()
 
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][DATA_CLIENT] = {}
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = airly
 
     hass.async_create_task(

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -17,10 +17,16 @@ from homeassistant.helpers.typing import HomeAssistantType
 from . import (
     DOMAIN,
     ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT,
+    ATTR_COLOR_NAME,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
+    ATTR_FLASH,
     ATTR_HS_COLOR,
+    ATTR_KELVIN,
+    ATTR_PROFILE,
     ATTR_RGB_COLOR,
+    ATTR_TRANSITION,
     ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
 )
@@ -28,8 +34,36 @@ from . import (
 _LOGGER = logging.getLogger(__name__)
 
 VALID_STATES = {STATE_ON, STATE_OFF}
-ATTR_GROUP = [ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_WHITE_VALUE]
-COLOR_GROUP = [ATTR_COLOR_TEMP, ATTR_HS_COLOR, ATTR_RGB_COLOR, ATTR_XY_COLOR]
+
+ATTR_GROUP = [
+    ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT,
+    ATTR_EFFECT,
+    ATTR_FLASH,
+    ATTR_WHITE_VALUE,
+    ATTR_TRANSITION,
+]
+
+COLOR_GROUP = [
+    ATTR_COLOR_NAME,
+    ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
+    ATTR_KELVIN,
+    ATTR_PROFILE,
+    ATTR_RGB_COLOR,
+    ATTR_XY_COLOR,
+]
+
+DEPRECATED_GROUP = [
+    ATTR_BRIGHTNESS_PCT,
+    ATTR_COLOR_NAME,
+    ATTR_FLASH,
+    ATTR_KELVIN,
+    ATTR_PROFILE,
+    ATTR_TRANSITION,
+]
+
+DEPRECATION_WARNING = "The use of other attributes than device state attributes is deprecated and will be removed in a future release. Read the logs for further details: https://www.home-assistant.io/integrations/scene/"
 
 
 async def _async_reproduce_state(
@@ -47,6 +81,10 @@ async def _async_reproduce_state(
             "Invalid state specified for %s: %s", state.entity_id, state.state
         )
         return
+
+    # Warn if deprecated attributes are used
+    if any(attr in DEPRECATED_GROUP for attr in state.attributes):
+        _LOGGER.warning(DEPRECATION_WARNING)
 
     # Return if we are already at the right state.
     if cur_state.state == state.state and all(

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -8,6 +8,7 @@ import urllib
 
 import async_timeout
 import pysonos
+from pysonos import alarms
 from pysonos.exceptions import SoCoException, SoCoUPnPException
 import pysonos.snapshot
 
@@ -1163,7 +1164,7 @@ class SonosEntity(MediaPlayerDevice):
         """Set the alarm clock on the player."""
 
         alarm = None
-        for one_alarm in pysonos.alarms.get_alarms(self.soco):
+        for one_alarm in alarms.get_alarms(self.soco):
             # pylint: disable=protected-access
             if one_alarm._alarm_id == str(data[ATTR_ALARM_ID]):
                 alarm = one_alarm

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 101
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 6, 1)

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -1,13 +1,19 @@
 """Test reproduce state for Light."""
+from homeassistant.components.light.reproduce_state import DEPRECATION_WARNING
 from homeassistant.core import State
 
 from tests.common import async_mock_service
 
 VALID_BRIGHTNESS = {"brightness": 180}
 VALID_WHITE_VALUE = {"white_value": 200}
+VALID_FLASH = {"flash": "short"}
 VALID_EFFECT = {"effect": "random"}
+VALID_TRANSITION = {"transition": 15}
+VALID_COLOR_NAME = {"color_name": "red"}
 VALID_COLOR_TEMP = {"color_temp": 240}
 VALID_HS_COLOR = {"hs_color": (345, 75)}
+VALID_KELVIN = {"kelvin": 4000}
+VALID_PROFILE = {"profile": "relax"}
 VALID_RGB_COLOR = {"rgb_color": (255, 63, 111)}
 VALID_XY_COLOR = {"xy_color": (0.59, 0.274)}
 
@@ -17,9 +23,14 @@ async def test_reproducing_states(hass, caplog):
     hass.states.async_set("light.entity_off", "off", {})
     hass.states.async_set("light.entity_bright", "on", VALID_BRIGHTNESS)
     hass.states.async_set("light.entity_white", "on", VALID_WHITE_VALUE)
+    hass.states.async_set("light.entity_flash", "on", VALID_FLASH)
     hass.states.async_set("light.entity_effect", "on", VALID_EFFECT)
+    hass.states.async_set("light.entity_trans", "on", VALID_TRANSITION)
+    hass.states.async_set("light.entity_name", "on", VALID_COLOR_NAME)
     hass.states.async_set("light.entity_temp", "on", VALID_COLOR_TEMP)
     hass.states.async_set("light.entity_hs", "on", VALID_HS_COLOR)
+    hass.states.async_set("light.entity_kelvin", "on", VALID_KELVIN)
+    hass.states.async_set("light.entity_profile", "on", VALID_PROFILE)
     hass.states.async_set("light.entity_rgb", "on", VALID_RGB_COLOR)
     hass.states.async_set("light.entity_xy", "on", VALID_XY_COLOR)
 
@@ -32,9 +43,14 @@ async def test_reproducing_states(hass, caplog):
             State("light.entity_off", "off"),
             State("light.entity_bright", "on", VALID_BRIGHTNESS),
             State("light.entity_white", "on", VALID_WHITE_VALUE),
+            State("light.entity_flash", "on", VALID_FLASH),
             State("light.entity_effect", "on", VALID_EFFECT),
+            State("light.entity_trans", "on", VALID_TRANSITION),
+            State("light.entity_name", "on", VALID_COLOR_NAME),
             State("light.entity_temp", "on", VALID_COLOR_TEMP),
             State("light.entity_hs", "on", VALID_HS_COLOR),
+            State("light.entity_kelvin", "on", VALID_KELVIN),
+            State("light.entity_profile", "on", VALID_PROFILE),
             State("light.entity_rgb", "on", VALID_RGB_COLOR),
             State("light.entity_xy", "on", VALID_XY_COLOR),
         ],
@@ -59,16 +75,21 @@ async def test_reproducing_states(hass, caplog):
             State("light.entity_xy", "off"),
             State("light.entity_off", "on", VALID_BRIGHTNESS),
             State("light.entity_bright", "on", VALID_WHITE_VALUE),
-            State("light.entity_white", "on", VALID_EFFECT),
-            State("light.entity_effect", "on", VALID_COLOR_TEMP),
+            State("light.entity_white", "on", VALID_FLASH),
+            State("light.entity_flash", "on", VALID_EFFECT),
+            State("light.entity_effect", "on", VALID_TRANSITION),
+            State("light.entity_trans", "on", VALID_COLOR_NAME),
+            State("light.entity_name", "on", VALID_COLOR_TEMP),
             State("light.entity_temp", "on", VALID_HS_COLOR),
-            State("light.entity_hs", "on", VALID_RGB_COLOR),
+            State("light.entity_hs", "on", VALID_KELVIN),
+            State("light.entity_kelvin", "on", VALID_PROFILE),
+            State("light.entity_profile", "on", VALID_RGB_COLOR),
             State("light.entity_rgb", "on", VALID_XY_COLOR),
         ],
         blocking=True,
     )
 
-    assert len(turn_on_calls) == 7
+    assert len(turn_on_calls) == 12
 
     expected_calls = []
 
@@ -80,21 +101,41 @@ async def test_reproducing_states(hass, caplog):
     expected_bright["entity_id"] = "light.entity_bright"
     expected_calls.append(expected_bright)
 
-    expected_white = VALID_EFFECT
+    expected_white = VALID_FLASH
     expected_white["entity_id"] = "light.entity_white"
     expected_calls.append(expected_white)
 
-    expected_effect = VALID_COLOR_TEMP
+    expected_flash = VALID_EFFECT
+    expected_flash["entity_id"] = "light.entity_flash"
+    expected_calls.append(expected_flash)
+
+    expected_effect = VALID_TRANSITION
     expected_effect["entity_id"] = "light.entity_effect"
     expected_calls.append(expected_effect)
+
+    expected_trans = VALID_COLOR_NAME
+    expected_trans["entity_id"] = "light.entity_trans"
+    expected_calls.append(expected_trans)
+
+    expected_name = VALID_COLOR_TEMP
+    expected_name["entity_id"] = "light.entity_name"
+    expected_calls.append(expected_name)
 
     expected_temp = VALID_HS_COLOR
     expected_temp["entity_id"] = "light.entity_temp"
     expected_calls.append(expected_temp)
 
-    expected_hs = VALID_RGB_COLOR
+    expected_hs = VALID_KELVIN
     expected_hs["entity_id"] = "light.entity_hs"
     expected_calls.append(expected_hs)
+
+    expected_kelvin = VALID_PROFILE
+    expected_kelvin["entity_id"] = "light.entity_kelvin"
+    expected_calls.append(expected_kelvin)
+
+    expected_profile = VALID_RGB_COLOR
+    expected_profile["entity_id"] = "light.entity_profile"
+    expected_calls.append(expected_profile)
 
     expected_rgb = VALID_XY_COLOR
     expected_rgb["entity_id"] = "light.entity_rgb"
@@ -115,3 +156,14 @@ async def test_reproducing_states(hass, caplog):
     assert len(turn_off_calls) == 1
     assert turn_off_calls[0].domain == "light"
     assert turn_off_calls[0].data == {"entity_id": "light.entity_xy"}
+
+
+async def test_deprecation_warning(hass, caplog):
+    """Test deprecation warning."""
+    hass.states.async_set("light.entity_off", "off", {})
+    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+    await hass.helpers.state.async_reproduce_state(
+        [State("light.entity_off", "on", {"brightness_pct": 80})], blocking=True
+    )
+    assert len(turn_on_calls) == 1
+    assert DEPRECATION_WARNING in caplog.text

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -144,14 +144,18 @@ async def test_get_integration_with_requirements(hass):
         assert integration.domain == "test_component"
 
     assert len(mock_is_installed.mock_calls) == 3
-    assert mock_is_installed.mock_calls[0][1][0] == "test-comp==1.0.0"
-    assert mock_is_installed.mock_calls[1][1][0] == "test-comp-dep==1.0.0"
-    assert mock_is_installed.mock_calls[2][1][0] == "test-comp-after-dep==1.0.0"
+    assert sorted(mock_call[1][0] for mock_call in mock_is_installed.mock_calls) == [
+        "test-comp-after-dep==1.0.0",
+        "test-comp-dep==1.0.0",
+        "test-comp==1.0.0",
+    ]
 
     assert len(mock_inst.mock_calls) == 3
-    assert mock_inst.mock_calls[0][1][0] == "test-comp==1.0.0"
-    assert mock_inst.mock_calls[1][1][0] == "test-comp-dep==1.0.0"
-    assert mock_inst.mock_calls[2][1][0] == "test-comp-after-dep==1.0.0"
+    assert sorted(mock_call[1][0] for mock_call in mock_inst.mock_calls) == [
+        "test-comp-after-dep==1.0.0",
+        "test-comp-dep==1.0.0",
+        "test-comp==1.0.0",
+    ]
 
 
 async def test_install_with_wheels_index(hass):


### PR DESCRIPTION
- Fix missing import ([@timmccor] - [#28460]) ([sonos docs])
- Fix Airly if more than one config entry ([@bieniu] - [#28498]) ([airly docs])
- Add deprecated attributes to light.reproduce_state ([@Santobert] - [#28557]) ([light docs])

[#28460]: https://github.com/home-assistant/home-assistant/pull/28460
[#28498]: https://github.com/home-assistant/home-assistant/pull/28498
[#28557]: https://github.com/home-assistant/home-assistant/pull/28557
[@Santobert]: https://github.com/Santobert
[@bieniu]: https://github.com/bieniu
[@timmccor]: https://github.com/timmccor
[airly docs]: https://www.home-assistant.io/integrations/airly/
[light docs]: https://www.home-assistant.io/integrations/light/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/