### PR TITLE
Monkeypatch imghdr bug

### DIFF
--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -65,6 +65,33 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+# Monkeypatch bug in imagehdr
+# https://stackoverflow.com/a/57693121/7969681 for details
+from imghdr import tests
+
+def test_jpeg1(h, f):
+    """JPEG data in JFIF format"""
+    if b'JFIF' in h[:23]:
+        return 'jpeg'
+
+
+JPEG_MARK = b'\xff\xd8\xff\xdb\x00C\x00\x08\x06\x06' \
+            b'\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f'
+
+def test_jpeg2(h, f):
+    """JPEG with small header"""
+    if len(h) >= 32 and 67 == h[5] and h[:32] == JPEG_MARK:
+        return 'jpeg'
+
+
+def test_jpeg3(h, f):
+    """JPEG data in JFIF or Exif format"""
+    if h[6:10] in (b'JFIF', b'Exif') or h[:2] == b'\xff\xd8':
+        return 'jpeg'
+
+tests.append(test_jpeg1)
+tests.append(test_jpeg2)
+tests.append(test_jpeg3)
 
 def get_service(hass, config, discovery_info=None):
     """Get the mail notification service."""

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -70,7 +70,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 def test_jpeg1(h, f):
-    """JPEG data in JFIF format"""
+    """JPEG data in JFIF format."""
     if b"JFIF" in h[:23]:
         return "jpeg"
 
@@ -82,13 +82,13 @@ JPEG_MARK = (
 
 
 def test_jpeg2(h, f):
-    """JPEG with small header"""
+    """JPEG with small header."""
     if len(h) >= 32 and 67 == h[5] and h[:32] == JPEG_MARK:
         return "jpeg"
 
 
 def test_jpeg3(h, f):
-    """JPEG data in JFIF or Exif format"""
+    """JPEG data in JFIF or Exif format."""
     if h[6:10] in (b"JFIF", b"Exif") or h[:2] == b"\xff\xd8":
         return "jpeg"
 

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -3,6 +3,7 @@ from email.mime.application import MIMEApplication
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from imghdr import tests
 import email.utils
 import logging
 import os
@@ -65,33 +66,37 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-# Monkeypatch bug in imagehdr
-# https://stackoverflow.com/a/57693121/7969681 for details
-from imghdr import tests
+# Monkeypatch bug in imagehdr, https://stackoverflow.com/a/57693121/7969681 for details
+
 
 def test_jpeg1(h, f):
     """JPEG data in JFIF format"""
-    if b'JFIF' in h[:23]:
-        return 'jpeg'
+    if b"JFIF" in h[:23]:
+        return "jpeg"
 
 
-JPEG_MARK = b'\xff\xd8\xff\xdb\x00C\x00\x08\x06\x06' \
-            b'\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f'
+JPEG_MARK = (
+    b"\xff\xd8\xff\xdb\x00C\x00\x08\x06\x06"
+    b"\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f"
+)
+
 
 def test_jpeg2(h, f):
     """JPEG with small header"""
     if len(h) >= 32 and 67 == h[5] and h[:32] == JPEG_MARK:
-        return 'jpeg'
+        return "jpeg"
 
 
 def test_jpeg3(h, f):
     """JPEG data in JFIF or Exif format"""
-    if h[6:10] in (b'JFIF', b'Exif') or h[:2] == b'\xff\xd8':
-        return 'jpeg'
+    if h[6:10] in (b"JFIF", b"Exif") or h[:2] == b"\xff\xd8":
+        return "jpeg"
+
 
 tests.append(test_jpeg1)
 tests.append(test_jpeg2)
 tests.append(test_jpeg3)
+
 
 def get_service(hass, config, discovery_info=None):
     """Get the mail notification service."""


### PR DESCRIPTION
Imghdr has an unresolved bug from 7 years ago where it cannot properly 
identify all possible JPEG images. This code extends the imghdr tests to 
fix this problem.

## Description:

**Related issue (if applicable):** fixes #13874, fixes #28734 

I don't expect this patch to be accepted—I'm not a python developer so I don't really have any idea what a proper fix (even as a monkeypatch) would actually look like.  I just know that this fixes the problem, and it _looks_ like its extending the underlying imghdr library in as close to a proper fashion as a monkeypatch gets.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
