### PR TITLE
Add update service and multiple domains to namecheapdns

### DIFF
--- a/homeassistant/components/namecheapdns/__init__.py
+++ b/homeassistant/components/namecheapdns/__init__.py
@@ -5,7 +5,14 @@ import logging
 import defusedxml.ElementTree as ET
 import voluptuous as vol
 
-from homeassistant.const import CONF_DOMAIN, CONF_HOST, CONF_PASSWORD
+from homeassistant.const import (
+    CONF_DOMAIN,
+    CONF_DOMAINS,
+    CONF_HOSTS,
+    CONF_PASSWORD,
+    ATTR_DOMAIN,
+    CONF_SCAN_INTERVAL,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
@@ -14,22 +21,35 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "namecheapdns"
 
-INTERVAL = timedelta(minutes=5)
-
 ATTR_HOST = "host"
-ATTR_DOMAIN = "domain"
 ATTR_PASSWORD = "password"
-ATTR_IP = "ip"
 
 UPDATE_URL = "https://dynamicdns.park-your-domain.com/update"
+
+DEFAULT_HOST = "@"
+DEFAULT_INTERVAL = 5
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
-                vol.Required(CONF_DOMAIN): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_HOST, default="@"): cv.string,
+                vol.Optional(CONF_DOMAINS): vol.All(
+                    cv.ensure_list,
+                    [
+                        vol.Schema(
+                            {
+                                vol.Required(CONF_DOMAIN): cv.string,
+                                vol.Optional(CONF_HOSTS): vol.All(
+                                    cv.ensure_list, [cv.string]
+                                ),
+                                vol.Required(CONF_PASSWORD): cv.string,
+                            }
+                        )
+                    ],
+                ),
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL
+                ): cv.positive_int,
             }
         )
     },
@@ -39,41 +59,68 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Initialize the namecheap DNS component."""
-    host = config[DOMAIN][CONF_HOST]
-    domain = config[DOMAIN][CONF_DOMAIN]
-    password = config[DOMAIN][CONF_PASSWORD]
+    interval = timedelta(minutes=config[DOMAIN][CONF_SCAN_INTERVAL])
+    if CONF_DOMAINS in config[DOMAIN]:
+        domains = config[DOMAIN][CONF_DOMAINS]
+    else:
+        domains = None
 
     session = async_get_clientsession(hass)
 
-    result = await _update_namecheapdns(session, host, domain, password)
+    result = await _update_all_namecheapdns(session, domains)
 
     if not result:
         return False
 
     async def update_domain_interval(now):
         """Update the namecheap DNS entry."""
-        await _update_namecheapdns(session, host, domain, password)
+        await _update_all_namecheapdns(session, domains)
 
     async def handle_update(call):
         """Handle service call to update the namecheap DNS entry."""
-        service_host = call.data.get(ATTR_HOST, host)
-        service_domain = call.data.get(ATTR_DOMAIN, domain)
-        service_password = call.data.get(ATTR_PASSWORD, password)
-        await _update_namecheapdns(
-            session, service_host, service_domain, service_password
-        )
+        host = call.data.get(ATTR_HOST, DEFAULT_HOST)
+        domain = call.data.get(ATTR_DOMAIN)
+        password = call.data.get(ATTR_PASSWORD)
+        await _update_namecheapdns(session, host, domain, password)
+
+    async def handle_update_all(call):
+        """Handle service call to update all configured domains."""
+        await _update_all_namecheapdns(session, domains)
 
     hass.services.async_register(DOMAIN, "update", handle_update)
+    hass.services.async_register(DOMAIN, "update_all", handle_update_all)
 
-    async_track_time_interval(hass, update_domain_interval, INTERVAL)
+    if CONF_DOMAINS in config[DOMAIN]:
+        async_track_time_interval(hass, update_domain_interval, interval)
 
     return result
+
+
+async def _update_all_namecheapdns(session, domains):
+    """Update all configured domains."""
+    if domains is not None:
+        _LOGGER.debug("Updating all configured domains")
+        for domain_dict in domains:
+            domain = domain_dict[CONF_DOMAIN]
+            password = domain_dict[CONF_PASSWORD]
+            if CONF_HOSTS in domain_dict:
+                for host in domain_dict[CONF_HOSTS]:
+                    resp = await _update_namecheapdns(session, host, domain, password)
+                    if not resp:
+                        return resp
+            else:
+                _LOGGER.debug("No hosts configured, updating default")
+                return await _update_namecheapdns(
+                    session, DEFAULT_HOST, domain, password
+                )
+    else:
+        _LOGGER.debug("No domains to update")
+    return True
 
 
 async def _update_namecheapdns(session, host, domain, password):
     """Update namecheap DNS entry."""
     params = {"host": host, "domain": domain, "password": password}
-    _LOGGER.debug("Updating %s.%s using namecheapdns", host, domain)
     resp = await session.get(UPDATE_URL, params=params)
     xml_string = await resp.text()
     root = ET.fromstring(xml_string)
@@ -81,8 +128,10 @@ async def _update_namecheapdns(session, host, domain, password):
 
     if int(err_count) != 0:
         _LOGGER.warning("Updating namecheap domain failed: %s", domain)
+        for error in root.find("errors"):
+            _LOGGER.warning(error.text)
         return False
-    else:
-        _LOGGER.debug("Updated %s.%s", host, domain)
+
+    _LOGGER.debug("Updated %s.%s", host, domain)
 
     return True


### PR DESCRIPTION
## Breaking Change:

Configurations for a single domain in namecheapdns will no longer work. The expected format of a configuration is now:

```
namecheapdns:
  scan_interval: interval_in_minutes
  domains:
    - domain: domain1.com
      hosts:
        - host1
        - host2
      password: password1
    - domain: domain2.com
      password: password2 
```

## Description:

Add a service to the namecheapdns integration to allow updating of any domain.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11123

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
