### PR TITLE
Add google_assistant humidity sensors

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -128,6 +128,7 @@ DEVICE_CLASS_TO_GOOGLE_TYPES = {
     (media_player.DOMAIN, media_player.DEVICE_CLASS_TV): TYPE_TV,
     (media_player.DOMAIN, media_player.DEVICE_CLASS_SPEAKER): TYPE_SPEAKER,
     (sensor.DOMAIN, sensor.DEVICE_CLASS_TEMPERATURE): TYPE_SENSOR,
+    (sensor.DOMAIN, sensor.DEVICE_CLASS_HUMIDITY): TYPE_SENSOR,
 }
 
 CHALLENGE_ACK_NEEDED = "ackNeeded"

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -80,6 +80,7 @@ TRAIT_MODES = PREFIX_TRAITS + "Modes"
 TRAIT_OPENCLOSE = PREFIX_TRAITS + "OpenClose"
 TRAIT_VOLUME = PREFIX_TRAITS + "Volume"
 TRAIT_ARMDISARM = PREFIX_TRAITS + "ArmDisarm"
+TRAIT_HUMIDITY_SETTING = PREFIX_TRAITS + "HumiditySetting"
 
 PREFIX_COMMANDS = "action.devices.commands."
 COMMAND_ONOFF = PREFIX_COMMANDS + "OnOff"
@@ -844,6 +845,56 @@ class TemperatureSettingTrait(_Trait):
                 },
                 blocking=True,
                 context=data.context,
+            )
+
+
+@register_trait
+class HumiditySettingTrait(_Trait):
+    """Trait to offer humidity setting functionality.
+
+    https://developers.google.com/actions/smarthome/traits/humiditysetting
+    """
+
+    name = TRAIT_HUMIDITY_SETTING
+    commands = []
+
+    @staticmethod
+    def supported(domain, features, device_class):
+        """Test if state is supported."""
+        return domain == sensor.DOMAIN and device_class == sensor.DEVICE_CLASS_HUMIDITY
+
+    def sync_attributes(self):
+        """Return humidity attributes for a sync request."""
+        response = {}
+        attrs = self.state.attributes
+        domain = self.state.domain
+        if domain == sensor.DOMAIN:
+            device_class = attrs.get(ATTR_DEVICE_CLASS)
+            if device_class == sensor.DEVICE_CLASS_HUMIDITY:
+                response["queryOnlyHumiditySetting"] = True
+
+        return response
+
+    def query_attributes(self):
+        """Return humidity query attributes."""
+        response = {}
+        attrs = self.state.attributes
+        domain = self.state.domain
+        if domain == sensor.DOMAIN:
+            device_class = attrs.get(ATTR_DEVICE_CLASS)
+            if device_class == sensor.DEVICE_CLASS_HUMIDITY:
+                current_humidity = self.state.state
+                if current_humidity is not None:
+                    response["humidityAmbientPercent"] = round(float(current_humidity))
+
+        return response
+
+    async def execute(self, command, data, params, challenge):
+        """Execute a humidity command."""
+        domain = self.state.domain
+        if domain == sensor.DOMAIN:
+            raise SmartHomeError(
+                ERR_NOT_SUPPORTED, "Execute is not supported by sensor"
             )
 
 


### PR DESCRIPTION
## Description:

Expose humidity sensors to Google Assistant

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11155

## Example entry for `configuration.yaml` (if applicable):

No configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
