### PR TITLE
Remove bogus unit from invalid temperature state

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -380,8 +380,9 @@ class Entity:
                 state = str(round(temp) if prec == 0 else round(temp, prec))
                 attr[ATTR_UNIT_OF_MEASUREMENT] = units.temperature_unit
         except ValueError:
-            # Could not convert state to float
-            pass
+            # Could not convert state to float - avoid passing along invalid
+            # unit_of_measurement in this case
+            attr[ATTR_UNIT_OF_MEASUREMENT] = None
 
         if (
             self._context is not None


### PR DESCRIPTION
## Description:

Normally states representing temperature measurements have the value and
unit_of_measurement converted to the unit system of the user's
preference. In cases where the value is non-numeric (e.g. "unknown" or
"unavailable"), the unit_of_measurement should be removed, so avoid
confusion when using the state history (e.g. the lovelave "history
graph" card).

**Related issue (if applicable):** fixes #28774

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
