### PR TITLE
Add ombi password authentication option

### DIFF
--- a/homeassistant/components/ombi/__init__.py
+++ b/homeassistant/components/ombi/__init__.py
@@ -60,12 +60,13 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_HOST): cv.string,
                 vol.Required(CONF_USERNAME): cv.string,
-                vol.Optional(CONF_API_KEY): cv.string,
-                vol.Optional(CONF_PASSWORD): cv.string,
+                vol.Exclusive(CONF_API_KEY, "auth"): cv.string,
+                vol.Exclusive(CONF_PASSWORD, "auth"): cv.string,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                 vol.Optional(CONF_URLBASE, default=DEFAULT_URLBASE): urlbase,
                 vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-            }
+            },
+            cv.has_at_least_one_key("auth"),
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -75,21 +76,14 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the Ombi component platform."""
 
-    password = config[DOMAIN].get(CONF_PASSWORD)
-    api_key = config[DOMAIN].get(CONF_API_KEY)
-
-    if password is None and api_key is None:
-        _LOGGER.warning("Unable to setup Ombi. Neither api_key nor password supplied.")
-        return False
-
     ombi = pyombi.Ombi(
         ssl=config[DOMAIN][CONF_SSL],
         host=config[DOMAIN][CONF_HOST],
         port=config[DOMAIN][CONF_PORT],
         urlbase=config[DOMAIN][CONF_URLBASE],
         username=config[DOMAIN][CONF_USERNAME],
-        password=password,
-        api_key=api_key,
+        password=config[DOMAIN].get(CONF_PASSWORD),
+        api_key=config[DOMAIN].get(CONF_API_KEY),
     )
 
     try:

--- a/homeassistant/components/ombi/manifest.json
+++ b/homeassistant/components/ombi/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://www.home-assistant.io/integrations/ombi/",
     "dependencies": [],
     "codeowners": ["@larssont"],
-    "requirements": ["pyombi==0.1.5"]
+    "requirements": ["pyombi==0.1.10"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1376,7 +1376,7 @@ pynzbgetapi==0.2.0
 pyobihai==1.2.0
 
 # homeassistant.components.ombi
-pyombi==0.1.5
+pyombi==0.1.10
 
 # homeassistant.components.openuv
 pyopenuv==1.0.9


### PR DESCRIPTION
## Description:
Adds the option to authenticate with a user password instead of an API key. Either a password or an API key must be supplied to successfully authenticate, if both are supplied the API key takes precedence.

**Related issue (if applicable):** fixes #28274

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11169

## Example entry for `configuration.yaml` (if applicable):
```yaml
ombi:
  host: 192.168.1.120
  username: MyUsername
  password: MyPassword123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
