### PR TITLE
Fix simple typo: unhasable -> unhashable

### DIFF
--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -39,7 +39,7 @@ def test_simple_dict():
 
 
 def test_unhashable_key():
-    """Test an unhasable key."""
+    """Test an unhashable key."""
     files = {YAML_CONFIG_FILE: "message:\n  {{ states.state }}"}
     with pytest.raises(HomeAssistantError), patch_yaml_files(files):
         load_yaml_config_file(YAML_CONFIG_FILE)


### PR DESCRIPTION
## Description:
Simple typo in tests/util/test_yaml.py

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works (No new code - typo only).

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
