### PR TITLE
Upgrade discogs_client to 2.2.2

### DIFF
--- a/homeassistant/components/discogs/manifest.json
+++ b/homeassistant/components/discogs/manifest.json
@@ -3,7 +3,7 @@
   "name": "Discogs",
   "documentation": "https://www.home-assistant.io/integrations/discogs",
   "requirements": [
-    "discogs_client==2.2.1"
+    "discogs_client==2.2.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/discogs/sensor.py
+++ b/homeassistant/components/discogs/sensor.py
@@ -66,7 +66,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Discogs sensor."""
-
     token = config[CONF_TOKEN]
     name = config[CONF_NAME]
 
@@ -104,7 +103,7 @@ class DiscogsSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self._name, SENSORS[self._type]["name"])
+        return f"{self._name} {SENSORS[self._type]['name']}"
 
     @property
     def state(self):
@@ -136,10 +135,7 @@ class DiscogsSensor(Entity):
         return {
             "cat_no": self._attrs["labels"][0]["catno"],
             "cover_image": self._attrs["cover_image"],
-            "format": "{} ({})".format(
-                self._attrs["formats"][0]["name"],
-                self._attrs["formats"][0]["descriptions"][0],
-            ),
+            "format": f"{self._attrs['formats'][0]['name']} ({self._attrs['formats'][0]['descriptions'][0]})",
             "label": self._attrs["labels"][0]["name"],
             "released": self._attrs["year"],
             ATTR_ATTRIBUTION: ATTRIBUTION,
@@ -154,9 +150,7 @@ class DiscogsSensor(Entity):
         random_record = collection.releases[random_index].release
 
         self._attrs = random_record.data
-        return "{} - {}".format(
-            random_record.data["artists"][0]["name"], random_record.data["title"]
-        )
+        return f"{random_record.data['artists'][0]['name']} - {random_record.data['title']}"
 
     def update(self):
         """Set state to the amount of records in user's collection."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -414,7 +414,7 @@ denonavr==0.7.10
 directpy==0.5
 
 # homeassistant.components.discogs
-discogs_client==2.2.1
+discogs_client==2.2.2
 
 # homeassistant.components.discord
 discord.py==1.2.4


### PR DESCRIPTION
## Description:
- Upgrade discogs_client to 2.2.2 ([commit history](https://github.com/discogs/discogs_client/commits/master))
- Update string formatting style

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: discogs
    token: !secret discogs_api
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
