### PR TITLE
Add hvac_action to HomematicIP Cloud Climate

### DIFF
--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -10,6 +10,7 @@ from homematicip.functionalHomes import IndoorClimateHome
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
@@ -139,6 +140,22 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
             if self._heat_mode_enabled
             else [HVAC_MODE_AUTO, HVAC_MODE_COOL]
         )
+
+    @property
+    def hvac_action(self) -> Optional[str]:
+        """
+        Return the current hvac_action.
+
+        This is only relevant for radiator thermostats.
+        """
+        if (
+            self._has_radiator_thermostat
+            and self._device.valvePosition
+            and self._heat_mode_enabled
+        ):
+            return CURRENT_HVAC_HEAT
+
+        return None
 
     @property
     def preset_mode(self) -> Optional[str]:
@@ -311,7 +328,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     @property
     def _first_radiator_thermostat(
-        self,
+        self
     ) -> Optional[Union[AsyncHeatingThermostat, AsyncHeatingThermostatCompact]]:
         """Return the first radiator thermostat from the hmip heating group."""
         for device in self._device.devices:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -149,7 +149,11 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
         This is only relevant for radiator thermostats.
         """
-        if self._device.floorHeatingMode == "RADIATOR":
+        if (
+            self._device.floorHeatingMode == "RADIATOR"
+            and self._has_radiator_thermostat
+            and self._heat_mode_enabled
+        ):
             return (
                 CURRENT_HVAC_HEAT if self._device.valvePosition else CURRENT_HVAC_IDLE
             )
@@ -327,7 +331,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     @property
     def _first_radiator_thermostat(
-        self
+        self,
     ) -> Optional[Union[AsyncHeatingThermostat, AsyncHeatingThermostatCompact]]:
         """Return the first radiator thermostat from the hmip heating group."""
         for device in self._device.devices:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -11,6 +11,7 @@ from homematicip.functionalHomes import IndoorClimateHome
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
@@ -148,12 +149,10 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
         This is only relevant for radiator thermostats.
         """
-        if (
-            self._has_radiator_thermostat
-            and self._device.valvePosition
-            and self._heat_mode_enabled
-        ):
-            return CURRENT_HVAC_HEAT
+        if self._device.floorHeatingMode == "RADIATOR":
+            return (
+                CURRENT_HVAC_HEAT if self._device.valvePosition else CURRENT_HVAC_IDLE
+            )
 
         return None
 

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -7,8 +7,11 @@ from homematicip.functionalHomes import IndoorClimateHome
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.climate.const import (
     ATTR_CURRENT_TEMPERATURE,
+    ATTR_HVAC_ACTION,
     ATTR_PRESET_MODE,
     ATTR_PRESET_MODES,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
@@ -214,6 +217,17 @@ async def test_hmip_heating_group_heat(hass, default_mock_hap):
     assert len(hmip_device.mock_calls) == service_call_counter + 24
     # Only fire event from last async_manipulate_test_data available.
     assert hmip_device.mock_calls[-1][0] == "fire_update_event"
+
+    await async_manipulate_test_data(hass, hmip_device, "floorHeatingMode", "RADIATOR")
+    await async_manipulate_test_data(hass, hmip_device, "valvePosition", 0.1)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == HVAC_MODE_AUTO
+    assert ha_state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_HEAT
+    await async_manipulate_test_data(hass, hmip_device, "floorHeatingMode", "RADIATOR")
+    await async_manipulate_test_data(hass, hmip_device, "valvePosition", 0.0)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == HVAC_MODE_AUTO
+    assert ha_state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
 
 
 async def test_hmip_heating_group_cool(hass, default_mock_hap):

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -5265,7 +5265,7 @@
             "setPointTemperature": 5.0,
             "type": "HEATING",
             "unreach": false,
-            "valvePosition": 0.0,
+            "valvePosition": 0.1,
             "valveSilentModeEnabled": false,
             "valveSilentModeSupported": false,
             "heatingFailureSupported": true,

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -5265,7 +5265,7 @@
             "setPointTemperature": 5.0,
             "type": "HEATING",
             "unreach": false,
-            "valvePosition": 0.1,
+            "valvePosition": 0.0,
             "valveSilentModeEnabled": false,
             "valveSilentModeSupported": false,
             "heatingFailureSupported": true,


### PR DESCRIPTION
## Description:
Add hvac_action to HomematicIP Cloud Climate

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
