### PR TITLE
Fix REST sensor UTF payload

### DIFF
--- a/homeassistant/components/rest/binary_sensor.py
+++ b/homeassistant/components/rest/binary_sensor.py
@@ -64,8 +64,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     else:
         auth = None
 
-    rest = RestData(method, resource, auth, headers, payload, verify_ssl,
-                    timeout)
+    rest = RestData(method, resource, auth, headers,
+                    payload.encode('utf-8') if payload else None,
+                    verify_ssl, timeout)
     rest.update()
     if rest.data is None:
         raise PlatformNotReady

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -76,8 +76,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             auth = HTTPBasicAuth(username, password)
     else:
         auth = None
-    rest = RestData(method, resource, auth, headers, payload, verify_ssl,
-                    timeout)
+    rest = RestData(method, resource, auth, headers,
+                    payload.encode('utf-8') if payload else None,
+                    verify_ssl, timeout)
     rest.update()
     if rest.data is None:
         raise PlatformNotReady


### PR DESCRIPTION
## Description:

This fixes issue with using non-ascee characters in REST sensors payload

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rest
    resource: http://IP_ADDRESS/ENDPOINT
    method: POST
    payload: '{ "data" : "данные" }'
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
