### PR TITLE
Fix changing venstar operation_mode

### DIFF
--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -278,7 +278,7 @@ class VenstarThermostat(ClimateDevice):
         temperature = kwargs.get(ATTR_TEMPERATURE)
 
         if operation_mode and self._mode_map.get(operation_mode) != self._client.mode:
-            set_temp = self._set_operation_mode(self._mode_map.get(operation_mode))
+            set_temp = self._set_operation_mode(operation_mode)
 
         if set_temp:
             if (


### PR DESCRIPTION
## Description: 
In the other PR for venstar, I accidentally did a conditional check against a value from `self._mode_map` when we should be checking the key

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: venstar
    host: !secret venstar_host
    humidifier: true
    timeout: 300
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
