### PR TITLE
Add small speed improvement when unloading RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -351,8 +351,12 @@ async def async_unload_entry(hass, config_entry):
     remove_listener = hass.data[DOMAIN][DATA_LISTENER].pop(config_entry.entry_id)
     remove_listener()
 
-    for component in ("binary_sensor", "sensor", "switch"):
-        await hass.config_entries.async_forward_entry_unload(config_entry, component)
+    tasks = [
+        hass.config_entries.async_forward_entry_unload(config_entry, component)
+        for component in ("binary_sensor", "sensor", "switch")
+    ]
+
+    await asyncio.gather(*tasks)
 
     return True
 


### PR DESCRIPTION
## Description:

This PR adds some small speed improvements to `rainmachine` by removing components concurrently when unloading the integration.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
