### PR TITLE
Truncate Environment Canada sensor state values

### DIFF
--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -125,7 +125,7 @@ class ECSensor(Entity):
         value = sensor_data.get("value")
 
         if isinstance(value, list):
-            self._state = " | ".join([str(s.get("title")) for s in value])
+            self._state = " | ".join([str(s.get("title")) for s in value])[:255]
             self._attr.update(
                 {
                     ATTR_DETAIL: " | ".join([str(s.get("detail")) for s in value]),
@@ -135,7 +135,7 @@ class ECSensor(Entity):
         elif self.sensor_type == "tendency":
             self._state = str(value).capitalize()
         else:
-            self._state = value
+            self._state = value[:255]
 
         if sensor_data.get("unit") == "C" or self.sensor_type in [
             "wind_chill",


### PR DESCRIPTION
## Description:

Ensures that state values do not exceed 255 characters

**Related issue (if applicable):** fixes issue raised at https://community.home-assistant.io/t/support-for-environment-canada-platforms/126241/109

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
