### PR TITLE
Add support for conversation ID to conversation integration

### DIFF
--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import timedelta
 import logging
 import time
+from typing import Optional
 
 import async_timeout
 from aiohttp import ClientSession, ClientError
@@ -205,9 +206,11 @@ class AlmondAgent(conversation.AbstractConversationAgent):
         """Initialize the agent."""
         self.api = api
 
-    async def async_process(self, text: str) -> intent.IntentResponse:
+    async def async_process(
+        self, text: str, conversation_id: Optional[str] = None
+    ) -> intent.IntentResponse:
         """Process a sentence."""
-        response = await self.api.async_converse_text(text)
+        response = await self.api.async_converse_text(text, conversation_id)
 
         buffer = ""
         for message in response["messages"]:

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -1,5 +1,6 @@
 """Agent foundation for conversation integration."""
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from homeassistant.helpers import intent
 
@@ -8,5 +9,7 @@ class AbstractConversationAgent(ABC):
     """Abstract conversation agent."""
 
     @abstractmethod
-    async def async_process(self, text: str) -> intent.IntentResponse:
+    async def async_process(
+        self, text: str, conversation_id: Optional[str] = None
+    ) -> intent.IntentResponse:
         """Process a sentence."""

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -1,6 +1,7 @@
 """Standard conversastion implementation for Home Assistant."""
 import logging
 import re
+from typing import Optional
 
 from homeassistant import core
 from homeassistant.components.cover import INTENT_CLOSE_COVER, INTENT_OPEN_COVER
@@ -107,7 +108,9 @@ class DefaultAgent(AbstractConversationAgent):
         for intent_type, sentences in UTTERANCES[component].items():
             async_register(self.hass, intent_type, sentences)
 
-    async def async_process(self, text) -> intent.IntentResponse:
+    async def async_process(
+        self, text: str, conversation_id: Optional[str] = None
+    ) -> intent.IntentResponse:
         """Process a sentence."""
         intents = self.hass.data[DOMAIN]
 


### PR DESCRIPTION
## Description:
Add support for conversation IDs so that agents can keep track.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
