### PR TITLE
Disable volume controls if openhome volume control disabled

### DIFF
--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -2,9 +2,7 @@
   "domain": "openhome",
   "name": "Openhome",
   "documentation": "https://www.home-assistant.io/integrations/openhome",
-  "requirements": [
-    "openhomedevice==0.4.2"
-  ],
+  "requirements": ["openhomedevice==0.6.3"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -17,14 +17,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING
 
-SUPPORT_OPENHOME = (
-    SUPPORT_SELECT_SOURCE
-    | SUPPORT_VOLUME_STEP
-    | SUPPORT_VOLUME_MUTE
-    | SUPPORT_VOLUME_SET
-    | SUPPORT_TURN_OFF
-    | SUPPORT_TURN_ON
-)
+SUPPORT_OPENHOME = SUPPORT_SELECT_SOURCE | SUPPORT_TURN_OFF | SUPPORT_TURN_ON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,13 +72,18 @@ class OpenhomeDevice(MediaPlayerDevice):
         self._in_standby = self._device.IsInStandby()
         self._transport_state = self._device.TransportState()
         self._track_information = self._device.TrackInfo()
-        self._volume_level = self._device.VolumeLevel()
-        self._volume_muted = self._device.IsMuted()
         self._source = self._device.Source()
         self._name = self._device.Room().decode("utf-8")
         self._supported_features = SUPPORT_OPENHOME
         source_index = {}
         source_names = list()
+
+        if self._device.VolumeEnabled():
+            self._supported_features |= (
+                SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET
+            )
+            self._volume_level = self._device.VolumeLevel()
+            self._volume_muted = self._device.IsMuted()
 
         for source in self._device.Sources():
             source_names.append(source["name"])

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -917,7 +917,7 @@ onvif-zeep-async==0.2.0
 openevsewifi==0.4
 
 # homeassistant.components.openhome
-openhomedevice==0.4.2
+openhomedevice==0.6.3
 
 # homeassistant.components.opensensemap
 opensensemap-api==0.1.5


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #25531 

## Checklist:
  - [x] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.
