### PR TITLE
Improve MAX! Cube integration

### DIFF
--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -113,10 +113,9 @@ class MaxCubeClimate(ClimateDevice):
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
         if device.target_temperature == OFF_TEMPERATURE:
             return HVAC_MODE_OFF
-        elif device.target_temperature == ON_TEMPERATURE:
+        if device.target_temperature == ON_TEMPERATURE:
             return HVAC_MODE_HEAT
-        else:
-            return HVAC_MODE_AUTO
+        return HVAC_MODE_AUTO
 
     @property
     def hvac_modes(self):
@@ -136,11 +135,11 @@ class MaxCubeClimate(ClimateDevice):
             temp = ON_TEMPERATURE
             mode = MAX_DEVICE_MODE_MANUAL
         else:
-            # Reset the temperature to a sane value
-            # TODO: Ideally, we should send 0 and the device will
-            # set its temperature according to the schedule. However
-            # current version of the library has a bug which causes
-            # an exception when setting values below 8.
+            # Reset the temperature to a sane value.
+            # Ideally, we should send 0 and the device will set its
+            # temperature according to the schedule. However, current
+            # version of the library has a bug which causes an
+            # exception when setting values below 8.
             if temp in [OFF_TEMPERATURE, ON_TEMPERATURE]:
                 temp = device.eco_temperature
             mode = MAX_DEVICE_MODE_AUTOMATIC
@@ -167,14 +166,16 @@ class MaxCubeClimate(ClimateDevice):
                 if cube.is_thermostat(device) and device.valve_position > 0:
                     valve = device.valve_position
                     break
+        else:
+            return None
 
         # Assume heating when valve is open
         if valve > 0:
             return CURRENT_HVAC_HEAT
-        else:
-            return CURRENT_HVAC_OFF if self.hvac_mode == HVAC_MODE_OFF else CURRENT_HVAC_IDLE
 
-        return None
+        return (
+            CURRENT_HVAC_OFF if self.hvac_mode == HVAC_MODE_OFF else CURRENT_HVAC_IDLE
+        )
 
     @property
     def target_temperature(self):
@@ -209,7 +210,7 @@ class MaxCubeClimate(ClimateDevice):
         if device.mode == MAX_DEVICE_MODE_MANUAL:
             if device.target_temperature == device.comfort_temperature:
                 return PRESET_COMFORT
-            elif device.target_temperature == device.eco_temperature:
+            if device.target_temperature == device.eco_temperature:
                 return PRESET_ECO
 
         return self.map_mode_max_hass(device.mode)
@@ -217,7 +218,14 @@ class MaxCubeClimate(ClimateDevice):
     @property
     def preset_modes(self):
         """Return available preset modes."""
-        return [PRESET_NONE, PRESET_BOOST, PRESET_COMFORT, PRESET_ECO, PRESET_MANUAL, PRESET_AWAY]
+        return [
+            PRESET_NONE,
+            PRESET_BOOST,
+            PRESET_COMFORT,
+            PRESET_ECO,
+            PRESET_MANUAL,
+            PRESET_AWAY,
+        ]
 
     def set_preset_mode(self, preset_mode):
         """Set new operation mode."""

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -15,9 +15,14 @@ from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
     HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
     PRESET_AWAY,
     PRESET_BOOST,
+    PRESET_COMFORT,
+    PRESET_ECO,
     PRESET_NONE,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
@@ -29,6 +34,11 @@ from . import DATA_KEY
 _LOGGER = logging.getLogger(__name__)
 
 PRESET_MANUAL = "manual"
+# There are two magic temperature values, which indicate:
+# Off (valve fully closed)
+OFF_TEMPERATURE = 4.5
+# On (valve fully open)
+ON_TEMPERATURE = 30.5
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
@@ -54,7 +64,6 @@ class MaxCubeClimate(ClimateDevice):
     def __init__(self, handler, name, rf_address):
         """Initialize MAX! Cube ClimateDevice."""
         self._name = name
-        self._operation_list = [HVAC_MODE_AUTO]
         self._rf_address = rf_address
         self._cubehandle = handler
 
@@ -101,12 +110,48 @@ class MaxCubeClimate(ClimateDevice):
     @property
     def hvac_mode(self):
         """Return current operation mode."""
-        return HVAC_MODE_AUTO
+        device = self._cubehandle.cube.device_by_rf(self._rf_address)
+        if device.target_temperature == OFF_TEMPERATURE:
+            return HVAC_MODE_OFF
+        elif device.target_temperature == ON_TEMPERATURE:
+            return HVAC_MODE_HEAT
+        else:
+            return HVAC_MODE_AUTO
 
     @property
     def hvac_modes(self):
         """Return the list of available operation modes."""
-        return self._operation_list
+        return [HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_HEAT]
+
+    def set_hvac_mode(self, hvac_mode: str):
+        """Set new target hvac mode."""
+        device = self._cubehandle.cube.device_by_rf(self._rf_address)
+        temp = device.target_temperature
+        mode = device.mode
+
+        if hvac_mode == HVAC_MODE_OFF:
+            temp = OFF_TEMPERATURE
+            mode = MAX_DEVICE_MODE_MANUAL
+        elif hvac_mode == HVAC_MODE_HEAT:
+            temp = ON_TEMPERATURE
+            mode = MAX_DEVICE_MODE_MANUAL
+        else:
+            # Reset the temperature to a sane value
+            # TODO: Ideally, we should send 0 and the device will
+            # set its temperature according to the schedule. However
+            # current version of the library has a bug which causes
+            # an exception when setting values below 8.
+            if temp in [OFF_TEMPERATURE, ON_TEMPERATURE]:
+                temp = device.eco_temperature
+            mode = MAX_DEVICE_MODE_AUTOMATIC
+
+        cube = self._cubehandle.cube
+        with self._cubehandle.mutex:
+            try:
+                cube.set_temperature_mode(device, temp, mode)
+            except (socket.timeout, socket.error):
+                _LOGGER.error("Setting HVAC mode failed")
+                return
 
     @property
     def hvac_action(self):
@@ -118,7 +163,7 @@ class MaxCubeClimate(ClimateDevice):
             if device.valve_position > 0:
                 return CURRENT_HVAC_HEAT
             else:
-                return CURRENT_HVAC_IDLE
+                return CURRENT_HVAC_IDLE if self.hvac_mode == HVAC_MODE_AUTO else CURRENT_HVAC_OFF
 
         return None
 
@@ -149,24 +194,43 @@ class MaxCubeClimate(ClimateDevice):
     def preset_mode(self):
         """Return the current preset mode."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
+        if self.hvac_mode in [HVAC_MODE_OFF, HVAC_MODE_HEAT]:
+            return PRESET_NONE
+
+        if device.mode == MAX_DEVICE_MODE_MANUAL:
+            if device.target_temperature == device.comfort_temperature:
+                return PRESET_COMFORT
+            elif device.target_temperature == device.eco_temperature:
+                return PRESET_ECO
+
         return self.map_mode_max_hass(device.mode)
 
     @property
     def preset_modes(self):
         """Return available preset modes."""
-        return [PRESET_NONE, PRESET_MANUAL, PRESET_BOOST, PRESET_AWAY]
+        return [PRESET_NONE, PRESET_BOOST, PRESET_COMFORT, PRESET_ECO, PRESET_MANUAL, PRESET_AWAY]
 
     def set_preset_mode(self, preset_mode):
         """Set new operation mode."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
-        mode = self.map_mode_hass_max(preset_mode) or MAX_DEVICE_MODE_AUTOMATIC
+        temp = device.target_temperature
+        mode = MAX_DEVICE_MODE_AUTOMATIC
+
+        if preset_mode in [PRESET_COMFORT, PRESET_ECO]:
+            mode = MAX_DEVICE_MODE_MANUAL
+            if preset_mode == PRESET_COMFORT:
+                temp = device.comfort_temperature
+            else:
+                temp = device.eco_temperature
+        else:
+            mode = self.map_mode_hass_max(preset_mode) or MAX_DEVICE_MODE_AUTOMATIC
 
         with self._cubehandle.mutex:
             try:
-                self._cubehandle.cube.set_mode(device, mode)
+                self._cubehandle.cube.set_temperature_mode(device, temp, mode)
             except (socket.timeout, OSError):
                 _LOGGER.error("Setting operation mode failed")
-                return False
+                return
 
     def update(self):
         """Get latest data from MAX! Cube."""

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -31,7 +31,9 @@ from . import DATA_KEY
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_VALVE_POSITION = "valve_position"
 PRESET_MANUAL = "manual"
+
 # There are two magic temperature values, which indicate:
 # Off (valve fully closed)
 OFF_TEMPERATURE = 4.5
@@ -170,7 +172,7 @@ class MaxCubeClimate(ClimateDevice):
         if valve > 0:
             return CURRENT_HVAC_HEAT
         else:
-            return CURRENT_HVAC_IDLE if self.hvac_mode == HVAC_MODE_AUTO else CURRENT_HVAC_OFF
+            return CURRENT_HVAC_OFF if self.hvac_mode == HVAC_MODE_OFF else CURRENT_HVAC_IDLE
 
         return None
 
@@ -238,6 +240,18 @@ class MaxCubeClimate(ClimateDevice):
             except (socket.timeout, OSError):
                 _LOGGER.error("Setting operation mode failed")
                 return
+
+    @property
+    def state_attributes(self):
+        """Return the optional state attributes."""
+        cube = self._cubehandle.cube
+        device = cube.device_by_rf(self._rf_address)
+        attributes = super().state_attributes
+
+        if cube.is_thermostat(device):
+            attributes[ATTR_VALVE_POSITION] = device.valve_position
+
+        return attributes
 
     def update(self):
         """Get latest data from MAX! Cube."""

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -7,10 +7,14 @@ from maxcube.device import (
     MAX_DEVICE_MODE_BOOST,
     MAX_DEVICE_MODE_MANUAL,
     MAX_DEVICE_MODE_VACATION,
+    MAX_THERMOSTAT,
+    MAX_THERMOSTAT_PLUS,
 )
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
     HVAC_MODE_AUTO,
     PRESET_AWAY,
     PRESET_BOOST,
@@ -103,6 +107,20 @@ class MaxCubeClimate(ClimateDevice):
     def hvac_modes(self):
         """Return the list of available operation modes."""
         return self._operation_list
+
+    @property
+    def hvac_action(self):
+        """Return the current running hvac operation if supported."""
+        device = self._cubehandle.cube.device_by_rf(self._rf_address)
+
+        if device.type in [MAX_THERMOSTAT, MAX_THERMOSTAT_PLUS]:
+            # Assume heating when valve is open
+            if device.valve_position > 0:
+                return CURRENT_HVAC_HEAT
+            else:
+                return CURRENT_HVAC_IDLE
+
+        return None
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -12,6 +12,9 @@ from maxcube.device import (
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
+    PRESET_AWAY,
+    PRESET_BOOST,
+    PRESET_NONE,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -22,8 +25,6 @@ from . import DATA_KEY
 _LOGGER = logging.getLogger(__name__)
 
 PRESET_MANUAL = "manual"
-PRESET_BOOST = "boost"
-PRESET_VACATION = "vacation"
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
@@ -95,7 +96,7 @@ class MaxCubeClimate(ClimateDevice):
 
     @property
     def hvac_mode(self):
-        """Return current operation (auto, manual, boost, vacation)."""
+        """Return current operation mode."""
         return HVAC_MODE_AUTO
 
     @property
@@ -135,7 +136,7 @@ class MaxCubeClimate(ClimateDevice):
     @property
     def preset_modes(self):
         """Return available preset modes."""
-        return [PRESET_BOOST, PRESET_MANUAL, PRESET_VACATION]
+        return [PRESET_NONE, PRESET_MANUAL, PRESET_BOOST, PRESET_AWAY]
 
     def set_preset_mode(self, preset_mode):
         """Set new operation mode."""
@@ -164,9 +165,11 @@ class MaxCubeClimate(ClimateDevice):
     @staticmethod
     def map_mode_hass_max(mode):
         """Map Home Assistant Operation Modes to MAX! Operation Modes."""
-        if mode == PRESET_MANUAL:
+        if mode == PRESET_NONE:
+            mode = MAX_DEVICE_MODE_AUTOMATIC
+        elif mode == PRESET_MANUAL:
             mode = MAX_DEVICE_MODE_MANUAL
-        elif mode == PRESET_VACATION:
+        elif mode == PRESET_AWAY:
             mode = MAX_DEVICE_MODE_VACATION
         elif mode == PRESET_BOOST:
             mode = MAX_DEVICE_MODE_BOOST
@@ -178,10 +181,12 @@ class MaxCubeClimate(ClimateDevice):
     @staticmethod
     def map_mode_max_hass(mode):
         """Map MAX! Operation Modes to Home Assistant Operation Modes."""
-        if mode == MAX_DEVICE_MODE_MANUAL:
+        if mode == MAX_DEVICE_MODE_AUTOMATIC:
+            operation_mode = PRESET_NONE
+        elif mode == MAX_DEVICE_MODE_MANUAL:
             operation_mode = PRESET_MANUAL
         elif mode == MAX_DEVICE_MODE_VACATION:
-            operation_mode = PRESET_VACATION
+            operation_mode = PRESET_AWAY
         elif mode == MAX_DEVICE_MODE_BOOST:
             operation_mode = PRESET_BOOST
         else:


### PR DESCRIPTION
## Breaking Change:

Custom `vacation` preset was replaced with standard `away`. Additionally, `manual` preset was removed in favor of HVAC mode `heat`. This might affect people's scripts, templates or automations.

## Description:

A few improvements to the MAX! Cube platform:

1. It wasn't possible to return to automatic (scheduled) operation after switching to `manual` preset. `none` preset was added, which switches thermostats to automatic (scheduled) operation.

2. *Manual* preset was removed. HVAC mode *Heat* now switches thermostats into manual mode.

3. `hvac_action` was implemented, based on the valve position: if it's open (position higher than 0), we assume that hot water is flowing and heating is active. Else, the thermostat is in *Idle* mode. For wall thermostats, if at least one thermostat in the room has its valve open, then heating is active.

4. Support for *Comfort*, *Eco*, *Off* and *On* modes was added. *Comfort*, *Eco* and *On* are exposed as presets and switch thermostats into manual mode with corresponding temperatures, programmed on the thermostats. *Off* corresponds to HVAC mode *Off*.

5. Valve position is exposed as state attribute.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html