### PR TITLE
Add uptime and number of reboot for bbox sensor

### DIFF
--- a/homeassistant/components/bbox/sensor.py
+++ b/homeassistant/components/bbox/sensor.py
@@ -51,8 +51,8 @@ SENSOR_TYPES = {
         BANDWIDTH_MEGABITS_SECONDS,
         "mdi:upload",
     ],
-    "uptime": ["Uptime", None, "mdi:clock", ],
-    "number_of_reboots": ["Number of reboot", None, "mdi:restart", ],
+    "uptime": ["Uptime", None, "mdi:clock"],
+    "number_of_reboots": ["Number of reboot", None, "mdi:restart"],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/bbox/sensor.py
+++ b/homeassistant/components/bbox/sensor.py
@@ -9,9 +9,15 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_MONITORED_VARIABLES, ATTR_ATTRIBUTION
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_MONITORED_VARIABLES,
+    ATTR_ATTRIBUTION,
+    DEVICE_CLASS_TIMESTAMP,
+)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+from homeassistant.util.dt import utcnow
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,8 +51,8 @@ SENSOR_TYPES = {
         BANDWIDTH_MEGABITS_SECONDS,
         "mdi:upload",
     ],
-    "uptime": ["Uptime", None, "mdi:clock",],
-    "number_of_reboots": ["Number of reboot", None, "mdi:restart",],
+    "uptime": ["Uptime", None, "mdi:clock", ],
+    "number_of_reboots": ["Number of reboot", None, "mdi:restart", ],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -74,9 +80,59 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sensors = []
     for variable in config[CONF_MONITORED_VARIABLES]:
-        sensors.append(BboxSensor(bbox_data, variable, name))
+        if variable == "uptime":
+            sensors.append(BboxUptimeSensor(bbox_data, variable, name))
+        else:
+            sensors.append(BboxSensor(bbox_data, variable, name))
 
     add_entities(sensors, True)
+
+
+class BboxUptimeSensor(Entity):
+    """Bbox uptime sensor."""
+
+    def __init__(self, bbox_data, sensor_type, name):
+        """Initialize the sensor."""
+        self.client_name = name
+        self.type = sensor_type
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self._icon = SENSOR_TYPES[sensor_type][2]
+        self.bbox_data = bbox_data
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self.client_name} {self._name}"
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {ATTR_ATTRIBUTION: ATTRIBUTION}
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor."""
+        return DEVICE_CLASS_TIMESTAMP
+
+    def update(self):
+        """Get the latest data from Bbox and update the state."""
+        self.bbox_data.update()
+        uptime = utcnow() - timedelta(
+            seconds=self.bbox_data.router_infos["device"]["uptime"]
+        )
+        self._state = uptime.replace(microsecond=0).isoformat()
 
 
 class BboxSensor(Entity):
@@ -128,10 +184,6 @@ class BboxSensor(Entity):
             self._state = round(self.bbox_data.data["rx"]["bandwidth"] / 1000, 2)
         elif self.type == "current_up_bandwidth":
             self._state = round(self.bbox_data.data["tx"]["bandwidth"] / 1000, 2)
-        elif self.type == "uptime":
-            self._state = str(
-                timedelta(seconds=self.bbox_data.router_infos["device"]["uptime"])
-            )
         elif self.type == "number_of_reboots":
             self._state = self.bbox_data.router_infos["device"]["numberofboots"]
 


### PR DESCRIPTION
## Description:

This modification add number of reboot and uptime of the bbox router. If the code is fine I will update the doc as soon as possible.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: bbox
    monitored_variables:
      - down_max_bandwidth
      - up_max_bandwidth
      - current_down_bandwidth
      - current_up_bandwidth
      - uptime
      - number_of_reboots
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html