### PR TITLE
Fix Comfoconnect errors during startup

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -61,6 +61,7 @@ homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/ciscospark/* @fbradyirl
 homeassistant/components/cloud/* @home-assistant/cloud
 homeassistant/components/cloudflare/* @ludeeus
+homeassistant/components/comfoconnect/* @michaelarnauts
 homeassistant/components/config/* @home-assistant/core
 homeassistant/components/configurator/* @home-assistant/core
 homeassistant/components/conversation/* @home-assistant/core

--- a/homeassistant/components/comfoconnect/__init__.py
+++ b/homeassistant/components/comfoconnect/__init__.py
@@ -136,7 +136,3 @@ class ComfoConnectBridge:
 
         # Notify listeners that we have received an update
         dispatcher_send(self.hass, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, var)
-
-    def subscribe_sensor(self, sensor_id):
-        """Subscribe for the specified sensor."""
-        self.comfoconnect.register_sensor(sensor_id)

--- a/homeassistant/components/comfoconnect/__init__.py
+++ b/homeassistant/components/comfoconnect/__init__.py
@@ -1,15 +1,14 @@
 """Support to control a Zehnder ComfoAir Q350/450/600 ventilation unit."""
 import logging
 
-import voluptuous as vol
 from pycomfoconnect import (
     SENSOR_TEMPERATURE_EXTRACT,
     SENSOR_TEMPERATURE_OUTDOOR,
     Bridge,
     ComfoConnect,
 )
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -18,6 +17,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/comfoconnect/__init__.py
+++ b/homeassistant/components/comfoconnect/__init__.py
@@ -1,14 +1,15 @@
 """Support to control a Zehnder ComfoAir Q350/450/600 ventilation unit."""
 import logging
 
+import voluptuous as vol
 from pycomfoconnect import (
     SENSOR_TEMPERATURE_EXTRACT,
     SENSOR_TEMPERATURE_OUTDOOR,
     Bridge,
     ComfoConnect,
 )
-import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -17,7 +18,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import discovery
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,7 +102,6 @@ class ComfoConnectBridge:
 
     def __init__(self, hass, bridge, name, token, friendly_name, pin):
         """Initialize the ComfoConnect bridge."""
-
         self.data = {}
         self.name = name
         self.hass = hass

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -45,7 +45,9 @@ class ComfoConnectFan(FanEntity):
     async def async_added_to_hass(self):
         """Register for sensor updates."""
         self._ccb.comfoconnect.register_sensor(SENSOR_FAN_SPEED_MODE)
-        async_dispatcher_connect(self.hass, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, self._handle_update)
+        async_dispatcher_connect(
+            self.hass, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, self._handle_update
+        )
 
     def _handle_update(self, var):
         """Handle update callbacks."""

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -18,6 +18,7 @@ from homeassistant.components.fan import (
     FanEntity,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
 from . import DOMAIN, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, ComfoConnectBridge
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/comfoconnect/manifest.json
+++ b/homeassistant/components/comfoconnect/manifest.json
@@ -6,5 +6,5 @@
     "pycomfoconnect==0.3"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@michaelarnauts"]
 }

--- a/homeassistant/components/comfoconnect/sensor.py
+++ b/homeassistant/components/comfoconnect/sensor.py
@@ -109,7 +109,9 @@ class ComfoConnectSensor(Entity):
     async def async_added_to_hass(self):
         """Register for sensor updates."""
         self._ccb.comfoconnect.register_sensor(self._sensor_id)
-        async_dispatcher_connect(self.hass, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, self._handle_update)
+        async_dispatcher_connect(
+            self.hass, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, self._handle_update
+        )
 
     def _handle_update(self, var):
         """Handle update callbacks."""

--- a/homeassistant/components/comfoconnect/sensor.py
+++ b/homeassistant/components/comfoconnect/sensor.py
@@ -85,8 +85,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         sensors.append(
             ComfoConnectSensor(
-                hass,
-                name="%s %s" % (ccb.name, SENSOR_TYPES[sensor_type][0]),
+                name=f"{ccb.name} {SENSOR_TYPES[sensor_type][0]}",
                 ccb=ccb,
                 sensor_type=sensor_type,
             )
@@ -98,7 +97,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ComfoConnectSensor(Entity):
     """Representation of a ComfoConnect sensor."""
 
-    def __init__(self, hass, name, ccb: ComfoConnectBridge, sensor_type) -> None:
+    def __init__(self, name, ccb: ComfoConnectBridge, sensor_type) -> None:
         """Initialize the ComfoConnect sensor."""
         self._ccb = ccb
         self._sensor_type = sensor_type

--- a/homeassistant/components/comfoconnect/sensor.py
+++ b/homeassistant/components/comfoconnect/sensor.py
@@ -13,6 +13,7 @@ from pycomfoconnect import (
 from homeassistant.const import CONF_RESOURCES, TEMP_CELSIUS
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
+
 from . import (
     ATTR_AIR_FLOW_EXHAUST,
     ATTR_AIR_FLOW_SUPPLY,


### PR DESCRIPTION
## Description:
This pull request fixes the "AttributeError: 'NoneType' object has no attribute 'add_job'" errors by using the `async_added_to_hass` callback.

I'm not 100% sure if this approach is correct, but it is working fine for me the last couple of days.

**Related issue (if applicable):** fixes #22781

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
