### PR TITLE
Add state dependent icons to moon sensor

### DIFF
--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -13,7 +13,16 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Moon"
 
-ICON = "mdi:brightness-3"
+MOON_ICONS = {
+    STATE_NEW_MOON: "mdi:moon-new",
+    STATE_WAXING_CRESCENT: "mdi:moon-waxing-crescent",
+    STATE_FIRST_QUARTER: "mdi:moon-first-quarter",
+    STATE_WAXING_GIBBOUS: "mdi:moon-waxing-gibbous",
+    STATE_FULL_MOON: "mdi:moon-full",
+    STATE_WANING_GIBBOUS: "moon-waning-gibbous",
+    STATE_LAST_QUARTER: "mdi:moon-last-quarter",
+    STATE_WANING_CRESCENT: "mdi:moon-waning-crescent"
+}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string}
@@ -62,7 +71,7 @@ class MoonSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        return ICON
+        return MOON_ICONS.get(self._state, "mdi:brightness-3")
 
     async def async_update(self):
         """Get the time and updates the states."""

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -63,20 +63,20 @@ class MoonSensor(Entity):
     def state(self):
         """Return the state of the device."""
         if self._state == 0:
-            return "new_moon"
+            return "STATE_NEW_MOON"
         if self._state < 7:
-            return "waxing_crescent"
+            return "STATE_WAXING_CRESCENT"
         if self._state == 7:
-            return "first_quarter"
+            return "STATE_FIRST_QUARTER"
         if self._state < 14:
-            return "waxing_gibbous"
+            return "STATE_WAXING_GIBBOUS"
         if self._state == 14:
-            return "full_moon"
+            return "STATE_FULL_MOON"
         if self._state < 21:
-            return "waning_gibbous"
+            return "STATE_WANING_GIBBOUS"
         if self._state == 21:
-            return "last_quarter"
-        return "waning_crescent"
+            return "STATE_LAST_QUARTER"
+        return "STATE_WANING_CRESCENT"
 
     @property
     def icon(self):

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -63,20 +63,20 @@ class MoonSensor(Entity):
     def state(self):
         """Return the state of the device."""
         if self._state == 0:
-            return "STATE_NEW_MOON"
+            return STATE_NEW_MOON
         if self._state < 7:
-            return "STATE_WAXING_CRESCENT"
+            return STATE_WAXING_CRESCENT
         if self._state == 7:
-            return "STATE_FIRST_QUARTER"
+            return STATE_FIRST_QUARTER
         if self._state < 14:
-            return "STATE_WAXING_GIBBOUS"
+            return STATE_WAXING_GIBBOUS
         if self._state == 14:
-            return "STATE_FULL_MOON"
+            return STATE_FULL_MOON
         if self._state < 21:
-            return "STATE_WANING_GIBBOUS"
+            return STATE_WANING_GIBBOUS
         if self._state == 21:
-            return "STATE_LAST_QUARTER"
-        return "STATE_WANING_CRESCENT"
+            return STATE_LAST_QUARTER
+        return STATE_WANING_CRESCENT
 
     @property
     def icon(self):

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -13,24 +13,25 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Moon"
 
-STATE_NEW_MOON = "new_moon"
-STATE_WAXING_CRESCENT = "waxing_crescent"
 STATE_FIRST_QUARTER = "first_quarter"
-STATE_WAXING_GIBBOUS = "waxing_gibbous"
 STATE_FULL_MOON = "full_moon"
-STATE_WANING_GIBBOUS = "waning_gibbous"
 STATE_LAST_QUARTER = "last_quarter"
+STATE_NEW_MOON = "new_moon"
 STATE_WANING_CRESCENT = "waning_crescent"
+STATE_WANING_GIBBOUS = "waning_gibbous"
+STATE_WAXING_GIBBOUS = "waxing_gibbous"
+STATE_WAXING_CRESCENT = "waxing_crescent"
 
 MOON_ICONS = {
-    STATE_NEW_MOON: "mdi:moon-new",
-    STATE_WAXING_CRESCENT: "mdi:moon-waxing-crescent",
     STATE_FIRST_QUARTER: "mdi:moon-first-quarter",
-    STATE_WAXING_GIBBOUS: "mdi:moon-waxing-gibbous",
     STATE_FULL_MOON: "mdi:moon-full",
-    STATE_WANING_GIBBOUS: "mdi:moon-waning-gibbous",
     STATE_LAST_QUARTER: "mdi:moon-last-quarter",
-    STATE_WANING_CRESCENT: "mdi:moon-waning-crescent"
+    STATE_NEW_MOON: "mdi:moon-new",
+    STATE_WANING_CRESCENT: "mdi:moon-waning-crescent",   
+    STATE_WANING_GIBBOUS: "mdi:moon-waning-gibbous",
+    STATE_WAXING_CRESCENT: "mdi:moon-waxing-crescent",
+    STATE_WAXING_GIBBOUS: "mdi:moon-waxing-gibbous"
+    
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -80,7 +81,7 @@ class MoonSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        return MOON_ICONS.get(self._state, "mdi:brightness-3")
+        return MOON_ICONS.get(self.state, "mdi:brightness-3")
 
     async def async_update(self):
         """Get the time and updates the states."""

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -13,6 +13,15 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Moon"
 
+STATE_NEW_MOON = "new_moon"
+STATE_WAXING_CRESCENT = "waxing_crescent"
+STATE_FIRST_QUARTER = "first_quarter"
+STATE_WAXING_GIBBOUS = "waxing_gibbous"
+STATE_FULL_MOON = "full_moon"
+STATE_WANING_GIBBOUS = "waning_gibbous"
+STATE_LAST_QUARTER = "last_quarter"
+STATE_WANING_CRESCENT = "waning_crescent"
+
 MOON_ICONS = {
     STATE_NEW_MOON: "mdi:moon-new",
     STATE_WAXING_CRESCENT: "mdi:moon-waxing-crescent",

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -28,7 +28,7 @@ MOON_ICONS = {
     STATE_FIRST_QUARTER: "mdi:moon-first-quarter",
     STATE_WAXING_GIBBOUS: "mdi:moon-waxing-gibbous",
     STATE_FULL_MOON: "mdi:moon-full",
-    STATE_WANING_GIBBOUS: "moon-waning-gibbous",
+    STATE_WANING_GIBBOUS: "mdi:moon-waning-gibbous",
     STATE_LAST_QUARTER: "mdi:moon-last-quarter",
     STATE_WANING_CRESCENT: "mdi:moon-waning-crescent"
 }

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -27,11 +27,10 @@ MOON_ICONS = {
     STATE_FULL_MOON: "mdi:moon-full",
     STATE_LAST_QUARTER: "mdi:moon-last-quarter",
     STATE_NEW_MOON: "mdi:moon-new",
-    STATE_WANING_CRESCENT: "mdi:moon-waning-crescent",   
+    STATE_WANING_CRESCENT: "mdi:moon-waning-crescent",
     STATE_WANING_GIBBOUS: "mdi:moon-waning-gibbous",
     STATE_WAXING_CRESCENT: "mdi:moon-waxing-crescent",
     STATE_WAXING_GIBBOUS: "mdi:moon-waxing-gibbous"
-    
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -1,13 +1,14 @@
 """Support for tracking the moon phases."""
 import logging
 
+from astral import Astral
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
-import homeassistant.util.dt as dt_util
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class MoonSensor(Entity):
     """Representation of a Moon sensor."""
 
     def __init__(self, name):
-        """Initialize the sensor."""
+        """Initialize the moon sensor."""
         self._name = name
         self._state = None
 
@@ -84,7 +85,5 @@ class MoonSensor(Entity):
 
     async def async_update(self):
         """Get the time and updates the states."""
-        from astral import Astral
-
         today = dt_util.as_local(dt_util.utcnow()).date()
         self._state = Astral().moon_phase(today)

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -30,7 +30,7 @@ MOON_ICONS = {
     STATE_WANING_CRESCENT: "mdi:moon-waning-crescent",
     STATE_WANING_GIBBOUS: "mdi:moon-waning-gibbous",
     STATE_WAXING_CRESCENT: "mdi:moon-waxing-crescent",
-    STATE_WAXING_GIBBOUS: "mdi:moon-waxing-gibbous"
+    STATE_WAXING_GIBBOUS: "mdi:moon-waxing-gibbous",
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(


### PR DESCRIPTION
Material design icons have icons for all sensor.states, let's use these natively in the component.
Based on the Season icons, tried to change accordingly.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
