### PR TITLE
fix typo in comments

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -272,13 +272,13 @@ class EntityPlatform:
         entity.platform = self
 
         # Async entity
-        # PARALLEL_UPDATE == None: entity.parallel_updates = None
-        # PARALLEL_UPDATE == 0:    entity.parallel_updates = None
-        # PARALLEL_UPDATE > 0:     entity.parallel_updates = Semaphore(p)
+        # PARALLEL_UPDATES == None: entity.parallel_updates = None
+        # PARALLEL_UPDATES == 0:    entity.parallel_updates = None
+        # PARALLEL_UPDATES > 0:     entity.parallel_updates = Semaphore(p)
         # Sync entity
-        # PARALLEL_UPDATE == None: entity.parallel_updates = Semaphore(1)
-        # PARALLEL_UPDATE == 0:    entity.parallel_updates = None
-        # PARALLEL_UPDATE > 0:     entity.parallel_updates = Semaphore(p)
+        # PARALLEL_UPDATES == None: entity.parallel_updates = Semaphore(1)
+        # PARALLEL_UPDATES == 0:    entity.parallel_updates = None
+        # PARALLEL_UPDATES > 0:     entity.parallel_updates = Semaphore(p)
         if hasattr(entity, "async_update") and not self.parallel_updates:
             entity.parallel_updates = None
         elif not hasattr(entity, "async_update") and self.parallel_updates == 0:


### PR DESCRIPTION
The global is called `PARALLEL_UPDATES` not `PARALLEL_UPDATE`.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
