### PR TITLE
Add @rohankapoorcom to CODEOWNERS for speedtestdotnet and fastdotcom

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -95,6 +95,7 @@ homeassistant/components/eq3btsmart/* @rytilahti
 homeassistant/components/esphome/* @OttoWinter
 homeassistant/components/essent/* @TheLastProject
 homeassistant/components/evohome/* @zxdavb
+homeassistant/components/fastdotcom/* @rohankapoorcom
 homeassistant/components/file/* @fabaff
 homeassistant/components/filter/* @dgomes
 homeassistant/components/fitbit/* @robbiet480
@@ -282,6 +283,7 @@ homeassistant/components/soma/* @ratsept
 homeassistant/components/somfy/* @tetienne
 homeassistant/components/songpal/* @rytilahti
 homeassistant/components/spaceapi/* @fabaff
+homeassistant/components/speedtestdotnet/* @rohankapoorcom
 homeassistant/components/spider/* @peternijssen
 homeassistant/components/sql/* @dgomes
 homeassistant/components/statistics/* @fabaff

--- a/homeassistant/components/fastdotcom/manifest.json
+++ b/homeassistant/components/fastdotcom/manifest.json
@@ -6,5 +6,7 @@
     "fastdotcom==0.0.3"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@rohankapoorcom"
+  ]
 }

--- a/homeassistant/components/speedtestdotnet/manifest.json
+++ b/homeassistant/components/speedtestdotnet/manifest.json
@@ -6,5 +6,7 @@
     "speedtest-cli==2.1.2"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@rohankapoorcom"
+  ]
 }


### PR DESCRIPTION
## Description:

Add myself as the CODEOWNERS for fastdotcom and speedtestdotnet. I've done the majority of the work on these components (including the last rewrite) and plan on doing further work here. This includes swapping out the speedtestdotnet library implementation to use the [new API](https://www.speedtest.net/insights/blog/introducing-speedtest-cli/) released by Ookla.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
