### PR TITLE
Align naming

### DIFF
--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -5,14 +5,12 @@ import logging
 import voluptuous as vol
 import wakeonlan
 
-from homeassistant.const import CONF_MAC
+from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_MAC
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "wake_on_lan"
-
-CONF_BROADCAST_ADDRESS = "broadcast_address"
 
 SERVICE_SEND_MAGIC_PACKET = "send_magic_packet"
 

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -7,14 +7,12 @@ import voluptuous as vol
 import wakeonlan
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_HOST, CONF_MAC, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.script import Script
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_BROADCAST_ADDRESS = "broadcast_address"
-CONF_MAC_ADDRESS = "mac_address"
 CONF_OFF_ACTION = "turn_off"
 
 DEFAULT_NAME = "Wake on LAN"
@@ -22,7 +20,7 @@ DEFAULT_PING_TIMEOUT = 1
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_MAC_ADDRESS): cv.string,
+        vol.Required(CONF_MAC): cv.string,
         vol.Optional(CONF_BROADCAST_ADDRESS): cv.string,
         vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -35,16 +33,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up a wake on lan switch."""
     broadcast_address = config.get(CONF_BROADCAST_ADDRESS)
     host = config.get(CONF_HOST)
-    mac_address = config.get(CONF_MAC_ADDRESS)
-    name = config.get(CONF_NAME)
+    mac_address = config[CONF_MAC]
+    name = config[CONF_NAME]
     off_action = config.get(CONF_OFF_ACTION)
 
     add_entities(
-        [WOLSwitch(hass, name, host, mac_address, off_action, broadcast_address)], True
+        [WolSwitch(hass, name, host, mac_address, off_action, broadcast_address)], True
     )
 
 
-class WOLSwitch(SwitchDevice):
+class WolSwitch(SwitchDevice):
     """Representation of a wake on lan switch."""
 
     def __init__(self, hass, name, host, mac_address, off_action, broadcast_address):

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -30,7 +30,7 @@ def system():
     return "Windows"
 
 
-class TestWOLSwitch(unittest.TestCase):
+class TestWolSwitch(unittest.TestCase):
     """Test the wol switch."""
 
     def setUp(self):

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -53,7 +53,7 @@ class TestWolSwitch(unittest.TestCase):
             {
                 "switch": {
                     "platform": "wake_on_lan",
-                    "mac_address": "00-01-02-03-04-05",
+                    "mac": "00-01-02-03-04-05",
                     "host": "validhostname",
                 }
             },
@@ -89,7 +89,7 @@ class TestWolSwitch(unittest.TestCase):
             {
                 "switch": {
                     "platform": "wake_on_lan",
-                    "mac_address": "00-01-02-03-04-05",
+                    "mac": "00-01-02-03-04-05",
                     "host": "validhostname",
                 }
             },
@@ -113,7 +113,7 @@ class TestWolSwitch(unittest.TestCase):
         assert setup_component(
             self.hass,
             switch.DOMAIN,
-            {"switch": {"platform": "wake_on_lan", "mac_address": "00-01-02-03-04-05"}},
+            {"switch": {"platform": "wake_on_lan", "mac": "00-01-02-03-04-05"}},
         )
 
     @patch("wakeonlan.send_magic_packet", new=send_magic_packet)
@@ -126,7 +126,7 @@ class TestWolSwitch(unittest.TestCase):
             {
                 "switch": {
                     "platform": "wake_on_lan",
-                    "mac_address": "00-01-02-03-04-05",
+                    "mac": "00-01-02-03-04-05",
                     "broadcast_address": "255.255.255.255",
                 }
             },
@@ -150,7 +150,7 @@ class TestWolSwitch(unittest.TestCase):
             {
                 "switch": {
                     "platform": "wake_on_lan",
-                    "mac_address": "00-01-02-03-04-05",
+                    "mac": "00-01-02-03-04-05",
                     "host": "validhostname",
                     "turn_off": {"service": "shell_command.turn_off_target"},
                 }
@@ -192,7 +192,7 @@ class TestWolSwitch(unittest.TestCase):
             {
                 "switch": {
                     "platform": "wake_on_lan",
-                    "mac_address": "00-01-02-03-04-05",
+                    "mac": "00-01-02-03-04-05",
                     "host": "invalidhostname",
                 }
             },


### PR DESCRIPTION
## Breaking Change:
The configuration key `mac_address:` was renamed to `mac:` to be in sync with with the service.

## Description:
- Use `mac:` for the service and the platform
- Use constant from `const.py`

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11205

## Example entry for `configuration.yaml` (if applicable):
```yaml
wake_on_lan:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
