### PR TITLE
Allow frontend PWA icons to be masked

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -52,6 +52,7 @@ MANIFEST_JSON = {
             "src": "/static/icons/favicon-{size}x{size}.png".format(size=size),
             "sizes": "{size}x{size}".format(size=size),
             "type": "image/png",
+            "purpose": "maskable any",
         }
         for size in (192, 384, 512, 1024)
     ],


### PR DESCRIPTION
Closes https://github.com/home-assistant/home-assistant-polymer/issues/3545