### PR TITLE
Fix Synology camera whitelist

### DIFF
--- a/homeassistant/components/synology/camera.py
+++ b/homeassistant/components/synology/camera.py
@@ -62,7 +62,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # add cameras
     devices = []
     for camera in cameras:
-        if not config.get(CONF_WHITELIST):
+        if not config.get(CONF_WHITELIST) or camera.name in config.get(CONG_WHITELIST):
             device = SynologyCamera(surveillance, camera.camera_id, verify_ssl)
             devices.append(device)
 

--- a/homeassistant/components/synology/camera.py
+++ b/homeassistant/components/synology/camera.py
@@ -62,7 +62,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # add cameras
     devices = []
     for camera in cameras:
-        if not config.get(CONF_WHITELIST) or camera.name in config.get(CONG_WHITELIST):
+        if not config.get(CONF_WHITELIST) or camera.name in config.get(CONF_WHITELIST):
             device = SynologyCamera(surveillance, camera.camera_id, verify_ssl)
             devices.append(device)
 

--- a/homeassistant/components/synology/camera.py
+++ b/homeassistant/components/synology/camera.py
@@ -62,7 +62,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # add cameras
     devices = []
     for camera in cameras:
-        if not config.get(CONF_WHITELIST) or camera.name in config.get(CONF_WHITELIST):
+        if not config[CONF_WHITELIST] or camera.name in config[CONF_WHITELIST]:
             device = SynologyCamera(surveillance, camera.camera_id, verify_ssl)
             devices.append(device)
 


### PR DESCRIPTION
## Description:
If whitelist config list is set, no camera is added to HA at all.

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: synology
    url: http://dsm:5000/
    username: camera
    password: !secret synology_camera
    timeout: 15
    name: Webcam
    whitelist:
       - Webcam
    verify_ssl: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
