### PR TITLE
Upgrade psutil to 5.6.5

### DIFF
--- a/homeassistant/components/systemmonitor/manifest.json
+++ b/homeassistant/components/systemmonitor/manifest.json
@@ -3,7 +3,7 @@
   "name": "Systemmonitor",
   "documentation": "https://www.home-assistant.io/integrations/systemmonitor",
   "requirements": [
-    "psutil==5.6.3"
+    "psutil==5.6.5"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -7,11 +7,10 @@ import psutil
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_RESOURCES, STATE_OFF, STATE_ON, CONF_TYPE
-from homeassistant.helpers.entity import Entity
+from homeassistant.const import CONF_RESOURCES, CONF_TYPE, STATE_OFF, STATE_ON
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1020,7 +1020,7 @@ prometheus_client==0.7.1
 protobuf==3.6.1
 
 # homeassistant.components.systemmonitor
-psutil==5.6.3
+psutil==5.6.5
 
 # homeassistant.components.ptvsd
 ptvsd==4.2.8


### PR DESCRIPTION
## Description:
Changelog: https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#565

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: disk_use_percent
        arg: /home
      - type: memory_free
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
