### PR TITLE
Fix ble_tracker randomly pygatt thrown error

### DIFF
--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -80,6 +80,9 @@ def setup_scanner(hass, config, see, discovery_info=None):
         except RuntimeError as error:
             _LOGGER.error("Error during Bluetooth LE scan: %s", error)
             return {}
+        except pygatt.exceptions.BLEError as error:
+            _LOGGER.error("BLEError during Bluetooth LE scan: %s", error)
+            return {}
         return devices
 
     yaml_path = hass.config.path(YAML_DEVICES)

--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -77,11 +77,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
             devices = {x["address"]: x["name"] for x in devs}
             _LOGGER.debug("Bluetooth LE devices discovered = %s", devices)
-        except RuntimeError as error:
+        except (RuntimeError, pygatt.exceptions.BLEError) as error:
             _LOGGER.error("Error during Bluetooth LE scan: %s", error)
-            return {}
-        except pygatt.exceptions.BLEError as error:
-            _LOGGER.error("BLEError during Bluetooth LE scan: %s", error)
             return {}
         return devices
 


### PR DESCRIPTION
## Description:

Catch Pygatt error that appear randomly over the time to override component fatal fault issue

**Related issue (if applicable):** fixes #26584


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
