### PR TITLE
Ensure SimpliSafe alarm control panels can return from being offline

### DIFF
--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -133,6 +133,8 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
             self._online = False
             return
 
+        self._online = True
+
         if self._system.state == SystemStates.off:
             self._state = STATE_ALARM_DISARMED
         elif self._system.state in (SystemStates.home, SystemStates.home_count):


### PR DESCRIPTION
## Description:

While creating https://github.com/home-assistant/home-assistant/pull/28666, I accidentally introduced the possibility that after going offline due to an error state, the SimpliSafe `alarm_control_panel` would never come back online. This PR fixes that.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
