### PR TITLE
Add attribution and onboarding commands to conversation and Almond

### DIFF
--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -225,7 +225,7 @@ class AlmondAgent(conversation.AbstractConversationAgent):
         elif self.entry.data["type"] != TYPE_LOCAL:
             host = f"{host}/me"
         return {
-            "text": "Send anonymized commands to the authors of Almond for training.",
+            "text": "Would you like to opt-in to share your anonymized commands with Stanford to improve Almond's responses?",
             "url": f"{host}/conversation",
         }
 

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -217,7 +217,7 @@ class AlmondAgent(conversation.AbstractConversationAgent):
     async def async_get_onboarding(self):
         """Get onboard url if not onboarded."""
         if self.entry.data.get("onboarded"):
-            return False
+            return None
 
         host = self.entry.data["host"]
         if self.entry.data.get("is_hassio"):

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -229,10 +229,10 @@ class AlmondAgent(conversation.AbstractConversationAgent):
             "url": f"{host}/conversation",
         }
 
-    async def async_set_onboarding(self, new_data):
+    async def async_set_onboarding(self, shown):
         """Set onboarding status."""
         self.hass.config_entries.async_update_entry(
-            self.entry, data={**self.entry.data, **new_data}
+            self.entry, data={**self.entry.data, **{"onboarded": shown}}
         )
 
         return True

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -232,7 +232,7 @@ class AlmondAgent(conversation.AbstractConversationAgent):
     async def async_set_onboarding(self, shown):
         """Set onboarding status."""
         self.hass.config_entries.async_update_entry(
-            self.entry, data={**self.entry.data, **{"onboarded": shown}}
+            self.entry, data={**self.entry.data, "onboarded": shown}
         )
 
         return True

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -10,6 +10,7 @@ from aiohttp import ClientSession, ClientError
 from pyalmond import AlmondLocalAuth, AbstractAlmondWebAuth, WebAlmondAPI
 import voluptuous as vol
 
+from homeassistant import core
 from homeassistant.const import CONF_TYPE, CONF_HOST
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.auth.const import GROUP_ID_ADMIN
@@ -95,9 +96,9 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, entry):
     """Set up Almond config entry."""
     websession = aiohttp_client.async_get_clientsession(hass)
+
     if entry.data["type"] == TYPE_LOCAL:
         auth = AlmondLocalAuth(entry.data["host"], websession)
-
     else:
         # OAuth2
         implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
@@ -109,7 +110,7 @@ async def async_setup_entry(hass, entry):
         auth = AlmondOAuth(entry.data["host"], websession, oauth_session)
 
     api = WebAlmondAPI(auth)
-    agent = AlmondAgent(api)
+    agent = AlmondAgent(hass, api, entry)
 
     # Hass.io does its own configuration of Almond.
     if entry.data.get("is_hassio") or entry.data["type"] != TYPE_LOCAL:
@@ -202,9 +203,39 @@ class AlmondOAuth(AbstractAlmondWebAuth):
 class AlmondAgent(conversation.AbstractConversationAgent):
     """Almond conversation agent."""
 
-    def __init__(self, api: WebAlmondAPI):
+    def __init__(self, hass: core.HomeAssistant, api: WebAlmondAPI, entry):
         """Initialize the agent."""
+        self.hass = hass
         self.api = api
+        self.entry = entry
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return {"name": "Powered by Almond", "url": "https://almond.stanford.edu/"}
+
+    async def async_get_onboarding(self):
+        """Get onboard url if not onboarded."""
+        if self.entry.data.get("onboarded"):
+            return False
+
+        host = self.entry.data["host"]
+        if self.entry.data.get("is_hassio"):
+            host = "/core_almond"
+        elif self.entry.data["type"] != TYPE_LOCAL:
+            host = f"{host}/me"
+        return {
+            "text": "Send anonymized commands to the authors of Almond for training.",
+            "url": f"{host}/conversation",
+        }
+
+    async def async_set_onboarding(self, new_data):
+        """Set onboarding status."""
+        self.hass.config_entries.async_update_entry(
+            self.entry, data={**self.entry.data, **new_data}
+        )
+
+        return True
 
     async def async_process(
         self, text: str, conversation_id: Optional[str] = None

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -106,10 +106,14 @@ async def get_intent(hass: core.HomeAssistant, text: str, conversation_id: str):
 
 
 @websocket_api.async_response
-@websocket_api.websocket_command({"type": "conversation/process", "text": str, vol.Optional("conversation_id"): str})
+@websocket_api.websocket_command(
+    {"type": "conversation/process", "text": str, vol.Optional("conversation_id"): str}
+)
 async def websocket_process(hass, connection, msg):
     """Process text."""
-    connection.send_result(msg["id"], await get_intent(hass, msg["text"], msg.get("conversation_id")))
+    connection.send_result(
+        msg["id"], await get_intent(hass, msg["text"], msg.get("conversation_id"))
+    )
 
 
 @websocket_api.async_response
@@ -147,10 +151,14 @@ class ConversationProcessView(http.HomeAssistantView):
     url = "/api/conversation/process"
     name = "api:conversation:process"
 
-    @RequestDataValidator(vol.Schema({vol.Required("text"): str, vol.Optional("conversation_id"): str}))
+    @RequestDataValidator(
+        vol.Schema({vol.Required("text"): str, vol.Optional("conversation_id"): str})
+    )
     async def post(self, request, data):
         """Send a request for processing."""
         hass = request.app["hass"]
-        intent_result = await get_intent(hass, data["text"], data.get("conversation_id"))
+        intent_result = await get_intent(
+            hass, data["text"], data.get("conversation_id")
+        )
 
         return self.json(intent_result)

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -5,7 +5,7 @@ import re
 import voluptuous as vol
 
 from homeassistant import core
-from homeassistant.components import http
+from homeassistant.components import http, websocket_api
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.helpers import config_validation as cv, intent
 from homeassistant.loader import bind_hass
@@ -39,6 +39,21 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+WS_TYPE_GET_ONBOARDING = "conversation/onboarding/get"
+WS_TYPE_SET_ONBOARDING = "conversation/onboarding/set"
+WS_TYPE_GET_ATTRIBUTION = "conversation/attribution"
+
+SCHEMA_GET_ONBOARDING = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
+    {vol.Required("type"): WS_TYPE_GET_ONBOARDING}
+)
+
+SCHEMA_SET_ONBOARDING = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
+    {vol.Required("type"): WS_TYPE_SET_ONBOARDING, vol.Required("data"): dict}
+)
+
+SCHEMA_GET_ATTRIBUTION = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
+    {vol.Required("type"): WS_TYPE_GET_ATTRIBUTION}
+)
 
 async_register = bind_hass(async_register)  # pylint: disable=invalid-name
 
@@ -72,11 +87,60 @@ async def async_setup(hass, config):
         except intent.IntentHandleError as err:
             _LOGGER.error("Error processing %s: %s", text, err)
 
+    @websocket_api.async_response
+    async def websocket_get_onboarding(hass, connection, msg):
+        """Do we need onboarding."""
+        agent = hass.data.get(DATA_AGENT)
+
+        if agent is None:
+            agent = hass.data[DATA_AGENT] = DefaultAgent(hass)
+            await agent.async_initialize(config)
+        connection.send_result(msg["id"], await agent.async_get_onboarding())
+
+    @websocket_api.async_response
+    async def websocket_set_onboarding(hass, connection, msg):
+        """Set onboarding status."""
+        agent = hass.data.get(DATA_AGENT)
+
+        if agent is None:
+            agent = hass.data[DATA_AGENT] = DefaultAgent(hass)
+            await agent.async_initialize(config)
+
+        success = await agent.async_set_onboarding(msg.get("data"))
+
+        if success:
+            connection.send_result(msg["id"])
+        else:
+            connection.send_error(msg["id"])
+
+    @websocket_api.async_response
+    async def websocket_get_attribution(hass, connection, msg):
+        """Get attribution data."""
+        agent = hass.data.get(DATA_AGENT)
+
+        if agent is None:
+            agent = hass.data[DATA_AGENT] = DefaultAgent(hass)
+            await agent.async_initialize(config)
+
+        connection.send_result(msg["id"], agent.attribution)
+
     hass.services.async_register(
         DOMAIN, SERVICE_PROCESS, handle_service, schema=SERVICE_PROCESS_SCHEMA
     )
 
     hass.http.register_view(ConversationProcessView(process))
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_GET_ATTRIBUTION, websocket_get_attribution, SCHEMA_GET_ATTRIBUTION
+    )
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_GET_ONBOARDING, websocket_get_onboarding, SCHEMA_GET_ONBOARDING
+    )
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SET_ONBOARDING, websocket_set_onboarding, SCHEMA_SET_ONBOARDING
+    )
 
     return True
 

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -8,6 +8,19 @@ from homeassistant.helpers import intent
 class AbstractConversationAgent(ABC):
     """Abstract conversation agent."""
 
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return False
+
+    async def async_get_onboarding(self):
+        """Get onboard data."""
+        return False
+
+    async def async_set_onboarding(self, new_data):
+        """Set onboard data."""
+        return True
+
     @abstractmethod
     async def async_process(
         self, text: str, conversation_id: Optional[str] = None

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -11,11 +11,11 @@ class AbstractConversationAgent(ABC):
     @property
     def attribution(self):
         """Return the attribution."""
-        return False
+        return None
 
     async def async_get_onboarding(self):
         """Get onboard data."""
-        return False
+        return None
 
     async def async_set_onboarding(self, new_data):
         """Set onboard data."""

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -17,7 +17,7 @@ class AbstractConversationAgent(ABC):
         """Get onboard data."""
         return None
 
-    async def async_set_onboarding(self, new_data):
+    async def async_set_onboarding(self, shown):
         """Set onboard data."""
         return True
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
