### PR TITLE
Skip updating idle Plex clients

### DIFF
--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -153,8 +153,8 @@ class PlexServer:
 
         self._known_clients.update(new_clients)
 
-        idle_clients = self._known_clients.difference(available_clients).difference(
-            self._known_idle
+        idle_clients = (self._known_clients - self._known_idle).difference(
+            available_clients
         )
         for client_id in idle_clients:
             self.refresh_entity(client_id, None, None)


### PR DESCRIPTION
## Description:
Don't dispatch calls to refresh Plex `media_player` entities that are already known to be idle.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
