### PR TITLE
Add support for Efesto heating devices

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -181,6 +181,7 @@ omit =
     homeassistant/components/ecovacs/*
     homeassistant/components/eddystone_temperature/sensor.py
     homeassistant/components/edimax/switch.py
+    homeassistant/components/efesto/climate.py
     homeassistant/components/egardia/*
     homeassistant/components/eight_sleep/*
     homeassistant/components/eliqonline/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -181,7 +181,8 @@ omit =
     homeassistant/components/ecovacs/*
     homeassistant/components/eddystone_temperature/sensor.py
     homeassistant/components/edimax/switch.py
-    homeassistant/components/efesto/*
+    homeassistant/components/efesto/const.py
+    homeassistant/components/efesto/climate.py
     homeassistant/components/egardia/*
     homeassistant/components/eight_sleep/*
     homeassistant/components/eliqonline/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -181,7 +181,7 @@ omit =
     homeassistant/components/ecovacs/*
     homeassistant/components/eddystone_temperature/sensor.py
     homeassistant/components/edimax/switch.py
-    homeassistant/components/efesto/climate.py
+    homeassistant/components/efesto/*
     homeassistant/components/egardia/*
     homeassistant/components/eight_sleep/*
     homeassistant/components/eliqonline/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -88,6 +88,7 @@ homeassistant/components/dynalite/* @ziv1234
 homeassistant/components/dyson/* @etheralm
 homeassistant/components/ecobee/* @marthoc
 homeassistant/components/ecovacs/* @OverloadUT
+homeassistant/components/efesto/* @fredericvl
 homeassistant/components/egardia/* @jeroenterheerdt
 homeassistant/components/eight_sleep/* @mezz64
 homeassistant/components/elgato/* @frenck

--- a/homeassistant/components/efesto/.translations/en.json
+++ b/homeassistant/components/efesto/.translations/en.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "abort": {
+            "device_already_configured": "Device is already configured."
+        },
+        "error": {
+            "efesto_error": "Failed to connect to Efesto with current parameters."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "device": "Device ID of Efesto heater",
+                    "name": "Friendly name for the Efesto heater",
+                    "password": "Password",
+                    "url": "URL of Efesto web application",
+                    "username": "Username"
+                },
+                "title": "Fill in Efesto parameters"
+            }
+        },
+        "title": "Efesto"
+    }
+}

--- a/homeassistant/components/efesto/.translations/en.json
+++ b/homeassistant/components/efesto/.translations/en.json
@@ -4,7 +4,10 @@
             "device_already_configured": "Device is already configured."
         },
         "error": {
-            "efesto_error": "Failed to connect to Efesto with current parameters."
+            "connection_error": "Connection to URL not possible.",
+            "invalid_url": "Given URL is not a valid Efesto URL.",
+            "unauthorized": "Failed to login, please check credentials.",
+            "unknown_error": "Unkown error, please double check device id."
         },
         "step": {
             "user": {

--- a/homeassistant/components/efesto/__init__.py
+++ b/homeassistant/components/efesto/__init__.py
@@ -1,1 +1,25 @@
 """Support for Efesto heating devices."""
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+
+
+async def async_setup(hass, config):
+    """Set up the Efesto integration, nothing to do."""
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up a config entry for Efesto."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, CLIMATE_DOMAIN)
+    )
+
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_unload(entry, CLIMATE_DOMAIN)
+    )
+
+    return True

--- a/homeassistant/components/efesto/__init__.py
+++ b/homeassistant/components/efesto/__init__.py
@@ -1,0 +1,1 @@
+"""Support for Efesto heating devices."""

--- a/homeassistant/components/efesto/climate.py
+++ b/homeassistant/components/efesto/climate.py
@@ -2,11 +2,11 @@
 import logging
 
 from efestoclient import (
-    EfestoClient,
-    Error,
-    UnauthorizedError,
     ConnectionError,
+    EfestoClient,
+    Error as EfestoError,
     InvalidURLError,
+    UnauthorizedError,
 )
 
 from homeassistant.components.climate import ClimateDevice
@@ -84,7 +84,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     except InvalidURLError:
         _LOGGER.error("Invalid Efesto URL: %s", url)
         return False
-    except Error as err:
+    except EfestoError as err:
         _LOGGER.error("Unknown Efesto error: %s", err)
         return False
 
@@ -217,14 +217,14 @@ class EfestoHeatingDevice(ClimateDevice):
         """Turn device off."""
         try:
             self.client.set_off()
-        except Error as err:
+        except EfestoError as err:
             _LOGGER.error("Failed to turn off device (original message: %s)", err)
 
     def turn_on(self):
         """Turn device on."""
         try:
             self.client.set_on()
-        except Error as err:
+        except EfestoError as err:
             _LOGGER.error("Failed to turn on device (original message: %s)", err)
 
     def set_temperature(self, **kwargs):
@@ -235,7 +235,7 @@ class EfestoHeatingDevice(ClimateDevice):
 
         try:
             self.client.set_temperature(round(temperature))
-        except Error as err:
+        except EfestoError as err:
             _LOGGER.error("Failed to set temperature (original message: %s)", err)
 
     def set_fan_mode(self, fan_mode):
@@ -245,7 +245,7 @@ class EfestoHeatingDevice(ClimateDevice):
 
         try:
             self.client.set_power(fan_mode)
-        except Error as err:
+        except EfestoError as err:
             _LOGGER.error("Failed to set temperature (original message: %s)", err)
 
     def set_hvac_mode(self, hvac_mode):
@@ -265,7 +265,7 @@ class EfestoHeatingDevice(ClimateDevice):
         except ConnectionError:
             _LOGGER.error("Connection to %s not possible", self.client.url)
             return False
-        except Error as err:
+        except EfestoError as err:
             _LOGGER.error("Error: %s", err)
             return False
 

--- a/homeassistant/components/efesto/climate.py
+++ b/homeassistant/components/efesto/climate.py
@@ -1,0 +1,284 @@
+"""Support for Efesto heating devices."""
+import logging
+import voluptuous as vol
+import efestoclient
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_FAN_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_DEVICE,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_URL,
+    CONF_USERNAME,
+    PRECISION_WHOLE,
+    TEMP_CELSIUS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_URL): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_DEVICE): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
+    }
+)
+
+ATTR_DEVICE_STATUS = "device_status"
+ATTR_HUMAN_DEVICE_STATUS = "human_device_status"
+ATTR_REAL_POWER = "real_power"
+ATTR_SMOKE_TEMP = "smoke_temperature"
+
+DOMAIN = "Efesto"
+
+FAN_1 = 1
+FAN_2 = 2
+FAN_3 = 3
+FAN_4 = 4
+FAN_5 = 5
+FAN_MODES = [
+    FAN_1,
+    FAN_2,
+    FAN_3,
+    FAN_4,
+    FAN_5,
+]
+
+CURRENT_HVAC_MAP_EFESTO_HEAT = {
+    "ON": CURRENT_HVAC_HEAT,
+    "CLEANING FIRE-POT": CURRENT_HVAC_HEAT,
+    "FLAME LIGHT": CURRENT_HVAC_HEAT,
+    "OFF": CURRENT_HVAC_OFF,
+}
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Efesto device."""
+    url = config.get(CONF_URL)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    device = config.get(CONF_DEVICE)
+    name = config.get(CONF_NAME)
+
+    try:
+        client = efestoclient.EfestoClient(url, username, password, device, False)
+        add_entities([EfestoHeatingDevice(client, name, device)], True)
+    except efestoclient.Error as err:
+        _LOGGER.error("Error while connecting to the Efesto web service: %s", err)
+
+
+class EfestoHeatingDevice(ClimateDevice):
+    """Representation of a Efesto heating device."""
+
+    def __init__(self, client, name, device_id):
+        """Initialize the thermostat."""
+        self.client = client
+        self._device_id = device_id
+        self._on = False
+        self._device_status = None
+        self._idle_info = None
+        self._human_device_status = None
+        self._current_temperature = None
+        self._target_temperature = None
+        self._smoke_temperature = None
+        self._real_power = None
+        self._current_power = None
+        self._name = name if name else device_id
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        data = {
+            ATTR_DEVICE_STATUS: self._device_status,
+            ATTR_HUMAN_DEVICE_STATUS: self._human_device_status,
+            ATTR_SMOKE_TEMP: self._smoke_temperature,
+            ATTR_REAL_POWER: self._real_power,
+        }
+        return data
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._device_id
+
+    @property
+    def name(self):
+        """Return the name of the Efesto, if any."""
+        return self._name
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "manufacturer": "Efesto",
+        }
+
+    @property
+    def precision(self):
+        """Return the precision of the system."""
+        return PRECISION_WHOLE
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return PRECISION_WHOLE
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    @property
+    def hvac_mode(self):
+        """Return hvac operation ie. heat, cool mode.
+
+        Need to be one of HVAC_MODE_*.
+        """
+        if self._on:
+            return HVAC_MODE_HEAT
+        return HVAC_MODE_OFF
+
+    @property
+    def hvac_modes(self):
+        """Return the list of available hvac operation modes.
+
+        Need to be a subset of HVAC_MODES.
+        """
+        return [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+
+    @property
+    def fan_mode(self):
+        """Return fan mode."""
+        if self._current_power in FAN_MODES:
+            return self._current_power
+        return FAN_1
+
+    @property
+    def fan_modes(self):
+        """Return the list of available fan modes."""
+        return FAN_MODES
+
+    @property
+    def hvac_action(self):
+        """Return the current running hvac operation if supported.
+
+        Need to be one of CURRENT_HVAC_*.
+        """
+        if self._human_device_status in CURRENT_HVAC_MAP_EFESTO_HEAT:
+            return CURRENT_HVAC_MAP_EFESTO_HEAT.get(self._human_device_status)
+        return CURRENT_HVAC_IDLE
+
+    def turn_off(self):
+        """Turn device off."""
+        try:
+            json = self.client.set_off()
+            _LOGGER.debug("Turn off response: %s", json)
+            if json["status"] > 0:
+                _LOGGER.error("Failed to turn off device (%s)", json["message"])
+        except ValueError:
+            _LOGGER.error("Failed to turn off device")
+
+    def turn_on(self):
+        """Turn device on."""
+        try:
+            json = self.client.set_on()
+            _LOGGER.debug("Turn on response: %s", json)
+            if json["status"] > 0:
+                _LOGGER.error("Failed to turn on device (%s)", json["message"])
+        except ValueError:
+            _LOGGER.error("Failed to turn on device")
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        json = self.client.set_temperature(round(temperature))
+        _LOGGER.debug("Set temperature response: %s", json)
+        if json["status"] > 0:
+            _LOGGER.error("Failed to set temperature")
+
+    def set_fan_mode(self, fan_mode):
+        """Set new target fan mode."""
+        if fan_mode is None:
+            return
+        json = self.client.set_power(fan_mode)
+        _LOGGER.debug("Set fan (power) response: %s", json)
+        if json["status"] > 0:
+            _LOGGER.error("Failed to set fan (power)")
+
+    def set_hvac_mode(self, hvac_mode):
+        """Set new target hvac mode."""
+        if hvac_mode == HVAC_MODE_OFF:
+            self.turn_off()
+        elif hvac_mode == HVAC_MODE_HEAT:
+            self.turn_on()
+
+    def update(self):
+        """Get the latest data."""
+        try:
+            json = self.client.get_status()
+            _LOGGER.debug("Get status response: %s", json)
+
+            if json["status"] != 0:
+                _LOGGER.error("Update failed (%s)", json["message"])
+                return
+
+            self._device_status = json["deviceStatus"]
+
+            if json["airTemperature"]:
+                self._current_temperature = json["airTemperature"]
+            if json["lastSetAirTemperature"]:
+                self._target_temperature = json["lastSetAirTemperature"]
+            if json["deviceStatusTranslated"]:
+                self._human_device_status = json["deviceStatusTranslated"]
+            if json["smokeTemperature"]:
+                self._smoke_temperature = json["smokeTemperature"]
+            if json["realPower"]:
+                self._real_power = json["realPower"]
+            if json["lastSetPower"]:
+                self._current_power = json["lastSetPower"]
+
+            if self._device_status == 0:
+                self._on = False
+            else:
+                self._on = True
+                if "idle_info" in json:
+                    self._idle_info = json["idle_info"]
+                    self._human_device_status = json["idle_info"]
+                    if self._idle_info == "TURNING OFF":
+                        self._on = False
+        except ValueError:
+            _LOGGER.error(
+                "Update failed (wrong device id or no connection to Efesto server)"
+            )

--- a/homeassistant/components/efesto/climate.py
+++ b/homeassistant/components/efesto/climate.py
@@ -1,7 +1,13 @@
 """Support for Efesto heating devices."""
 import logging
 
-import efestoclient
+from efestoclient import (
+    EfestoClient,
+    Error,
+    UnauthorizedError,
+    ConnectionError,
+    InvalidURLError,
+)
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
@@ -67,18 +73,18 @@ async def async_setup_entry(hass, entry, async_add_entities):
     name = entry.title
 
     try:
-        client = efestoclient.EfestoClient(url, username, password, device)
+        client = EfestoClient(url, username, password, device)
         client.get_status()
-    except efestoclient.UnauthorizedError:
+    except UnauthorizedError:
         _LOGGER.error("Wrong credentials for device %s", device)
         return False
-    except efestoclient.ConnectionError:
+    except ConnectionError:
         _LOGGER.error("Connection to %s not possible", url)
         return False
-    except efestoclient.InvalidURLError:
+    except InvalidURLError:
         _LOGGER.error("Invalid Efesto URL: %s", url)
         return False
-    except efestoclient.Error as err:
+    except Error as err:
         _LOGGER.error("Unknown Efesto error: %s", err)
         return False
 
@@ -211,14 +217,14 @@ class EfestoHeatingDevice(ClimateDevice):
         """Turn device off."""
         try:
             self.client.set_off()
-        except efestoclient.Error as err:
+        except Error as err:
             _LOGGER.error("Failed to turn off device (original message: %s)", err)
 
     def turn_on(self):
         """Turn device on."""
         try:
             self.client.set_on()
-        except efestoclient.Error as err:
+        except Error as err:
             _LOGGER.error("Failed to turn on device (original message: %s)", err)
 
     def set_temperature(self, **kwargs):
@@ -229,7 +235,7 @@ class EfestoHeatingDevice(ClimateDevice):
 
         try:
             self.client.set_temperature(round(temperature))
-        except efestoclient.Error as err:
+        except Error as err:
             _LOGGER.error("Failed to set temperature (original message: %s)", err)
 
     def set_fan_mode(self, fan_mode):
@@ -239,7 +245,7 @@ class EfestoHeatingDevice(ClimateDevice):
 
         try:
             self.client.set_power(fan_mode)
-        except efestoclient.Error as err:
+        except Error as err:
             _LOGGER.error("Failed to set temperature (original message: %s)", err)
 
     def set_hvac_mode(self, hvac_mode):
@@ -253,13 +259,13 @@ class EfestoHeatingDevice(ClimateDevice):
         """Get the latest data."""
         try:
             device = self.client.get_status()
-        except efestoclient.UnauthorizedError:
+        except UnauthorizedError:
             _LOGGER.error("Wrong credentials for device %s", device)
             return False
-        except efestoclient.ConnectionError:
+        except ConnectionError:
             _LOGGER.error("Connection to %s not possible", self.client.url)
             return False
-        except efestoclient.Error as err:
+        except Error as err:
             _LOGGER.error("Error: %s", err)
             return False
 

--- a/homeassistant/components/efesto/climate.py
+++ b/homeassistant/components/efesto/climate.py
@@ -1,10 +1,9 @@
 """Support for Efesto heating devices."""
 import logging
-import voluptuous as vol
+
 import efestoclient
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
@@ -17,7 +16,6 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_DEVICE,
-    CONF_NAME,
     CONF_PASSWORD,
     CONF_URL,
     CONF_USERNAME,
@@ -40,16 +38,6 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_URL): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_DEVICE): cv.string,
-        vol.Optional(CONF_NAME): cv.string,
-    }
-)
-
 FAN_MODES = [
     FAN_1,
     FAN_2,
@@ -68,7 +56,6 @@ CURRENT_HVAC_MAP_EFESTO_HEAT = {
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up Efesto climate, nothing to do."""
-    return True
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/homeassistant/components/efesto/climate.py
+++ b/homeassistant/components/efesto/climate.py
@@ -1,7 +1,7 @@
 """Support for Efesto heating devices."""
 import logging
 
-from efestoclient import (
+from efestoclient import (  # pylint: disable=redefined-builtin
     ConnectionError,
     EfestoClient,
     Error as EfestoError,

--- a/homeassistant/components/efesto/climate.py
+++ b/homeassistant/components/efesto/climate.py
@@ -84,21 +84,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_import)
 
 
-# def setup_platform(hass, config, add_entities, discovery_info=None):
-#     """Set up the Efesto device."""
-#     url = config.get(CONF_URL)
-#     username = config.get(CONF_USERNAME)
-#     password = config.get(CONF_PASSWORD)
-#     device = config.get(CONF_DEVICE)
-#     name = config.get(CONF_NAME)
-
-#     try:
-#         client = efestoclient.EfestoClient(url, username, password, device, False)
-#         add_entities([EfestoHeatingDevice(client, name, device)], True)
-#     except efestoclient.Error as err:
-#         _LOGGER.error("Error while connecting to the Efesto web service: %s", err)
-
-
 async def async_setup_entry(hass, entry, async_add_entities):
     """Add Efesto device entry."""
     url = entry.data[CONF_URL]

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict
 import logging
 
-from efestoclient import (
+from efestoclient import (  # pylint: disable=redefined-builtin
     ConnectionError,
     EfestoClient,
     Error as EfestoError,

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -3,11 +3,11 @@ from collections import OrderedDict
 import logging
 
 from efestoclient import (
-    EfestoClient,
-    Error,
-    UnauthorizedError,
     ConnectionError,
+    EfestoClient,
+    Error as EfestoError,
     InvalidURLError,
+    UnauthorizedError,
 )
 import voluptuous as vol
 
@@ -68,7 +68,7 @@ class EfestoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "connection_error"
             except InvalidURLError:
                 errors["base"] = "invalid_url"
-            except Error:
+            except EfestoError:
                 errors["base"] = "unknown_error"
 
             if "base" not in errors:

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -55,15 +55,6 @@ class EfestoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 client = efestoclient.EfestoClient(url, username, password, device_id)
                 client.get_status()
-                return self.async_create_entry(
-                    title=name,
-                    data={
-                        CONF_URL: url,
-                        CONF_USERNAME: username,
-                        CONF_PASSWORD: password,
-                        CONF_DEVICE: device_id,
-                    },
-                )
             except efestoclient.UnauthorizedError:
                 errors["base"] = "unauthorized"
             except efestoclient.ConnectionError:
@@ -72,6 +63,16 @@ class EfestoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_url"
             except efestoclient.Error:
                 errors["base"] = "unknown_error"
+
+            return self.async_create_entry(
+                title=name,
+                data={
+                    CONF_URL: url,
+                    CONF_USERNAME: username,
+                    CONF_PASSWORD: password,
+                    CONF_DEVICE: device_id,
+                },
+            )
         else:
             user_input = {}
 

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -24,7 +24,6 @@ def device_entries(hass):
     )
 
 
-@config_entries.HANDLERS.register(DOMAIN)
 class EfestoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Efesto Config Flow handler."""
 

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -1,0 +1,102 @@
+"""Config flow for Efesto."""
+from collections import OrderedDict
+import efestoclient
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_URL,
+    CONF_USERNAME,
+)
+from homeassistant.core import callback
+from .const import DOMAIN
+
+
+@callback
+def device_entries(hass):
+    """Return the host,port tuples for the domain."""
+    return set(
+        entry.data[CONF_DEVICE] for entry in hass.config_entries.async_entries(DOMAIN)
+    )
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class EfestoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Efesto Config Flow handler."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def _entry_in_configuration_exists(self, user_input) -> bool:
+        """Return True if device already exists in configuration."""
+        device_id = user_input[CONF_DEVICE]
+        if device_id in device_entries(self.hass):
+            return True
+        return False
+
+    async def async_step_user(self, user_input=None):
+        """User initiated integration."""
+        errors = {}
+        if user_input is not None:
+            # Validate user input
+            url = user_input[CONF_URL]
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
+            device_id = user_input[CONF_DEVICE]
+            name = user_input.get(CONF_NAME, "Efesto")
+
+            if self._entry_in_configuration_exists(user_input):
+                return self.async_abort(reason="device_already_configured")
+
+            try:
+                client = efestoclient.EfestoClient(
+                    url, username, password, device_id, False
+                )
+                client.get_status()
+                return self.async_create_entry(
+                    title=name,
+                    data={
+                        CONF_URL: url,
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: password,
+                        CONF_DEVICE: device_id,
+                    },
+                )
+            except efestoclient.Error:
+                errors["base"] = "efesto_error"
+        else:
+            user_input = {}
+
+        data_schema = OrderedDict()
+        data_schema[vol.Required(CONF_URL, default=user_input.get(CONF_URL))] = str
+        data_schema[
+            vol.Required(CONF_USERNAME, default=user_input.get(CONF_USERNAME))
+        ] = str
+        data_schema[
+            vol.Required(CONF_PASSWORD, default=user_input.get(CONF_PASSWORD))
+        ] = str
+        data_schema[
+            vol.Required(CONF_DEVICE, default=user_input.get(CONF_DEVICE))
+        ] = str
+        data_schema[vol.Optional(CONF_NAME, default=user_input.get(CONF_NAME))] = str
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors
+        )
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        if self._entry_in_configuration_exists(user_input):
+            return self.async_abort(reason="device_already_configured")
+        return self.async_create_entry(
+            title=user_input.get(CONF_NAME, "Efesto"),
+            data={
+                CONF_URL: user_input[CONF_URL],
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_DEVICE: user_input[CONF_DEVICE],
+            },
+        )

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -2,7 +2,13 @@
 from collections import OrderedDict
 import logging
 
-import efestoclient
+from efestoclient import (
+    EfestoClient,
+    Error,
+    UnauthorizedError,
+    ConnectionError,
+    InvalidURLError,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -54,15 +60,15 @@ class EfestoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="device_already_configured")
 
             try:
-                client = efestoclient.EfestoClient(url, username, password, device_id)
+                client = EfestoClient(url, username, password, device_id)
                 client.get_status()
-            except efestoclient.UnauthorizedError:
+            except UnauthorizedError:
                 errors["base"] = "unauthorized"
-            except efestoclient.ConnectionError:
+            except ConnectionError:
                 errors["base"] = "connection_error"
-            except efestoclient.InvalidURLError:
+            except InvalidURLError:
                 errors["base"] = "invalid_url"
-            except efestoclient.Error:
+            except Error:
                 errors["base"] = "unknown_error"
 
             if "base" not in errors:

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Efesto."""
 from collections import OrderedDict
 import logging
+
 import efestoclient
 import voluptuous as vol
 
@@ -12,6 +13,7 @@ from homeassistant.const import (
     CONF_URL,
     CONF_USERNAME,
 )
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/efesto/config_flow.py
+++ b/homeassistant/components/efesto/config_flow.py
@@ -64,15 +64,16 @@ class EfestoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except efestoclient.Error:
                 errors["base"] = "unknown_error"
 
-            return self.async_create_entry(
-                title=name,
-                data={
-                    CONF_URL: url,
-                    CONF_USERNAME: username,
-                    CONF_PASSWORD: password,
-                    CONF_DEVICE: device_id,
-                },
-            )
+            if "base" not in errors:
+                return self.async_create_entry(
+                    title=name,
+                    data={
+                        CONF_URL: url,
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: password,
+                        CONF_DEVICE: device_id,
+                    },
+                )
         else:
             user_input = {}
 

--- a/homeassistant/components/efesto/const.py
+++ b/homeassistant/components/efesto/const.py
@@ -1,0 +1,14 @@
+"""Efesto constants."""
+
+DOMAIN = "efesto"
+
+ATTR_DEVICE_STATUS = "device_status"
+ATTR_HUMAN_DEVICE_STATUS = "human_device_status"
+ATTR_REAL_POWER = "real_power"
+ATTR_SMOKE_TEMP = "smoke_temperature"
+
+FAN_1 = 1
+FAN_2 = 2
+FAN_3 = 3
+FAN_4 = 4
+FAN_5 = 5

--- a/homeassistant/components/efesto/manifest.json
+++ b/homeassistant/components/efesto/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "efesto",
+  "name": "Efesto",
+  "documentation": "https://www.home-assistant.io/components/efesto",
+  "requirements": ["efestoclient==0.0.8"],
+  "dependencies": [],
+  "codeowners": ["@fredericvl"]
+}

--- a/homeassistant/components/efesto/manifest.json
+++ b/homeassistant/components/efesto/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "efesto",
   "name": "Efesto",
-  "documentation": "https://www.home-assistant.io/components/efesto",
+  "documentation": "https://www.home-assistant.io/integrations/efesto",
   "requirements": ["efestoclient==0.0.10"],
   "dependencies": [],
   "codeowners": ["@fredericvl"],

--- a/homeassistant/components/efesto/manifest.json
+++ b/homeassistant/components/efesto/manifest.json
@@ -2,7 +2,8 @@
   "domain": "efesto",
   "name": "Efesto",
   "documentation": "https://www.home-assistant.io/components/efesto",
-  "requirements": ["efestoclient==0.0.8"],
+  "requirements": ["efestoclient==0.0.9"],
   "dependencies": [],
-  "codeowners": ["@fredericvl"]
+  "codeowners": ["@fredericvl"],
+  "config_flow": true
 }

--- a/homeassistant/components/efesto/manifest.json
+++ b/homeassistant/components/efesto/manifest.json
@@ -2,7 +2,7 @@
   "domain": "efesto",
   "name": "Efesto",
   "documentation": "https://www.home-assistant.io/components/efesto",
-  "requirements": ["efestoclient==0.0.9"],
+  "requirements": ["efestoclient==0.0.10"],
   "dependencies": [],
   "codeowners": ["@fredericvl"],
   "config_flow": true

--- a/homeassistant/components/efesto/strings.json
+++ b/homeassistant/components/efesto/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "title": "Efesto",
+    "step": {
+      "user": {
+        "title": "Fill in Efesto parameters",
+        "data": {
+          "url": "URL of Efesto web application",
+          "username": "Username",
+          "password": "Password",
+          "device": "Device ID of Efesto heater",
+          "name": "Friendly name for the Efesto heater"
+        }
+      }
+    },
+    "error": {
+      "efesto_error": "Failed to connect to Efesto with current parameters."
+    },
+    "abort": {
+      "device_already_configured": "Device is already configured."
+    }
+  }
+}

--- a/homeassistant/components/efesto/strings.json
+++ b/homeassistant/components/efesto/strings.json
@@ -14,7 +14,10 @@
       }
     },
     "error": {
-      "efesto_error": "Failed to connect to Efesto with current parameters."
+      "unauthorized": "Failed to login, please check credentials.",
+      "connection_error": "Connection to URL not possible.",
+      "invalid_url": "Given URL is not a valid Efesto URL.",
+      "unknown_error": "Unkown error, please double check device id."
     },
     "abort": {
       "device_already_configured": "Device is already configured."

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -22,6 +22,7 @@ FLOWS = [
     "dialogflow",
     "dynalite",
     "ecobee",
+    "efesto",
     "elgato",
     "emulated_roku",
     "esphome",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -474,6 +474,9 @@ ecoaliface==0.4.0
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4
 
+# homeassistant.components.efesto
+efestoclient==0.0.8
+
 # homeassistant.components.elgato
 elgato==0.2.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -475,7 +475,7 @@ ecoaliface==0.4.0
 eebrightbox==0.0.4
 
 # homeassistant.components.efesto
-efestoclient==0.0.8
+efestoclient==0.0.9
 
 # homeassistant.components.elgato
 elgato==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -475,7 +475,7 @@ ecoaliface==0.4.0
 eebrightbox==0.0.4
 
 # homeassistant.components.efesto
-efestoclient==0.0.9
+efestoclient==0.0.10
 
 # homeassistant.components.elgato
 elgato==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -176,6 +176,9 @@ dynalite_devices==0.1.22
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4
 
+# homeassistant.components.efesto
+efestoclient==0.0.10
+
 # homeassistant.components.elgato
 elgato==0.2.0
 

--- a/tests/components/efesto/__init__.py
+++ b/tests/components/efesto/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Efesto component."""

--- a/tests/components/efesto/test_config_flow.py
+++ b/tests/components/efesto/test_config_flow.py
@@ -1,0 +1,184 @@
+"""Tests for the Efesto config flow."""
+from unittest.mock import patch
+from efestoclient import (  # pylint: disable=redefined-builtin
+    ConnectionError,
+    Error,
+    InvalidURLError,
+    UnauthorizedError,
+)
+
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.efesto.const import DOMAIN
+from homeassistant.const import (
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_DEVICE,
+    CONF_NAME,
+)
+
+from tests.common import mock_coro
+
+
+async def test_full_form_flow(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch("efestoclient.EfestoClient") as client, patch(
+        "efestoclient.EfestoClient.get_status",
+        side_effect=client,
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.efesto.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, patch(
+        "homeassistant.components.efesto.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_URL: "http://example.com",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                CONF_DEVICE: "AABBCCDDEEFF",
+                CONF_NAME: "MyHeater",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "MyHeater"
+    assert result2["data"] == {
+        CONF_URL: "http://example.com",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+        CONF_DEVICE: "AABBCCDDEEFF",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_abort_if_device_already_configured(hass):
+    """Test we abort if device is already configured."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.efesto.config_flow.EfestoConfigFlow._entry_in_configuration_exists",
+        return_value=mock_coro(True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_URL: "http://example.com",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                CONF_DEVICE: "AABBCCDDEEFF",
+                CONF_NAME: "MyHeater",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["reason"] == "device_already_configured"
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "efestoclient.EfestoClient", side_effect=UnauthorizedError("explanation"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_URL: "http://example.com",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                CONF_DEVICE: "AABBCCDDEEFF",
+                CONF_NAME: "MyHeater",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "unauthorized"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "efestoclient.EfestoClient", side_effect=ConnectionError("explanation"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_URL: "http://example.com",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                CONF_DEVICE: "AABBCCDDEEFF",
+                CONF_NAME: "MyHeater",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "connection_error"}
+
+
+async def test_form_invalid_url(hass):
+    """Test we handle invalid url error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "efestoclient.EfestoClient", side_effect=InvalidURLError("explanation"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_URL: "http://example.com",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                CONF_DEVICE: "AABBCCDDEEFF",
+                CONF_NAME: "MyHeater",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "invalid_url"}
+
+
+async def test_form_unknown_error(hass):
+    """Test we handle unknown error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "efestoclient.EfestoClient", side_effect=Error("explanation"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_URL: "http://example.com",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                CONF_DEVICE: "AABBCCDDEEFF",
+                CONF_NAME: "MyHeater",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "unknown_error"}

--- a/tests/components/efesto/test_config_flow.py
+++ b/tests/components/efesto/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from efestoclient import (  # pylint: disable=redefined-builtin
     ConnectionError,
-    Error,
+    Error as EfestoError,
     InvalidURLError,
     UnauthorizedError,
 )
@@ -29,8 +29,10 @@ async def test_full_form_flow(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch("efestoclient.EfestoClient") as client, patch(
-        "efestoclient.EfestoClient.get_status",
+    with patch(
+        "homeassistant.components.efesto.config_flow.EfestoClient"
+    ) as client, patch(
+        "homeassistant.components.efesto.config_flow.EfestoClient.get_status",
         side_effect=client,
         return_value=mock_coro(True),
     ), patch(
@@ -95,7 +97,8 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "efestoclient.EfestoClient", side_effect=UnauthorizedError("explanation"),
+        "homeassistant.components.efesto.config_flow.EfestoClient",
+        side_effect=UnauthorizedError("explanation"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -119,7 +122,8 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "efestoclient.EfestoClient", side_effect=ConnectionError("explanation"),
+        "homeassistant.components.efesto.config_flow.EfestoClient",
+        side_effect=ConnectionError("explanation"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -143,7 +147,8 @@ async def test_form_invalid_url(hass):
     )
 
     with patch(
-        "efestoclient.EfestoClient", side_effect=InvalidURLError("explanation"),
+        "homeassistant.components.efesto.config_flow.EfestoClient",
+        side_effect=InvalidURLError("explanation"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -167,7 +172,8 @@ async def test_form_unknown_error(hass):
     )
 
     with patch(
-        "efestoclient.EfestoClient", side_effect=Error("explanation"),
+        "homeassistant.components.efesto.config_flow.EfestoClient",
+        side_effect=EfestoError("explanation"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/efesto/test_config_flow.py
+++ b/tests/components/efesto/test_config_flow.py
@@ -7,7 +7,7 @@ from efestoclient import (  # pylint: disable=redefined-builtin
     UnauthorizedError,
 )
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.efesto.const import DOMAIN
 from homeassistant.const import (
     CONF_URL,
@@ -22,7 +22,6 @@ from tests.common import mock_coro
 
 async def test_full_form_flow(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/efesto/test_config_flow.py
+++ b/tests/components/efesto/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the Efesto config flow."""
 from unittest.mock import patch
+
 from efestoclient import (  # pylint: disable=redefined-builtin
     ConnectionError,
     Error,
@@ -10,11 +11,11 @@ from efestoclient import (  # pylint: disable=redefined-builtin
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.efesto.const import DOMAIN
 from homeassistant.const import (
-    CONF_URL,
-    CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_DEVICE,
     CONF_NAME,
+    CONF_PASSWORD,
+    CONF_URL,
+    CONF_USERNAME,
 )
 
 from tests.common import mock_coro


### PR DESCRIPTION
## Description:
Efesto is the application brand name of Micronova.
Micronova manufactures the electronics for pellet stoves and can be controlled via a wifi module.
Normally the heating device is being managed through their Efesto web interface.
This platform makes it possible to manage the heating devices from your Efesto account.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11158

## Configuration
Via integrations (config flow)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
