### PR TITLE
Bump up ZHA dependencies.

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,11 +4,11 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
-    "bellows-homeassistant==0.10.0",
+    "bellows-homeassistant==0.11.0",
     "zha-quirks==0.0.27",
-    "zigpy-deconz==0.6.0",
-    "zigpy-homeassistant==0.10.0",
-    "zigpy-xbee-homeassistant==0.6.0",
+    "zigpy-deconz==0.7.0",
+    "zigpy-homeassistant==0.11.0",
+    "zigpy-xbee-homeassistant==0.7.0",
     "zigpy-zigate==0.5.0"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -285,7 +285,7 @@ beautifulsoup4==4.8.1
 beewi_smartclim==0.0.7
 
 # homeassistant.components.zha
-bellows-homeassistant==0.10.0
+bellows-homeassistant==0.11.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.6.2
@@ -2063,13 +2063,13 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.6.0
+zigpy-deconz==0.7.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.10.0
+zigpy-homeassistant==0.11.0
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.6.0
+zigpy-xbee-homeassistant==0.7.0
 
 # homeassistant.components.zha
 zigpy-zigate==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -103,7 +103,7 @@ av==6.1.2
 axis==25
 
 # homeassistant.components.zha
-bellows-homeassistant==0.10.0
+bellows-homeassistant==0.11.0
 
 # homeassistant.components.bom
 bomradarloop==0.1.3
@@ -640,13 +640,13 @@ zeroconf==0.23.0
 zha-quirks==0.0.27
 
 # homeassistant.components.zha
-zigpy-deconz==0.6.0
+zigpy-deconz==0.7.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.10.0
+zigpy-homeassistant==0.11.0
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.6.0
+zigpy-xbee-homeassistant==0.7.0
 
 # homeassistant.components.zha
 zigpy-zigate==0.5.0


### PR DESCRIPTION
## Description:
Bump up ZHA dependencies.
- `bellows-homeassistant==0.11.0`
- `zha-quirks==0.0.27`
- `zigpy-deconz==0.7.0`
- `zigpy-homeassistant==0.11.0`
- `zigpy-xbee-homeassistant==0.7.0`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
