### PR TITLE
Fix Swisscom empty response received

### DIFF
--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -92,6 +92,10 @@ class SwisscomDeviceScanner(DeviceScanner):
             _LOGGER.info("No response from Swisscom Internet Box")
             return devices
 
+        if "status" not in request.json():
+            _LOGGER.info("No status in response from Swisscom Internet Box")
+            return devices
+
         for device in request.json()["status"]:
             try:
                 devices[device["Key"]] = {


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #28781 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```
device_tracker:
  - platform: swisscom
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
