### PR TITLE
Add an early start sensor for tado heating zones

### DIFF
--- a/homeassistant/components/tado/sensor.py
+++ b/homeassistant/components/tado/sensor.py
@@ -20,6 +20,7 @@ CLIMATE_HEAT_SENSOR_TYPES = [
     "heating",
     "tado mode",
     "overlay",
+    "early start",
 ]
 
 CLIMATE_COOL_SENSOR_TYPES = [
@@ -252,3 +253,9 @@ class TadoSensor(Entity):
             else:
                 self._state = False
                 self._state_attributes = {}
+
+        elif self.zone_variable == "early start":
+            if "preparation" in data and data["preparation"] is not None:
+                self._state = True
+            else:
+                self._state = False


### PR DESCRIPTION
## Description:
Add a sensor indicating whether a tado heating zone is 'early start' heating to meet a desired temperature+schedule combination.
'Early start' is the term the tado UI uses for this pre-heat situation, so the term should be familiar to tado users.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A; other tado sensors are not explicitly documented, merely mentioned with
> There is currently support for the following device types within Home Assistant: 
> - ...
> - Sensor - for some additional information of the zones.

## Example entry for `configuration.yaml` (if applicable):
```yaml
tado:
  username: !secret tado_username
  password: !secret tado_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
