### PR TITLE
Upgrade bimmer_connected to 0.6.2

### DIFF
--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -3,7 +3,7 @@
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
   "requirements": [
-    "bimmer_connected==0.6.1"
+    "bimmer_connected==0.6.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -3,7 +3,7 @@
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
   "requirements": [
-    "bimmer_connected==0.6.0"
+    "bimmer_connected==0.6.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -288,7 +288,7 @@ beewi_smartclim==0.0.7
 bellows-homeassistant==0.10.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.6.1
+bimmer_connected==0.6.2
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -288,7 +288,7 @@ beewi_smartclim==0.0.7
 bellows-homeassistant==0.10.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.6.0
+bimmer_connected==0.6.1
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1


### PR DESCRIPTION
## Description:
Upgrade bimmer_connected to [0.6.2](https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.6.2)

**Related issue (if applicable):** fixes #25447

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
