### PR TITLE
Create base entity for SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -249,11 +249,12 @@ class SimpliSafe:
 class SimpliSafeEntity(Entity):
     """Define a base SimpliSafe entity."""
 
-    def __init__(self, system, name):
+    def __init__(self, system, name, serial):
         """Initialize."""
         self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_SYSTEM_ID: system.system_id}
         self._name = name
+        self._serial = serial
         self._system = system
 
     @property
@@ -280,7 +281,7 @@ class SimpliSafeEntity(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        return self._system.system_id
+        return f"{self._system.system_id}_{self._serial}"
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -249,7 +249,7 @@ class SimpliSafe:
 class SimpliSafeEntity(Entity):
     """Define a base SimpliSafe entity."""
 
-    def __init__(self, system, name, serial):
+    def __init__(self, system, name, *, serial=None):
         """Initialize."""
         self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_SYSTEM_ID: system.system_id}
@@ -281,7 +281,9 @@ class SimpliSafeEntity(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        return f"{self._system.system_id}_{self._serial}"
+        if self._serial:
+            return f"{self._serial}"
+        return f"{self._system.serial}"
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -253,8 +253,8 @@ class SimpliSafeEntity(Entity):
         """Initialize."""
         self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_SYSTEM_ID: system.system_id}
-        self._available = True
         self._name = name
+        self._online = True
         self._system = system
 
         if serial:
@@ -265,7 +265,12 @@ class SimpliSafeEntity(Entity):
     @property
     def available(self):
         """Return whether the entity is available."""
-        return self._available
+        # We can easily detect if the V3 system is offline, but no simple check exists
+        # for the V2 system. Therefore, we mark the entity as available if:
+        #   1. We can verify that the system is online (assuming True if we can't)
+        #   2. We can verify that the entity is online
+        system_offline = self._system.version == 3 and self._system.offline
+        return not system_offline and self._online
 
     @property
     def device_info(self):

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -249,11 +249,12 @@ class SimpliSafe:
 class SimpliSafeEntity(Entity):
     """Define a base SimpliSafe entity."""
 
-    def __init__(self, system):
+    def __init__(self, system, name):
         """Initialize."""
-        self._system = system
         self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_SYSTEM_ID: system.system_id}
+        self._name = name
+        self._system = system
 
     @property
     def device_info(self):
@@ -262,9 +263,7 @@ class SimpliSafeEntity(Entity):
             "identifiers": {(DOMAIN, self._system.system_id)},
             "manufacturer": "SimpliSafe",
             "model": self._system.version,
-            # The name should become more dynamic once we deduce a way to
-            # get various other sensors from SimpliSafe in a reliable manner:
-            "name": "Keypad",
+            "name": self._name,
             "via_device": (DOMAIN, self._system.serial),
         }
 
@@ -276,7 +275,7 @@ class SimpliSafeEntity(Entity):
     @property
     def name(self):
         """Return the name of the entity."""
-        return self._system.address
+        return f"{self._system.address} {self._name}"
 
     @property
     def unique_id(self):

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -254,8 +254,12 @@ class SimpliSafeEntity(Entity):
         self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_SYSTEM_ID: system.system_id}
         self._name = name
-        self._serial = serial
         self._system = system
+
+        if serial:
+            self._serial = serial
+        else:
+            self._serial = system.serial
 
     @property
     def device_info(self):
@@ -281,9 +285,7 @@ class SimpliSafeEntity(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        if self._serial:
-            return f"{self._serial}"
-        return f"{self._system.serial}"
+        return self._serial
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -253,6 +253,7 @@ class SimpliSafeEntity(Entity):
         """Initialize."""
         self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_SYSTEM_ID: system.system_id}
+        self._available = True
         self._name = name
         self._system = system
 
@@ -260,6 +261,11 @@ class SimpliSafeEntity(Entity):
             self._serial = serial
         else:
             self._serial = system.serial
+
+    @property
+    def available(self):
+        """Return whether the entity is available."""
+        return self._available
 
     @property
     def device_info(self):

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -129,7 +129,10 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         if event_data.get("pinName"):
             self._changed_by = event_data["pinName"]
 
-        if self._system.state == SystemStates.error:
+        # The V3 system has the offline property, but the V2 system doesn't:
+        offline = getattr(self._system, "offline", False) and self._system.offline
+        if offline or self._system.state == SystemStates.error:
+            self._available = False
             return
 
         if self._system.state == SystemStates.off:

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -58,7 +58,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
 
     def __init__(self, simplisafe, system, code):
         """Initialize the SimpliSafe alarm."""
-        super().__init__(system, "Alarm Control Panel")
+        super().__init__(system, "Alarm Control Panel", system.serial)
         self._changed_by = None
         self._code = code
         self._simplisafe = simplisafe

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -129,10 +129,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         if event_data.get("pinName"):
             self._changed_by = event_data["pinName"]
 
-        # We can easily detect if the V3 system is offline, but no simple check exists
-        # for the V2 system:
-        offline = self._system.version == 3 and self._system.offline
-        if offline or self._system.state == SystemStates.error:
+        if self._system.state == SystemStates.error:
             self._available = False
             return
 

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -130,7 +130,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
             self._changed_by = event_data["pinName"]
 
         if self._system.state == SystemStates.error:
-            self._available = False
+            self._online = False
             return
 
         if self._system.state == SystemStates.off:

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -58,7 +58,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
 
     def __init__(self, simplisafe, system, code):
         """Initialize the SimpliSafe alarm."""
-        super().__init__(system, "Alarm Control Panel", system.serial)
+        super().__init__(system, "Alarm Control Panel")
         self._changed_by = None
         self._code = code
         self._simplisafe = simplisafe

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -130,7 +130,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
             self._changed_by = event_data["pinName"]
 
         # The V3 system has the offline property, but the V2 system doesn't:
-        offline = getattr(self._system, "offline", False) and self._system.offline
+        offline = self._system.version == 3 and self._system.offline
         if offline or self._system.state == SystemStates.error:
             self._available = False
             return

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -16,11 +16,10 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
 )
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.dt import utc_from_timestamp
 
-from .const import DATA_CLIENT, DOMAIN, TOPIC_UPDATE
+from . import SimpliSafeEntity
+from .const import DATA_CLIENT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +32,6 @@ ATTR_LAST_EVENT_SENSOR_TYPE = "last_event_sensor_type"
 ATTR_LAST_EVENT_TIMESTAMP = "last_event_timestamp"
 ATTR_LAST_EVENT_TYPE = "last_event_type"
 ATTR_RF_JAMMING = "rf_jamming"
-ATTR_SYSTEM_ID = "system_id"
 ATTR_WALL_POWER_LEVEL = "wall_power_level"
 ATTR_WIFI_STRENGTH = "wifi_strength"
 
@@ -55,18 +53,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     )
 
 
-class SimpliSafeAlarm(AlarmControlPanel):
+class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
     """Representation of a SimpliSafe alarm."""
 
     def __init__(self, simplisafe, system, code):
         """Initialize the SimpliSafe alarm."""
-        self._async_unsub_dispatcher_connect = None
-        self._attrs = {ATTR_SYSTEM_ID: system.system_id}
+        super().__init__(system)
         self._changed_by = None
         self._code = code
         self._simplisafe = simplisafe
         self._state = None
-        self._system = system
 
         # Some properties only exist for V2 or V3 systems:
         for prop in (
@@ -94,37 +90,9 @@ class SimpliSafeAlarm(AlarmControlPanel):
         return FORMAT_TEXT
 
     @property
-    def device_info(self):
-        """Return device registry information for this entity."""
-        return {
-            "identifiers": {(DOMAIN, self._system.system_id)},
-            "manufacturer": "SimpliSafe",
-            "model": self._system.version,
-            # The name should become more dynamic once we deduce a way to
-            # get various other sensors from SimpliSafe in a reliable manner:
-            "name": "Keypad",
-            "via_device": (DOMAIN, self._system.serial),
-        }
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return self._attrs
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return self._system.address
-
-    @property
     def state(self):
         """Return the state of the entity."""
         return self._state
-
-    @property
-    def unique_id(self):
-        """Return the unique ID of the entity."""
-        return self._system.system_id
 
     def _validate_code(self, code, state):
         """Validate given code."""
@@ -132,18 +100,6 @@ class SimpliSafeAlarm(AlarmControlPanel):
         if not check:
             _LOGGER.warning("Wrong code entered for %s", state)
         return check
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-
-        @callback
-        def update():
-            """Update the state."""
-            self.async_schedule_update_ha_state(True)
-
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, TOPIC_UPDATE, update
-        )
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
@@ -202,8 +158,3 @@ class SimpliSafeAlarm(AlarmControlPanel):
                 ATTR_LAST_EVENT_TYPE: last_event["eventType"],
             }
         )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -129,7 +129,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         if event_data.get("pinName"):
             self._changed_by = event_data["pinName"]
 
-        # We can easily detect if the V3 system is offline, but not such check exists
+        # We can easily detect if the V3 system is offline, but no simple check exists
         # for the V2 system:
         offline = self._system.version == 3 and self._system.offline
         if offline or self._system.state == SystemStates.error:

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -129,7 +129,8 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         if event_data.get("pinName"):
             self._changed_by = event_data["pinName"]
 
-        # The V3 system has the offline property, but the V2 system doesn't:
+        # We can easily detect if the V3 system is offline, but not such check exists
+        # for the V2 system:
         offline = self._system.version == 3 and self._system.offline
         if offline or self._system.state == SystemStates.error:
             self._available = False

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -2,7 +2,7 @@
 import logging
 import re
 
-from simplipy.sensor import SensorTypes
+from simplipy.entity import EntityTypes
 from simplipy.system import SystemStates
 
 from homeassistant.components.alarm_control_panel import (
@@ -152,7 +152,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
                 ATTR_ALARM_ACTIVE: self._system.alarm_going_off,
                 ATTR_LAST_EVENT_INFO: last_event["info"],
                 ATTR_LAST_EVENT_SENSOR_NAME: last_event["sensorName"],
-                ATTR_LAST_EVENT_SENSOR_TYPE: SensorTypes(last_event["sensorType"]).name,
+                ATTR_LAST_EVENT_SENSOR_TYPE: EntityTypes(last_event["sensorType"]).name,
                 ATTR_LAST_EVENT_TIMESTAMP: utc_from_timestamp(
                     last_event["eventTimestamp"]
                 ),

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -58,7 +58,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
 
     def __init__(self, simplisafe, system, code):
         """Initialize the SimpliSafe alarm."""
-        super().__init__(system)
+        super().__init__(system, "Alarm Control Panel")
         self._changed_by = None
         self._code = code
         self._simplisafe = simplisafe

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
   "requirements": [
-    "simplisafe-python==5.0.1"
+    "simplisafe-python==5.1.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1769,7 +1769,7 @@ shodan==1.19.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.0.1
+simplisafe-python==5.1.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -546,7 +546,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.0.1
+simplisafe-python==5.1.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
## Breaking Change:

In order to make room for future SimpliSafe entities, this PR introduces both a new friendly name and a new unique ID for the `alarm_control_panel` entity; therefore, a new entity will be generated with an entity ID format of `alarm_control_panel.{address}_alarm_control_panel`. Users should:

1. Navigate to the entity registry (`Configuration -> Entity Registry`).
2. Delete the old `alarm_control_panel` (whose name will now be `Unavailable`).
3. Make a note of the new `alarm_control_panel`'s entity ID and update automations as appropriate.

## Description:

In preparation for adding a new lock entity to the SimpliSafe integration, this PR:

1. moves several of the properties that will be common to both the alarm control panel and the lock to a base entity class.
2. establishes the `available` property for all SimpliSafe entities.
3. bumps `simplisafe-python` to 5.1.0 (changelog: https://github.com/bachya/simplisafe-python/releases/tag/5.1.0)

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
