### PR TITLE
Make intents end Snips session without speech

### DIFF
--- a/homeassistant/components/snips/__init__.py
+++ b/homeassistant/components/snips/__init__.py
@@ -150,22 +150,22 @@ async def async_setup(hass, config):
             )
             if "plain" in intent_response.speech:
                 snips_response = intent_response.speech["plain"]["speech"]
+
+            notification = {"sessionId": request.get("sessionId", "default")}
+
+            if snips_response:
+                notification["text"] = snips_response
+
+            _LOGGER.debug("send_response %s", json.dumps(notification))
+            mqtt.async_publish(
+                hass, "hermes/dialogueManager/endSession", json.dumps(notification)
+            )
         except intent.UnknownIntent:
             _LOGGER.warning(
                 "Received unknown intent %s", request["intent"]["intentName"]
             )
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
-
-        notification = {"sessionId": request.get("sessionId", "default")}
-
-        if snips_response:
-            notification["text"] = snips_response
-
-        _LOGGER.debug("send_response %s", json.dumps(notification))
-        mqtt.async_publish(
-            hass, "hermes/dialogueManager/endSession", json.dumps(notification)
-        )
 
     await hass.components.mqtt.async_subscribe(INTENT_TOPIC, message_received)
 

--- a/homeassistant/components/snips/__init__.py
+++ b/homeassistant/components/snips/__init__.py
@@ -135,7 +135,6 @@ async def async_setup(hass, config):
             intent_type = request["intent"]["intentName"].split("__")[-1]
         else:
             intent_type = request["intent"]["intentName"].split(":")[-1]
-        snips_response = None
         slots = {}
         for slot in request.get("slots", []):
             slots[slot["slotName"]] = {"value": resolve_slot_values(slot)}
@@ -148,13 +147,10 @@ async def async_setup(hass, config):
             intent_response = await intent.async_handle(
                 hass, DOMAIN, intent_type, slots, request["input"]
             )
-            if "plain" in intent_response.speech:
-                snips_response = intent_response.speech["plain"]["speech"]
-
             notification = {"sessionId": request.get("sessionId", "default")}
 
-            if snips_response:
-                notification["text"] = snips_response
+            if "plain" in intent_response.speech:
+                notification["text"] = intent_response.speech["plain"]["speech"]
 
             _LOGGER.debug("send_response %s", json.dumps(notification))
             mqtt.async_publish(

--- a/homeassistant/components/snips/__init__.py
+++ b/homeassistant/components/snips/__init__.py
@@ -157,16 +157,15 @@ async def async_setup(hass, config):
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
 
-        if snips_response:
-            notification = {
-                "sessionId": request.get("sessionId", "default"),
-                "text": snips_response,
-            }
+        notification = {"sessionId": request.get("sessionId", "default")}
 
-            _LOGGER.debug("send_response %s", json.dumps(notification))
-            mqtt.async_publish(
-                hass, "hermes/dialogueManager/endSession", json.dumps(notification)
-            )
+        if snips_response:
+            notification["text"] = snips_response
+
+        _LOGGER.debug("send_response %s", json.dumps(notification))
+        mqtt.async_publish(
+            hass, "hermes/dialogueManager/endSession", json.dumps(notification)
+        )
 
     await hass.components.mqtt.async_subscribe(INTENT_TOPIC, message_received)
 


### PR DESCRIPTION
## Description:

The snips component did not end a session when speech was not configured on an intent_script.
This led to session timeout. 
I have changed this behaviour to always end the session and add speech if configured

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x ] There is no commented out code in this PR.
  - [x ] I have followed the [development checklist][dev-checklist]
