### PR TITLE
Add Deluge config_flow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -73,6 +73,7 @@ homeassistant/components/daikin/* @fredrike @rofrantz
 homeassistant/components/darksky/* @fabaff
 homeassistant/components/deconz/* @kane610
 homeassistant/components/delijn/* @bollewolle
+homeassistant/components/deluge/* @engrbm87
 homeassistant/components/demo/* @home-assistant/core
 homeassistant/components/device_automation/* @home-assistant/core
 homeassistant/components/digital_ocean/* @fabaff

--- a/homeassistant/components/deluge/.translations/en.json
+++ b/homeassistant/components/deluge/.translations/en.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Host is already configured."
+        },
+        "error": {
+            "cannot_connect": "Unable to Connect to host",
+            "password_error": "Incorrect password",
+            "user_error": "Username doesn't exist",
+            "name_exists": "Name already exists"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "name": "Name",
+                    "password": "Password",
+                    "port": "Port",
+                    "username": "Username"
+                },
+                "title": "Setup Deluge Client"
+            }
+        },
+        "title": "Deluge"
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Update frequency"
+                },
+                "title": "Configure options for Deluge"
+            }
+        }
+    }
+}

--- a/homeassistant/components/deluge/__init__.py
+++ b/homeassistant/components/deluge/__init__.py
@@ -1,1 +1,356 @@
-"""The deluge component."""
+"""The Deluge integration."""
+import asyncio
+from datetime import timedelta
+import logging
+
+from deluge_client import DelugeRPCClient, FailedToReconnectException
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import (
+    ATTR_TORRENT,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    DATA_UPDATED,
+    SERVICE_ADD_TORRENT,
+)
+from .errors import UserNameError, PasswordError, CannotConnect, UnknownError
+
+_LOGGER = logging.getLogger(__name__)
+
+DELUGE_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Required(CONF_HOST): cv.string,
+            vol.Required(CONF_PASSWORD): cv.string,
+            vol.Required(CONF_USERNAME): cv.string,
+            vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(
+                CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+            ): cv.time_period,
+        }
+    )
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: vol.All(cv.ensure_list, [DELUGE_SCHEMA])}, extra=vol.ALLOW_EXTRA
+)
+
+PLATFORMS = ["sensor", "switch"]
+
+SERVICE_ADD_TORRENT_SCHEMA = vol.Schema(
+    {vol.Required(ATTR_TORRENT): cv.string, vol.Required(CONF_HOST): cv.string}
+)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Import the Deluge component from config."""
+    if DOMAIN in config:
+        for entry in config[DOMAIN]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
+                )
+            )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Deluge from a config entry."""
+    client = DelugeClient(hass, entry)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+
+    if not await client.async_setup():
+        return False
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        client = hass.data[DOMAIN].pop(entry.entry_id)
+        if client.unsub_timer:
+            client.unsub_timer()
+
+    return unload_ok
+
+
+async def get_api(hass, entry):
+    """Get Transmission client."""
+    host = entry[CONF_HOST]
+    port = entry[CONF_PORT]
+    username = entry.get(CONF_USERNAME)
+    password = entry.get(CONF_PASSWORD)
+
+    try:
+        api = await hass.async_add_executor_job(
+            DelugeRPCClient, host, port, username, password
+        )
+        api.connect()
+        _LOGGER.debug("Successfully connected to %s", host)
+        return api
+
+    except ConnectionRefusedError as error:
+        _LOGGER.error(error)
+        raise CannotConnect
+    except Exception as error:  # pylint: disable=broad-except
+        _LOGGER.error(str(error))
+        if "Username does not exist" in str(error):
+            raise UserNameError
+        if "Password does not match" in str(error):
+            raise PasswordError
+
+
+class DelugeClient:
+    """Deluge Client Object."""
+
+    def __init__(self, hass, config_entry):
+        """Initialize the Deluge client."""
+        self.hass = hass
+        self.config_entry = config_entry
+        self._deluge_data = None
+        self.unsub_timer = None
+
+    @property
+    def api(self):
+        """Return the _deluge_data object."""
+        return self._deluge_data
+
+    async def async_setup(self):
+        """Set up the Deluge client."""
+
+        try:
+            deluge_api = await get_api(self.hass, self.config_entry.data)
+        except CannotConnect:
+            raise ConfigEntryNotReady
+        except (UserNameError, PasswordError, UnknownError):
+            return False
+
+        self._deluge_data = DelugeData(self.hass, self.config_entry, deluge_api)
+
+        await self.hass.async_add_executor_job(self._deluge_data.init_torrent_list)
+        await self.hass.async_add_executor_job(self._deluge_data.update)
+        self.add_options()
+        self.set_scan_interval(self.config_entry.options[CONF_SCAN_INTERVAL])
+
+        for component in PLATFORMS:
+            self.hass.async_create_task(
+                self.hass.config_entries.async_forward_entry_setup(
+                    self.config_entry, component
+                )
+            )
+
+        def add_torrent(service):
+            """Add new torrent to download."""
+            torrent = service.data[ATTR_TORRENT]
+            if torrent.startswith(("http", "ftp:")):
+                deluge_api.core.add_torrent_url(torrent, {})
+            elif torrent.startswith(("magnet:")):
+                deluge_api.core.add_torrent_magnet(torrent, {})
+            else:
+                _LOGGER.warning(
+                    "Could not add torrent: unsupported type or no permission"
+                )
+
+        self.hass.services.async_register(
+            DOMAIN, SERVICE_ADD_TORRENT, add_torrent, schema=SERVICE_ADD_TORRENT_SCHEMA
+        )
+
+        self.config_entry.add_update_listener(self.async_options_updated)
+
+        return True
+
+    def add_options(self):
+        """Add options for entry."""
+        if not self.config_entry.options:
+            scan_interval = self.config_entry.data.pop(
+                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+            )
+            options = {CONF_SCAN_INTERVAL: scan_interval}
+
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, options=options
+            )
+
+    def set_scan_interval(self, scan_interval):
+        """Update scan interval."""
+
+        def refresh(event_time):
+            """Get the latest data from Transmission."""
+            self._deluge_data.update()
+
+        if self.unsub_timer is not None:
+            self.unsub_timer()
+        self.unsub_timer = async_track_time_interval(
+            self.hass, refresh, timedelta(seconds=scan_interval)
+        )
+
+    @staticmethod
+    async def async_options_updated(hass, entry):
+        """Triggered by config entry options updates."""
+        hass.data[DOMAIN][entry.entry_id].set_scan_interval(
+            entry.options[CONF_SCAN_INTERVAL]
+        )
+
+
+class DelugeData:
+    """Get the latest data and update the states."""
+
+    def __init__(self, hass, config, api):
+        """Initialize the Deluge Data object."""
+        self.hass = hass
+        self.config = config
+        self.data = None
+        self.torrents = None
+        self.session = None
+        self.available = True
+        self._api = api
+        self.completed_torrents = []
+        self.started_torrents = []
+
+    @property
+    def host(self):
+        """Return the host name."""
+        return self.config.data[CONF_HOST]
+
+    @property
+    def signal_update(self):
+        """Update signal per deluge entry."""
+        return f"{DATA_UPDATED}-{self.host}"
+
+    def update(self):
+        """Get the latest data from deluge instance."""
+        try:
+            self.data = self._api.core.get_session_status(
+                [
+                    "upload_rate",
+                    "download_rate",
+                    "dht_upload_rate",
+                    "dht_download_rate",
+                ],
+            )
+            self.torrents = self._api.core.get_torrents_status({}, ["name", "state"])
+            self.check_completed_torrent()
+            self.check_started_torrent()
+            _LOGGER.debug("Torrent Data for %s Updated", self.host)
+
+            self.available = True
+        except FailedToReconnectException:
+            self.available = False
+            _LOGGER.error("Unable to connect to Deeluge client %s", self.host)
+
+        dispatcher_send(self.hass, self.signal_update)
+
+    def init_torrent_list(self):
+        """Initialize torrent lists."""
+        self.torrents = self._api.core.get_torrents_status({}, ["name", "state"])
+        self.completed_torrents = [
+            self.torrents[var][b"name"].decode("utf8")
+            for var in self.torrents
+            if self.torrents[var][b"state"].decode("utf8") == "Seeding"
+        ]
+        self.started_torrents = [
+            self.torrents[var][b"name"].decode("utf8")
+            for var in self.torrents
+            if self.torrents[var][b"state"].decode("utf8") == "Downloading"
+        ]
+
+    def check_completed_torrent(self):
+        """Get completed torrent functionality."""
+        completed_torrents = [
+            self.torrents[var][b"name"].decode("utf8")
+            for var in self.torrents
+            if self.torrents[var][b"state"].decode("utf8") == "Seeding"
+        ]
+
+        tmp_completed_torrents = list(
+            set(completed_torrents).difference(self.completed_torrents)
+        )
+
+        for var in tmp_completed_torrents:
+            self.hass.bus.fire("deluge_downloaded_torrent", {"name": var})
+
+        self.completed_torrents = completed_torrents
+
+    def check_started_torrent(self):
+        """Get started torrent functionality."""
+        started_torrents = [
+            self.torrents[var][b"name"].decode("utf8")
+            for var in self.torrents
+            if self.torrents[var][b"state"].decode("utf8") == "Downloading"
+        ]
+
+        tmp_started_torrents = list(
+            set(started_torrents).difference(self.started_torrents)
+        )
+
+        for var in tmp_started_torrents:
+            self.hass.bus.fire("deluge_started_torrent", {"name": var})
+        self.started_torrents = started_torrents
+
+    def get_torrents_count(self):
+        """Get the number of all torrents."""
+        return len(self.torrents)
+
+    def get_started_torrent_count(self):
+        """Get the number of started torrents."""
+        return len(self.started_torrents)
+
+    def get_completed_torrent_count(self):
+        """Get the number of completed torrents."""
+        return len(self.completed_torrents)
+
+    def get_paused_torrents_count(self):
+        """Get the number of paused torrents."""
+        paused_torrents = [
+            self.torrents[var][b"name"].decode("utf8")
+            for var in self.torrents
+            if self.torrents[var][b"state"].decode("utf8") == "Paused"
+        ]
+        return len(paused_torrents)
+
+    def get_active_torrents_count(self):
+        """Get the number of active torrents."""
+        active_torrents = [
+            self.torrents[var][b"name"].decode("utf8")
+            for var in self.torrents
+            if self.torrents[var][b"state"].decode("utf8") in ["Seeding", "Downloading"]
+        ]
+        return len(active_torrents)
+
+    def start_torrents(self):
+        """Start all torrents."""
+        torrent_ids = self._api.core.get_session_state()
+        self._api.core.resume_torrents(torrent_ids)
+
+    def stop_torrents(self):
+        """Stop all active torrents."""
+        torrent_ids = self._api.core.get_session_state()
+        self._api.core.pause_torrents(torrent_ids)

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.core import callback
 
 from . import get_api
 from .const import DEFAULT_NAME, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
-from .errors import UserNameError, PasswordError, CannotConnect, UnknownError
+from .errors import CannotConnect, PasswordError, UnknownError, UserNameError
 
 DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Transmission Bittorent Client."""
+"""Config flow for Deluge Client."""
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -1,0 +1,101 @@
+"""Config flow for Transmission Bittorent Client."""
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.core import callback
+
+from . import get_api
+from .const import DEFAULT_NAME, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .errors import UserNameError, PasswordError, CannotConnect, UnknownError
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+    }
+)
+
+
+class DelugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Deluge config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return DelugeOptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        if user_input is not None:
+
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.data[CONF_HOST] == user_input[CONF_HOST]:
+                    return self.async_abort(reason="already_configured")
+                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                    errors[CONF_NAME] = "name_exists"
+                    break
+
+            try:
+                await get_api(self.hass, user_input)
+
+            except UserNameError:
+                errors[CONF_USERNAME] = "user_error"
+            except PasswordError:
+                errors[CONF_PASSWORD] = "password_error"
+            except (CannotConnect, UnknownError):
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_config):
+        """Import from Deluge client config."""
+        import_config[CONF_SCAN_INTERVAL] = import_config[CONF_SCAN_INTERVAL].seconds
+        return await self.async_step_user(user_input=import_config)
+
+
+class DelugeOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Deluge client options."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = {
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=self.config_entry.options.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                ),
+            ): int
+        }
+
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.core import callback
 
 from . import get_api
 from .const import DEFAULT_NAME, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
-from .errors import CannotConnect, PasswordError, UnknownError, UserNameError
+from .errors import CannotConnect, PasswordError, UserNameError, UnknownError
 
 DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -53,7 +53,7 @@ class DelugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     break
 
             try:
-                await get_api(self.hass, user_input)
+                await self.hass.async_add_executor_job(get_api, self.hass, user_input)
 
             except UserNameError:
                 errors[CONF_USERNAME] = "user_error"

--- a/homeassistant/components/deluge/const.py
+++ b/homeassistant/components/deluge/const.py
@@ -1,0 +1,26 @@
+"""Constants for the Transmission Bittorent Client component."""
+DOMAIN = "deluge"
+
+DEFAULT_NAME = "Deluge"
+DEFAULT_PORT = 58846
+DEFAULT_SCAN_INTERVAL = 120
+
+DHT_UPLOAD = 1000
+DHT_DOWNLOAD = 1000
+
+SENSOR_TYPES = {
+    "active_torrents": ["Active Torrents", None],
+    "current_status": ["Status", None],
+    "download_speed": ["Down Speed", "MB/s"],
+    "paused_torrents": ["Paused Torrents", None],
+    "total_torrents": ["Total Torrents", None],
+    "upload_speed": ["Up Speed", "MB/s"],
+    "completed_torrents": ["Completed Torrents", None],
+    "started_torrents": ["Started Torrents", None],
+}
+DELUGE_SWITCH = "Switch"
+
+ATTR_TORRENT = "torrent"
+SERVICE_ADD_TORRENT = "add_torrent"
+
+DATA_UPDATED = "deluge_data_updated"

--- a/homeassistant/components/deluge/const.py
+++ b/homeassistant/components/deluge/const.py
@@ -1,12 +1,19 @@
-"""Constants for the Transmission Bittorent Client component."""
+"""Constants for the Deluge Client component."""
 DOMAIN = "deluge"
 
+ATTR_TORRENT = "torrent"
+
 DEFAULT_NAME = "Deluge"
+DELUGE_SWITCH = "Switch"
 DEFAULT_PORT = 58846
 DEFAULT_SCAN_INTERVAL = 120
 
 DHT_UPLOAD = 1000
 DHT_DOWNLOAD = 1000
+
+SERVICE_ADD_TORRENT = "add_torrent"
+
+DATA_UPDATED = "deluge_data_updated"
 
 SENSOR_TYPES = {
     "active_torrents": ["Active Torrents", None],
@@ -18,9 +25,3 @@ SENSOR_TYPES = {
     "completed_torrents": ["Completed Torrents", None],
     "started_torrents": ["Started Torrents", None],
 }
-DELUGE_SWITCH = "Switch"
-
-ATTR_TORRENT = "torrent"
-SERVICE_ADD_TORRENT = "add_torrent"
-
-DATA_UPDATED = "deluge_data_updated"

--- a/homeassistant/components/deluge/errors.py
+++ b/homeassistant/components/deluge/errors.py
@@ -1,0 +1,18 @@
+"""Errors for the Deluge component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class UserNameError(HomeAssistantError):
+    """Wrong Username."""
+
+
+class PasswordError(HomeAssistantError):
+    """Wrong Password."""
+
+
+class CannotConnect(HomeAssistantError):
+    """Unable to connect to client."""
+
+
+class UnknownError(HomeAssistantError):
+    """Unknown Error."""

--- a/homeassistant/components/deluge/errors.py
+++ b/homeassistant/components/deluge/errors.py
@@ -12,7 +12,3 @@ class PasswordError(HomeAssistantError):
 
 class CannotConnect(HomeAssistantError):
     """Unable to connect to client."""
-
-
-class UnknownError(HomeAssistantError):
-    """Unknown Error."""

--- a/homeassistant/components/deluge/errors.py
+++ b/homeassistant/components/deluge/errors.py
@@ -12,3 +12,7 @@ class PasswordError(HomeAssistantError):
 
 class CannotConnect(HomeAssistantError):
     """Unable to connect to client."""
+
+
+class UnknownError(HomeAssistantError):
+    """Unknown error occured."""

--- a/homeassistant/components/deluge/manifest.json
+++ b/homeassistant/components/deluge/manifest.json
@@ -6,5 +6,8 @@
     "deluge-client==1.7.1"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@engrbm87"
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -93,8 +93,8 @@ class DelugeSensor(Entity):
             self._state = self.client.api.get_started_torrent_count()
 
         if self.data:
-            upload = self.data[b"upload_rate"] - self.data[b"dht_upload_rate"]
-            download = self.data[b"download_rate"] - self.data[b"dht_download_rate"]
+            upload = self.data["upload_rate"] - self.data["dht_upload_rate"]
+            download = self.data["download_rate"] - self.data["dht_download_rate"]
 
         if self.type == "current_status":
             if self.data:

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -51,7 +51,7 @@ class DelugeSensor(Entity):
     @property
     def unique_id(self):
         """Return the unique id of the entity."""
-        return f"{self.client.api.host}-{self.name}"
+        return f"{self.client.api.host}-{self.type}"
 
     @property
     def state(self):
@@ -83,7 +83,7 @@ class DelugeSensor(Entity):
     def _schedule_immediate_update(self):
         self.async_schedule_update_ha_state(True)
 
-    def update(self):
+    async def async_update(self):
         """Get the latest data from Deluge and updates the state."""
         self.data = self.client.api.data
 
@@ -129,3 +129,4 @@ class DelugeSensor(Entity):
         """Unsub from update dispatcher."""
         if self.unsub_dispatcher:
             self.unsub_dispatcher()
+            self.unsub_dispatcher = None

--- a/homeassistant/components/deluge/services.yaml
+++ b/homeassistant/components/deluge/services.yaml
@@ -1,5 +1,5 @@
 add_torrent:
-  description: Add a new torrent to download (URL, magnet link or Base64 encoded).
+  description: Add a new torrent to download (URL, magnet link).
   fields:
     host:
       description: client host name as entered during entry config

--- a/homeassistant/components/deluge/services.yaml
+++ b/homeassistant/components/deluge/services.yaml
@@ -1,0 +1,9 @@
+add_torrent:
+  description: Add a new torrent to download (URL, magnet link or Base64 encoded).
+  fields:
+    host:
+      description: client host name as entered during entry config
+      example: localhost
+    torrent:
+      description: URL, magnet link or Base64 encoded file.
+      example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent

--- a/homeassistant/components/deluge/services.yaml
+++ b/homeassistant/components/deluge/services.yaml
@@ -1,9 +1,9 @@
 add_torrent:
   description: Add a new torrent to download (URL, magnet link).
   fields:
-    host:
-      description: client host name as entered during entry config
-      example: localhost
+    name:
+      description: client name as entered during entry config
+      example: Deluge
     torrent:
       description: URL, magnet link or Base64 encoded file.
       example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent

--- a/homeassistant/components/deluge/strings.json
+++ b/homeassistant/components/deluge/strings.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "title": "Deluge",
+    "step": {
+      "user": {
+        "title": "Setup Deluge Client",
+        "data": {
+          "name": "Name",
+          "host": "Host",
+          "username": "Username",
+          "password": "Password",
+          "port": "Port"
+        }
+      }
+    },
+    "error": {
+      "name_exists": "Name already exists",
+      "user_error": "Username doesn't exist",
+      "password_error": "Incorrect password",
+      "cannot_connect": "Unable to Connect to host"
+    },
+    "abort": {
+      "already_configured": "Host is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure options for Deluge",
+        "data": {
+          "scan_interval": "Update frequency"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -1,4 +1,4 @@
-"""Support for setting the Deluge BitTorrent client in Pause."""
+"""Support for starting/stoping the Deluge client torrents."""
 import logging
 
 from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -4,9 +4,9 @@ import logging
 from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-
 from homeassistant.helpers.entity import ToggleEntity
-from .const import DOMAIN, DELUGE_SWITCH
+
+from .const import DELUGE_SWITCH, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -18,6 +18,7 @@ FLOWS = [
     "coolmaster",
     "daikin",
     "deconz",
+    "deluge",
     "dialogflow",
     "ecobee",
     "emulated_roku",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -139,6 +139,9 @@ datadog==0.15.0
 # homeassistant.components.ohmconnect
 defusedxml==0.6.0
 
+# homeassistant.components.deluge
+deluge-client==1.7.1
+
 # homeassistant.components.directv
 directpy==0.5
 

--- a/tests/components/deluge/__init__.py
+++ b/tests/components/deluge/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Deluge integration."""

--- a/tests/components/deluge/test_config_flow.py
+++ b/tests/components/deluge/test_config_flow.py
@@ -1,93 +1,253 @@
-"""Test the Deluge config flow."""
+"""Tests for Transmission config flow."""
+from datetime import timedelta
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
-from homeassistant.components.deluge.const import DOMAIN
-from homeassistant.components.deluge.config_flow import CannotConnect, InvalidAuth
+import pytest
 
-from tests.common import mock_coro
+from homeassistant import data_entry_flow
+from homeassistant.components.deluge import config_flow
+from homeassistant.components.deluge.const import (
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+
+from tests.common import MockConfigEntry
+
+NAME = "Deluge"
+HOST = "192.168.1.100"
+USERNAME = "username"
+PASSWORD = "password"
+PORT = 5555
+SCAN_INTERVAL = 10
+
+MOCK_ENTRY = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_USERNAME: USERNAME,
+    CONF_PASSWORD: PASSWORD,
+    CONF_PORT: PORT,
+}
 
 
-async def test_form(hass):
-    """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+@pytest.fixture(name="api")
+def mock_deluge_api():
+    """Mock an api."""
+    with patch("deluge_client.DelugeRPCClient.connect"):
+        yield
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    flow = config_flow.DelugeFlowHandler()
+    flow.hass = hass
+    return flow
+
+
+async def test_flow_works(hass, api):
+    """Test user config."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # test with all required provided
+    result = await flow.async_step_user(MOCK_ENTRY)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_PORT] == PORT
+
+
+async def test_options(hass):
+    """Test updating options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CONF_NAME,
+        data=MOCK_ENTRY,
+        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
     )
+    flow = init_config_flow(hass)
+    options_flow = flow.async_get_options_flow(entry)
+
+    result = await options_flow.async_step_init()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+    result = await options_flow.async_step_init({CONF_SCAN_INTERVAL: 10})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"][CONF_SCAN_INTERVAL] == 10
+
+
+async def test_import(hass, api):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with minimum fields only
+    result = await flow.async_step_import(
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "password",
+            CONF_PORT: DEFAULT_PORT,
+            CONF_SCAN_INTERVAL: timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+    assert result["data"][CONF_NAME] == DEFAULT_NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+    assert result["data"][CONF_USERNAME] == "user"
+    assert result["data"][CONF_PASSWORD] == "password"
+    assert result["data"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
+
+    # import with all
+    result = await flow.async_step_import(
+        {
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_PORT: PORT,
+            CONF_SCAN_INTERVAL: timedelta(seconds=SCAN_INTERVAL),
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_PORT] == PORT
+    assert result["data"][CONF_SCAN_INTERVAL] == SCAN_INTERVAL
+
+
+async def test_host_already_configured(hass, api):
+    """Test host is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_ENTRY,
+        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
+    )
+    entry.add_to_hass(hass)
+    flow = init_config_flow(hass)
+    result = await flow.async_step_user(MOCK_ENTRY)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_name_already_configured(hass, api):
+    """Test name is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_ENTRY,
+        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
+    )
+    entry.add_to_hass(hass)
+
+    mock_entry = MOCK_ENTRY.copy()
+    mock_entry[CONF_HOST] = "0.0.0.0"
+    flow = init_config_flow(hass)
+    result = await flow.async_step_user(mock_entry)
+
     assert result["type"] == "form"
-    assert result["errors"] == {}
+    assert result["errors"] == {CONF_NAME: "name_exists"}
 
+
+async def test_error_on_wrong_credentials(hass):
+    """Test with wrong credentials."""
+    flow = init_config_flow(hass)
+
+    # test wrong username
     with patch(
-        "homeassistant.components.deluge.config_flow.validate_input",
-        return_value=mock_coro({"title": "Test Title"}),
-    ), patch(
-        "homeassistant.components.deluge.async_setup", return_value=mock_coro(True)
-    ) as mock_setup, patch(
-        "homeassistant.components.deluge.async_setup_entry",
-        return_value=mock_coro(True),
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == "Test Title"
-    assert result2["data"] == {
-        "host": "1.1.1.1",
-        "username": "test-username",
-        "password": "test-password",
-    }
-    await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_invalid_auth(hass):
-    """Test we handle invalid auth."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.deluge.config_flow.validate_input",
-        side_effect=InvalidAuth,
+        "deluge_client.DelugeRPCClient.connect",
+        side_effect=Exception("Username does not exist"),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result = await flow.async_step_user(
             {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
+                CONF_NAME: NAME,
+                CONF_HOST: HOST,
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+                CONF_PORT: PORT,
+            }
         )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {
+            CONF_USERNAME: "user_error",
+        }
 
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "invalid_auth"}
+    # test wrong password
+    with patch(
+        "deluge_client.DelugeRPCClient.connect",
+        side_effect=Exception("Password does not match"),
+    ):
+        result = await flow.async_step_user(
+            {
+                CONF_NAME: NAME,
+                CONF_HOST: HOST,
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+                CONF_PORT: PORT,
+            }
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {
+            CONF_PASSWORD: "password_error",
+        }
 
 
-async def test_form_cannot_connect(hass):
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+async def test_error_on_connection_failure(hass):
+    """Test when connection to host fails."""
+    flow = init_config_flow(hass)
 
     with patch(
-        "homeassistant.components.deluge.config_flow.validate_input",
-        side_effect=CannotConnect,
+        "deluge_client.DelugeRPCClient.connect", side_effect=ConnectionRefusedError,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result = await flow.async_step_user(
             {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
+                CONF_NAME: NAME,
+                CONF_HOST: HOST,
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+                CONF_PORT: PORT,
+            }
         )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "cannot_connect"}
 
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "cannot_connect"}
+
+async def test_error_on_unknwon_error(hass):
+    """Test when connection to host fails."""
+    flow = init_config_flow(hass)
+
+    with patch(
+        "deluge_client.DelugeRPCClient.connect", side_effect=Exception("timed out"),
+    ):
+        result = await flow.async_step_user(
+            {
+                CONF_NAME: NAME,
+                CONF_HOST: HOST,
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+                CONF_PORT: PORT,
+            }
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/components/deluge/test_config_flow.py
+++ b/tests/components/deluge/test_config_flow.py
@@ -1,0 +1,93 @@
+"""Test the Deluge config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.deluge.const import DOMAIN
+from homeassistant.components.deluge.config_flow import CannotConnect, InvalidAuth
+
+from tests.common import mock_coro
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.deluge.config_flow.validate_input",
+        return_value=mock_coro({"title": "Test Title"}),
+    ), patch(
+        "homeassistant.components.deluge.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, patch(
+        "homeassistant.components.deluge.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Test Title"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.deluge.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.deluge.config_flow.validate_input",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/deluge/test_config_flow.py
+++ b/tests/components/deluge/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Tests for Transmission config flow."""
+"""Tests for Deluge config flow."""
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/deluge/test_init.py
+++ b/tests/components/deluge/test_init.py
@@ -1,0 +1,114 @@
+"""Tests for Deluge init."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+from homeassistant.components import deluge
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, mock_coro
+
+MOCK_ENTRY = MockConfigEntry(
+    domain=deluge.DOMAIN,
+    data={
+        deluge.CONF_NAME: "Deluge",
+        deluge.CONF_HOST: "0.0.0.0",
+        deluge.CONF_USERNAME: "user",
+        deluge.CONF_PASSWORD: "pass",
+        deluge.CONF_PORT: 5555,
+    },
+)
+
+
+@pytest.fixture(name="api")
+def mock_deluge_api():
+    """Mock an api."""
+    with patch("deluge_client.DelugeRPCClient.connect"):
+        yield
+
+
+async def test_setup_with_no_config(hass):
+    """Test that we do not discover anything or try to set up a Deluge client."""
+    assert await async_setup_component(hass, deluge.DOMAIN, {}) is True
+    assert deluge.DOMAIN not in hass.data
+
+
+async def test_setup_with_config(hass, api):
+    """Test that we import the config and setup the client."""
+    config = {
+        deluge.DOMAIN: {
+            deluge.CONF_NAME: "Deluge",
+            deluge.CONF_HOST: "0.0.0.0",
+            deluge.CONF_USERNAME: "user",
+            deluge.CONF_PASSWORD: "pass",
+            deluge.CONF_PORT: 5555,
+        },
+        deluge.DOMAIN: {
+            deluge.CONF_NAME: "Deluge2",
+            deluge.CONF_HOST: "0.0.0.1",
+            deluge.CONF_USERNAME: "user",
+            deluge.CONF_PASSWORD: "pass",
+            deluge.CONF_PORT: 5555,
+        },
+    }
+    assert await async_setup_component(hass, deluge.DOMAIN, config) is True
+
+
+async def test_successful_config_entry(hass, api):
+    """Test that configured Deluge is configured successfully."""
+
+    entry = MOCK_ENTRY
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        deluge.DelugeData, "init_torrent_list", return_value=True
+    ), patch.object(deluge.DelugeData, "update", return_value=True):
+        assert await deluge.async_setup_entry(hass, entry) is True
+        assert entry.options == {
+            deluge.CONF_SCAN_INTERVAL: deluge.DEFAULT_SCAN_INTERVAL
+        }
+
+
+async def test_setup_failed(hass):
+    """Test Deluge failed due to an error."""
+
+    entry = MOCK_ENTRY
+    entry.add_to_hass(hass)
+
+    # test connection error raising ConfigEntryNotReady
+    with patch(
+        "deluge_client.DelugeRPCClient.connect", side_effect=ConnectionRefusedError,
+    ), pytest.raises(ConfigEntryNotReady):
+
+        await deluge.async_setup_entry(hass, entry)
+
+    # test Authentication error returning false
+
+    with patch(
+        "deluge_client.DelugeRPCClient.connect",
+        side_effect=Exception("Username does not exist"),
+    ):
+
+        assert await deluge.async_setup_entry(hass, entry) is False
+
+
+async def test_unload_entry(hass, api):
+    """Test removing transmission client."""
+    entry = MOCK_ENTRY
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries, "async_forward_entry_unload", return_value=mock_coro(True)
+    ) as unload_entry, patch.object(
+        deluge.DelugeData, "init_torrent_list", return_value=True
+    ), patch.object(
+        deluge.DelugeData, "update", return_value=True
+    ):
+        assert await deluge.async_setup_entry(hass, entry)
+
+        assert await deluge.async_unload_entry(hass, entry)
+        assert unload_entry.call_count == 2
+        assert entry.entry_id not in hass.data[deluge.DOMAIN]


### PR DESCRIPTION
## Breaking Change:
Deluge is now an integration that provides related sensors and switches to control and monitor torrents. Previously configured sensors and switches should be removed and the new config schema should be used as shown below.

## Description:
- Deluge is now an Integration that can be configured using `config_flow`. Once configured the sensors and switches are auto created and can be disabled manually using Entity_Registry.
- Scan Interval can be set using the entry options.
- `add_torrent` service to add torrent using `url` or `magnet link`.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
deluge:
  - host: localhost
    username: user
    password: pass
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
