### PR TITLE
Bump pytile and re-order imports

### DIFF
--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -2,6 +2,8 @@
 import logging
 from datetime import timedelta
 
+from pytile import async_login
+from pytile.errors import SessionExpiredError, TileError
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA
@@ -43,8 +45,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     """Validate the configuration and return a Tile scanner."""
-    from pytile import async_login
-
     websession = aiohttp_client.async_get_clientsession(hass)
 
     config_file = hass.config.path(
@@ -89,8 +89,6 @@ class TileScanner:
 
     async def async_init(self):
         """Further initialize connection to the Tile servers."""
-        from pytile.errors import TileError
-
         try:
             await self._client.async_init()
         except TileError as err:
@@ -105,10 +103,6 @@ class TileScanner:
 
     async def _async_update(self, now=None):
         """Update info from Tile."""
-        from pytile.errors import SessionExpiredError, TileError
-
-        _LOGGER.debug("Updating Tile data")
-
         try:
             await self._client.async_init()
             tiles = await self._client.tiles.all(

--- a/homeassistant/components/tile/manifest.json
+++ b/homeassistant/components/tile/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tile",
   "documentation": "https://www.home-assistant.io/integrations/tile",
   "requirements": [
-    "pytile==3.0.0"
+    "pytile==3.0.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1609,7 +1609,7 @@ python_opendata_transport==0.1.4
 pythonegardia==1.0.40
 
 # homeassistant.components.tile
-pytile==3.0.0
+pytile==3.0.1
 
 # homeassistant.components.touchline
 pytouchline==0.7


### PR DESCRIPTION
## Description:

This PR bumps `pytile` to 3.0.1 (changelog: https://github.com/bachya/pytile/releases/tag/3.0.1) and, since I was in there, moves `pytile` imports to the top.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/28556

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: tile
    username: !secret tile_email
    password: !secret tile_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
