### PR TITLE
Add Lutron hybrid keypad raise/lower buttons

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -72,6 +72,7 @@ def setup(hass, base_config):
                 if button.name != "Unknown Button" and button.button_type in (
                     "SingleAction",
                     "Toggle",
+                    "SingleSceneRaiseLower",
                 ):
                     # Associate an LED with a button if there is one
                     led = next(

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -73,6 +73,7 @@ def setup(hass, base_config):
                     "SingleAction",
                     "Toggle",
                     "SingleSceneRaiseLower",
+                    "MasterRaiseLower",
                 ):
                     # Associate an LED with a button if there is one
                     led = next(


### PR DESCRIPTION
## Description:
Allow detection of raise/lower buttons from RadioRA2 hybrid keypads. These are already detected by pylutron and just need to be exposed (they do not have any associated LEDs)

Strangely enough, the documentation already seems to suggest that raise/lower buttons are supported... Now they actually are

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
