### PR TITLE
Enable config flow for Tesla

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -675,7 +675,14 @@ omit =
     homeassistant/components/telnet/switch.py
     homeassistant/components/temper/sensor.py
     homeassistant/components/tensorflow/image_processing.py
-    homeassistant/components/tesla/*
+    homeassistant/components/tesla/__init__.py
+    homeassistant/components/tesla/binary_sensor.py
+    homeassistant/components/tesla/climate.py
+    homeassistant/components/tesla/const.py
+    homeassistant/components/tesla/device_tracker.py
+    homeassistant/components/tesla/lock.py
+    homeassistant/components/tesla/sensor.py
+    homeassistant/components/tesla/switch.py
     homeassistant/components/tfiac/climate.py
     homeassistant/components/thermoworks_smoke/sensor.py
     homeassistant/components/thethingsnetwork/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -300,7 +300,7 @@ homeassistant/components/tahoma/* @philklei
 homeassistant/components/tautulli/* @ludeeus
 homeassistant/components/tellduslive/* @fredrike
 homeassistant/components/template/* @PhracturedBlue
-homeassistant/components/tesla/* @zabuldon
+homeassistant/components/tesla/* @zabuldon @alandtse
 homeassistant/components/tfiac/* @fredrike @mellado
 homeassistant/components/thethingsnetwork/* @fabaff
 homeassistant/components/threshold/* @fabaff

--- a/homeassistant/components/tesla/.translations/en.json
+++ b/homeassistant/components/tesla/.translations/en.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "error": {
+      "connection_error": "Error connecting; check network and retry.\n{message}",
+      "identifier_exists": "Email already registered",
+      "invalid_credentials": "Invalid credentials",
+      "unknown_error": "Unknown error, please report log info"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Seconds between scans"
+        },
+        "description": "Please enter your information.",
+        "title": "Tesla - Configuration"
+      }
+    },
+    "title": "Tesla"
+  }
+}

--- a/homeassistant/components/tesla/.translations/en.json
+++ b/homeassistant/components/tesla/.translations/en.json
@@ -10,13 +10,21 @@
       "user": {
         "data": {
           "username": "Email Address",
-          "password": "Password",
-          "scan_interval": "Seconds between scans"
+          "password": "Password"
         },
         "description": "Please enter your information.",
         "title": "Tesla - Configuration"
       }
     },
     "title": "Tesla"
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Seconds between scans"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/tesla/.translations/en.json
+++ b/homeassistant/components/tesla/.translations/en.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "error": {
-      "connection_error": "Error connecting; check network and retry.\n{message}",
+      "connection_error": "Error connecting; check network and retry",
       "identifier_exists": "Email already registered",
       "invalid_credentials": "Invalid credentials",
       "unknown_error": "Unknown error, please report log info"

--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -115,7 +115,7 @@ async def async_setup_entry(hass, config_entry):
             _LOGGER.warning("Unable to communicate with Tesla API: %s", ex.message)
             return False
 
-    all_devices = await hass.data[DOMAIN][config_entry.entry_id][
+    all_devices = hass.data[DOMAIN][config_entry.entry_id][
         "controller"
     ].get_homeassistant_components()
 
@@ -221,8 +221,8 @@ class TeslaDevice(Entity):
 
     async def async_update(self):
         """Update the state of the device."""
-        if self.config_entry and await self.controller.is_token_refreshed():
-            (refresh_token, access_token) = await self.controller.get_tokens()
+        if self.config_entry and self.controller.is_token_refreshed():
+            (refresh_token, access_token) = self.controller.get_tokens()
             _async_save_refresh_token(
                 self.hass, self.config_entry, access_token, refresh_token
             )

--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -11,9 +11,11 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
-from homeassistant.helpers import aiohttp_client, config_validation as cv, discovery
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
+from .config_flow import configured_instances
 
 from .const import DOMAIN, TESLA_COMPONENTS
 
@@ -41,11 +43,44 @@ NOTIFICATION_TITLE = "Tesla integration setup"
 async def async_setup(hass, base_config):
     """Set up of Tesla component."""
     config = base_config.get(DOMAIN)
-
+    if not config:
+        return True
     email = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     update_interval = config.get(CONF_SCAN_INTERVAL)
-    if hass.data.get(DOMAIN) is None:
+    if email in configured_instances(hass):
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if email == entry.title:
+                hass.config_entries.async_update_entry(
+                    entry,
+                    data={
+                        CONF_USERNAME: email,
+                        CONF_PASSWORD: password,
+                        CONF_SCAN_INTERVAL: update_interval,
+                    },
+                )
+                break
+    else:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data={
+                    CONF_USERNAME: email,
+                    CONF_PASSWORD: password,
+                    CONF_SCAN_INTERVAL: update_interval,
+                },
+            )
+        )
+    return True
+
+
+def setup_entry(hass, config_entry):
+    """Set up Tesla as config entry."""
+
+    _LOGGER.info("Loaded teslajsonpy==%s", teslajsonpy_version)
+    if DOMAIN not in hass.data:
+        config = config_entry.data
         try:
             websession = aiohttp_client.async_get_clientsession(hass)
             controller = teslaAPI(
@@ -61,7 +96,7 @@ async def async_setup(hass, base_config):
             if ex.code == 401:
                 hass.components.persistent_notification.create(
                     "Error:<br />Please check username and password."
-                    "You will need to restart Home Assistant after fixing.",
+                    "Please remove and readd the Integration.",
                     title=NOTIFICATION_TITLE,
                     notification_id=NOTIFICATION_ID,
                 )
@@ -69,12 +104,15 @@ async def async_setup(hass, base_config):
                 hass.components.persistent_notification.create(
                     "Error:<br />Can't communicate with Tesla API.<br />"
                     "Error code: {} Reason: {}"
-                    "You will need to restart Home Assistant after fixing."
+                    "Please remove and readd the Integration.",
                     "".format(ex.code, ex.message),
                     title=NOTIFICATION_TITLE,
                     notification_id=NOTIFICATION_ID,
                 )
-            _LOGGER.error("Unable to communicate with Tesla API: %s", ex.message)
+            _LOGGER.warning("Unable to communicate with Tesla API: %s", ex.message)
+            return False
+        except BaseException as ex:
+            _LOGGER.warning("Unknown error: %s", ex)
             return False
     all_devices = controller.get_homeassistant_components()
     if not all_devices:
@@ -84,9 +122,28 @@ async def async_setup(hass, base_config):
         hass.data[DOMAIN]["devices"][device.hass_type].append(device)
 
     for component in TESLA_COMPONENTS:
-        hass.async_create_task(
-            discovery.async_load_platform(hass, component, DOMAIN, {}, base_config)
+        hass.async_add_job(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set up Tesla as config entry."""
+    return await hass.async_add_executor_job(setup_entry, hass, config_entry)
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for component in TESLA_COMPONENTS:
+        _LOGGER.debug("Attemping to unload %s", component)
+        if component == "device_tracker":
+            await hass.data[DOMAIN]["devices"]["device_tracker"].unload()
+        else:
+            await hass.config_entries.async_forward_entry_unload(entry, component)
+    username = entry.data["username"]
+    hass.data.pop(DOMAIN)
+    _LOGGER.debug("Unloaded entry for %s", username)
     return True
 
 
@@ -135,3 +192,13 @@ class TeslaDevice(Entity):
     async def async_update(self):
         """Update the state of the device."""
         await self.tesla_device.async_update()
+    @property
+    def device_info(self):
+        """Return the device_info of the device."""
+        return {
+            "identifiers": {(DOMAIN, self.tesla_device.id())},
+            "name": self.tesla_device.car_name(),
+            "manufacturer": "Tesla",
+            "model": self.tesla_device.car_type,
+            "sw_version": self.tesla_device.car_version,
+        }

--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_USERNAME,
 )
-from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -200,11 +199,6 @@ class TeslaDevice(Entity):
         return self.tesla_id
 
     @property
-    def icon(self):
-        """Return the icon of the sensor."""
-        return self._icon
-
-    @property
     def should_poll(self):
         """Return the polling state."""
         return self.tesla_device.should_poll
@@ -216,18 +210,6 @@ class TeslaDevice(Entity):
         if self.tesla_device.has_battery():
             attr[ATTR_BATTERY_LEVEL] = self.tesla_device.battery_level()
         return attr
-
-    async def async_added_to_hass(self):
-        """Register state update callback."""
-        pass
-
-    async def async_will_remove_from_hass(self):
-        """Prepare for unload."""
-        pass
-
-    async def async_update(self):
-        """Update the state of the device."""
-        await self.tesla_device.async_update()
 
     @property
     def device_info(self):
@@ -242,11 +224,11 @@ class TeslaDevice(Entity):
 
     async def async_added_to_hass(self):
         """Register state update callback."""
-        await super().async_added_to_hass()
+        pass
 
     async def async_will_remove_from_hass(self):
         """Prepare for unload."""
-        await super().async_will_remove_from_hass()
+        pass
 
     async def async_update(self):
         """Update the state of the device."""

--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -5,19 +5,23 @@ import logging
 from teslajsonpy import Controller as teslaAPI, TeslaException
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
+    CONF_ACCESS_TOKEN,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
+    CONF_TOKEN,
     CONF_USERNAME,
 )
 from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
-from .config_flow import configured_instances
 
-from .const import DOMAIN, TESLA_COMPONENTS
+from .config_flow import configured_instances
+from .const import DATA_LISTENER, DOMAIN, TESLA_COMPONENTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,8 +40,13 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-NOTIFICATION_ID = "tesla_integration_notification"
-NOTIFICATION_TITLE = "Tesla integration setup"
+
+@callback
+def _async_save_refresh_token(hass, config_entry, access_token, token):
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={**config_entry.data, CONF_ACCESS_TOKEN: access_token, CONF_TOKEN: token},
+    )
 
 
 async def async_setup(hass, base_config):
@@ -47,102 +56,94 @@ async def async_setup(hass, base_config):
         return True
     email = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    update_interval = config.get(CONF_SCAN_INTERVAL)
     if email in configured_instances(hass):
         for entry in hass.config_entries.async_entries(DOMAIN):
             if email == entry.title:
-                hass.config_entries.async_update_entry(
-                    entry,
-                    data={
-                        CONF_USERNAME: email,
-                        CONF_PASSWORD: password,
-                        CONF_SCAN_INTERVAL: update_interval,
-                    },
-                )
+                try:
+                    websession = aiohttp_client.async_get_clientsession(hass)
+                    controller = teslaAPI(
+                        websession, email=email, password=password, update_interval=300
+                    )
+                    (refresh_token, access_token) = await controller.connect(
+                        test_login=True
+                    )
+                    hass.config_entries.async_update_entry(
+                        entry,
+                        data={
+                            CONF_ACCESS_TOKEN: access_token,
+                            CONF_TOKEN: refresh_token,
+                        },
+                    )
+                except TeslaException as ex:
+                    _LOGGER.warning(
+                        "Configuration.yaml credentials cannot communicate with Tesla API: %s",
+                        ex.message,
+                    )
                 break
     else:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": SOURCE_IMPORT},
-                data={
-                    CONF_USERNAME: email,
-                    CONF_PASSWORD: password,
-                    CONF_SCAN_INTERVAL: update_interval,
-                },
+                data={CONF_USERNAME: email, CONF_PASSWORD: password},
             )
-        )
-    return True
-
-
-def setup_entry(hass, config_entry):
-    """Set up Tesla as config entry."""
-
-    _LOGGER.info("Loaded teslajsonpy==%s", teslajsonpy_version)
-    if DOMAIN not in hass.data:
-        config = config_entry.data
-        try:
-            websession = aiohttp_client.async_get_clientsession(hass)
-            controller = teslaAPI(
-                websession,
-                email=email,
-                password=password,
-                update_interval=update_interval,
-            )
-            await controller.connect(test_login=False)
-            hass.data[DOMAIN] = {"controller": controller, "devices": defaultdict(list)}
-            _LOGGER.debug("Connected to the Tesla API.")
-        except TeslaException as ex:
-            if ex.code == 401:
-                hass.components.persistent_notification.create(
-                    "Error:<br />Please check username and password."
-                    "Please remove and readd the Integration.",
-                    title=NOTIFICATION_TITLE,
-                    notification_id=NOTIFICATION_ID,
-                )
-            else:
-                hass.components.persistent_notification.create(
-                    "Error:<br />Can't communicate with Tesla API.<br />"
-                    "Error code: {} Reason: {}"
-                    "Please remove and readd the Integration.",
-                    "".format(ex.code, ex.message),
-                    title=NOTIFICATION_TITLE,
-                    notification_id=NOTIFICATION_ID,
-                )
-            _LOGGER.warning("Unable to communicate with Tesla API: %s", ex.message)
-            return False
-        except BaseException as ex:
-            _LOGGER.warning("Unknown error: %s", ex)
-            return False
-    all_devices = controller.get_homeassistant_components()
-    if not all_devices:
-        return False
-
-    for device in all_devices:
-        hass.data[DOMAIN]["devices"][device.hass_type].append(device)
-
-    for component in TESLA_COMPONENTS:
-        hass.async_add_job(
-            hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
     return True
 
 
 async def async_setup_entry(hass, config_entry):
     """Set up Tesla as config entry."""
-    return await hass.async_add_executor_job(setup_entry, hass, config_entry)
+
+    if DOMAIN not in hass.data or config_entry.entry_id not in hass.data[DOMAIN]:
+        config = config_entry.data
+        if DOMAIN not in hass.data:
+            hass.data[DOMAIN] = {}
+        try:
+            websession = aiohttp_client.async_get_clientsession(hass)
+            controller = teslaAPI(
+                websession, refresh_token=config[CONF_TOKEN], update_interval=300
+            )
+            (refresh_token, access_token) = await controller.connect()
+            _async_save_refresh_token(hass, config_entry, access_token, refresh_token)
+            hass.data[DOMAIN][config_entry.entry_id] = {
+                "controller": controller,
+                "devices": defaultdict(list),
+                DATA_LISTENER: list,
+            }
+            _LOGGER.debug("Connected to the Tesla API.")
+        except TeslaException as ex:
+            _LOGGER.warning("Unable to communicate with Tesla API: %s", ex.message)
+            return False
+
+    all_devices = await hass.data[DOMAIN][config_entry.entry_id][
+        "controller"
+    ].get_homeassistant_components()
+
+    if not all_devices:
+        return False
+
+    for device in all_devices:
+        hass.data[DOMAIN][config_entry.entry_id]["devices"][device.hass_type].append(
+            device
+        )
+
+    for component in TESLA_COMPONENTS:
+        _LOGGER.debug("Loading %s", component)
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
+        )
+    return True
 
 
-async def async_unload_entry(hass, entry) -> bool:
+async def async_unload_entry(hass, config_entry) -> bool:
     """Unload a config entry."""
     for component in TESLA_COMPONENTS:
-        _LOGGER.debug("Attemping to unload %s", component)
-        if component == "device_tracker":
-            await hass.data[DOMAIN]["devices"]["device_tracker"].unload()
-        else:
-            await hass.config_entries.async_forward_entry_unload(entry, component)
-    username = entry.data["username"]
-    hass.data.pop(DOMAIN)
+        await hass.config_entries.async_forward_entry_unload(config_entry, component)
+    if DATA_LISTENER in hass.data[DOMAIN][config_entry.entry_id]:
+        for listener in hass.data[DOMAIN][config_entry.entry_id][DATA_LISTENER]:
+            listener()
+    username = config_entry.title
+    hass.data[DOMAIN].pop(config_entry.entry_id)
     _LOGGER.debug("Unloaded entry for %s", username)
     return True
 
@@ -150,10 +151,11 @@ async def async_unload_entry(hass, entry) -> bool:
 class TeslaDevice(Entity):
     """Representation of a Tesla device."""
 
-    def __init__(self, tesla_device, controller):
+    def __init__(self, tesla_device, controller, config_entry=None):
         """Initialise the Tesla device."""
         self.tesla_device = tesla_device
         self.controller = controller
+        self.config_entry = config_entry
         self._name = self.tesla_device.name
         self.tesla_id = slugify(self.tesla_device.uniq_name)
         self._attributes = {}
@@ -167,6 +169,11 @@ class TeslaDevice(Entity):
     def unique_id(self) -> str:
         """Return a unique ID."""
         return self.tesla_id
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
 
     @property
     def should_poll(self):
@@ -192,6 +199,7 @@ class TeslaDevice(Entity):
     async def async_update(self):
         """Update the state of the device."""
         await self.tesla_device.async_update()
+
     @property
     def device_info(self):
         """Return the device_info of the device."""
@@ -202,3 +210,21 @@ class TeslaDevice(Entity):
             "model": self.tesla_device.car_type,
             "sw_version": self.tesla_device.car_version,
         }
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self):
+        """Prepare for unload."""
+        await super().async_will_remove_from_hass()
+
+    async def async_update(self):
+        """Update the state of the device."""
+        if self.config_entry and await self.controller.is_token_refreshed():
+            (refresh_token, access_token) = await self.controller.get_tokens()
+            _async_save_refresh_token(
+                self.hass, self.config_entry, access_token, refresh_token
+            )
+            _LOGGER.debug("Saving new tokens in config_entry")
+        await self.tesla_device.async_update()

--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 from collections import defaultdict
 import logging
 
-from teslajsonpy import Controller as teslaAPI, TeslaException
+from teslajsonpy import Controller as TeslaAPI, TeslaException
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
@@ -22,10 +22,10 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.util import slugify
 
 from .config_flow import (
-    configured_instances,
-    validate_input,
     CannotConnect,
     InvalidAuth,
+    configured_instances,
+    validate_input,
 )
 from .const import DATA_LISTENER, DOMAIN, TESLA_COMPONENTS
 
@@ -75,7 +75,7 @@ async def async_setup(hass, base_config):
         return True
     email = config[CONF_USERNAME]
     password = config[CONF_PASSWORD]
-    scan_interval = config.get(CONF_SCAN_INTERVAL)
+    scan_interval = config[CONF_SCAN_INTERVAL]
     if email in configured_instances(hass):
         try:
             info = await validate_input(hass, config)
@@ -100,7 +100,7 @@ async def async_setup(hass, base_config):
         async_call_later(
             hass,
             15,
-            lambda: _update_entry(email, options={CONF_SCAN_INTERVAL: scan_interval}),
+            lambda _: _update_entry(email, options={CONF_SCAN_INTERVAL: scan_interval}),
         )
     return True
 
@@ -110,11 +110,11 @@ async def async_setup_entry(hass, config_entry):
 
     if DOMAIN not in hass.data or config_entry.entry_id not in hass.data[DOMAIN]:
         config = config_entry.data
-        if DOMAIN not in hass.data:
-            hass.data[DOMAIN] = {}
+        hass.data.setdefault(DOMAIN, {})
+
         try:
             websession = aiohttp_client.async_get_clientsession(hass)
-            controller = teslaAPI(
+            controller = TeslaAPI(
                 websession,
                 refresh_token=config[CONF_TOKEN],
                 update_interval=config_entry.options.get(CONF_SCAN_INTERVAL, 300),

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -15,6 +15,21 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
         for device in hass.data[TESLA_DOMAIN]["devices"]["binary_sensor"]
     ]
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["binary_sensor"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaBinarySensor(TeslaDevice, BinarySensorDevice):

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -10,34 +10,34 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla binary sensor."""
-    devices = [
-        TeslaBinarySensor(device, hass.data[TESLA_DOMAIN]["controller"], "connectivity")
-        for device in hass.data[TESLA_DOMAIN]["devices"]["binary_sensor"]
-    ]
-    add_entities(devices, True)
-    return True
+    if discovery_info is None:
+        return
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Tesla binary_sensors by config_entry."""
-    return await hass.async_add_executor_job(
-        setup_platform, hass, config_entry.data, async_add_devices, None
+    async_add_devices(
+        [
+            TeslaBinarySensor(
+                device,
+                hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"],
+                "connectivity",
+                config_entry,
+            )
+            for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"][
+                "binary_sensor"
+            ]
+        ],
+        True,
     )
-
-
-async def async_unload_entry(hass, entry) -> bool:
-    """Unload a config entry."""
-    for device in hass.data[TESLA_DOMAIN]["devices"]["binary_sensor"]:
-        await device.async_remove()
-    return True
 
 
 class TeslaBinarySensor(TeslaDevice, BinarySensorDevice):
     """Implement an Tesla binary sensor for parking and charger."""
 
-    def __init__(self, tesla_device, controller, sensor_type):
+    def __init__(self, tesla_device, controller, sensor_type, config_entry=None):
         """Initialise of a Tesla binary sensor."""
-        super().__init__(tesla_device, controller)
+        super().__init__(tesla_device, controller, config_entry)
         self._state = False
         self._sensor_type = sensor_type
 

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -10,8 +10,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla binary sensor."""
-    if discovery_info is None:
-        return
+    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -8,7 +8,7 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Tesla binary sensor."""
     pass
 
@@ -34,7 +34,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class TeslaBinarySensor(TeslaDevice, BinarySensorDevice):
     """Implement an Tesla binary sensor for parking and charger."""
 
-    def __init__(self, tesla_device, controller, sensor_type, config_entry=None):
+    def __init__(self, tesla_device, controller, sensor_type, config_entry):
         """Initialise of a Tesla binary sensor."""
         super().__init__(tesla_device, controller, config_entry)
         self._state = False

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -15,7 +15,7 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
-    async_add_devices(
+    async_add_entities(
         [
             TeslaBinarySensor(
                 device,

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -13,7 +13,7 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
     async_add_devices(
         [

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT,
+    HVAC_MODE_AUTO,
     HVAC_MODE_OFF,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -13,39 +13,38 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+SUPPORT_HVAC = [HVAC_MODE_AUTO, HVAC_MODE_OFF]
 
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla climate platform."""
-    devices = [
-        TeslaThermostat(device, hass.data[TESLA_DOMAIN]["controller"])
-        for device in hass.data[TESLA_DOMAIN]["devices"]["climate"]
-    ]
-    add_entities(devices, True)
-    return True
+    if discovery_info is None:
+        return
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Tesla binary_sensors by config_entry."""
-    return await hass.async_add_executor_job(
-        setup_platform, hass, config_entry.data, async_add_devices, None
+    async_add_devices(
+        [
+            TeslaThermostat(
+                device,
+                hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"],
+                config_entry,
+            )
+            for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"][
+                "climate"
+            ]
+        ],
+        True,
     )
-
-
-async def async_unload_entry(hass, entry) -> bool:
-    """Unload a config entry."""
-    for device in hass.data[TESLA_DOMAIN]["devices"]["climate"]:
-        await device.async_remove()
-    return True
 
 
 class TeslaThermostat(TeslaDevice, ClimateDevice):
     """Representation of a Tesla climate."""
 
-    def __init__(self, tesla_device, controller):
+    def __init__(self, tesla_device, controller, config_entry=None):
         """Initialize the Tesla device."""
-        super().__init__(tesla_device, controller)
+        super().__init__(tesla_device, controller, config_entry)
         self._target_temperature = None
         self._temperature = None
 
@@ -61,7 +60,7 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         Need to be one of HVAC_MODE_*.
         """
         if self.tesla_device.is_hvac_enabled():
-            return HVAC_MODE_HEAT
+            return HVAC_MODE_AUTO
         return HVAC_MODE_OFF
 
     @property

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -13,7 +13,7 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_HVAC = [HVAC_MODE_AUTO, HVAC_MODE_OFF]
+SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
 
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
@@ -60,7 +60,7 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         Need to be one of HVAC_MODE_*.
         """
         if self.tesla_device.is_hvac_enabled():
-            return HVAC_MODE_AUTO
+            return HVAC_MODE_HEAT
         return HVAC_MODE_OFF
 
     @property

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -23,6 +23,21 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
         for device in hass.data[TESLA_DOMAIN]["devices"]["climate"]
     ]
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["climate"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaThermostat(TeslaDevice, ClimateDevice):

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -18,8 +18,7 @@ SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla climate platform."""
-    if discovery_info is None:
-        return
+    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -16,14 +16,14 @@ _LOGGER = logging.getLogger(__name__)
 SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
 
 
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Tesla climate platform."""
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
-    async_add_devices(
+    async_add_entities(
         [
             TeslaThermostat(
                 device,
@@ -41,7 +41,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 class TeslaThermostat(TeslaDevice, ClimateDevice):
     """Representation of a Tesla climate."""
 
-    def __init__(self, tesla_device, controller, config_entry=None):
+    def __init__(self, tesla_device, controller, config_entry):
         """Initialize the Tesla device."""
         super().__init__(tesla_device, controller, config_entry)
         self._target_temperature = None

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -36,9 +36,6 @@ class TeslaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    def __init__(self):
-        """Initialize the config flow."""
-
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
         return await self.async_step_user(import_config)

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -38,8 +38,6 @@ class TeslaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize the config flow."""
-        self.login = None
-        self.config = {}
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
@@ -63,8 +61,6 @@ class TeslaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors={CONF_USERNAME: "identifier_exists"},
                 description_placeholders={},
             )
-
-        self.config[CONF_USERNAME] = user_input[CONF_USERNAME]
 
         try:
             info = await validate_input(self.hass, user_input)

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -1,0 +1,107 @@
+"""Tesla Config Flow."""
+from collections import OrderedDict, defaultdict
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+
+DOMAIN = "tesla"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def configured_instances(hass):
+    """Return a set of configured Tesla instances."""
+    return set(entry.title for entry in hass.config_entries.async_entries(DOMAIN))
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class TeslaFlowHandler(config_entries.ConfigFlow):
+    """Handle a Tesla config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize the config flow."""
+        self.login = None
+        self.config = OrderedDict()
+        self.data_schema = OrderedDict(
+            [
+                (vol.Required(CONF_USERNAME), str),
+                (vol.Required(CONF_PASSWORD), str),
+                (
+                    vol.Optional(CONF_SCAN_INTERVAL, default=300),
+                    vol.All(cv.positive_int, vol.Clamp(min=300)),
+                ),
+            ]
+        )
+
+    async def _show_form(
+        self, step="user", placeholders=None, errors=None, data_schema=None
+    ) -> None:
+        """Show the form to the user."""
+        _LOGGER.debug("show_form %s %s %s %s", step, placeholders, errors, data_schema)
+        data_schema = data_schema or vol.Schema(self.data_schema)
+        if step == "user":
+            return self.async_show_form(
+                step_id=step,
+                data_schema=data_schema,
+                errors=errors if errors else {},
+                description_placeholders=placeholders if placeholders else {},
+            )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        from teslajsonpy import Controller as teslaAPI, TeslaException
+
+        if not user_input:
+            return await self._show_form(data_schema=vol.Schema(self.data_schema))
+
+        if user_input[CONF_USERNAME] in configured_instances(self.hass):
+            return await self._show_form(errors={CONF_USERNAME: "identifier_exists"})
+
+        self.config[CONF_USERNAME] = user_input[CONF_USERNAME]
+        self.config[CONF_PASSWORD] = user_input[CONF_PASSWORD]
+        from datetime import timedelta
+
+        self.config[CONF_SCAN_INTERVAL] = (
+            user_input[CONF_SCAN_INTERVAL]
+            if not isinstance(user_input[CONF_SCAN_INTERVAL], timedelta)
+            else user_input[CONF_SCAN_INTERVAL].total_seconds()
+        )
+
+        try:
+            controller = teslaAPI(
+                self.config[CONF_USERNAME],
+                self.config[CONF_PASSWORD],
+                self.config[CONF_SCAN_INTERVAL],
+            )
+            self.hass.data[DOMAIN] = {
+                "controller": controller,
+                "devices": defaultdict(list),
+            }
+            _LOGGER.debug("Connected to the Tesla API.")
+            return self.async_create_entry(
+                title=self.config[CONF_USERNAME], data=self.config
+            )
+        except TeslaException as ex:
+            if ex.code == 401:
+                return await self._show_form(errors={"base": "invalid_credentials"})
+            _LOGGER.error("Unable to communicate with Tesla API: %s", ex.message)
+            return await self._show_form(
+                errors={"base": "connection_error"},
+                placeholders={"message": f"\n> {ex.message}"},
+            )
+        except BaseException as ex:
+            _LOGGER.warning("Unknown error: %s", ex)
+            return await self._show_form(errors={"base": "unknown_error"})

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -61,7 +61,12 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         if user_input[CONF_USERNAME] in configured_instances(self.hass):
-            return await self._show_form(errors={CONF_USERNAME: "identifier_exists"})
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.data_schema,
+                errors={CONF_USERNAME: "identifier_exists"},
+                description_placeholders={},
+            )
 
         self.config[CONF_USERNAME] = user_input[CONF_USERNAME]
 

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -53,7 +53,12 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the start of the config flow."""
 
         if not user_input:
-            return await self._show_form(data_schema=self.data_schema)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.data_schema,
+                errors={},
+                description_placeholders={},
+            )
 
         if user_input[CONF_USERNAME] in configured_instances(self.hass):
             return await self._show_form(errors={CONF_USERNAME: "identifier_exists"})
@@ -64,21 +69,18 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             info = await validate_input(self.hass, user_input)
             return self.async_create_entry(title=user_input[CONF_USERNAME], data=info)
         except CannotConnect:
-            return await self._show_form(errors={"base": "connection_error"})
-        except InvalidAuth:
-            return await self._show_form(errors={"base": "invalid_credentials"})
-
-    async def _show_form(
-        self, step="user", placeholders=None, errors=None, data_schema=None
-    ) -> None:
-        """Show the form to the user."""
-        data_schema = data_schema or self.data_schema
-        if step == "user":
             return self.async_show_form(
-                step_id=step,
-                data_schema=data_schema,
-                errors=errors if errors else {},
-                description_placeholders=placeholders if placeholders else {},
+                step_id="user",
+                data_schema=self.data_schema,
+                errors={"base": "connection_error"},
+                description_placeholders={},
+            )
+        except InvalidAuth:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.data_schema,
+                errors={"base": "invalid_credentials"},
+                description_placeholders={},
             )
 
     @staticmethod

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -3,6 +3,9 @@ import logging
 
 import voluptuous as vol
 
+from teslajsonpy import Controller as teslaAPI
+from teslajsonpy import TeslaException
+
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
@@ -14,8 +17,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers import config_validation as cv
-from teslajsonpy import Controller as teslaAPI
-from teslajsonpy import TeslaException
 
 from .const import DOMAIN
 

--- a/homeassistant/components/tesla/device_tracker.py
+++ b/homeassistant/components/tesla/device_tracker.py
@@ -4,6 +4,8 @@ import logging
 from homeassistant.helpers.event import async_track_utc_time_change
 from homeassistant.util import slugify
 
+from homeassistant.components.device_tracker import see as dev_see
+
 from . import DOMAIN as TESLA_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -11,11 +13,25 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     """Set up the Tesla tracker."""
-    tracker = TeslaDeviceTracker(
+    hass.data[TESLA_DOMAIN]["devices"]["device_tracker"] = tracker = TeslaDeviceTracker(
         hass, config, async_see, hass.data[TESLA_DOMAIN]["devices"]["devices_tracker"]
     )
     await tracker.update_info()
     async_track_utc_time_change(hass, tracker.update_info, second=range(0, 60, 30))
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_scanner, hass, config_entry.data, dev_see, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    _LOGGER.debug("Unloading %s", hass.data[TESLA_DOMAIN]["devices"]["device_tracker"])
+    hass.data[TESLA_DOMAIN]["devices"]["device_tracker"].unload()
     return True
 
 
@@ -27,6 +43,9 @@ class TeslaDeviceTracker:
         self.hass = hass
         self.see = see
         self.devices = tesla_devices
+        self._listener = track_utc_time_change(
+            self.hass, self.update_info, second=range(0, 60, 30)
+        )
 
     async def update_info(self, now=None):
         """Update the device info."""
@@ -43,3 +62,7 @@ class TeslaDeviceTracker:
                 await self.see(
                     dev_id=dev_id, host_name=name, gps=(lat, lon), attributes=attrs
                 )
+
+    async def unload(self):
+        """Update the device info."""
+        self.hass.async_add_executor_job(self._listener)

--- a/homeassistant/components/tesla/device_tracker.py
+++ b/homeassistant/components/tesla/device_tracker.py
@@ -1,68 +1,81 @@
 """Support for tracking Tesla cars."""
 import logging
 
-from homeassistant.helpers.event import async_track_utc_time_change
 from homeassistant.util import slugify
 
-from homeassistant.components.device_tracker import see as dev_see
+from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
 
-from . import DOMAIN as TESLA_DOMAIN
+from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_scanner(hass, config, async_see, discovery_info=None):
-    """Set up the Tesla tracker."""
-    hass.data[TESLA_DOMAIN]["devices"]["device_tracker"] = tracker = TeslaDeviceTracker(
-        hass, config, async_see, hass.data[TESLA_DOMAIN]["devices"]["devices_tracker"]
-    )
-    await tracker.update_info()
-    async_track_utc_time_change(hass, tracker.update_info, second=range(0, 60, 30))
-    return True
-
-
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Tesla binary_sensors by config_entry."""
-    return await hass.async_add_executor_job(
-        setup_scanner, hass, config_entry.data, dev_see, None
-    )
+    devices = [
+        TeslaDeviceEntity(
+            device,
+            hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"],
+            config_entry,
+        )
+        for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"][
+            "devices_tracker"
+        ]
+    ]
+    async_add_devices(devices, True)
 
 
-async def async_unload_entry(hass, entry) -> bool:
-    """Unload a config entry."""
-    _LOGGER.debug("Unloading %s", hass.data[TESLA_DOMAIN]["devices"]["device_tracker"])
-    hass.data[TESLA_DOMAIN]["devices"]["device_tracker"].unload()
-    return True
-
-
-class TeslaDeviceTracker:
+class TeslaDeviceEntity(TrackerEntity, TeslaDevice):
     """A class representing a Tesla device."""
 
-    def __init__(self, hass, config, see, tesla_devices):
+    def __init__(self, tesla_device, controller, config_entry=None):
         """Initialize the Tesla device scanner."""
-        self.hass = hass
-        self.see = see
-        self.devices = tesla_devices
-        self._listener = track_utc_time_change(
-            self.hass, self.update_info, second=range(0, 60, 30)
-        )
+        super().__init__(tesla_device, controller, config_entry)
+        self._unique_id = slugify(self.tesla_device.uniq_name)
+        self._latitude = None
+        self._longitude = None
+        self._attributes = {
+            "trackr_id": self.unique_id,
+            "id": self.unique_id,
+            "name": self.name,
+        }
+        self._listener = None
 
-    async def update_info(self, now=None):
+    async def async_update(self):
         """Update the device info."""
-        for device in self.devices:
-            await device.async_update()
-            name = device.name
-            _LOGGER.debug("Updating device position: %s", name)
-            dev_id = slugify(device.uniq_name)
-            location = device.get_location()
-            if location:
-                lat = location["latitude"]
-                lon = location["longitude"]
-                attrs = {"trackr_id": dev_id, "id": dev_id, "name": name}
-                await self.see(
-                    dev_id=dev_id, host_name=name, gps=(lat, lon), attributes=attrs
-                )
+        _LOGGER.debug("Updating device position: %s", self.name)
+        await super().async_update()
+        location = self.tesla_device.get_location()
+        if location:
+            self._latitude = location["latitude"]
+            self._longitude = location["longitude"]
+            self._attributes = {
+                "trackr_id": self.unique_id,
+                "id": self.unique_id,
+                "name": self.name,
+                "gps": (self.latitude, self.longitude),
+                "heading": location["heading"],
+                "speed": location["speed"],
+                "source_type": self.source_type,
+            }
 
-    async def unload(self):
-        """Update the device info."""
-        self.hass.async_add_executor_job(self._listener)
+    @property
+    def latitude(self) -> float:
+        """Return latitude value of the device."""
+        return self._latitude
+
+    @property
+    def longitude(self) -> float:
+        """Return longitude value of the device."""
+        return self._longitude
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return True
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return SOURCE_TYPE_GPS

--- a/homeassistant/components/tesla/device_tracker.py
+++ b/homeassistant/components/tesla/device_tracker.py
@@ -1,8 +1,6 @@
 """Support for tracking Tesla cars."""
 import logging
 
-from homeassistant.util import slugify
-
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 
@@ -11,9 +9,9 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
-    devices = [
+    entities = [
         TeslaDeviceEntity(
             device,
             hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"],
@@ -23,23 +21,18 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             "devices_tracker"
         ]
     ]
-    async_add_devices(devices, True)
+    async_add_entities(entities, True)
 
 
 class TeslaDeviceEntity(TrackerEntity, TeslaDevice):
     """A class representing a Tesla device."""
 
-    def __init__(self, tesla_device, controller, config_entry=None):
+    def __init__(self, tesla_device, controller, config_entry):
         """Initialize the Tesla device scanner."""
         super().__init__(tesla_device, controller, config_entry)
-        self._unique_id = slugify(self.tesla_device.uniq_name)
         self._latitude = None
         self._longitude = None
-        self._attributes = {
-            "trackr_id": self.unique_id,
-            "id": self.unique_id,
-            "name": self.name,
-        }
+        self._attributes = {"trackr_id": self.unique_id}
         self._listener = None
 
     async def async_update(self):
@@ -52,12 +45,8 @@ class TeslaDeviceEntity(TrackerEntity, TeslaDevice):
             self._longitude = location["longitude"]
             self._attributes = {
                 "trackr_id": self.unique_id,
-                "id": self.unique_id,
-                "name": self.name,
-                "gps": (self.latitude, self.longitude),
                 "heading": location["heading"],
                 "speed": location["speed"],
-                "source_type": self.source_type,
             }
 
     @property
@@ -72,7 +61,7 @@ class TeslaDeviceEntity(TrackerEntity, TeslaDevice):
 
     @property
     def should_poll(self):
-        """No polling needed."""
+        """Return whether polling is needed."""
         return True
 
     @property

--- a/homeassistant/components/tesla/device_tracker.py
+++ b/homeassistant/components/tesla/device_tracker.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(entities, True)
 
 
-class TeslaDeviceEntity(TrackerEntity, TeslaDevice):
+class TeslaDeviceEntity(TeslaDevice, TrackerEntity):
     """A class representing a Tesla device."""
 
     def __init__(self, tesla_device, controller, config_entry):

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -11,8 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla lock platform."""
-    if discovery_info is None:
-        return
+    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -11,35 +11,37 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla lock platform."""
-    devices = [
-        TeslaLock(device, hass.data[TESLA_DOMAIN]["controller"])
-        for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]
-    ]
-    add_entities(devices, True)
-    return True
+    if discovery_info is None:
+        return
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Tesla binary_sensors by config_entry."""
-    return await hass.async_add_executor_job(
-        setup_platform, hass, config_entry.data, async_add_devices, None
-    )
+    devices = [
+        TeslaLock(
+            device,
+            hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"],
+            config_entry,
+        )
+        for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"]["lock"]
+    ]
+    async_add_devices(devices, True)
 
 
-async def async_unload_entry(hass, entry) -> bool:
-    """Unload a config entry."""
-    for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]:
-        await device.async_remove()
-    return True
+# async def async_unload_entry(hass, entry) -> bool:
+#     """Unload a config entry."""
+#     for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]:
+#         await device.async_remove()
+#     return True
 
 
 class TeslaLock(TeslaDevice, LockDevice):
     """Representation of a Tesla door lock."""
 
-    def __init__(self, tesla_device, controller):
+    def __init__(self, tesla_device, controller, config_entry=None):
         """Initialise of the lock."""
         self._state = None
-        super().__init__(tesla_device, controller)
+        super().__init__(tesla_device, controller, config_entry)
 
     async def async_lock(self, **kwargs):
         """Send the lock command."""

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -16,6 +16,21 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
         for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]
     ]
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaLock(TeslaDevice, LockDevice):

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -9,14 +9,14 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Tesla lock platform."""
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
-    devices = [
+    entities = [
         TeslaLock(
             device,
             hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"],
@@ -24,20 +24,13 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         )
         for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"]["lock"]
     ]
-    async_add_devices(devices, True)
-
-
-# async def async_unload_entry(hass, entry) -> bool:
-#     """Unload a config entry."""
-#     for device in hass.data[TESLA_DOMAIN]["devices"]["lock"]:
-#         await device.async_remove()
-#     return True
+    async_add_entities(entities, True)
 
 
 class TeslaLock(TeslaDevice, LockDevice):
     """Representation of a Tesla door lock."""
 
-    def __init__(self, tesla_device, controller, config_entry=None):
+    def __init__(self, tesla_device, controller, config_entry):
         """Initialise of the lock."""
         self._state = None
         super().__init__(tesla_device, controller, config_entry)

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "tesla",
   "name": "Tesla",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
   "requirements": ["teslajsonpy==0.2.0"],
   "dependencies": [],

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tesla",
   "requirements": ["teslajsonpy==0.2.0"],
   "dependencies": [],
-  "codeowners": ["@zabuldon"]
+  "codeowners": ["@zabuldon", "@alandtse"]
 }

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -93,6 +93,9 @@ class TeslaSensor(TeslaDevice, Entity):
             self._attributes = {
                 "time_left": self.tesla_device.time_left,
                 "added_range": self.tesla_device.added_range,
+                "charge_current_request": self.tesla_device.charge_current_request,
+                "charger_actual_current": self.tesla_device.charger_actual_current,
+                "charger_voltage": self.tesla_device.charger_voltage,
             }
         else:
             self.current_value = self.tesla_device.get_value()

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -26,6 +26,21 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
         elif device.bin_type in [0xA, 0xB, 0x5]:
             devices.append(TeslaSensor(device, controller))
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["sensor"]:
+        await device.async_remove()
+    return True
 
 
 class TeslaSensor(TeslaDevice, Entity):

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -16,43 +16,32 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla sensor platform."""
-    controller = hass.data[TESLA_DOMAIN]["devices"]["controller"]
-    devices = []
-
-    for device in hass.data[TESLA_DOMAIN]["devices"]["sensor"]:
-        if device.bin_type == 0x4:
-            devices.append(TeslaSensor(device, controller, "inside"))
-            devices.append(TeslaSensor(device, controller, "outside"))
-        elif device.bin_type in [0xA, 0xB, 0x5]:
-            devices.append(TeslaSensor(device, controller))
-    add_entities(devices, True)
-    return True
+    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Tesla binary_sensors by config_entry."""
-    return await hass.async_add_executor_job(
-        setup_platform, hass, config_entry.data, async_add_devices, None
-    )
-
-
-async def async_unload_entry(hass, entry) -> bool:
-    """Unload a config entry."""
-    for device in hass.data[TESLA_DOMAIN]["devices"]["sensor"]:
-        await device.async_remove()
-    return True
+    controller = hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"]
+    devices = []
+    for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"]["sensor"]:
+        if device.bin_type == 0x4:
+            devices.append(TeslaSensor(device, controller, "inside", config_entry))
+            devices.append(TeslaSensor(device, controller, "outside", config_entry))
+        elif device.bin_type in [0xA, 0xB, 0x5]:
+            devices.append(TeslaSensor(device, controller))
+    async_add_devices(devices, True)
 
 
 class TeslaSensor(TeslaDevice, Entity):
     """Representation of Tesla sensors."""
 
-    def __init__(self, tesla_device, controller, sensor_type=None):
+    def __init__(self, tesla_device, controller, sensor_type=None, config_entry=None):
         """Initialize of the sensor."""
         self.current_value = None
         self._unit = None
         self.last_changed_time = None
         self.type = sensor_type
-        super().__init__(tesla_device, controller)
+        super().__init__(tesla_device, controller, config_entry)
 
         if self.type:
             self._name = f"{self.tesla_device.name} ({self.type})"
@@ -98,6 +87,13 @@ class TeslaSensor(TeslaDevice, Entity):
                 self._unit = LENGTH_KILOMETERS
                 self.current_value /= 0.621371
                 self.current_value = round(self.current_value, 2)
+        elif self.tesla_device.bin_type == 0xC:
+            self.current_value = self.tesla_device.charging_rate
+            self._unit = self.tesla_device.measurement
+            self._attributes = {
+                "time_left": self.tesla_device.time_left,
+                "added_range": self.tesla_device.added_range,
+            }
         else:
             self.current_value = self.tesla_device.get_value()
             if self.tesla_device.bin_type == 0x5:

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -87,16 +87,6 @@ class TeslaSensor(TeslaDevice, Entity):
                 self._unit = LENGTH_KILOMETERS
                 self.current_value /= 0.621371
                 self.current_value = round(self.current_value, 2)
-        elif self.tesla_device.bin_type == 0xC:
-            self.current_value = self.tesla_device.charging_rate
-            self._unit = self.tesla_device.measurement
-            self._attributes = {
-                "time_left": self.tesla_device.time_left,
-                "added_range": self.tesla_device.added_range,
-                "charge_current_request": self.tesla_device.charge_current_request,
-                "charger_actual_current": self.tesla_device.charger_actual_current,
-                "charger_voltage": self.tesla_device.charger_voltage,
-            }
         else:
             self.current_value = self.tesla_device.get_value()
             if self.tesla_device.bin_type == 0x5:

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -14,7 +14,7 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Tesla sensor platform."""
     pass
 
@@ -22,20 +22,20 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
     controller = hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"]
-    devices = []
+    entities = []
     for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"]["sensor"]:
         if device.bin_type == 0x4:
-            devices.append(TeslaSensor(device, controller, "inside", config_entry))
-            devices.append(TeslaSensor(device, controller, "outside", config_entry))
+            entities.append(TeslaSensor(device, controller, config_entry, "inside"))
+            entities.append(TeslaSensor(device, controller, config_entry, "outside"))
         elif device.bin_type in [0xA, 0xB, 0x5]:
-            devices.append(TeslaSensor(device, controller))
-    async_add_entities(devices, True)
+            entities.append(TeslaSensor(device, controller, config_entry))
+    async_add_entities(entities, True)
 
 
 class TeslaSensor(TeslaDevice, Entity):
     """Representation of Tesla sensors."""
 
-    def __init__(self, tesla_device, controller, sensor_type=None, config_entry=None):
+    def __init__(self, tesla_device, controller, config_entry, sensor_type=None):
         """Initialize of the sensor."""
         self.current_value = None
         self._unit = None

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -19,7 +19,7 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
     controller = hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"]
     devices = []

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             devices.append(TeslaSensor(device, controller, "outside", config_entry))
         elif device.bin_type in [0xA, 0xB, 0x5]:
             devices.append(TeslaSensor(device, controller))
-    async_add_devices(devices, True)
+    async_add_entities(devices, True)
 
 
 class TeslaSensor(TeslaDevice, Entity):

--- a/homeassistant/components/tesla/strings.json
+++ b/homeassistant/components/tesla/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "error": {
+      "connection_error": "Error connecting; check network and retry",
+      "identifier_exists": "Email already registered",
+      "invalid_credentials": "Invalid credentials",
+      "unknown_error": "Unknown error, please report log info"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Seconds between scans"
+        },
+        "description": "Please enter your information.",
+        "title": "Tesla - Configuration"
+      }
+    },
+    "title": "Tesla"
+  }
+}

--- a/homeassistant/components/tesla/strings.json
+++ b/homeassistant/components/tesla/strings.json
@@ -10,13 +10,21 @@
       "user": {
         "data": {
           "username": "Email Address",
-          "password": "Password",
-          "scan_interval": "Seconds between scans"
+          "password": "Password"
         },
         "description": "Please enter your information.",
         "title": "Tesla - Configuration"
       }
     },
     "title": "Tesla"
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Seconds between scans"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -102,12 +102,12 @@ class UpdateSwitch(TeslaDevice, SwitchDevice):
     async def async_turn_on(self, **kwargs):
         """Send the on command."""
         _LOGGER.debug("Enable updates: %s %s", self._name, self.tesla_device.id())
-        await self.controller.set_updates(self.tesla_device.id(), True)
+        self.controller.set_updates(self.tesla_device.id(), True)
 
     async def async_turn_off(self, **kwargs):
         """Send the off command."""
         _LOGGER.debug("Disable updates: %s %s", self._name, self.tesla_device.id())
-        await self.controller.set_updates(self.tesla_device.id(), False)
+        self.controller.set_updates(self.tesla_device.id(), False)
 
     @property
     def is_on(self):

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -11,8 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tesla switch platform."""
-    if discovery_info is None:
-        return
+    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -20,6 +20,21 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
         elif device.bin_type == 0x9:
             devices.append(RangeSwitch(device, controller))
     add_entities(devices, True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Tesla binary_sensors by config_entry."""
+    return await hass.async_add_executor_job(
+        setup_platform, hass, config_entry.data, async_add_devices, None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    for device in hass.data[TESLA_DOMAIN]["devices"]["switch"]:
+        await device.async_remove()
+    return True
 
 
 class ChargerSwitch(TeslaDevice, SwitchDevice):

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -9,28 +9,28 @@ from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Tesla switch platform."""
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Tesla binary_sensors by config_entry."""
     controller = hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"]
-    devices = []
+    entities = []
     for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"]["switch"]:
         if device.bin_type == 0x8:
-            devices.append(ChargerSwitch(device, controller, config_entry))
-            devices.append(UpdateSwitch(device, controller, config_entry))
+            entities.append(ChargerSwitch(device, controller, config_entry))
+            entities.append(UpdateSwitch(device, controller, config_entry))
         elif device.bin_type == 0x9:
-            devices.append(RangeSwitch(device, controller, config_entry))
-    async_add_devices(devices, True)
+            entities.append(RangeSwitch(device, controller, config_entry))
+    async_add_entities(entities, True)
 
 
 class ChargerSwitch(TeslaDevice, SwitchDevice):
     """Representation of a Tesla charger switch."""
 
-    def __init__(self, tesla_device, controller, config_entry=None):
+    def __init__(self, tesla_device, controller, config_entry):
         """Initialise of the switch."""
         self._state = None
         super().__init__(tesla_device, controller, config_entry)
@@ -60,7 +60,7 @@ class ChargerSwitch(TeslaDevice, SwitchDevice):
 class RangeSwitch(TeslaDevice, SwitchDevice):
     """Representation of a Tesla max range charging switch."""
 
-    def __init__(self, tesla_device, controller, config_entry=None):
+    def __init__(self, tesla_device, controller, config_entry):
         """Initialise the switch."""
         self._state = None
         super().__init__(tesla_device, controller, config_entry)
@@ -90,7 +90,7 @@ class RangeSwitch(TeslaDevice, SwitchDevice):
 class UpdateSwitch(TeslaDevice, SwitchDevice):
     """Representation of a Tesla update switch."""
 
-    def __init__(self, tesla_device, controller, config_entry=None):
+    def __init__(self, tesla_device, controller, config_entry):
         """Initialise the switch."""
         self._state = None
         tesla_device.type = "update switch"

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -68,6 +68,7 @@ FLOWS = [
     "somfy",
     "sonos",
     "tellduslive",
+    "tesla",
     "toon",
     "tplink",
     "traccar",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -579,9 +579,6 @@ sunwatcher==0.2.1
 # homeassistant.components.tellduslive
 tellduslive==0.10.10
 
-# homeassistant.components.tesla
-teslajsonpy==0.2.0
-
 # homeassistant.components.toon
 toonapilib==3.2.4
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -579,6 +579,9 @@ sunwatcher==0.2.1
 # homeassistant.components.tellduslive
 tellduslive==0.10.10
 
+# homeassistant.components.tesla
+teslajsonpy==0.2.0
+
 # homeassistant.components.toon
 toonapilib==3.2.4
 

--- a/tests/components/tesla/__init__.py
+++ b/tests/components/tesla/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Tesla integration."""

--- a/tests/components/tesla/test_config_flow.py
+++ b/tests/components/tesla/test_config_flow.py
@@ -89,7 +89,7 @@ async def test_form_cannot_connect(hass):
 async def test_form_repeat_identifier(hass):
     """Test we handle repeat identifiers."""
     entry = MockConfigEntry(domain=DOMAIN, title="test-username", data={}, options=None)
-    hass.config_entries._entries.append(entry)
+    entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -129,16 +129,32 @@ async def test_import(hass):
 async def test_option_flow(hass):
     """Test config flow options."""
     entry = MockConfigEntry(domain=DOMAIN, data={}, options=None)
-    hass.config_entries._entries.append(entry)
+    entry.add_to_hass(hass)
 
-    flow = await hass.config_entries.options._async_create_flow(
-        entry.entry_id, context={"source": "test"}, data=None
-    )
+    result = await hass.config_entries.options.flow.async_init(entry.entry_id)
 
-    result = await flow.async_step_init()
     assert result["type"] == "form"
     assert result["step_id"] == "init"
 
-    result = await flow.async_step_init(user_input={CONF_SCAN_INTERVAL: 350})
+    result = await hass.config_entries.options.flow.async_configure(
+        result["flow_id"], user_input={CONF_SCAN_INTERVAL: 350}
+    )
     assert result["type"] == "create_entry"
     assert result["data"] == {CONF_SCAN_INTERVAL: 350}
+
+
+async def test_option_flow_input_floor(hass):
+    """Test config flow options."""
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options=None)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.flow.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.flow.async_configure(
+        result["flow_id"], user_input={CONF_SCAN_INTERVAL: 1}
+    )
+    assert result["type"] == "create_entry"
+    assert result["data"] == {CONF_SCAN_INTERVAL: 300}

--- a/tests/components/tesla/test_config_flow.py
+++ b/tests/components/tesla/test_config_flow.py
@@ -1,0 +1,81 @@
+"""Test the Tesla config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.tesla.const import DOMAIN
+from homeassistant.components.tesla.config_flow import CannotConnect, InvalidAuth
+
+from tests.common import mock_coro
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.tesla.config_flow.validate_input",
+        return_value=mock_coro(
+            {"token": "test-refresh-token", "access_token": "test-access-token"}
+        ),
+    ), patch(
+        "homeassistant.components.tesla.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, patch(
+        "homeassistant.components.tesla.async_setup_entry", return_value=mock_coro(True)
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-username", "password": "test-password"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "test-username"
+    assert result2["data"] == {
+        "token": "test-refresh-token",
+        "access_token": "test-access-token",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.tesla.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-username", "password": "test-password"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_credentials"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.tesla.config_flow.validate_input",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-username", "password": "test-password"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "connection_error"}

--- a/tests/components/tesla/test_config_flow.py
+++ b/tests/components/tesla/test_config_flow.py
@@ -1,11 +1,18 @@
 """Test the Tesla config flow."""
-from unittest.mock import patch
-
-from homeassistant import config_entries, setup
-from homeassistant.components.tesla.const import DOMAIN
-from homeassistant.components.tesla.config_flow import CannotConnect, InvalidAuth
+from unittest.mock import Mock, patch
 
 from tests.common import mock_coro
+
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.tesla import config_flow
+from homeassistant.components.tesla.const import DOMAIN
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_PASSWORD,
+    CONF_TOKEN,
+    CONF_USERNAME,
+)
+from teslajsonpy import TeslaException
 
 
 async def test_form(hass):
@@ -18,22 +25,19 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.tesla.config_flow.validate_input",
-        return_value=mock_coro(
-            {"token": "test-refresh-token", "access_token": "test-access-token"}
-        ),
+        "teslajsonpy.Controller.connect",
+        return_value=mock_coro(("test-refresh-token", "test-access-token")),
     ), patch(
         "homeassistant.components.tesla.async_setup", return_value=mock_coro(True)
     ) as mock_setup, patch(
         "homeassistant.components.tesla.async_setup_entry", return_value=mock_coro(True)
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "test-username", "password": "test-password"},
+            result["flow_id"], {CONF_PASSWORD: "test", CONF_USERNAME: "test@email.com"}
         )
 
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == "test-username"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "test@email.com"
     assert result2["data"] == {
         "token": "test-refresh-token",
         "access_token": "test-access-token",
@@ -49,10 +53,7 @@ async def test_form_invalid_auth(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.tesla.config_flow.validate_input",
-        side_effect=InvalidAuth,
-    ):
+    with patch("teslajsonpy.Controller.connect", side_effect=TeslaException(401)):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"username": "test-username", "password": "test-password"},
@@ -68,14 +69,36 @@ async def test_form_cannot_connect(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.tesla.config_flow.validate_input",
-        side_effect=CannotConnect,
-    ):
+    with patch("teslajsonpy.Controller.connect", side_effect=TeslaException(code=404)):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "test-username", "password": "test-password"},
+            result["flow_id"], {CONF_PASSWORD: "test", CONF_USERNAME: "test@email.com"}
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "connection_error"}
+
+
+async def test_import(hass):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    with patch(
+        "teslajsonpy.Controller.connect",
+        return_value=mock_coro(("test-refresh-token", "test-access-token")),
+    ):
+        result = await flow.async_step_import(
+            {CONF_PASSWORD: "test", CONF_USERNAME: "test@email.com"}
+        )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "test@email.com"
+    assert result["data"][CONF_ACCESS_TOKEN] == "test-access-token"
+    assert result["data"][CONF_TOKEN] == "test-refresh-token"
+    assert result["description_placeholders"] is None
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    hass.config.api = Mock()
+    flow = config_flow.DomainConfigFlow()
+    flow.hass = hass
+    return flow


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
Device tracker entity names have changed due to the conversion to config_flow. They now follow the naming convention of the rest of the Tesla entities. The `id` device tracker entity attribute was also removed because it is a duplicate of `trackr_id`.

## Description:
This add config flow to Tesla.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11170

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
