### PR TITLE
Add sighthound integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -294,7 +294,7 @@ homeassistant/components/seventeentrack/* @bachya
 homeassistant/components/shell_command/* @home-assistant/core
 homeassistant/components/shiftr/* @fabaff
 homeassistant/components/shodan/* @fabaff
-homeassistant/components/signal_messenger/* @bbernhard
+homeassistant/components/sighthound/* @robmarkcole
 homeassistant/components/simplisafe/* @bachya
 homeassistant/components/sinch/* @bendikrb
 homeassistant/components/slide/* @ualex73

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -294,6 +294,7 @@ homeassistant/components/seventeentrack/* @bachya
 homeassistant/components/shell_command/* @home-assistant/core
 homeassistant/components/shiftr/* @fabaff
 homeassistant/components/shodan/* @fabaff
+homeassistant/components/signal_messenger/* @bbernhard
 homeassistant/components/sighthound/* @robmarkcole
 homeassistant/components/simplisafe/* @bachya
 homeassistant/components/sinch/* @bendikrb

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -294,8 +294,8 @@ homeassistant/components/seventeentrack/* @bachya
 homeassistant/components/shell_command/* @home-assistant/core
 homeassistant/components/shiftr/* @fabaff
 homeassistant/components/shodan/* @fabaff
-homeassistant/components/signal_messenger/* @bbernhard
 homeassistant/components/sighthound/* @robmarkcole
+homeassistant/components/signal_messenger/* @bbernhard
 homeassistant/components/simplisafe/* @bachya
 homeassistant/components/sinch/* @bendikrb
 homeassistant/components/slide/* @ualex73

--- a/homeassistant/components/sighthound/__init__.py
+++ b/homeassistant/components/sighthound/__init__.py
@@ -1,0 +1,1 @@
+"""The sighthound integration."""

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -1,0 +1,98 @@
+"""Person detection using Sighthound cloud service."""
+from datetime import timedelta
+import logging
+
+import simplehound.core as hound
+import voluptuous as vol
+
+from homeassistant.components.image_processing import (
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_SOURCE,
+    PLATFORM_SCHEMA,
+    ImageProcessingEntity,
+)
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import split_entity_id
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+EVENT_PERSON_DETECTED = "image_processing.person_detected"
+
+ATTR_PEOPLE = "people"
+CONF_ACCOUNT_TYPE = "account_type"
+DEV = "dev"
+PROD = "prod"
+
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+SCAN_INTERVAL = timedelta(days=365)  # NEVER SCAN.
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_ACCOUNT_TYPE, default=DEV): vol.In([DEV, PROD]),
+    }
+)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the platform."""
+
+    entities = []
+    for camera in config[CONF_SOURCE]:
+        sighthound = SighthoundEntity(
+            config.get(CONF_API_KEY),
+            config.get(CONF_ACCOUNT_TYPE),
+            camera.get(CONF_ENTITY_ID),
+            camera.get(CONF_NAME),
+        )
+        entities.append(sighthound)
+    add_devices(entities)
+
+
+class SighthoundEntity(ImageProcessingEntity):
+    """Create a sighthound entity."""
+
+    def __init__(self, api_key, account_type, camera_entity, name):
+        """Init."""
+        super().__init__()
+        self._api = hound.cloud(api_key, account_type)
+        self._camera = camera_entity
+        if name:
+            self._name = name
+        else:
+            self._camera_name = split_entity_id(camera_entity)[1]
+            self._name = f"sighthound_{self._camera_name}"
+        self._state = None
+
+    def process_image(self, image):
+        """Process an image."""
+        try:
+            detections = self._api.detect(image)
+            people = hound.get_people(detections)
+            self._state = len(people)
+
+        except hound.SimplehoundException as exc:
+            _LOGGER.error(str(exc))
+
+    @property
+    def camera_entity(self):
+        """Return camera entity id from process pictures."""
+        return self._camera
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return ATTR_PEOPLE

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -26,8 +26,6 @@ CONF_ACCOUNT_TYPE = "account_type"
 DEV = "dev"
 PROD = "prod"
 
-DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-
 SCAN_INTERVAL = timedelta(days=365)  # NEVER SCAN.
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/sighthound/manifest.json
+++ b/homeassistant/components/sighthound/manifest.json
@@ -3,7 +3,7 @@
         "name": "Sighthound",
         "documentation": "https://www.home-assistant.io/integrations/sighthound",
         "requirements": [
-                "simplehound==0.2"
+                "simplehound==0.3"
         ],
         "dependencies": [],
         "codeowners": [

--- a/homeassistant/components/sighthound/manifest.json
+++ b/homeassistant/components/sighthound/manifest.json
@@ -1,0 +1,12 @@
+{
+        "domain": "sighthound",
+        "name": "Sighthound",
+        "documentation": "https://www.home-assistant.io/integrations/sighthound",
+        "requirements": [
+                "simplehound==0.2"
+        ],
+        "dependencies": [],
+        "codeowners": [
+                "@robmarkcole"
+        ]
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1809,6 +1809,9 @@ sharp_aquos_rc==0.3.2
 # homeassistant.components.shodan
 shodan==1.21.2
 
+# homeassistant.components.sighthound
+simplehound==0.2
+
 # homeassistant.components.simplepush
 simplepush==1.1.4
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1810,7 +1810,7 @@ sharp_aquos_rc==0.3.2
 shodan==1.21.2
 
 # homeassistant.components.sighthound
-simplehound==0.2
+simplehound==0.3
 
 # homeassistant.components.simplepush
 simplepush==1.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -584,6 +584,9 @@ samsungctl[websocket]==0.7.1
 # homeassistant.components.sentry
 sentry-sdk==0.13.5
 
+# homeassistant.components.sighthound
+simplehound==0.2
+
 # homeassistant.components.simplisafe
 simplisafe-python==6.0.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -585,7 +585,7 @@ samsungctl[websocket]==0.7.1
 sentry-sdk==0.13.5
 
 # homeassistant.components.sighthound
-simplehound==0.2
+simplehound==0.3
 
 # homeassistant.components.simplisafe
 simplisafe-python==6.0.0

--- a/tests/components/sighthound/__init__.py
+++ b/tests/components/sighthound/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sighthound integration."""

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -1,0 +1,22 @@
+"""Tests for the Sighthound integration."""
+
+import homeassistant.components.image_processing as ip
+from homeassistant.const import CONF_API_KEY
+from homeassistant.setup import async_setup_component
+
+VALID_CONFIG = {
+    ip.DOMAIN: {
+        "platform": "sighthound",
+        CONF_API_KEY: "abc123",
+        ip.CONF_SOURCE: {ip.CONF_ENTITY_ID: "camera.demo_camera"},
+    },
+    "camera": {"platform": "demo"},
+}
+
+VALID_ENTITY_ID = "image_processing.sighthound_demo_camera"
+
+
+async def test_setup_platform(hass):
+    """Set up platform with one entity."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -55,7 +55,7 @@ def mock_image():
         yield image
 
 
-async def test_setup_platform(hass):
+async def test_setup_platform(hass, mock_detections):
     """Set up platform with one entity."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 import pytest
+import simplehound.core as hound
 
 import homeassistant.components.image_processing as ip
 import homeassistant.components.sighthound.image_processing as sh
@@ -53,6 +54,14 @@ def mock_image():
         return_value=b"Test",
     ) as image:
         yield image
+
+
+async def test_bad_api_key(hass, caplog):
+    """Catch bad api key."""
+    with patch("simplehound.core.cloud.detect", side_effect=hound.SimplehoundException):
+        await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+        assert "Sighthound error" in caplog.text
+        assert not hass.states.get(VALID_ENTITY_ID)
 
 
 async def test_setup_platform(hass, mock_detections):


### PR DESCRIPTION
# Description:
Adds integration for person detection with [Sighthound cloud](https://www.sighthound.com/products/cloud). The Sighthound Developer tier (free for non-commercial use) allows 5000 requests per month. If you need more requests per month you will need to sign up for a production account (i.e. Basic or Pro account).

This integration adds an image processing entity where the state of the entity is the number of people detected in an image. For each person detected, an image_processing.person_detected event is fired. The event data includes the entity_id of the image processing entity firing the event, and the bounding box around the detected person. **Note** that in order to prevent accidentally using up your requets to Sighthound, by default the component will not automatically scan images, but requires you to call the image_processing.scan service e.g. using an automation triggered by motion. Alternativley, periodic scanning can be enabled by configuring a scan_interval.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11203

## Example entry for `configuration.yaml` (if applicable):
```yaml
image_processing:
  - platform: sighthound
    api_key: some_key
    source:
      - entity_id: camera.my_cam
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
