### PR TITLE
Fix documentation URL in failed platform config check

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -456,7 +456,7 @@ def _format_config_error(ex: Exception, domain: str, config: Dict) -> str:
     )
 
     if domain != CONF_CORE:
-        integration = domain.rsplit(".")[-1]
+        integration = domain.split(".")[-1]
         message += (
             "Please check the docs at "
             f"https://home-assistant.io/integrations/{integration}/"

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -456,7 +456,7 @@ def _format_config_error(ex: Exception, domain: str, config: Dict) -> str:
     )
 
     if domain != CONF_CORE:
-        integration = domain.rsplit(".").pop()
+        integration = domain.rsplit(".")[-1]
         message += (
             "Please check the docs at "
             f"https://home-assistant.io/integrations/{integration}/"

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -456,9 +456,10 @@ def _format_config_error(ex: Exception, domain: str, config: Dict) -> str:
     )
 
     if domain != CONF_CORE:
+        integration = domain.rsplit(".").pop()
         message += (
             "Please check the docs at "
-            "https://home-assistant.io/integrations/{}/".format(domain)
+            f"https://home-assistant.io/integrations/{integration}/"
         )
 
     return message


### PR DESCRIPTION
## Description:

The documentation uses integration/component domains and does not use component urls anymore.

This is a small change to strip out the integration name for the documentation from the log message in case of a failed configuration check on a platform component.

**Related issue (if applicable):** fixes #28813

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: netgear
    url: http://192.168.2.2
    username: admin
    password: fake_password
    port: 80
```

Now results in:

```bash
$ hass --script check_config
Testing configuration at /Users/frenck/.homeassistant
Failed config
  device_tracker.netgear:
    - Invalid config for [device_tracker.netgear]: [url] is an invalid option for [device_tracker.netgear]. Check: device_tracker.netgear->url. (See ?, line ?). Please check the docs at https://home-assistant.io/integrations/netgear/
    - platform: netgear
      consider_home: 0:03:00
      new_device_defaults: ?
        hide_if_away: False
        track_new_devices: True
      password: fake_password
      port: 80
      url: http://192.168.2.2
      username: admin

Successful config (partial)
  device_tracker.netgear:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
