### PR TITLE
Downgrade duplicate YAML key log to warning

### DIFF
--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -211,7 +211,7 @@ def _ordered_dict(loader: SafeLineLoader, node: yaml.nodes.MappingNode) -> Order
 
         if key in seen:
             fname = getattr(loader.stream, "name", "")
-            _LOGGER.error(
+            _LOGGER.warning(
                 'YAML file %s contains duplicate key "%s". ' "Check lines %d and %d.",
                 fname,
                 key,


### PR DESCRIPTION
## Description:

In case of a duplicate YAML key, our configuration check will just pass. However, when actually using the configuration, Home Assistant will throw errors in the log. This is handled gracefully. Home Assistant will continue to work.

Hence, an `ERROR` level log message might suggest differently. (See raised issue #22525). This PR downgrades the log level to `WARNING` in case of a duplicate key.

**Related issue (if applicable):** fixes #22525

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
