### PR TITLE
Catch Zeroconf exception

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -8,7 +8,13 @@ import socket
 import ipaddress
 import voluptuous as vol
 
-from zeroconf import ServiceBrowser, ServiceInfo, ServiceStateChange, Zeroconf
+from zeroconf import (
+    ServiceBrowser,
+    ServiceInfo,
+    ServiceStateChange,
+    Zeroconf,
+    NonUniqueNameException,
+)
 
 from homeassistant import util
 from homeassistant.const import (
@@ -43,7 +49,7 @@ def setup(hass, config):
     params = {
         "version": __version__,
         "base_url": hass.config.api.base_url,
-        # always needs authentication
+        # Always needs authentication
         "requires_api_password": True,
     }
 
@@ -69,7 +75,12 @@ def setup(hass, config):
         Wait till started or otherwise HTTP is not up and running.
         """
         _LOGGER.info("Starting Zeroconf broadcast")
-        zeroconf.register_service(info)
+        try:
+            zeroconf.register_service(info)
+        except NonUniqueNameException:
+            _LOGGER.warning(
+                "Other Home Assistant instance present in the local network"
+            )
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, zeroconf_hass_start)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -78,8 +78,8 @@ def setup(hass, config):
         try:
             zeroconf.register_service(info)
         except NonUniqueNameException:
-            _LOGGER.warning(
-                "Other Home Assistant instance present in the local network"
+            _LOGGER.error(
+                "Home Assistant instance with identical name present in the local network"
             )
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, zeroconf_hass_start)


### PR DESCRIPTION
## Description:

If there is a running Home Assistant instance in the local network and the user start a second one then there is a traceback. It's more an issue which developers will encounter. 

```bash
2019-11-12 10:09:16 ERROR (MainThread) [homeassistant.core] Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/fab/Documents/repos/ha/home-assistant/homeassistant/components/zeroconf/__init__.py", line 72, in zeroconf_hass_start
    zeroconf.register_service(info)
  File "/home/fab/Documents/repos/ha/home-assistant/lib64/python3.7/site-packages/zeroconf.py", line 1921, in register_service
    self.check_service(info, allow_name_change)
  File "/home/fab/Documents/repos/ha/home-assistant/lib64/python3.7/site-packages/zeroconf.py", line 2062, in check_service
    raise NonUniqueNameException
zeroconf.NonUniqueNameException
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
default_config:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
