### PR TITLE
Change unique id for SAJ sensor based on device SN

### DIFF
--- a/homeassistant/components/saj/manifest.json
+++ b/homeassistant/components/saj/manifest.json
@@ -3,7 +3,7 @@
   "name": "SAJ",
   "documentation": "https://www.home-assistant.io/integrations/saj",
   "requirements": [
-    "pysaj==0.0.13"
+    "pysaj==0.0.14"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -46,6 +46,9 @@ SAJ_UNIT_MAPPINGS = {
     "": None,
 }
 
+ATTR_INVERTER_NAME = "inverter_name"
+ATTR_INVERTER_SN = "inverter_sn"
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
@@ -185,6 +188,14 @@ class SAJsensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return extra attributes of the sensor."""
+        return {
+            ATTR_INVERTER_NAME: self._inverter_name,
+            ATTR_INVERTER_SN: self._serialnumber,
+        }
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -46,9 +46,6 @@ SAJ_UNIT_MAPPINGS = {
     "": None,
 }
 
-ATTR_INVERTER_NAME = "inverter_name"
-ATTR_INVERTER_SN = "inverter_sn"
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
@@ -188,14 +185,6 @@ class SAJsensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
-
-    @property
-    def device_state_attributes(self):
-        """Return extra attributes of the sensor."""
-        return {
-            ATTR_INVERTER_NAME: self._inverter_name,
-            ATTR_INVERTER_SN: self._serialnumber,
-        }
 
     @property
     def unit_of_measurement(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1435,7 +1435,7 @@ pyrepetier==3.0.5
 pysabnzbd==1.1.0
 
 # homeassistant.components.saj
-pysaj==0.0.13
+pysaj==0.0.14
 
 # homeassistant.components.sony_projector
 pysdcp==1


### PR DESCRIPTION
## Breaking Change:
The entity unique id for all SAJ sensors was changed. Users may need to clear the old stale entities manually from the entity registry.

## Description:
With the current SAJ platform it's not possible to add multiple inverters because the unique id for the sensor would not be unique.
I've managed to get the serial number of the device and changed the unique id so it's based on that serial number.
This PR continues on this PR that got merged already: #28612 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
