### PR TITLE
Pull track position from MPD status

### DIFF
--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -198,7 +198,11 @@ class MpdDevice(MediaPlayerDevice):
 
     @property
     def media_position(self):
-        """Position of current playing media in seconds."""
+        """Position of current playing media in seconds.
+
+        This is returned as part of the mpd status rather than in the details
+        of the current song.
+        """
         return self._status.get("time")
 
     @property

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -134,7 +134,7 @@ class MpdDevice(MediaPlayerDevice):
         self._currentsong = self._client.currentsong()
 
         position = self._status["time"]
-        if  self._media_position != position:
+        if self._media_position != position:
             self._media_position_updated_at = dt_util.utcnow()
             self._media_position = position
 

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -203,7 +203,7 @@ class MpdDevice(MediaPlayerDevice):
         This is returned as part of the mpd status rather than in the details
         of the current song.
         """
-        return self._status.get("time")
+        return self._media_position
 
     @property
     def media_position_updated_at(self):

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -37,6 +37,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -98,6 +99,8 @@ class MpdDevice(MediaPlayerDevice):
         self._is_connected = False
         self._muted = False
         self._muted_volume = 0
+        self._media_position_updated_at = None
+        self._media_position = None
 
         # set up MPD client
         self._client = mpd.MPDClient()
@@ -129,6 +132,11 @@ class MpdDevice(MediaPlayerDevice):
         """Fetch status from MPD."""
         self._status = self._client.status()
         self._currentsong = self._client.currentsong()
+
+        position = self._status["time"]
+        if  self._media_position != position:
+            self._media_position_updated_at = dt_util.utcnow()
+            self._media_position = position
 
         self._update_playlists()
 
@@ -187,6 +195,16 @@ class MpdDevice(MediaPlayerDevice):
         """Return the duration of current playing media in seconds."""
         # Time does not exist for streams
         return self._currentsong.get("time")
+
+    @property
+    def media_position(self):
+        """Position of current playing media in seconds."""
+        return self._status.get("time")
+
+    @property
+    def media_position_updated_at(self):
+        """Last valid time of media position."""
+        return self._media_position_updated_at
 
     @property
     def media_title(self):


### PR DESCRIPTION
This allows the progress bar to work when using the media-control card in lovelace.

## Description:

Implemented the `media_position` and `media_position_updated_at` methods to return the position a track is at when using MPD.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
