### PR TITLE
Add logging to generic_thermostat component for keep-alive

### DIFF
--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -420,6 +420,7 @@ class GenericThermostat(ClimateDevice, RestoreEntity):
                     await self._async_heater_turn_off()
                 elif time is not None:
                     # The time argument is passed only in keep-alive case
+                    _LOGGER.info("Keep-alive - Turning on heater heater %s", self.heater_entity_id)
                     await self._async_heater_turn_on()
             else:
                 if (self.ac_mode and too_hot) or (not self.ac_mode and too_cold):
@@ -427,6 +428,7 @@ class GenericThermostat(ClimateDevice, RestoreEntity):
                     await self._async_heater_turn_on()
                 elif time is not None:
                     # The time argument is passed only in keep-alive case
+                    _LOGGER.info("Keep-alive - Turning off heater %s", self.heater_entity_id)
                     await self._async_heater_turn_off()
 
     @property


### PR DESCRIPTION

## Description:
Improve INFO level logging for the generic_thermostat when Keep-Alive is being used. 

When the keep alive config option is present the turn on/off service is called on the heater entity every time interval specified in keep alive. This created some odd behaviour in my particualr case.

Currently when the generic_thermostat turns on/off the heater/HVAC a log message is published but nothing is sent when Keep-Alive is called. This pull request adds some INFO level logging to make these service calls more obvious and help an end user debug/understand the functionality of keep alive. 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
