### PR TITLE
Fix unhandled exception when Swisscom Internet Box is not responsive

### DIFF
--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -80,9 +80,14 @@ class SwisscomDeviceScanner(DeviceScanner):
         {"service":"Devices", "method":"get",
         "parameters":{"expression":"lan and not self"}}"""
 
-        request = requests.post(url, headers=headers, data=data, timeout=10)
-
         devices = {}
+        
+        try:
+            request = requests.post(url, headers=headers, data=data, timeout=10)
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.ConnectTimeout):
+            _LOGGER.info("No response from Swisscom Internet Box")
+            return devices
+
         for device in request.json()["status"]:
             try:
                 devices[device["Key"]] = {

--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -81,7 +81,7 @@ class SwisscomDeviceScanner(DeviceScanner):
         "parameters":{"expression":"lan and not self"}}"""
 
         devices = {}
-        
+
         try:
             request = requests.post(url, headers=headers, data=data, timeout=10)
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.ConnectTimeout):

--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -84,7 +84,10 @@ class SwisscomDeviceScanner(DeviceScanner):
 
         try:
             request = requests.post(url, headers=headers, data=data, timeout=10)
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.ConnectTimeout):
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,requests.exceptions.ConnectTimeout
+        ):
             _LOGGER.info("No response from Swisscom Internet Box")
             return devices
 

--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -86,7 +86,8 @@ class SwisscomDeviceScanner(DeviceScanner):
             request = requests.post(url, headers=headers, data=data, timeout=10)
         except (
             requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,requests.exceptions.ConnectTimeout
+            requests.exceptions.Timeout,
+            requests.exceptions.ConnectTimeout,
         ):
             _LOGGER.info("No response from Swisscom Internet Box")
             return devices


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
From time to time, Swisscom Internet Box fails to respond and this causes an exception, which is currently not handled by the code:
```
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/device_tracker/setup.py", line 164, in async_device_tracker_scan
    found_devices = await scanner.async_scan_devices()
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/swisscom/device_tracker.py", line 46, in scan_devices
    self._update_info()
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/swisscom/device_tracker.py", line 67, in _update_info
    data = self.get_swisscom_data()
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/swisscom/device_tracker.py", line 83, in get_swisscom_data
    request = requests.post(url, headers=headers, data=data, timeout=10)
  File "/srv/homeassistant/lib/python3.7/site-packages/requests/api.py", line 116, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/srv/homeassistant/lib/python3.7/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/srv/homeassistant/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/srv/homeassistant/lib/python3.7/site-packages/requests/sessions.py", line 686, in send
    r.content
  File "/srv/homeassistant/lib/python3.7/site-packages/requests/models.py", line 828, in content
    self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
  File "/srv/homeassistant/lib/python3.7/site-packages/requests/models.py", line 757, in generate
    raise ConnectionError(e)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='192.168.1.1', port=80): Read timed out.
```
I've just added a try-except around the post.

**Related issue (if applicable):** fixes #28640 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```
device_tracker:
  - platform: swisscom
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
