### PR TITLE
Add support for SimpliSafe locks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -605,6 +605,7 @@ omit =
     homeassistant/components/simplepush/notify.py
     homeassistant/components/simplisafe/__init__.py
     homeassistant/components/simplisafe/alarm_control_panel.py
+    homeassistant/components/simplisafe/lock.py
     homeassistant/components/simulated/sensor.py
     homeassistant/components/sisyphus/*
     homeassistant/components/sky_hub/device_tracker.py

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -198,8 +198,12 @@ async def async_setup_entry(hass, config_entry):
 
 async def async_unload_entry(hass, entry):
     """Unload a SimpliSafe config entry."""
-    for component in ("alarm_control_panel", "lock"):
-        await hass.config_entries.async_forward_entry_unload(entry, component)
+    tasks = [
+        hass.config_entries.async_forward_entry_unload(entry, component)
+        for component in ("alarm_control_panel", "lock")
+    ]
+
+    await asyncio.gather(*tasks)
 
     hass.data[DOMAIN][DATA_CLIENT].pop(entry.entry_id)
     remove_listener = hass.data[DOMAIN][DATA_LISTENER].pop(entry.entry_id)

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -154,11 +154,10 @@ async def async_setup_entry(hass, config_entry):
     await simplisafe.async_update()
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = simplisafe
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(
-            config_entry, "alarm_control_panel"
+    for component in ("alarm_control_panel", "lock"):
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
-    )
 
     async def refresh(event_time):
         """Refresh data from the SimpliSafe account."""
@@ -199,7 +198,8 @@ async def async_setup_entry(hass, config_entry):
 
 async def async_unload_entry(hass, entry):
     """Unload a SimpliSafe config entry."""
-    await hass.config_entries.async_forward_entry_unload(entry, "alarm_control_panel")
+    for component in ("alarm_control_panel", "lock"):
+        await hass.config_entries.async_forward_entry_unload(entry, component)
 
     hass.data[DOMAIN][DATA_CLIENT].pop(entry.entry_id)
     remove_listener = hass.data[DOMAIN][DATA_LISTENER].pop(entry.entry_id)

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -26,5 +26,9 @@ class SimpliSafeLock(SimpliSafeEntity, LockDevice):
 
     def __init__(self, system, lock):
         """Initialize."""
-        super().__init__(system, lock.name)
+        super().__init__(system, lock.name, serial=lock.serial)
         self._lock = lock
+
+    async def async_update(self):
+        """Update lock status."""
+        self._attrs.update({})

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -26,5 +26,5 @@ class SimpliSafeLock(SimpliSafeEntity, LockDevice):
 
     def __init__(self, system, lock):
         """Initialize."""
-        super().__init__(system)
+        super().__init__(system, lock.name)
         self._lock = lock

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -1,0 +1,30 @@
+"""Support for SimpliSafe locks."""
+import logging
+
+from homeassistant.components.lock import LockDevice
+
+from . import SimpliSafeEntity
+from .const import DATA_CLIENT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up SimpliSafe locks based on a config entry."""
+    simplisafe = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+    async_add_entities(
+        [
+            SimpliSafeLock(system, lock)
+            for system in simplisafe.systems.values()
+            for lock in system.lock.values()
+        ]
+    )
+
+
+class SimpliSafeLock(SimpliSafeEntity, LockDevice):
+    """Define a SimpliSafe lock."""
+
+    def __init__(self, system, lock):
+        """Initialize."""
+        super().__init__(system)
+        self._lock = lock

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -4,7 +4,7 @@ import logging
 from simplipy.lock import LockStates
 
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.const import STATE_LOCKED, STATE_UNKNOWN, STATE_UNLOCKED
 
 from . import SimpliSafeEntity
 from .const import DATA_CLIENT, DOMAIN
@@ -15,7 +15,11 @@ ATTR_LOCK_LOW_BATTERY = "lock_low_battery"
 ATTR_JAMMED = "jammed"
 ATTR_PIN_PAD_LOW_BATTERY = "pin_pad_low_battery"
 
-STATE_MAP = {LockStates.locked: STATE_LOCKED, LockStates.unlocked: STATE_UNLOCKED}
+STATE_MAP = {
+    LockStates.locked: STATE_LOCKED,
+    LockStates.unknown: STATE_UNKNOWN,
+    LockStates.unlocked: STATE_UNLOCKED,
+}
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -61,6 +61,8 @@ class SimpliSafeLock(SimpliSafeEntity, LockDevice):
             self._online = False
             return
 
+        self._online = True
+
         self._attrs.update(
             {
                 ATTR_LOCK_LOW_BATTERY: self._lock.lock_low_battery,

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -25,7 +25,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         [
             SimpliSafeLock(system, lock)
             for system in simplisafe.systems.values()
-            for lock in system.lock.values()
+            for lock in system.locks.values()
         ]
     )
 

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -57,7 +57,7 @@ class SimpliSafeLock(SimpliSafeEntity, LockDevice):
 
     async def async_update(self):
         """Update lock status."""
-        if self._lock.disabled:
+        if self._lock.offline or self._lock.disabled:
             self._online = False
             return
 

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -45,7 +45,7 @@ class SimpliSafeLock(SimpliSafeEntity, LockDevice):
     @property
     def is_locked(self):
         """Return true if the lock is locked."""
-        return STATE_MAP[self._lock.state] == STATE_LOCKED
+        return STATE_MAP.get(self._lock.state) == STATE_LOCKED
 
     async def async_lock(self, **kwargs):
         """Lock the lock."""

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -1,12 +1,21 @@
 """Support for SimpliSafe locks."""
 import logging
 
+from simplipy.lock import LockStates
+
 from homeassistant.components.lock import LockDevice
+from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 
 from . import SimpliSafeEntity
 from .const import DATA_CLIENT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_LOCK_LOW_BATTERY = "lock_low_battery"
+ATTR_JAMMED = "jammed"
+ATTR_PIN_PAD_LOW_BATTERY = "pin_pad_low_battery"
+
+STATE_MAP = {LockStates.locked: STATE_LOCKED, LockStates.unlocked: STATE_UNLOCKED}
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -29,6 +38,29 @@ class SimpliSafeLock(SimpliSafeEntity, LockDevice):
         super().__init__(system, lock.name, serial=lock.serial)
         self._lock = lock
 
+    @property
+    def is_locked(self):
+        """Return true if the lock is locked."""
+        return STATE_MAP[self._lock.state] == STATE_LOCKED
+
+    async def async_lock(self, **kwargs):
+        """Lock the lock."""
+        await self._lock.lock()
+
+    async def async_unlock(self, **kwargs):
+        """Unlock the lock."""
+        await self._lock.unlock()
+
     async def async_update(self):
         """Update lock status."""
-        self._attrs.update({})
+        if self._lock.disabled:
+            self._online = False
+            return
+
+        self._attrs.update(
+            {
+                ATTR_LOCK_LOW_BATTERY: self._lock.lock_low_battery,
+                ATTR_JAMMED: self._lock.state == LockStates.jammed,
+                ATTR_PIN_PAD_LOW_BATTERY: self._lock.pin_pad_low_battery,
+            }
+        )

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
   "requirements": [
-    "simplisafe-python==5.1.1"
+    "simplisafe-python==5.2.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
   "requirements": [
-    "simplisafe-python==5.1.0"
+    "simplisafe-python==5.1.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1769,7 +1769,7 @@ shodan==1.19.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.1.0
+simplisafe-python==5.1.1
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1769,7 +1769,7 @@ shodan==1.19.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.1.1
+simplisafe-python==5.2.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -546,7 +546,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.1.1
+simplisafe-python==5.2.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -546,7 +546,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.1.0
+simplisafe-python==5.1.1
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
## Description:

This PR adds support for SimpliSafe locks.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11159

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
