### PR TITLE
Bump androidtv to 0.0.34

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
     "adb-shell==0.0.8",
-    "androidtv==0.0.33",
+    "androidtv==0.0.34",
     "pure-python-adb==0.2.2.dev0"
   ],
   "dependencies": [],

--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -4,7 +4,8 @@
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
     "adb-shell==0.0.8",
-    "androidtv==0.0.32"
+    "androidtv==0.0.33",
+    "pure-python-adb==0.2.2.dev0"
   ],
   "dependencies": [],
   "codeowners": ["@JeffLIrion"]

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -319,7 +319,7 @@ class ADBDevice(MediaPlayerDevice):
 
         # Property attributes
         self._adb_response = None
-        self._available = self.aftv.available
+        self._available = True
         self._current_app = None
         self._state = None
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -252,14 +252,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 def adb_decorator(override_available=False):
-    """Send an ADB command if the device is available and catch exceptions."""
+    """Wrap ADB methods and catch exceptions.
+
+    Allows for overriding the available status of the ADB connection via the
+    `override_available` parameter.
+    """
 
     def _adb_decorator(func):
-        """Wait if previous ADB commands haven't finished."""
+        """Wrap the provided ADB method and catch exceptions."""
 
         @functools.wraps(func)
         def _adb_exception_catcher(self, *args, **kwargs):
-            # If the device is unavailable, don't do anything
+            """Call an ADB-related method and catch exceptions."""
             if not self.available and not override_available:
                 return None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.32
+androidtv==0.0.33
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2
@@ -1027,6 +1027,9 @@ ptvsd==4.2.8
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.8
+
+# homeassistant.components.androidtv
+pure-python-adb==0.2.2.dev0
 
 # homeassistant.components.pushbullet
 pushbullet.py==0.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.33
+androidtv==0.0.34
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -78,7 +78,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.32
+androidtv==0.0.33
 
 # homeassistant.components.apns
 apns2==0.3.0
@@ -343,6 +343,9 @@ prometheus_client==0.7.1
 
 # homeassistant.components.ptvsd
 ptvsd==4.2.8
+
+# homeassistant.components.androidtv
+pure-python-adb==0.2.2.dev0
 
 # homeassistant.components.pushbullet
 pushbullet.py==0.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -78,7 +78,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.33
+androidtv==0.0.34
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -1,6 +1,5 @@
 """Define patches used for androidtv tests."""
 
-from socket import error as socket_error
 from unittest.mock import mock_open, patch
 
 
@@ -25,7 +24,7 @@ class AdbDeviceFake:
 
 
 class ClientFakeSuccess:
-    """A fake of the `adb_messenger.client.Client` class when the connection and shell commands succeed."""
+    """A fake of the `ppadb.client.Client` class when the connection and shell commands succeed."""
 
     def __init__(self, host="127.0.0.1", port=5037):
         """Initialize a `ClientFakeSuccess` instance."""
@@ -43,7 +42,7 @@ class ClientFakeSuccess:
 
 
 class ClientFakeFail:
-    """A fake of the `adb_messenger.client.Client` class when the connection and shell commands fail."""
+    """A fake of the `ppadb.client.Client` class when the connection and shell commands fail."""
 
     def __init__(self, host="127.0.0.1", port=5037):
         """Initialize a `ClientFakeFail` instance."""
@@ -59,7 +58,7 @@ class ClientFakeFail:
 
 
 class DeviceFake:
-    """A fake of the `adb_messenger.device.Device` class."""
+    """A fake of the `ppadb.device.Device` class."""
 
     def __init__(self, host):
         """Initialize a `DeviceFake` instance."""
@@ -75,7 +74,7 @@ class DeviceFake:
 
 
 def patch_connect(success):
-    """Mock the `adb_shell.adb_device.AdbDevice` and `adb_messenger.client.Client` classes."""
+    """Mock the `adb_shell.adb_device.AdbDevice` and `ppadb.client.Client` classes."""
 
     def connect_success_python(self, *args, **kwargs):
         """Mock the `AdbDeviceFake.connect` method when it succeeds."""
@@ -83,7 +82,7 @@ def patch_connect(success):
 
     def connect_fail_python(self, *args, **kwargs):
         """Mock the `AdbDeviceFake.connect` method when it fails."""
-        raise socket_error
+        raise OSError
 
     if success:
         return {


### PR DESCRIPTION
## Description:

Bump `androidtv` to 0.0.34.  

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
