### PR TITLE
ESPHome fix missing state in certain circumstances

### DIFF
--- a/homeassistant/components/esphome/binary_sensor.py
+++ b/homeassistant/components/esphome/binary_sensor.py
@@ -44,6 +44,8 @@ class EsphomeBinarySensor(EsphomeEntity, BinarySensorDevice):
             return self._entry_data.available
         if self._state is None:
             return None
+        if self._state.missing_state:
+            return None
         return self._state.state
 
     @property

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -138,7 +138,7 @@ class EsphomeClimateDevice(EsphomeEntity, ClimateDevice):
     @esphome_state_property
     def preset_mode(self):
         """Return current preset mode."""
-        return PRESET_AWAY if self._state.away else None
+        return PRESET_AWAY if self._state.away else PRESET_HOME
 
     @esphome_state_property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
   "requirements": [
-    "aioesphomeapi==2.4.2"
+    "aioesphomeapi==2.5.0"
   ],
   "dependencies": [],
   "zeroconf": ["_esphomelib._tcp.local."],

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -67,6 +67,8 @@ class EsphomeSensor(EsphomeEntity):
         """Return the state of the entity."""
         if math.isnan(self._state.state):
             return None
+        if self._state.missing_state:
+            return None
         return "{:.{prec}f}".format(
             self._state.state, prec=self._static_info.accuracy_decimals
         )
@@ -96,4 +98,6 @@ class EsphomeTextSensor(EsphomeEntity):
     @esphome_state_property
     def state(self) -> Optional[str]:
         """Return the state of the entity."""
+        if self._state.missing_state:
+            return None
         return self._state.state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -142,7 +142,7 @@ aiobotocore==0.10.2
 aiodns==2.0.0
 
 # homeassistant.components.esphome
-aioesphomeapi==2.4.2
+aioesphomeapi==2.5.0
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -50,7 +50,7 @@ aioautomatic==0.6.5
 aiobotocore==0.10.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.4.2
+aioesphomeapi==2.5.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

Update to https://github.com/home-assistant/home-assistant/commit/a79a9809f492e8ff594f9ef3b2d9fdc046a0f081#diff-93f6b37515c381072b16407f6a10e77c

The mentioned change had the unintended change that entities without a valid state would remain `unavailable` until a state is present.

This PR fixes that by adding a new property in the state message that indicates if a state is missing (not known yet).

Additionally, a small change for climate preset mode is included. It worked fine before too, just the UI was a bit messed up.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
