### PR TITLE
Catch samsungtv websocket exceptions

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -217,16 +217,13 @@ class SamsungTVDevice(MediaPlayerDevice):
         except AttributeError:
             # Auto-detect could not find working config yet
             pass
-        except (
-            samsung_exceptions.UnhandledResponse,
-            samsung_exceptions.AccessDenied,
-        ):
+        except (samsung_exceptions.UnhandledResponse, samsung_exceptions.AccessDenied):
             # We got a response so it's on.
             self._state = STATE_ON
             self._remote = None
             LOGGER.debug("Failed sending command %s", key, exc_info=True)
             return
-        except OSError, WebSocketException:
+        except (OSError, WebSocketException):
             self._state = STATE_OFF
             self._remote = None
         if self._power_off_in_progress():

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -210,8 +210,13 @@ class SamsungTVDevice(MediaPlayerDevice):
                 try:
                     self.get_remote().control(key)
                     break
-                except (samsung_exceptions.ConnectionClosed, BrokenPipeError):
+                except (
+                    samsung_exceptions.ConnectionClosed,
+                    BrokenPipeError,
+                    WebSocketException,
+                ):
                     # BrokenPipe can occur when the commands is sent to fast
+                    # WebSocketException can occur when timed out
                     self._remote = None
             self._state = STATE_ON
         except AttributeError:
@@ -223,7 +228,8 @@ class SamsungTVDevice(MediaPlayerDevice):
             self._remote = None
             LOGGER.debug("Failed sending command %s", key, exc_info=True)
             return
-        except (OSError, WebSocketException):
+        except OSError:
+            # Different reasons, e.g. hostname not resolveable
             self._state = STATE_OFF
             self._remote = None
         if self._power_off_in_progress():

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -6,7 +6,7 @@ import socket
 from samsungctl import exceptions as samsung_exceptions, Remote as SamsungRemote
 import voluptuous as vol
 import wakeonlan
-from websocket._exceptions import WebSocketException
+from websocket import WebSocketException
 
 from homeassistant.components.media_player import (
     MediaPlayerDevice,

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -6,6 +6,7 @@ import socket
 from samsungctl import exceptions as samsung_exceptions, Remote as SamsungRemote
 import voluptuous as vol
 import wakeonlan
+from websocket._exceptions import WebSocketException
 
 from homeassistant.components.media_player import (
     MediaPlayerDevice,
@@ -225,7 +226,7 @@ class SamsungTVDevice(MediaPlayerDevice):
             self._remote = None
             LOGGER.debug("Failed sending command %s", key, exc_info=True)
             return
-        except OSError:
+        except OSError, WebSocketException:
             self._state = STATE_OFF
             self._remote = None
         if self._power_off_in_progress():

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -8,6 +8,7 @@ from asynctest import mock
 import pytest
 from samsungctl import exceptions
 from tests.common import async_fire_time_changed
+from websocket import WebSocketException
 
 from homeassistant.components.media_player import DEVICE_CLASS_TV
 from homeassistant.components.media_player.const import (
@@ -380,6 +381,17 @@ async def test_send_key_unhandled_response(hass, remote):
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = mock.Mock(side_effect=exceptions.UnhandledResponse("Boom"))
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_ON
+
+
+async def test_send_key_websocketexception(hass, remote):
+    """Testing unhandled response exception."""
+    await setup_samsungtv(hass, MOCK_CONFIG)
+    remote.control = mock.Mock(side_effect=WebSocketException("Boom"))
     assert await hass.services.async_call(
         DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Catch websocket exceptions and assume state OFF

**Related issue (if applicable):** fixes #28842

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
