### PR TITLE
bump home mitemp_bt to 0.0.3. It has an important bugfix for reading …

### DIFF
--- a/homeassistant/components/mitemp_bt/manifest.json
+++ b/homeassistant/components/mitemp_bt/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mitemp bt",
   "documentation": "https://www.home-assistant.io/integrations/mitemp_bt",
   "requirements": [
-    "mitemp_bt==0.0.1"
+    "mitemp_bt==0.0.3"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -838,7 +838,7 @@ millheater==0.3.4
 minio==4.0.9
 
 # homeassistant.components.mitemp_bt
-mitemp_bt==0.0.1
+mitemp_bt==0.0.3
 
 # homeassistant.components.mopar
 motorparts==1.1.0


### PR DESCRIPTION
…temperatures under 10 grade

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
