### PR TITLE
Simplify getting alias from tplink smartplug.context

### DIFF
--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -115,6 +115,11 @@ class SmartPlugSwitch(SwitchDevice):
         """Return the state attributes of the device."""
         return self._emeter_params
 
+    @property
+    def _plug_from_context(self):
+        children = self.smartplug.sys_info["children"]
+        return next(c for c in children if c["id"] == self.smartplug.context)
+
     def update(self):
         """Update the TP-Link switch's state."""
         try:
@@ -126,21 +131,13 @@ class SmartPlugSwitch(SwitchDevice):
                     self._alias = self.smartplug.alias
                     self._device_id = self._mac
                 else:
-                    self._alias = [
-                        child
-                        for child in self.smartplug.sys_info["children"]
-                        if child["id"] == self.smartplug.context
-                    ][0]["alias"]
+                    self._alias = self._plug_from_context["alias"]
                     self._device_id = self.smartplug.context
 
             if self.smartplug.context is None:
                 self._state = self.smartplug.state == self.smartplug.SWITCH_STATE_ON
             else:
-                self._state = [
-                    child
-                    for child in self.smartplug.sys_info["children"]
-                    if child["id"] == self.smartplug.context
-                ][0]["state"] == 1
+                self._state = self._plug_from_context["state"] == 1
 
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -117,6 +117,7 @@ class SmartPlugSwitch(SwitchDevice):
 
     @property
     def _plug_from_context(self):
+        """Return the plug from the context."""
         children = self.smartplug.sys_info["children"]
         return next(c for c in children if c["id"] == self.smartplug.context)
 


### PR DESCRIPTION
## Description:

I simplified getting the alias when `smartplug.context is not None`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
