### PR TITLE
#28645: Bump up zm-py to 0.4.0

### DIFF
--- a/homeassistant/components/zoneminder/manifest.json
+++ b/homeassistant/components/zoneminder/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zoneminder",
   "documentation": "https://www.home-assistant.io/integrations/zoneminder",
   "requirements": [
-    "zm-py==0.3.3"
+    "zm-py==0.4.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2075,4 +2075,4 @@ zigpy-xbee-homeassistant==0.6.0
 zigpy-zigate==0.5.0
 
 # homeassistant.components.zoneminder
-zm-py==0.3.3
+zm-py==0.4.0


### PR DESCRIPTION
## Description:
@mnoorenberghe implemented the new ZM token authentication process in the zm-py library. We need to bump up to 0.4.0 to utilize that.

**Related issue (if applicable):** fixes #28645 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** No change

## Example entry for `configuration.yaml` (if applicable):
No change

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
