### PR TITLE
Cluster command arguments for issue_zigbee_cluster_command service.

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -141,7 +141,7 @@ SERVICE_SCHEMAS = {
             vol.Optional(ATTR_CLUSTER_TYPE, default=CLUSTER_TYPE_IN): cv.string,
             vol.Required(ATTR_COMMAND): cv.positive_int,
             vol.Required(ATTR_COMMAND_TYPE): cv.string,
-            vol.Optional(ATTR_ARGS, default=""): cv.string,
+            vol.Optional(ATTR_ARGS, default=[]): cv.ensure_list,
             vol.Optional(ATTR_MANUFACTURER): cv.positive_int,
         }
     ),
@@ -649,7 +649,7 @@ def async_load_api(hass):
                 cluster_id,
                 command,
                 command_type,
-                args,
+                *args,
                 cluster_type=cluster_type,
                 manufacturer=manufacturer,
             )

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -479,7 +479,7 @@ class ZHADevice(LogMixin):
         cluster_id,
         command,
         command_type,
-        args,
+        *args,
         cluster_type=CLUSTER_TYPE_IN,
         manufacturer=None,
     ):
@@ -487,7 +487,6 @@ class ZHADevice(LogMixin):
         cluster = self.async_get_cluster(endpoint_id, cluster_id, cluster_type)
         if cluster is None:
             return None
-        response = None
         if command_type == CLUSTER_COMMAND_SERVER:
             response = await cluster.command(
                 command, *args, manufacturer=manufacturer, expect_reply=True

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -78,7 +78,7 @@ issue_zigbee_cluster_command:
       example: "server"
     args:
       description: args to pass to the command
-      example: {}
+      example: '[arg1, arg2, argN]'
     manufacturer:
       description: manufacturer code
       example: 0x00FC
@@ -98,7 +98,7 @@ issue_zigbee_group_command:
       example: 0
     args:
       description: args to pass to the command
-      example: {}
+      example: '[arg1, arg2, argN]'
     manufacturer:
       description: manufacturer code
       example: 0x00FC


### PR DESCRIPTION
## Description:

Allow specification of cluster command arguments for `zha.issue_zigbee_cluster_command` service.
For example a `move_to_level_with_on_off` command on `Level` cluster of a light:
```
ieee: '7c:b0:3e:aa:00:ab:cd:ef'
endpoint_id: 3
cluster_id: 8
cluster_type: in
command: 0
command_type: server
args:
  - 254
  - 20
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
