### PR TITLE
Add verisure ethernet status

### DIFF
--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -1,7 +1,10 @@
 """Support for Verisure binary sensors."""
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice,
+    DEVICE_CLASS_CONNECTIVITY,
+)
 
 from . import CONF_DOOR_WINDOW, HUB as hub
 
@@ -22,6 +25,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 )
             ]
         )
+
+    sensors.extend([VerisureEthernetStatus()])
     add_entities(sensors)
 
 
@@ -66,3 +71,32 @@ class VerisureDoorWindowSensor(BinarySensorDevice):
     def update(self):
         """Update the state of the sensor."""
         hub.update_overview()
+
+
+class VerisureEthernetStatus(BinarySensorDevice):
+    """Representation of a Verisure VBOX internet status."""
+
+    @property
+    def name(self):
+        """Return the name of the binary sensor."""
+        return "Verisure Ethernet status"
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        return hub.get_first("$.ethernetConnectedNow")
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return hub.get_first("$.ethernetConnectedNow") is not None
+
+    # pylint: disable=no-self-use
+    def update(self):
+        """Update the state of the sensor."""
+        hub.update_overview()
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_CONNECTIVITY

--- a/tests/components/verisure/test_ethernet_status.py
+++ b/tests/components/verisure/test_ethernet_status.py
@@ -1,0 +1,67 @@
+"""Test Verisure ethernet status."""
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.setup import async_setup_component
+from homeassistant.components.verisure import DOMAIN as VERISURE_DOMAIN
+
+CONFIG = {
+    "verisure": {
+        "username": "test",
+        "password": "test",
+        "alarm": False,
+        "door_window": False,
+        "hygrometers": False,
+        "mouse": False,
+        "smartplugs": False,
+        "thermometers": False,
+        "smartcam": False,
+    }
+}
+
+
+@contextmanager
+def mock_hub(config, response):
+    """Extensively mock out a verisure hub."""
+    hub_prefix = "homeassistant.components.verisure.binary_sensor.hub"
+    verisure_prefix = "verisure.Session"
+    with patch(verisure_prefix) as session, patch(hub_prefix) as hub:
+        session.login.return_value = True
+
+        hub.config = config["verisure"]
+        hub.get.return_value = response
+        hub.get_first.return_value = response.get("ethernetConnectedNow", None)
+
+        yield hub
+
+
+async def setup_verisure(hass, config, response):
+    """Set up mock verisure."""
+    with mock_hub(config, response):
+        await async_setup_component(hass, VERISURE_DOMAIN, config)
+        await hass.async_block_till_done()
+
+
+async def test_verisure_no_ethernet_status(hass):
+    """Test no data from API."""
+    await setup_verisure(hass, CONFIG, {})
+    assert len(hass.states.async_all()) == 1
+    entity_id = hass.states.async_entity_ids()[0]
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_verisure_ethernet_status_disconnected(hass):
+    """Test disconnected."""
+    await setup_verisure(hass, CONFIG, {"ethernetConnectedNow": False})
+    assert len(hass.states.async_all()) == 1
+    entity_id = hass.states.async_entity_ids()[0]
+    assert hass.states.get(entity_id).state == "off"
+
+
+async def test_verisure_ethernet_status_connected(hass):
+    """Test connected."""
+    await setup_verisure(hass, CONFIG, {"ethernetConnectedNow": True})
+    assert len(hass.states.async_all()) == 1
+    entity_id = hass.states.async_entity_ids()[0]
+    assert hass.states.get(entity_id).state == "on"


### PR DESCRIPTION
## Breaking Change:
No breaking change

## Description:
Add a `binary_sensor` to know the ethernet connection status.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11135

## Example entry for `configuration.yaml` (if applicable):
```yaml
verisure:
  username: USERNAME
  password: PASSWORD
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
