### PR TITLE
Travis and tox config improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - python: "3.6.1"
       env: TOXENV=lint
     - python: "3.6.1"
-      env: TOXENV=pylint PYLINT_ARGS=--jobs=0
+      env: TOXENV=pylint PYLINT_ARGS=--jobs=0 TRAVIS_WAIT=30
     - python: "3.6.1"
       env: TOXENV=typing
     - python: "3.6.1"
@@ -33,4 +33,4 @@ cache:
     - $HOME/.cache/pre-commit
 install: pip install -U tox
 language: python
-script: travis_wait 50 tox --develop
+script: ${TRAVIS_WAIT:+travis_wait $TRAVIS_WAIT} tox --develop

--- a/tox.ini
+++ b/tox.ini
@@ -5,19 +5,21 @@ skip_missing_interpreters = True
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}
 commands =
-     pytest --timeout=9 --durations=10 -qq -o console_output_style=count -p no:sugar {posargs}
+     pytest --timeout=9 --durations=10 -n auto --dist=loadfile -qq -o console_output_style=count -p no:sugar {posargs}
      {toxinidir}/script/check_dirty
 deps =
      -r{toxinidir}/requirements_test_all.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
+     pytest-xdist
 
 [testenv:cov]
 commands =
-     pytest --timeout=9 --durations=10 -qq -o console_output_style=count -p no:sugar --cov --cov-report= {posargs}
+     pytest --timeout=9 --durations=10 -n auto --dist=loadfile -qq -o console_output_style=count -p no:sugar --cov --cov-report= {posargs}
      {toxinidir}/script/check_dirty
 deps =
      -r{toxinidir}/requirements_test_all.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
+     pytest-xdist
 
 [testenv:pylint]
 ignore_errors = True


### PR DESCRIPTION
## Description:

With this, we're around 30+ minutes in Travis, with easier to follow progress. Used to be hard to follow and timing out at 50 (unrelated to the previous travis_wait 50, that's coincidental)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
