### PR TITLE
Add config entry and device support to Demo

### DIFF
--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -3,34 +3,48 @@ import asyncio
 import logging
 import time
 
-from homeassistant import bootstrap
+from homeassistant import bootstrap, config_entries
 import homeassistant.core as ha
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
 
 DOMAIN = "demo"
 _LOGGER = logging.getLogger(__name__)
-COMPONENTS_WITH_DEMO_PLATFORM = [
+
+COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM = [
     "air_quality",
     "alarm_control_panel",
     "binary_sensor",
-    "calendar",
     "camera",
     "climate",
     "cover",
-    "device_tracker",
     "fan",
-    "image_processing",
     "light",
     "lock",
     "media_player",
-    "notify",
     "sensor",
-    "stt",
     "switch",
-    "tts",
-    "mailbox",
     "water_heater",
 ]
+
+COMPONENTS_WITH_DEMO_PLATFORM = [
+    "tts",
+    "stt",
+    "mailbox",
+    "notify",
+    "image_processing",
+    "calendar",
+    "device_tracker",
+]
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set the config entry up."""
+    # Set up demo platforms with config entry
+    for component in COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM:
+        hass.async_add_job(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
+        )
+    return True
 
 
 async def async_setup(hass, config):
@@ -38,14 +52,21 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    config.setdefault(ha.DOMAIN, {})
-    config.setdefault(DOMAIN, {})
+    if not hass.config_entries.async_entries(DOMAIN):
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data={}
+            )
+        )
 
     # Set up demo platforms
     for component in COMPONENTS_WITH_DEMO_PLATFORM:
         hass.async_create_task(
             hass.helpers.discovery.async_load_platform(component, DOMAIN, {}, config)
         )
+
+    config.setdefault(ha.DOMAIN, {})
+    config.setdefault(DOMAIN, {})
 
     # Set up sun
     if not hass.config.latitude:

--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -37,16 +37,6 @@ COMPONENTS_WITH_DEMO_PLATFORM = [
 ]
 
 
-async def async_setup_entry(hass, config_entry):
-    """Set the config entry up."""
-    # Set up demo platforms with config entry
-    for component in COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM:
-        hass.async_add_job(
-            hass.config_entries.async_forward_entry_setup(config_entry, component)
-        )
-    return True
-
-
 async def async_setup(hass, config):
     """Set up the demo environment."""
     if DOMAIN not in config:
@@ -194,6 +184,16 @@ async def async_setup(hass, config):
 
     hass.bus.async_listen(EVENT_HOMEASSISTANT_START, demo_start_listener)
 
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set the config entry up."""
+    # Set up demo platforms with config entry
+    for component in COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
+        )
     return True
 
 

--- a/homeassistant/components/demo/air_quality.py
+++ b/homeassistant/components/demo/air_quality.py
@@ -2,16 +2,16 @@
 from homeassistant.components.air_quality import AirQualityEntity
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Air Quality."""
-    add_entities(
+    async_add_entities(
         [DemoAirQuality("Home", 14, 23, 100), DemoAirQuality("Office", 4, 16, None)]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoAirQuality(AirQualityEntity):

--- a/homeassistant/components/demo/air_quality.py
+++ b/homeassistant/components/demo/air_quality.py
@@ -2,6 +2,11 @@
 from homeassistant.components.air_quality import AirQualityEntity
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Air Quality."""
     add_entities(

--- a/homeassistant/components/demo/alarm_control_panel.py
+++ b/homeassistant/components/demo/alarm_control_panel.py
@@ -14,11 +14,6 @@ from homeassistant.const import (
 )
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    await async_setup_platform(hass, {}, async_add_entities)
-
-
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo alarm control panel platform."""
     async_add_entities(
@@ -62,3 +57,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             )
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)

--- a/homeassistant/components/demo/alarm_control_panel.py
+++ b/homeassistant/components/demo/alarm_control_panel.py
@@ -14,6 +14,11 @@ from homeassistant.const import (
 )
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo alarm control panel platform."""
     async_add_entities(

--- a/homeassistant/components/demo/binary_sensor.py
+++ b/homeassistant/components/demo/binary_sensor.py
@@ -2,6 +2,11 @@
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo binary sensor platform."""
     add_entities(

--- a/homeassistant/components/demo/binary_sensor.py
+++ b/homeassistant/components/demo/binary_sensor.py
@@ -3,19 +3,19 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from . import DOMAIN
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo binary sensor platform."""
-    add_entities(
+    async_add_entities(
         [
             DemoBinarySensor("binary_1", "Basement Floor Wet", False, "moisture"),
             DemoBinarySensor("binary_2", "Movement Backyard", True, "motion"),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoBinarySensor(BinarySensorDevice):

--- a/homeassistant/components/demo/binary_sensor.py
+++ b/homeassistant/components/demo/binary_sensor.py
@@ -1,5 +1,6 @@
 """Demo platform that has two fake binary sensors."""
 from homeassistant.components.binary_sensor import BinarySensorDevice
+from . import DOMAIN
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -11,8 +12,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo binary sensor platform."""
     add_entities(
         [
-            DemoBinarySensor("Basement Floor Wet", False, "moisture"),
-            DemoBinarySensor("Movement Backyard", True, "motion"),
+            DemoBinarySensor("binary_1", "Basement Floor Wet", False, "moisture"),
+            DemoBinarySensor("binary_2", "Movement Backyard", True, "motion"),
         ]
     )
 
@@ -20,11 +21,28 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class DemoBinarySensor(BinarySensorDevice):
     """representation of a Demo binary sensor."""
 
-    def __init__(self, name, state, device_class):
+    def __init__(self, unique_id, name, state, device_class):
         """Initialize the demo sensor."""
+        self._unique_id = unique_id
         self._name = name
         self._state = state
         self._sensor_type = device_class
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            "name": self.name,
+        }
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
     @property
     def device_class(self):

--- a/homeassistant/components/demo/camera.py
+++ b/homeassistant/components/demo/camera.py
@@ -7,6 +7,11 @@ from homeassistant.components.camera import SUPPORT_ON_OFF, Camera
 _LOGGER = logging.getLogger(__name__)
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo camera platform."""
     async_add_entities([DemoCamera("Demo camera")])

--- a/homeassistant/components/demo/camera.py
+++ b/homeassistant/components/demo/camera.py
@@ -7,14 +7,14 @@ from homeassistant.components.camera import SUPPORT_ON_OFF, Camera
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    await async_setup_platform(hass, {}, async_add_entities)
-
-
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo camera platform."""
     async_add_entities([DemoCamera("Demo camera")])
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoCamera(Camera):

--- a/homeassistant/components/demo/climate.py
+++ b/homeassistant/components/demo/climate.py
@@ -1,4 +1,5 @@
 """Demo platform that offers a fake climate device."""
+import logging
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
@@ -20,8 +21,15 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from . import DOMAIN
 
 SUPPORT_FLAGS = 0
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo climate devices config entry."""
+    setup_platform(hass, {}, async_add_entities)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -29,6 +37,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(
         [
             DemoClimate(
+                unique_id="climate_1",
                 name="HeatPump",
                 target_temperature=68,
                 unit_of_measurement=TEMP_FAHRENHEIT,
@@ -46,6 +55,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 hvac_modes=[HVAC_MODE_HEAT, HVAC_MODE_OFF],
             ),
             DemoClimate(
+                unique_id="climate_2",
                 name="Hvac",
                 target_temperature=21,
                 unit_of_measurement=TEMP_CELSIUS,
@@ -63,6 +73,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 hvac_modes=[mode for mode in HVAC_MODES if mode != HVAC_MODE_HEAT_COOL],
             ),
             DemoClimate(
+                unique_id="climate_3",
                 name="Ecobee",
                 target_temperature=None,
                 unit_of_measurement=TEMP_CELSIUS,
@@ -89,6 +100,7 @@ class DemoClimate(ClimateDevice):
 
     def __init__(
         self,
+        unique_id,
         name,
         target_temperature,
         unit_of_measurement,
@@ -107,6 +119,7 @@ class DemoClimate(ClimateDevice):
         preset_modes=None,
     ):
         """Initialize the climate device."""
+        self._unique_id = unique_id
         self._name = name
         self._support_flags = SUPPORT_FLAGS
         if target_temperature is not None:
@@ -142,6 +155,22 @@ class DemoClimate(ClimateDevice):
         self._swing_modes = ["Auto", "1", "2", "3", "Off"]
         self._target_temperature_high = target_temp_high
         self._target_temperature_low = target_temp_low
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            "name": self.name,
+        }
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
     @property
     def supported_features(self):

--- a/homeassistant/components/demo/climate.py
+++ b/homeassistant/components/demo/climate.py
@@ -27,14 +27,9 @@ SUPPORT_FLAGS = 0
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo climate devices config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo climate devices."""
-    add_entities(
+    async_add_entities(
         [
             DemoClimate(
                 unique_id="climate_1",
@@ -93,6 +88,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             ),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo climate devices config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoClimate(ClimateDevice):

--- a/homeassistant/components/demo/config_flow.py
+++ b/homeassistant/components/demo/config_flow.py
@@ -1,0 +1,15 @@
+"""Config flow to configure demo component."""
+
+from homeassistant import config_entries
+from . import DOMAIN
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class DemoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Demo configuration flow."""
+
+    VERSION = 1
+
+    async def async_step_import(self, import_info):
+        """Set the config entry up from yaml."""
+        return self.async_create_entry(title="Demo", data={})

--- a/homeassistant/components/demo/config_flow.py
+++ b/homeassistant/components/demo/config_flow.py
@@ -4,8 +4,7 @@ from homeassistant import config_entries
 from . import DOMAIN
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class DemoConfigFlow(config_entries.ConfigFlow):
+class DemoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Demo configuration flow."""
 
     VERSION = 1

--- a/homeassistant/components/demo/config_flow.py
+++ b/homeassistant/components/demo/config_flow.py
@@ -4,7 +4,8 @@ from homeassistant import config_entries
 from . import DOMAIN
 
 
-class DemoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+@config_entries.HANDLERS.register(DOMAIN)
+class DemoConfigFlow(config_entries.ConfigFlow):
     """Demo configuration flow."""
 
     VERSION = 1

--- a/homeassistant/components/demo/config_flow.py
+++ b/homeassistant/components/demo/config_flow.py
@@ -5,7 +5,7 @@ from . import DOMAIN
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class DemoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class DemoConfigFlow(config_entries.ConfigFlow):
     """Demo configuration flow."""
 
     VERSION = 1

--- a/homeassistant/components/demo/config_flow.py
+++ b/homeassistant/components/demo/config_flow.py
@@ -1,11 +1,12 @@
 """Config flow to configure demo component."""
 
 from homeassistant import config_entries
+
+# pylint: disable=unused-import
 from . import DOMAIN
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class DemoConfigFlow(config_entries.ConfigFlow):
+class DemoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Demo configuration flow."""
 
     VERSION = 1

--- a/homeassistant/components/demo/cover.py
+++ b/homeassistant/components/demo/cover.py
@@ -10,6 +10,11 @@ from homeassistant.components.cover import (
 )
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo covers."""
     add_entities(

--- a/homeassistant/components/demo/cover.py
+++ b/homeassistant/components/demo/cover.py
@@ -8,6 +8,7 @@ from homeassistant.components.cover import (
     SUPPORT_OPEN,
     CoverDevice,
 )
+from . import DOMAIN
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -19,11 +20,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo covers."""
     add_entities(
         [
-            DemoCover(hass, "Kitchen Window"),
-            DemoCover(hass, "Hall Window", 10),
-            DemoCover(hass, "Living Room Window", 70, 50),
+            DemoCover(hass, "cover_1", "Kitchen Window"),
+            DemoCover(hass, "cover_2", "Hall Window", 10),
+            DemoCover(hass, "cover_3", "Living Room Window", 70, 50),
             DemoCover(
                 hass,
+                "cover_4",
                 "Garage Door",
                 device_class="garage",
                 supported_features=(SUPPORT_OPEN | SUPPORT_CLOSE),
@@ -38,6 +40,7 @@ class DemoCover(CoverDevice):
     def __init__(
         self,
         hass,
+        unique_id,
         name,
         position=None,
         tilt_position=None,
@@ -46,6 +49,7 @@ class DemoCover(CoverDevice):
     ):
         """Initialize the cover."""
         self.hass = hass
+        self._unique_id = unique_id
         self._name = name
         self._position = position
         self._device_class = device_class
@@ -63,6 +67,22 @@ class DemoCover(CoverDevice):
             self._closed = True
         else:
             self._closed = self.current_cover_position <= 0
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            "name": self.name,
+        }
+
+    @property
+    def unique_id(self):
+        """Return unique ID for cover."""
+        return self._unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/demo/cover.py
+++ b/homeassistant/components/demo/cover.py
@@ -11,14 +11,9 @@ from homeassistant.components.cover import (
 from . import DOMAIN
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo covers."""
-    add_entities(
+    async_add_entities(
         [
             DemoCover(hass, "cover_1", "Kitchen Window"),
             DemoCover(hass, "cover_2", "Hall Window", 10),
@@ -32,6 +27,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             ),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoCover(CoverDevice):

--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -15,6 +15,11 @@ FULL_SUPPORT = SUPPORT_SET_SPEED | SUPPORT_OSCILLATE | SUPPORT_DIRECTION
 LIMITED_SUPPORT = SUPPORT_SET_SPEED
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the demo fan platform."""
     add_entities_callback(

--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -15,19 +15,19 @@ FULL_SUPPORT = SUPPORT_SET_SPEED | SUPPORT_OSCILLATE | SUPPORT_DIRECTION
 LIMITED_SUPPORT = SUPPORT_SET_SPEED
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities_callback, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the demo fan platform."""
-    add_entities_callback(
+    async_add_entities(
         [
             DemoFan(hass, "Living Room Fan", FULL_SUPPORT),
             DemoFan(hass, "Ceiling Fan", LIMITED_SUPPORT),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoFan(FanEntity):

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -32,14 +32,9 @@ SUPPORT_DEMO = (
 )
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities_callback, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the demo light platform."""
-    add_entities_callback(
+    async_add_entities(
         [
             DemoLight(
                 "light_1",
@@ -57,6 +52,11 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
             ),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoLight(Light):

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -15,6 +15,8 @@ from homeassistant.components.light import (
     Light,
 )
 
+from . import DOMAIN
+
 LIGHT_COLORS = [(56, 86), (345, 75)]
 
 LIGHT_EFFECT_LIST = ["rainbow", "none"]
@@ -30,20 +32,29 @@ SUPPORT_DEMO = (
 )
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the demo light platform."""
     add_entities_callback(
         [
             DemoLight(
-                1,
+                "light_1",
                 "Bed Light",
                 False,
                 True,
                 effect_list=LIGHT_EFFECT_LIST,
                 effect=LIGHT_EFFECT_LIST[0],
             ),
-            DemoLight(2, "Ceiling Lights", True, True, LIGHT_COLORS[0], LIGHT_TEMPS[1]),
-            DemoLight(3, "Kitchen Lights", True, True, LIGHT_COLORS[1], LIGHT_TEMPS[0]),
+            DemoLight(
+                "light_2", "Ceiling Lights", True, True, LIGHT_COLORS[0], LIGHT_TEMPS[1]
+            ),
+            DemoLight(
+                "light_3", "Kitchen Lights", True, True, LIGHT_COLORS[1], LIGHT_TEMPS[0]
+            ),
         ]
     )
 
@@ -75,6 +86,17 @@ class DemoLight(Light):
         self._effect_list = effect_list
         self._effect = effect
         self._available = True
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            "name": self.name,
+        }
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/demo/lock.py
+++ b/homeassistant/components/demo/lock.py
@@ -4,6 +4,11 @@ from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.components.lock import SUPPORT_OPEN, LockDevice
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo lock platform."""
     add_entities(

--- a/homeassistant/components/demo/lock.py
+++ b/homeassistant/components/demo/lock.py
@@ -4,20 +4,20 @@ from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.components.lock import SUPPORT_OPEN, LockDevice
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo lock platform."""
-    add_entities(
+    async_add_entities(
         [
             DemoLock("Front Door", STATE_LOCKED),
             DemoLock("Kitchen Door", STATE_UNLOCKED),
             DemoLock("Openable Lock", STATE_LOCKED, True),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoLock(LockDevice):

--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -24,14 +24,9 @@ from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 import homeassistant.util.dt as dt_util
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the media player demo platform."""
-    add_entities(
+    async_add_entities(
         [
             DemoYoutubePlayer(
                 "Living Room",
@@ -46,6 +41,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             DemoTVShowPlayer(),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 YOUTUBE_COVER_URL_FORMAT = "https://img.youtube.com/vi/{}/hqdefault.jpg"

--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -24,6 +24,11 @@ from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 import homeassistant.util.dt as dt_util
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the media player demo platform."""
     add_entities(

--- a/homeassistant/components/demo/remote.py
+++ b/homeassistant/components/demo/remote.py
@@ -3,6 +3,11 @@ from homeassistant.components.remote import RemoteDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the demo remotes."""
     add_entities_callback(

--- a/homeassistant/components/demo/sensor.py
+++ b/homeassistant/components/demo/sensor.py
@@ -9,14 +9,9 @@ from homeassistant.helpers.entity import Entity
 from . import DOMAIN
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo sensors."""
-    add_entities(
+    async_add_entities(
         [
             DemoSensor(
                 "sensor_1",
@@ -31,6 +26,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             ),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoSensor(Entity):

--- a/homeassistant/components/demo/sensor.py
+++ b/homeassistant/components/demo/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
 )
 from homeassistant.helpers.entity import Entity
+from . import DOMAIN
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -18,9 +19,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(
         [
             DemoSensor(
-                "Outside Temperature", 15.6, DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, 12
+                "sensor_1",
+                "Outside Temperature",
+                15.6,
+                DEVICE_CLASS_TEMPERATURE,
+                TEMP_CELSIUS,
+                12,
             ),
-            DemoSensor("Outside Humidity", 54, DEVICE_CLASS_HUMIDITY, "%", None),
+            DemoSensor(
+                "sensor_2", "Outside Humidity", 54, DEVICE_CLASS_HUMIDITY, "%", None
+            ),
         ]
     )
 
@@ -28,13 +36,32 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class DemoSensor(Entity):
     """Representation of a Demo sensor."""
 
-    def __init__(self, name, state, device_class, unit_of_measurement, battery):
+    def __init__(
+        self, unique_id, name, state, device_class, unit_of_measurement, battery
+    ):
         """Initialize the sensor."""
+        self._unique_id = unique_id
         self._name = name
         self._state = state
         self._device_class = device_class
         self._unit_of_measurement = unit_of_measurement
         self._battery = battery
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            "name": self.name,
+        }
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
     @property
     def should_poll(self):

--- a/homeassistant/components/demo/sensor.py
+++ b/homeassistant/components/demo/sensor.py
@@ -8,6 +8,11 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo sensors."""
     add_entities(

--- a/homeassistant/components/demo/strings.json
+++ b/homeassistant/components/demo/strings.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "title": "Demo"
+  }
+}

--- a/homeassistant/components/demo/switch.py
+++ b/homeassistant/components/demo/switch.py
@@ -3,6 +3,11 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the demo switches."""
     add_entities_callback(

--- a/homeassistant/components/demo/switch.py
+++ b/homeassistant/components/demo/switch.py
@@ -4,19 +4,19 @@ from homeassistant.const import DEVICE_DEFAULT_NAME
 from . import DOMAIN
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities_callback, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the demo switches."""
-    add_entities_callback(
+    async_add_entities(
         [
             DemoSwitch("swith1", "Decorative Lights", True, None, True),
             DemoSwitch("swith2", "AC", False, "mdi:air-conditioner", False),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoSwitch(SwitchDevice):

--- a/homeassistant/components/demo/switch.py
+++ b/homeassistant/components/demo/switch.py
@@ -1,6 +1,7 @@
 """Demo platform that has two fake switches."""
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
+from . import DOMAIN
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -12,8 +13,8 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the demo switches."""
     add_entities_callback(
         [
-            DemoSwitch("Decorative Lights", True, None, True),
-            DemoSwitch("AC", False, "mdi:air-conditioner", False),
+            DemoSwitch("swith1", "Decorative Lights", True, None, True),
+            DemoSwitch("swith2", "AC", False, "mdi:air-conditioner", False),
         ]
     )
 
@@ -21,13 +22,30 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 class DemoSwitch(SwitchDevice):
     """Representation of a demo switch."""
 
-    def __init__(self, name, state, icon, assumed, device_class=None):
+    def __init__(self, unique_id, name, state, icon, assumed, device_class=None):
         """Initialize the Demo switch."""
+        self._unique_id = unique_id
         self._name = name or DEVICE_DEFAULT_NAME
         self._state = state
         self._icon = icon
         self._assumed = assumed
         self._device_class = device_class
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            "name": self.name,
+        }
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
     @property
     def should_poll(self):

--- a/homeassistant/components/demo/vacuum.py
+++ b/homeassistant/components/demo/vacuum.py
@@ -76,6 +76,11 @@ DEMO_VACUUM_NONE = "4_Fourth_floor"
 DEMO_VACUUM_STATE = "5_Fifth_floor"
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo vacuums."""
     add_entities(

--- a/homeassistant/components/demo/water_heater.py
+++ b/homeassistant/components/demo/water_heater.py
@@ -13,19 +13,19 @@ SUPPORT_FLAGS_HEATER = (
 )
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Demo config entry."""
-    setup_platform(hass, {}, async_add_entities)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Demo water_heater devices."""
-    add_entities(
+    async_add_entities(
         [
             DemoWaterHeater("Demo Water Heater", 119, TEMP_FAHRENHEIT, False, "eco"),
             DemoWaterHeater("Demo Water Heater Celsius", 45, TEMP_CELSIUS, True, "eco"),
         ]
     )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
 
 
 class DemoWaterHeater(WaterHeaterDevice):

--- a/homeassistant/components/demo/water_heater.py
+++ b/homeassistant/components/demo/water_heater.py
@@ -13,6 +13,11 @@ SUPPORT_FLAGS_HEATER = (
 )
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo water_heater devices."""
     add_entities(

--- a/homeassistant/components/demo/weather.py
+++ b/homeassistant/components/demo/weather.py
@@ -30,6 +30,11 @@ CONDITION_CLASSES = {
 }
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Demo config entry."""
+    setup_platform(hass, {}, async_add_entities)
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo weather."""
     add_entities(

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -498,6 +498,7 @@ async def test_unavailable_state_doesnt_sync(hass):
 async def test_device_class_switch(hass, device_class, google_type):
     """Test that a cover entity syncs to the correct device type."""
     sensor = DemoSwitch(
+        None,
         "Demo Sensor",
         state=False,
         icon="mdi:switch",
@@ -545,7 +546,9 @@ async def test_device_class_switch(hass, device_class, google_type):
 )
 async def test_device_class_binary_sensor(hass, device_class, google_type):
     """Test that a binary entity syncs to the correct device type."""
-    sensor = DemoBinarySensor("Demo Sensor", state=False, device_class=device_class)
+    sensor = DemoBinarySensor(
+        None, "Demo Sensor", state=False, device_class=device_class
+    )
     sensor.hass = hass
     sensor.entity_id = "binary_sensor.demo_sensor"
     await sensor.async_update_ha_state()
@@ -585,7 +588,7 @@ async def test_device_class_binary_sensor(hass, device_class, google_type):
 )
 async def test_device_class_cover(hass, device_class, google_type):
     """Test that a binary entity syncs to the correct device type."""
-    sensor = DemoCover(hass, "Demo Sensor", device_class=device_class)
+    sensor = DemoCover(None, hass, "Demo Sensor", device_class=device_class)
     sensor.hass = hass
     sensor.entity_id = "cover.demo_sensor"
     await sensor.async_update_ha_state()

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -24,24 +24,26 @@ async def prometheus_client(loop, hass, hass_client):
         hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
     )
 
-    sensor1 = DemoSensor("Television Energy", 74, None, ENERGY_KILO_WATT_HOUR, None)
+    sensor1 = DemoSensor(
+        None, "Television Energy", 74, None, ENERGY_KILO_WATT_HOUR, None
+    )
     sensor1.hass = hass
     sensor1.entity_id = "sensor.television_energy"
     await sensor1.async_update_ha_state()
 
     sensor2 = DemoSensor(
-        "Radio Energy", 14, DEVICE_CLASS_POWER, ENERGY_KILO_WATT_HOUR, None
+        None, "Radio Energy", 14, DEVICE_CLASS_POWER, ENERGY_KILO_WATT_HOUR, None
     )
     sensor2.hass = hass
     sensor2.entity_id = "sensor.radio_energy"
     await sensor2.async_update_ha_state()
 
-    sensor3 = DemoSensor("Electricity price", 0.123, None, "SEK/kWh", None)
+    sensor3 = DemoSensor(None, "Electricity price", 0.123, None, "SEK/kWh", None)
     sensor3.hass = hass
     sensor3.entity_id = "sensor.electricity_price"
     await sensor3.async_update_ha_state()
 
-    sensor4 = DemoSensor("Wind Direction", 25, None, "°", None)
+    sensor4 = DemoSensor(None, "Wind Direction", 25, None, "°", None)
     sensor4.hass = hass
     sensor4.entity_id = "sensor.wind_direction"
     await sensor4.async_update_ha_state()


### PR DESCRIPTION
## Description:
Adds device support to the demo platform so testing the frontend in a dev environment gets easier.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
