### PR TITLE
Allow to skip SSL validation on Plex websocket

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -160,7 +160,10 @@ async def async_setup_entry(hass, entry):
         async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
 
     session = async_get_clientsession(hass)
-    websocket = PlexWebsocket(plex_server.plex_server, update_plex, session)
+    verify_ssl = server_config.get(CONF_VERIFY_SSL)
+    websocket = PlexWebsocket(
+        plex_server.plex_server, update_plex, session=session, verify_ssl=verify_ssl
+    )
     hass.loop.create_task(websocket.listen())
     hass.data[PLEX_DOMAIN][WEBSOCKETS][server_id] = websocket
 

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -6,7 +6,7 @@
   "requirements": [
     "plexapi==3.0.6",
     "plexauth==0.0.5",
-    "plexwebsocket==0.0.3"
+    "plexwebsocket==0.0.4"
   ],
   "dependencies": [
     "http"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -980,7 +980,7 @@ plexapi==3.0.6
 plexauth==0.0.5
 
 # homeassistant.components.plex
-plexwebsocket==0.0.3
+plexwebsocket==0.0.4
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -326,7 +326,7 @@ plexapi==3.0.6
 plexauth==0.0.5
 
 # homeassistant.components.plex
-plexwebsocket==0.0.3
+plexwebsocket==0.0.4
 
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm


### PR DESCRIPTION
## Description:
Makes the websocket connection obey the `verify_ssl` configuration parameter. Non-websocket connections already obey this parameter.

Useful when using the IP of the Plex server while still wanting to use a secure connection as the hostname will not match in that scenario.

**Related issue (if applicable):** fixes #28589

## Example entry for `configuration.yaml` (if applicable):
```plex:
  host: MY_LOCAL.PLEX_HOSTNAME.HERE
  token: 20_CHAR_TOKEN_HERE
  ssl: true
  verify_ssl: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
