### PR TITLE
Fix climate device actions

### DIFF
--- a/homeassistant/components/climate/device_action.py
+++ b/homeassistant/components/climate/device_action.py
@@ -59,14 +59,16 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
                 CONF_TYPE: "set_hvac_mode",
             }
         )
-        actions.append(
-            {
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "set_preset_mode",
-            }
-        )
+
+        if state and const.ATTR_PRESET_MODES in state.attributes:
+            actions.append(
+                {
+                    CONF_DEVICE_ID: device_id,
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_ENTITY_ID: entry.entity_id,
+                    CONF_TYPE: "set_preset_mode",
+                }
+            )
 
     return actions
 

--- a/homeassistant/components/climate/device_action.py
+++ b/homeassistant/components/climate/device_action.py
@@ -59,8 +59,7 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
                 CONF_TYPE: "set_hvac_mode",
             }
         )
-
-        if state and const.ATTR_PRESET_MODES in state.attributes:
+        if state.attributes["supported_features"] & const.SUPPORT_PRESET_MODE:
             actions.append(
                 {
                     CONF_DEVICE_ID: device_id,

--- a/homeassistant/components/climate/device_condition.py
+++ b/homeassistant/components/climate/device_condition.py
@@ -61,7 +61,7 @@ async def async_get_conditions(
             }
         )
 
-        if state and const.ATTR_PRESET_MODES in state.attributes:
+        if state and state.attributes["supported_features"] & const.SUPPORT_PRESET_MODE:
             conditions.append(
                 {
                     CONF_CONDITION: "device",

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -39,6 +39,7 @@ async def test_get_actions(hass, device_reg, entity_reg):
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     hass.states.async_set("climate.test_5678", const.HVAC_MODE_COOL, {})
+    hass.states.async_set("climate.test_5678", "attributes", {"preset_modes": []})
     expected_actions = [
         {
             "domain": DOMAIN,
@@ -49,6 +50,28 @@ async def test_get_actions(hass, device_reg, entity_reg):
         {
             "domain": DOMAIN,
             "type": "set_preset_mode",
+            "device_id": device_entry.id,
+            "entity_id": "climate.test_5678",
+        },
+    ]
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    assert_lists_same(actions, expected_actions)
+
+
+async def test_get_action_hvac_only(hass, device_reg, entity_reg):
+    """Test we get the expected actions from a climate."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    hass.states.async_set("climate.test_5678", const.HVAC_MODE_COOL, {})
+    expected_actions = [
+        {
+            "domain": DOMAIN,
+            "type": "set_hvac_mode",
             "device_id": device_entry.id,
             "entity_id": "climate.test_5678",
         },

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -39,7 +39,7 @@ async def test_get_actions(hass, device_reg, entity_reg):
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     hass.states.async_set("climate.test_5678", const.HVAC_MODE_COOL, {})
-    hass.states.async_set("climate.test_5678", "attributes", {"preset_modes": []})
+    hass.states.async_set("climate.test_5678", "attributes", {"supported_features": 17})
     expected_actions = [
         {
             "domain": DOMAIN,
@@ -68,6 +68,7 @@ async def test_get_action_hvac_only(hass, device_reg, entity_reg):
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     hass.states.async_set("climate.test_5678", const.HVAC_MODE_COOL, {})
+    hass.states.async_set("climate.test_5678", "attributes", {"supported_features": 1})
     expected_actions = [
         {
             "domain": DOMAIN,

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -53,6 +53,7 @@ async def test_get_conditions(hass, device_reg, entity_reg):
             const.ATTR_PRESET_MODES: [const.PRESET_HOME, const.PRESET_AWAY],
         },
     )
+    hass.states.async_set("climate.test_5678", "attributes", {"supported_features": 17})
     expected_conditions = [
         {
             "condition": "device",
@@ -68,6 +69,38 @@ async def test_get_conditions(hass, device_reg, entity_reg):
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
         },
+    ]
+    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    assert_lists_same(conditions, expected_conditions)
+
+
+async def test_get_conditions_hvac_only(hass, device_reg, entity_reg):
+    """Test we get the expected conditions from a climate."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    hass.states.async_set(
+        f"{DOMAIN}.test_5678",
+        const.HVAC_MODE_COOL,
+        {
+            const.ATTR_HVAC_MODE: const.HVAC_MODE_COOL,
+            const.ATTR_PRESET_MODE: const.PRESET_AWAY,
+            const.ATTR_PRESET_MODES: [const.PRESET_HOME, const.PRESET_AWAY],
+        },
+    )
+    hass.states.async_set("climate.test_5678", "attributes", {"supported_features": 1})
+    expected_conditions = [
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_hvac_mode",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        }
     ]
     conditions = await async_get_device_automations(hass, "condition", device_entry.id)
     assert_lists_same(conditions, expected_conditions)


### PR DESCRIPTION
## Description:
A device action to set the preset_mode should only be available, if presets are used by the integration.
I used the same mechanism as used by device_condition and not the supported features flag.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
