### PR TITLE
Pulseaudio: Changed default port from 4712 to 4713

### DIFF
--- a/homeassistant/components/pulseaudio_loopback/switch.py
+++ b/homeassistant/components/pulseaudio_loopback/switch.py
@@ -22,7 +22,7 @@ CONF_TCP_TIMEOUT = "tcp_timeout"
 DEFAULT_BUFFER_SIZE = 1024
 DEFAULT_HOST = "localhost"
 DEFAULT_NAME = "paloopback"
-DEFAULT_PORT = 4712
+DEFAULT_PORT = 4713
 DEFAULT_TCP_TIMEOUT = 3
 
 IGNORED_SWITCH_WARN = "Switch is already in the desired state. Ignoring."


### PR DESCRIPTION
## Breaking Change:
**Pulseaudio_Loopback:** The default port was incorrectly set to 4712, however the [official documentation](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Network/#index1h2) states that the default port is 4713. Therefore, the port has been changed and all previously configured switches now need to listen to port 4713.
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #28846<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11224

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
