### PR TITLE
Make spotify playlist name validation less strict

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -307,7 +307,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
 
     def play_playlist(self, media_id, random_song):
         """Play random music in a playlist."""
-        if not media_id.startswith("spotify:playlist:"):
+        if not media_id.startswith("spotify:"):
             _LOGGER.error("media id must be spotify playlist uri")
             return
         kwargs = {"context_uri": media_id}


### PR DESCRIPTION
## Breaking Change:
None
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- Made spotify playlist name validation less strict by including playlists like artist playlist and albums and user's **own created playlist** 

**Related issue (if applicable):** fixes #25867<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
