### PR TITLE
Fix setting colors while reproducing a lights state

### DIFF
--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -44,13 +44,12 @@ ATTR_GROUP = [
     ATTR_TRANSITION,
 ]
 
-# This list needs to be ordered by the precision of the color models
 COLOR_GROUP = [
-    ATTR_RGB_COLOR,
-    ATTR_XY_COLOR,
     ATTR_HS_COLOR,
     ATTR_COLOR_TEMP,
-    # The following color models are deprecated
+    ATTR_RGB_COLOR,
+    ATTR_XY_COLOR,
+    # The following color attributes are deprecated
     ATTR_PROFILE,
     ATTR_COLOR_NAME,
     ATTR_KELVIN,

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -44,14 +44,16 @@ ATTR_GROUP = [
     ATTR_TRANSITION,
 ]
 
+# This list needs to be ordered by the precision of the color models
 COLOR_GROUP = [
-    ATTR_COLOR_NAME,
-    ATTR_COLOR_TEMP,
-    ATTR_HS_COLOR,
-    ATTR_KELVIN,
-    ATTR_PROFILE,
     ATTR_RGB_COLOR,
     ATTR_XY_COLOR,
+    ATTR_HS_COLOR,
+    ATTR_COLOR_TEMP,
+    # The following color models are deprecated
+    ATTR_PROFILE,
+    ATTR_COLOR_NAME,
+    ATTR_KELVIN,
 ]
 
 DEPRECATED_GROUP = [


### PR DESCRIPTION
## Breaking Change:
Nothing breaks

## Description:
We should set only one color attribute while reproducing a lights state, so we chose the first color attribute we encounter. This list is now ordered so that we choose that color attribute with the best accuracy.

**Related issue (if applicable):** fixes #

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
