### PR TITLE
Add opentherm_gw device support

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -358,11 +358,13 @@ class OpenThermGatewayDevice:
         self.update_signal = f"{DATA_OPENTHERM_GW}_{self.gw_id}_update"
         self.options_update_signal = f"{DATA_OPENTHERM_GW}_{self.gw_id}_options_update"
         self.gateway = pyotgw.pyotgw()
+        self.gw_version = None
 
     async def connect_and_subscribe(self):
         """Connect to serial device and subscribe report handler."""
-        await self.gateway.connect(self.hass.loop, self.device_path)
+        self.status = await self.gateway.connect(self.hass.loop, self.device_path)
         _LOGGER.debug("Connected to OpenTherm Gateway at %s", self.device_path)
+        self.gw_version = self.status.get(gw_vars.OTGW_BUILD)
 
         async def cleanup(event):
             """Reset overrides on the gateway."""

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -1,4 +1,5 @@
 """Support for OpenTherm Gateway devices."""
+import asyncio
 import logging
 from datetime import datetime, date
 
@@ -344,6 +345,18 @@ def register_services(hass):
     )
 
 
+async def async_unload_entry(hass, entry):
+    """Cleanup and disconnect from gateway."""
+    await asyncio.gather(
+        hass.config_entries.async_forward_entry_unload(entry, COMP_BINARY_SENSOR),
+        hass.config_entries.async_forward_entry_unload(entry, COMP_CLIMATE),
+        hass.config_entries.async_forward_entry_unload(entry, COMP_SENSOR),
+    )
+    gateway = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][entry.data[CONF_ID]]
+    await gateway.cleanup()
+    return True
+
+
 class OpenThermGatewayDevice:
     """OpenTherm Gateway device class."""
 
@@ -360,18 +373,19 @@ class OpenThermGatewayDevice:
         self.gateway = pyotgw.pyotgw()
         self.gw_version = None
 
+    async def cleanup(self, event=None):
+        """Reset overrides on the gateway."""
+        await self.gateway.set_control_setpoint(0)
+        await self.gateway.set_max_relative_mod("-")
+        await self.gateway.disconnect()
+
     async def connect_and_subscribe(self):
         """Connect to serial device and subscribe report handler."""
         self.status = await self.gateway.connect(self.hass.loop, self.device_path)
         _LOGGER.debug("Connected to OpenTherm Gateway at %s", self.device_path)
         self.gw_version = self.status.get(gw_vars.OTGW_BUILD)
 
-        async def cleanup(event):
-            """Reset overrides on the gateway."""
-            await self.gateway.set_control_setpoint(0)
-            await self.gateway.set_max_relative_mod("-")
-
-        self.hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, cleanup)
+        self.hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, self.cleanup)
 
         async def handle_report(status):
             """Handle reports from the OpenTherm Gateway."""

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -91,7 +91,7 @@ class OpenThermBinarySensor(BinarySensorDevice):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return f"{self._gateway.gw_id}-binary-sensor-{self._var}"
+        return f"{self._gateway.gw_id}-{self._var}"
 
     @property
     def is_on(self):

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import async_generate_entity_id
 
+from . import DOMAIN
 from .const import BINARY_SENSOR_INFO, DATA_GATEWAYS, DATA_OPENTHERM_GW
 
 
@@ -62,6 +63,22 @@ class OpenThermBinarySensor(BinarySensorDevice):
     def name(self):
         """Return the friendly name."""
         return self._friendly_name
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self._gateway.gw_id)},
+            "name": self._gateway.name,
+            "manufacturer": "Schelte Bron",
+            "model": "OpenTherm Gateway",
+            "sw_version": self._gateway.gw_version,
+        }
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._gateway.gw_id}-binary-sensor-{self._var}"
 
     @property
     def is_on(self):

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -45,13 +45,21 @@ class OpenThermBinarySensor(BinarySensorDevice):
         self._state = None
         self._device_class = device_class
         self._friendly_name = friendly_name_format.format(gw_dev.name)
+        self._unsub_updates = None
 
     async def async_added_to_hass(self):
         """Subscribe to updates from the component."""
         _LOGGER.debug("Added OpenTherm Gateway binary sensor %s", self._friendly_name)
-        async_dispatcher_connect(
+        self._unsub_updates = async_dispatcher_connect(
             self.hass, self._gateway.update_signal, self.receive_report
         )
+
+    async def async_will_remove_from_hass(self):
+        """Unsubscribe from updates from the component."""
+        _LOGGER.debug(
+            "Removing OpenTherm Gateway binary sensor %s", self._friendly_name
+        )
+        self._unsub_updates()
 
     @callback
     def receive_report(self, status):

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -61,6 +61,11 @@ class OpenThermBinarySensor(BinarySensorDevice):
         )
         self._unsub_updates()
 
+    @property
+    def entity_registry_enabled_default(self):
+        """Disable binary_sensors by default."""
+        return False
+
     @callback
     def receive_report(self, status):
         """Handle status updates from the component."""

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
+from . import DOMAIN
 from .const import CONF_FLOOR_TEMP, CONF_PRECISION, DATA_GATEWAYS, DATA_OPENTHERM_GW
 
 
@@ -135,6 +136,17 @@ class OpenThermClimate(ClimateDevice):
     def name(self):
         """Return the friendly name."""
         return self.friendly_name
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self._gateway.gw_id)},
+            "name": self._gateway.name,
+            "manufacturer": "Schelte Bron",
+            "model": "OpenTherm Gateway",
+            "sw_version": self._gateway.gw_version,
+        }
 
     @property
     def unique_id(self):

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -3,7 +3,7 @@ import logging
 
 from pyotgw import vars as gw_vars
 
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import ClimateDevice, ENTITY_ID_FORMAT
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
@@ -25,6 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import async_generate_entity_id
 
 from . import DOMAIN
 from .const import CONF_FLOOR_TEMP, CONF_PRECISION, DATA_GATEWAYS, DATA_OPENTHERM_GW
@@ -54,6 +55,9 @@ class OpenThermClimate(ClimateDevice):
     def __init__(self, gw_dev, options):
         """Initialize the device."""
         self._gateway = gw_dev
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, gw_dev.gw_id, hass=gw_dev.hass
+        )
         self.friendly_name = gw_dev.name
         self.floor_temp = options[CONF_FLOOR_TEMP]
         self.temp_precision = options.get(CONF_PRECISION)

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 
+from . import DOMAIN
 from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, SENSOR_INFO
 
 
@@ -68,6 +69,22 @@ class OpenThermSensor(Entity):
     def name(self):
         """Return the friendly name of the sensor."""
         return self._friendly_name
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self._gateway.gw_id)},
+            "name": self._gateway.name,
+            "manufacturer": "Schelte Bron",
+            "model": "OpenTherm Gateway",
+            "sw_version": self._gateway.gw_version,
+        }
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._gateway.gw_id}-sensor-{self._var}"
 
     @property
     def device_class(self):

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -95,7 +95,7 @@ class OpenThermSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return f"{self._gateway.gw_id}-sensor-{self._var}"
+        return f"{self._gateway.gw_id}-{self._var}"
 
     @property
     def device_class(self):

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -48,13 +48,19 @@ class OpenThermSensor(Entity):
         self._device_class = device_class
         self._unit = unit
         self._friendly_name = friendly_name_format.format(gw_dev.name)
+        self._unsub_updates = None
 
     async def async_added_to_hass(self):
         """Subscribe to updates from the component."""
         _LOGGER.debug("Added OpenTherm Gateway sensor %s", self._friendly_name)
-        async_dispatcher_connect(
+        self._unsub_updates = async_dispatcher_connect(
             self.hass, self._gateway.update_signal, self.receive_report
         )
+
+    async def async_will_remove_from_hass(self):
+        """Unsubscribe from updates from the component."""
+        _LOGGER.debug("Removing OpenTherm Gateway sensor %s", self._friendly_name)
+        self._unsub_updates()
 
     @callback
     def receive_report(self, status):

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -62,6 +62,11 @@ class OpenThermSensor(Entity):
         _LOGGER.debug("Removing OpenTherm Gateway sensor %s", self._friendly_name)
         self._unsub_updates()
 
+    @property
+    def entity_registry_enabled_default(self):
+        """Disable sensors by default."""
+        return False
+
     @callback
     def receive_report(self, status):
         """Handle status updates from the component."""


### PR DESCRIPTION
## Breaking Change:
Breaks enabled `sensor` and `binary_sensor` entities, these are now disabled by default and can be re-enabled through the `Devices` panel.
Breaks `entity_id` of the `climate` entity in some configurations. The `entity_id` is now based on the `gateway_id` rather than the configured `name` to guarantee uniqueness.

## Description:
Add device support to the `opentherm_gw` integration.

**Related issue (if applicable):** fixes #28378 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11163

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
