### PR TITLE
Error checks

### DIFF
--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -49,7 +49,7 @@ class Fan(HomeAccessory):
     """
 
     def __init__(self, *args):
-        """Initialize a new Light accessory object."""
+        """Initialize a new Fan accessory object."""
         super().__init__(*args, category=CATEGORY_FAN)
         self._flag = {
             CHAR_ACTIVE: False,
@@ -70,7 +70,8 @@ class Fan(HomeAccessory):
             speed_list = self.hass.states.get(self.entity_id).attributes.get(
                 ATTR_SPEED_LIST
             )
-            self.speed_mapping = HomeKitSpeedMapping(speed_list)
+            if speed_list is not None:
+                self.speed_mapping = HomeKitSpeedMapping(speed_list)
             chars.append(CHAR_ROTATION_SPEED)
 
         serv_fan = self.add_preload_service(SERV_FANV2, chars)

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -171,7 +171,7 @@ class HomeKitSpeedMapping:
 
     def __init__(self, speed_list):
         """Initialize a new SpeedMapping object."""
-        if speed_list[0] != fan.SPEED_OFF:
+        if speed_list is not None and speed_list[0] != fan.SPEED_OFF:
             _LOGGER.warning(
                 "%s does not contain the speed setting "
                 "%s as its first element. "

--- a/homeassistant/components/synologydsm/sensor.py
+++ b/homeassistant/components/synologydsm/sensor.py
@@ -119,24 +119,26 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ]
 
         # Handle all volumes
-        for volume in config.get(CONF_VOLUMES, api.storage.volumes):
-            sensors += [
-                SynoNasStorageSensor(
-                    api, name, variable, _STORAGE_VOL_MON_COND[variable], volume
-                )
-                for variable in monitored_conditions
-                if variable in _STORAGE_VOL_MON_COND
-            ]
+        if api.storage.volumes is not None:
+            for volume in config.get(CONF_VOLUMES, api.storage.volumes):
+                sensors += [
+                    SynoNasStorageSensor(
+                        api, name, variable, _STORAGE_VOL_MON_COND[variable], volume
+                    )
+                    for variable in monitored_conditions
+                    if variable in _STORAGE_VOL_MON_COND
+                ]
 
         # Handle all disks
-        for disk in config.get(CONF_DISKS, api.storage.disks):
-            sensors += [
-                SynoNasStorageSensor(
-                    api, name, variable, _STORAGE_DSK_MON_COND[variable], disk
-                )
-                for variable in monitored_conditions
-                if variable in _STORAGE_DSK_MON_COND
-            ]
+        if api.storage.disks is not None:
+            for disk in config.get(CONF_DISKS, api.storage.disks):
+                sensors += [
+                    SynoNasStorageSensor(
+                        api, name, variable, _STORAGE_DSK_MON_COND[variable], disk
+                    )
+                    for variable in monitored_conditions
+                    if variable in _STORAGE_DSK_MON_COND
+                ]
 
         add_entities(sensors, True)
 

--- a/homeassistant/components/synologydsm/sensor.py
+++ b/homeassistant/components/synologydsm/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     EVENT_HOMEASSISTANT_START,
     CONF_DISKS,
-    CONF_SCAN_INTERVAL,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -31,7 +30,7 @@ CONF_VOLUMES = "volumes"
 DEFAULT_NAME = "Synology DSM"
 DEFAULT_PORT = 5001
 
-SCAN_INTERVAL = timedelta(seconds=15)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
 
 _UTILISATION_MON_COND = {
     "cpu_other_load": ["CPU Load (Other)", "%", "mdi:chip"],
@@ -89,7 +88,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         ),
         vol.Optional(CONF_DISKS): cv.ensure_list,
         vol.Optional(CONF_VOLUMES): cv.ensure_list,
-        vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
     }
 )
 
@@ -103,7 +101,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         Delay the setup until Home Assistant is fully initialized.
         This allows any entities to be created already
         """
-        global SCAN_INTERVAL
         name = config.get(CONF_NAME)
         host = config.get(CONF_HOST)
         port = config.get(CONF_PORT)
@@ -112,7 +109,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         use_ssl = config.get(CONF_SSL)
         unit = hass.config.units.temperature_unit
         monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
-        SCAN_INTERVAL = config.get(CONF_SCAN_INTERVAL)
 
         api = SynoApi(host, port, username, password, unit, use_ssl)
 
@@ -168,7 +164,7 @@ class SynoApi:
         self.utilisation = self._api.utilisation
         self.storage = self._api.storage
 
-    @Throttle(SCAN_INTERVAL)
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update function for updating api information."""
         self._api.update()


### PR DESCRIPTION
Description:

This adds a few error checks that can cause errors.

If a fan doesn't have a speed list (MQTT discovery that wasn't setup up properly and was missing speed list), then Homekit would crash in the setup.

Similar with the Synology apps crashing if the disks or volumes was empty for any reason. 

It should now ignore these empty lists and continue on.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
