### PR TITLE
Add play media support and Spotify control to Openhome

### DIFF
--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -5,9 +5,11 @@ from openhomedevice.Device import Device
 
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_MUSIC,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
+    SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
@@ -94,13 +96,14 @@ class OpenhomeDevice(MediaPlayerDevice):
         self._source_names = source_names
 
         if self._source["type"] == "Radio":
-            self._supported_features |= SUPPORT_STOP | SUPPORT_PLAY
-        if self._source["type"] in ("Playlist", "Cloud"):
+            self._supported_features |= SUPPORT_STOP | SUPPORT_PLAY | SUPPORT_PLAY_MEDIA
+        if self._source["type"] in ("Playlist", "Spotify"):
             self._supported_features |= (
                 SUPPORT_PREVIOUS_TRACK
                 | SUPPORT_NEXT_TRACK
                 | SUPPORT_PAUSE
                 | SUPPORT_PLAY
+                | SUPPORT_PLAY_MEDIA
             )
 
         if self._in_standby:
@@ -122,6 +125,18 @@ class OpenhomeDevice(MediaPlayerDevice):
     def turn_off(self):
         """Put device in standby."""
         self._device.SetStandby(True)
+
+    def play_media(self, media_type, media_id, **kwargs):
+        """Send the play_media command to the media player."""
+        if not media_type == MEDIA_TYPE_MUSIC:
+            _LOGGER.error(
+                "Invalid media type %s. Only %s is supported",
+                media_type,
+                MEDIA_TYPE_MUSIC,
+            )
+            return
+        track_details = {"title": "Home Assistant", "uri": media_id}
+        self._device.PlayMedia(track_details)
 
     def media_pause(self):
         """Send pause command."""


### PR DESCRIPTION
## Description:

This adds `media_player.play_media` service for `openhome` devices and adds Spotify support as a source for `openhome` devices. Therefore, the Spotify support of `openhome` devices can be utilized by pausing, skipping tracks and so on.

**Related feature request:**

https://community.home-assistant.io/t/media-player-play-media-support-for-openhome/133472/3

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11153

## Example entry for `configuration.yaml` (if applicable):
```yaml
action:
  - service: media_player.play_media
    data_template:
      entity_id:
        - media_player.linn_bedroom
      media_content_id: "http://172.24.32.13/Doorbell.mp3"
      media_content_type: audio/mp4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
