### PR TITLE
Upgrade async_upnp_client==0.14.12

### DIFF
--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Dlna dmr",
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
   "requirements": [
-    "async-upnp-client==0.14.11"
+    "async-upnp-client==0.14.12"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
   "requirements": [
-    "async-upnp-client==0.14.11"
+    "async-upnp-client==0.14.12"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -243,7 +243,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.upnp
-async-upnp-client==0.14.11
+async-upnp-client==0.14.12
 
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -94,7 +94,7 @@ arcam-fmj==0.4.3
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.upnp
-async-upnp-client==0.14.11
+async-upnp-client==0.14.12
 
 # homeassistant.components.stream
 av==6.1.2


### PR DESCRIPTION
## Description:

Upgrade `async_upnp_client==0.14.12`, fixing https://github.com/StevenLooman/async_upnp_client/issues/41

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
