### PR TITLE
Add host field to add_torrent service

### DIFF
--- a/homeassistant/components/transmission/.translations/en.json
+++ b/homeassistant/components/transmission/.translations/en.json
@@ -1,42 +1,34 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Host is already configured.",
-            "one_instance_allowed": "Only a single instance is necessary."
-        },
-        "error": {
-            "cannot_connect": "Unable to Connect to host",
-            "name_exists": "Name already exists",
-            "wrong_credentials": "Wrong username or password"
-        },
+        "title": "Transmission",
         "step": {
-            "options": {
-                "data": {
-                    "scan_interval": "Update frequency"
-                },
-                "title": "Configure Options"
-            },
             "user": {
+                "title": "Setup Transmission Client",
                 "data": {
-                    "host": "Host",
                     "name": "Name",
+                    "host": "Host",
+                    "username": "Username",
                     "password": "Password",
-                    "port": "Port",
-                    "username": "Username"
-                },
-                "title": "Setup Transmission Client"
+                    "port": "Port"
+                }
             }
         },
-        "title": "Transmission"
+        "error": {
+            "name_exists": "Name already exists",
+            "wrong_credentials": "Wrong username or password",
+            "cannot_connect": "Unable to Connect to host"
+        },
+        "abort": {
+            "already_configured": "Host is already configured."
+        }
     },
     "options": {
         "step": {
             "init": {
+                "title": "Configure options for Transmission",
                 "data": {
                     "scan_interval": "Update frequency"
-                },
-                "description": "Configure options for Transmission",
-                "title": "Configure options for Transmission"
+                }
             }
         }
     }

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -174,16 +174,16 @@ class TransmissionClient:
                     break
             if tm_client is None:
                 _LOGGER.error("Transmission instance is not found")
+                return
+            torrent = service.data[ATTR_TORRENT]
+            if torrent.startswith(
+                ("http", "ftp:", "magnet:")
+            ) or self.hass.config.is_allowed_path(torrent):
+                tm_client.tm_api.add_torrent(torrent)
             else:
-                torrent = service.data[ATTR_TORRENT]
-                if torrent.startswith(
-                    ("http", "ftp:", "magnet:")
-                ) or self.hass.config.is_allowed_path(torrent):
-                    tm_client.tm_api.add_torrent(torrent)
-                else:
-                    _LOGGER.warning(
-                        "Could not add torrent: unsupported type or no permission"
-                    )
+                _LOGGER.warning(
+                    "Could not add torrent: unsupported type or no permission"
+                )
 
         self.hass.services.async_register(
             DOMAIN, SERVICE_ADD_TORRENT, add_torrent, schema=SERVICE_ADD_TORRENT_SCHEMA

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 SERVICE_ADD_TORRENT_SCHEMA = vol.Schema(
-    {vol.Required(ATTR_TORRENT): cv.string, vol.Required(CONF_HOST): cv.string}
+    {vol.Required(ATTR_TORRENT): cv.string, vol.Required(CONF_NAME): cv.string}
 )
 
 TRANS_SCHEMA = vol.All(
@@ -169,11 +169,11 @@ class TransmissionClient:
             """Add new torrent to download."""
             tm_client = None
             for entry in self.hass.config_entries.async_entries(DOMAIN):
-                if entry.data[CONF_HOST] == service.data[CONF_HOST]:
+                if entry.data[CONF_NAME] == service.data[CONF_NAME]:
                     tm_client = self.hass.data[DOMAIN][entry.entry_id]
                     break
             if tm_client is None:
-                _LOGGER.error("Transmission host is not found")
+                _LOGGER.error("Transmission instance is not found")
             else:
                 torrent = service.data[ATTR_TORRENT]
                 if torrent.startswith(

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -16,9 +16,19 @@ from . import get_api
 from .const import DEFAULT_NAME, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
 from .errors import AuthenticationError, CannotConnect, UnknownError
 
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+        vol.Required(CONF_HOST): str,
+        vol.Optional(CONF_USERNAME): str,
+        vol.Optional(CONF_PASSWORD): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+    }
+)
+
 
 class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a UniFi config flow."""
+    """Handle Tansmission config flow."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
@@ -57,17 +67,7 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
-                    vol.Required(CONF_HOST): str,
-                    vol.Optional(CONF_USERNAME): str,
-                    vol.Optional(CONF_PASSWORD): str,
-                    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-                }
-            ),
-            errors=errors,
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors,
         )
 
     async def async_step_import(self, import_config):

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -95,7 +95,7 @@ class TransmissionSensor(Entity):
         """Handle entity which will be added."""
         self.unsub_update = async_dispatcher_connect(
             self.hass,
-            self._tm_client.api.signal_options_update,
+            self._tm_client.api.signal_update,
             self._schedule_immediate_update,
         )
 

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -52,6 +52,7 @@ class TransmissionSensor(Entity):
         self._data = None
         self.client_name = client_name
         self.type = sensor_type
+        self.unsub_update = None
 
     @property
     def name(self):
@@ -92,7 +93,7 @@ class TransmissionSensor(Entity):
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
-        async_dispatcher_connect(
+        self.unsub_update = async_dispatcher_connect(
             self.hass,
             self._tm_client.api.signal_options_update,
             self._schedule_immediate_update,
@@ -101,6 +102,11 @@ class TransmissionSensor(Entity):
     @callback
     def _schedule_immediate_update(self):
         self.async_schedule_update_ha_state(True)
+
+    async def will_remove_from_hass(self):
+        """Unsubscribe from update dispatcher."""
+        if self.unsub_update:
+            self.unsub_update()
 
     def update(self):
         """Get the latest data from Transmission and updates the state."""

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -107,6 +107,7 @@ class TransmissionSensor(Entity):
         """Unsubscribe from update dispatcher."""
         if self.unsub_update:
             self.unsub_update()
+            self.unsub_update = None
 
     def update(self):
         """Get the latest data from Transmission and updates the state."""

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -1,6 +1,9 @@
 add_torrent:
   description: Add a new torrent to download (URL, magnet link or Base64 encoded).
   fields:
+    host:
+      description: Host name as entered during entry config
+      example: localhost
     torrent:
       description: URL, magnet link or Base64 encoded file.
       example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -1,9 +1,9 @@
 add_torrent:
   description: Add a new torrent to download (URL, magnet link or Base64 encoded).
   fields:
-    host:
-      description: Host name as entered during entry config
-      example: localhost
+    name:
+      description: Instance name as entered during entry config
+      example: Transmission
     torrent:
       description: URL, magnet link or Base64 encoded file.
       example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -40,6 +40,7 @@ class TransmissionSwitch(ToggleEntity):
         self._tm_client = tm_client
         self._state = STATE_OFF
         self._data = None
+        self.unsub_update = None
 
     @property
     def name(self):
@@ -93,7 +94,7 @@ class TransmissionSwitch(ToggleEntity):
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
-        async_dispatcher_connect(
+        self.unsub_update = async_dispatcher_connect(
             self.hass,
             self._tm_client.api.signal_options_update,
             self._schedule_immediate_update,
@@ -102,6 +103,11 @@ class TransmissionSwitch(ToggleEntity):
     @callback
     def _schedule_immediate_update(self):
         self.async_schedule_update_ha_state(True)
+
+    async def will_remove_from_hass(self):
+        """Unsubscribe from update dispatcher."""
+        if self.unsub_update:
+            self.unsub_update()
 
     def update(self):
         """Get the latest data from Transmission and updates the state."""

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -96,7 +96,7 @@ class TransmissionSwitch(ToggleEntity):
         """Handle entity which will be added."""
         self.unsub_update = async_dispatcher_connect(
             self.hass,
-            self._tm_client.api.signal_options_update,
+            self._tm_client.api.signal_update,
             self._schedule_immediate_update,
         )
 

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -108,6 +108,7 @@ class TransmissionSwitch(ToggleEntity):
         """Unsubscribe from update dispatcher."""
         if self.unsub_update:
             self.unsub_update()
+            self.unsub_update = None
 
     def update(self):
         """Get the latest data from Transmission and updates the state."""

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -98,7 +98,6 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
-    # assert result["data"]["options"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
 
     # test with all provided
     result = await flow.async_step_user(MOCK_ENTRY)
@@ -110,7 +109,6 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
     assert result["data"][CONF_PORT] == PORT
-    # assert result["data"]["options"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
 
 
 async def test_options(hass):


### PR DESCRIPTION
## Breaking Change:
In order to support multiple Transmission instances the `add_torrent` service requires two parameters now:
- Name: The name of the entry specified during setup
- Torrent: The torrent url (or file) to download

## Description:
This is a follow up PR to #28136. It adds the following:
- Specify name in `add_torrent` service to handle multiple configured instances using same service name.
- make the entity unsubscribe from update dispatcher when disabled.
- cleanup stale code from PR #28136


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11291


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
