### PR TITLE
Resolve hosts for fritzbox_callmonitor

### DIFF
--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -59,13 +59,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Fritz!Box call monitor sensor platform."""
     name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    # Check that host is a valid IP address; otherwise try to resolve it.
-    try:
-        socket.inet_pton(socket.AF_INET, host)
-    except socket.error:
-        host = socket.gethostbyname(host)
-
+    # Try to resolve a hostname; if it is already an IP, it will be returned as-is
+    host = socket.gethostbyname(config.get(CONF_HOST))
     port = config.get(CONF_PORT)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -60,6 +60,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Fritz!Box call monitor sensor platform."""
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
+    # Check that host is a valid IP address; otherwise try to resolve it.
+    try:
+        socket.inet_pton(socket.AF_INET, host)
+    except socket.error:
+        host = socket.gethostbyname(host)
+
     port = config.get(CONF_PORT)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -64,12 +64,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     try:
         host = socket.gethostbyname(host)
     except socket.error:
-        _LOGGER.warning(
-            "Could not resolve hostname: %s.\nTrying default address %s",
-            host,
-            DEFAULT_HOST,
-        )
-        host = DEFAULT_HOST
+        _LOGGER.error("Could not resolve hostname %s", host)
     port = config.get(CONF_PORT)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -65,6 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         host = socket.gethostbyname(host)
     except socket.error:
         _LOGGER.error("Could not resolve hostname %s", host)
+        return
     port = config.get(CONF_PORT)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -59,8 +59,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Fritz!Box call monitor sensor platform."""
     name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
     # Try to resolve a hostname; if it is already an IP, it will be returned as-is
-    host = socket.gethostbyname(config.get(CONF_HOST))
+    try:
+        host = socket.gethostbyname(host)
+    except socket.error:
+        _LOGGER.warning(
+            "Could not resolve hostname: %s.\nTrying default address %s",
+            host,
+            DEFAULT_HOST,
+        )
+        host = DEFAULT_HOST
     port = config.get(CONF_PORT)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)


### PR DESCRIPTION
If the configuration supplied "host" is not an IP address, try resolving it

## Description:
I had written a hostname as "host" in my configuration.yaml for the fritzbox_callmonitor platform, and was getting warnings "fritzbox_callmonitor is taking longer than 10 seconds to initialize", and also could not find the phonebook with id 0.

Finally I found out, that I have to pass an IP address, and not a hostname in the host parameter. I personally find it nicer if both can be accepted, so I created this patch that checks whether host is an IP address, and if it isn't, tries to resolve it as a hostname.

**Related issue (if applicable):** I haven't created (or found) an issue for that; I can create one if required. Might be related to #21143.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11196

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: fritzbox_callmonitor
  username: myFritzboxUser
  password: MY_PASSWORD
  host: fritzbox.example.com
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
