### PR TITLE
Add autodiscovery for miio platform

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -1,1 +1,120 @@
 """Support for Xiaomi Miio."""
+import asyncio
+import binascii
+import logging
+import socket
+from typing import List
+
+from construct import ConstructError
+from miio import Device, Message
+import voluptuous as vol
+
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
+from homeassistant.helpers import discovery
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_MODEL = "model"
+CONFIG_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
+
+DOMAIN = "xiaomi_miio"
+
+DISCOVERY_SOCKET_ADDR = ("<broadcast>", 54321)
+DISCOVERY_TIMEOUT = 3  # seconds
+DISCOVERY_HELLO_MESSAGE = bytes.fromhex(
+    "21310020ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+)
+
+SUPPORTED_DEVICES = {"philips.light.bulb": "light"}
+
+
+async def async_setup(hass, config):
+    """Set up the Xiaomi component."""
+
+    discovered_devices = await discover_miio_devices()
+    for device in discovered_devices:
+        device_info = await hass.async_add_executor_job(device.info)
+        try:
+            platform = SUPPORTED_DEVICES[device_info.model]
+        except KeyError:
+            _LOGGER.warning("Unsupported MIIO device model: %s", device_info.model)
+            continue
+
+        info = {
+            CONF_HOST: device.ip,
+            CONF_TOKEN: binascii.hexlify(device.token).decode(),
+            CONF_MODEL: device_info.model,
+            CONF_NAME: make_device_name(device_info.model, device_info.mac_address),
+        }
+        discovery.load_platform(hass, platform, DOMAIN, info, config)
+
+    return True
+
+
+class DiscoveryProto:
+    """Protocol to discover mmio devices in local network."""
+
+    def __init__(self):
+        """Construct an instance."""
+
+        self.transport = None
+        self._seen_addrs: List[str] = []
+        self._devices: List[Device] = []
+        self.devices_discovered = asyncio.get_event_loop().create_future()
+
+    def connection_made(self, trans):
+        """Handle new connection."""
+
+        self.transport = trans
+        self.transport.sendto(DISCOVERY_HELLO_MESSAGE, DISCOVERY_SOCKET_ADDR)
+
+    def datagram_received(self, data, addr):
+        """Handle incoming response."""
+
+        if addr[0] in self._seen_addrs:
+            return
+
+        try:
+            message = Message.parse(data)  # type: Message
+        except ConstructError as ex:
+            _LOGGER.warning("Error while reading discover results: %s", ex)
+            return
+
+        token = binascii.hexlify(message.checksum).decode()
+        self._seen_addrs.append(addr[0])
+        self._devices.append(Device(ip=addr[0], token=token))
+        _LOGGER.debug("  IP %s - token: %s", addr[0], token)
+
+    def error_received(self, exc):
+        """Handle errors."""
+
+        _LOGGER.warning("Error received: %s", exc)
+        self.devices_discovered.set_result(self._devices)
+        self.transport.close()
+
+    def connection_lost(self, exc):
+        """Handle connection closed by other side."""
+
+        self.devices_discovered.set_result(self._devices)
+        self.transport.close()
+
+
+async def discover_miio_devices():
+    """Asyncronously discover available devices by sending broadcast UDP packet."""
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+
+    loop = asyncio.get_event_loop()
+    transport, protocol = await loop.create_datagram_endpoint(DiscoveryProto, sock=sock)
+    loop.call_later(DISCOVERY_TIMEOUT, transport.close)
+
+    return await protocol.devices_discovered
+
+
+def make_device_name(model: str, mac: str) -> str:
+    """Generate well-formed unique device name."""
+
+    pretty_mac = "".join(mac.split(":"))[-4:]
+    pretty_model = " ".join(s.capitalize() for s in model.split("."))
+    return f"Xiaomi {pretty_model} {pretty_mac}"

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -33,12 +33,12 @@ from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import color, dt
 
+from . import CONF_MODEL
+
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Xiaomi Philips Light"
 DATA_KEY = "light.xiaomi_miio"
-
-CONF_MODEL = "model"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -127,10 +127,21 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
+    if discovery_info is not None:
+        config = discovery_info
+
     host = config[CONF_HOST]
     token = config[CONF_TOKEN]
-    name = config[CONF_NAME]
+    name = config.get(CONF_NAME)
     model = config.get(CONF_MODEL)
+
+    if host in hass.data[DATA_KEY]:
+        _LOGGER.warning(
+            "Device at %s (token %s...) already initialized, check your config",
+            host,
+            token[:5],
+        )
+        return
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
 

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -152,18 +152,27 @@ def mirobo_errors_fixture():
 def test_xiaomi_exceptions(hass, caplog, mock_mirobo_errors):
     """Test vacuum supported features."""
     entity_name = "test_vacuum_cleaner_error"
-    yield from async_setup_component(
-        hass,
-        DOMAIN,
-        {
-            DOMAIN: {
-                CONF_PLATFORM: PLATFORM,
-                CONF_HOST: "127.0.0.1",
-                CONF_NAME: entity_name,
-                CONF_TOKEN: "12345678901234567890123456789012",
-            }
-        },
-    )
+
+    async def fake_discovery():
+        return []
+
+    with mock.patch(
+        "homeassistant.components.xiaomi_miio.discover_miio_devices",
+        side_effect=fake_discovery,
+    ):
+        yield from async_setup_component(
+            hass,
+            DOMAIN,
+            {
+                DOMAIN: {
+                    CONF_PLATFORM: PLATFORM,
+                    CONF_HOST: "127.0.0.1",
+                    CONF_NAME: entity_name,
+                    CONF_TOKEN: "12345678901234567890123456789012",
+                }
+            },
+        )
+
     yield from hass.async_block_till_done()
 
     assert "Initializing with host 127.0.0.1 (token 12345...)" in caplog.text


### PR DESCRIPTION
## Description:

While discovery via sending broadcast UDP message is not 100% working solution it in fact works pretty well for some Philips bulbs (those called Zhirui) so I decided to enable discovery for this particular model to cleanup config by getting rid of a few configuration entries and secrets.

This perhaps might even work for other Xiaomi Philips lamps as well but I don't have a hardware to test with unfortunately.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11132

## Example entry for `configuration.yaml` (if applicable):
```yaml
xiaomi_miio:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
