### PR TITLE
Bump pyotgw to 0.5b1

### DIFF
--- a/homeassistant/components/opentherm_gw/manifest.json
+++ b/homeassistant/components/opentherm_gw/manifest.json
@@ -3,7 +3,7 @@
   "name": "Opentherm Gateway",
   "documentation": "https://www.home-assistant.io/integrations/opentherm_gw",
   "requirements": [
-    "pyotgw==0.5b0"
+    "pyotgw==0.5b1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1388,7 +1388,7 @@ pyoppleio==1.0.5
 pyota==2.0.5
 
 # homeassistant.components.opentherm_gw
-pyotgw==0.5b0
+pyotgw==0.5b1
 
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -460,7 +460,7 @@ pynx584==0.4
 pyopenuv==1.0.9
 
 # homeassistant.components.opentherm_gw
-pyotgw==0.5b0
+pyotgw==0.5b1
 
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp


### PR DESCRIPTION
## Description:
A bug was found in the way pyotgw handles iSense thermostats, causing pyotgw to stop processing messages from the gateway. This was fixed in 0.5b1.

**Related issue (if applicable):** mvn23/pyotgw#10

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
