### PR TITLE
Add serial to caseta devices

### DIFF
--- a/homeassistant/components/lutron_caseta/.translations/en.json
+++ b/homeassistant/components/lutron_caseta/.translations/en.json
@@ -1,0 +1,5 @@
+{
+    "config": {
+        "title": "Lutron Caséta"
+    }
+}

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -108,8 +108,8 @@ class LutronCasetaDevice(Entity):
 
     @property
     def unique_id(self):
-        """Return the unique ID of the device (model + serial)."""
-        return "{}.{}".format(self._device_model, self._device_serial)
+        """Return the unique ID of the device (serial)."""
+        return str(self._device_serial)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -80,7 +80,6 @@ class LutronCasetaDevice(Entity):
         self._device_type = device["type"]
         self._device_name = device["name"]
         self._device_zone = device["zone"]
-        self._device_model = device["model"]
         self._device_serial = device["serial"]
         self._state = None
         self._smartbridge = bridge
@@ -95,11 +94,6 @@ class LutronCasetaDevice(Entity):
     def name(self):
         """Return the name of the device."""
         return self._device_name
-
-    @property
-    def model(self):
-        """Return the model number of the device."""
-        return self._device_model
 
     @property
     def serial(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -77,7 +77,6 @@ class LutronCasetaDevice(Entity):
         [:param]bridge the smartbridge object
         """
         self._device = device
-        self._state = None
         self._smartbridge = bridge
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -80,6 +80,8 @@ class LutronCasetaDevice(Entity):
         self._device_type = device["type"]
         self._device_name = device["name"]
         self._device_zone = device["zone"]
+        self._device_model = device["model"]
+        self._device_serial = device["serial"]
         self._state = None
         self._smartbridge = bridge
 
@@ -93,6 +95,21 @@ class LutronCasetaDevice(Entity):
     def name(self):
         """Return the name of the device."""
         return self._device_name
+
+    @property
+    def model(self):
+        """Return the model number of the device."""
+        return self._device_model
+
+    @property
+    def serial(self):
+        """Return the serial number of the device."""
+        return self._device_serial
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the device (model + serial)."""
+        return "{}.{}".format(self._device_model, self._device_serial)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -76,39 +76,40 @@ class LutronCasetaDevice(Entity):
         [:param]device the device metadata
         [:param]bridge the smartbridge object
         """
-        self._device_id = device["device_id"]
-        self._device_type = device["type"]
-        self._device_name = device["name"]
-        self._device_zone = device["zone"]
-        self._device_serial = device["serial"]
+        self._device = device
         self._state = None
         self._smartbridge = bridge
 
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._smartbridge.add_subscriber(
-            self._device_id, self.async_schedule_update_ha_state
+            self.device_id, self.async_schedule_update_ha_state
         )
+
+    @property
+    def device_id(self):
+        """Return the device ID used for calling pylutron_caseta."""
+        return self._device["device_id"]
 
     @property
     def name(self):
         """Return the name of the device."""
-        return self._device_name
+        return self._device["name"]
 
     @property
     def serial(self):
         """Return the serial number of the device."""
-        return self._device_serial
+        return self._device["serial"]
 
     @property
     def unique_id(self):
         """Return the unique ID of the device (serial)."""
-        return str(self._device_serial)
+        return str(self.serial)
 
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {"Device ID": self._device_id, "Zone ID": self._device_zone}
+        attr = {"Device ID": self.device_id, "Zone ID": self._device["zone"]}
         return attr
 
     @property

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -47,19 +47,19 @@ class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        self._smartbridge.set_value(self._device_id, 0)
+        self._smartbridge.set_value(self.device_id, 0)
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        self._smartbridge.set_value(self._device_id, 100)
+        self._smartbridge.set_value(self.device_id, 100)
 
     async def async_set_cover_position(self, **kwargs):
         """Move the shade to a specific position."""
         if ATTR_POSITION in kwargs:
             position = kwargs[ATTR_POSITION]
-            self._smartbridge.set_value(self._device_id, position)
+            self._smartbridge.set_value(self.device_id, position)
 
     async def async_update(self):
         """Call when forcing a refresh of the device."""
-        self._state = self._smartbridge.get_device_by_id(self._device_id)
+        self._state = self._smartbridge.get_device_by_id(self.device_id)
         _LOGGER.debug(self._state)

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -38,12 +38,12 @@ class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self._state["current_state"] < 1
+        return self._device["current_state"] < 1
 
     @property
     def current_cover_position(self):
         """Return the current position of cover."""
-        return self._state["current_state"]
+        return self._device["current_state"]
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
@@ -61,5 +61,5 @@ class LutronCasetaCover(LutronCasetaDevice, CoverDevice):
 
     async def async_update(self):
         """Call when forcing a refresh of the device."""
-        self._state = self._smartbridge.get_device_by_id(self.device_id)
-        _LOGGER.debug(self._state)
+        self._device = self._smartbridge.get_device_by_id(self.device_id)
+        _LOGGER.debug(self._device)

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -37,7 +37,7 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
     @property
     def brightness(self):
         """Return the brightness of the light."""
-        return to_hass_level(self._state["current_state"])
+        return to_hass_level(self._device["current_state"])
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
@@ -51,9 +51,9 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state["current_state"] > 0
+        return self._device["current_state"] > 0
 
     async def async_update(self):
         """Call when forcing a refresh of the device."""
-        self._state = self._smartbridge.get_device_by_id(self.device_id)
-        _LOGGER.debug(self._state)
+        self._device = self._smartbridge.get_device_by_id(self.device_id)
+        _LOGGER.debug(self._device)

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -42,11 +42,11 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-        self._smartbridge.set_value(self._device_id, to_lutron_level(brightness))
+        self._smartbridge.set_value(self.device_id, to_lutron_level(brightness))
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
-        self._smartbridge.set_value(self._device_id, 0)
+        self._smartbridge.set_value(self.device_id, 0)
 
     @property
     def is_on(self):
@@ -55,5 +55,5 @@ class LutronCasetaLight(LutronCasetaDevice, Light):
 
     async def async_update(self):
         """Call when forcing a refresh of the device."""
-        self._state = self._smartbridge.get_device_by_id(self._device_id)
+        self._state = self._smartbridge.get_device_by_id(self.device_id)
         _LOGGER.debug(self._state)

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -3,7 +3,7 @@
   "name": "Lutron caseta",
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
   "requirements": [
-    "pylutron-caseta==0.5.0"
+    "pylutron-caseta==0.5.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/lutron_caseta/strings.json
+++ b/homeassistant/components/lutron_caseta/strings.json
@@ -1,0 +1,5 @@
+{
+    "config": {
+        "title": "Lutron Caséta"
+    }
+}

--- a/homeassistant/components/lutron_caseta/switch.py
+++ b/homeassistant/components/lutron_caseta/switch.py
@@ -27,11 +27,11 @@ class LutronCasetaLight(LutronCasetaDevice, SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
-        self._smartbridge.turn_on(self._device_id)
+        self._smartbridge.turn_on(self.device_id)
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
-        self._smartbridge.turn_off(self._device_id)
+        self._smartbridge.turn_off(self.device_id)
 
     @property
     def is_on(self):
@@ -40,5 +40,5 @@ class LutronCasetaLight(LutronCasetaDevice, SwitchDevice):
 
     async def async_update(self):
         """Update when forcing a refresh of the device."""
-        self._state = self._smartbridge.get_device_by_id(self._device_id)
+        self._state = self._smartbridge.get_device_by_id(self.device_id)
         _LOGGER.debug(self._state)

--- a/homeassistant/components/lutron_caseta/switch.py
+++ b/homeassistant/components/lutron_caseta/switch.py
@@ -36,9 +36,9 @@ class LutronCasetaLight(LutronCasetaDevice, SwitchDevice):
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state["current_state"] > 0
+        return self._device["current_state"] > 0
 
     async def async_update(self):
         """Update when forcing a refresh of the device."""
-        self._state = self._smartbridge.get_device_by_id(self.device_id)
-        _LOGGER.debug(self._state)
+        self._device = self._smartbridge.get_device_by_id(self.device_id)
+        _LOGGER.debug(self._device)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1317,7 +1317,7 @@ pylitejet==0.1
 pyloopenergy==0.1.3
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.5.0
+pylutron-caseta==0.5.1
 
 # homeassistant.components.lutron
 pylutron==0.2.5


### PR DESCRIPTION
## Description:

This adds serial numbers to lutron_caseta devices and enables the entity registry.

This was previously entered as #14037 which could not be merged because pylutron_caseta had not released.

**Related issue (if applicable):** Incidentally, because this brings in the new release of pylutron_caseta it also partially addresses #22907. It does not add support for fans, but users will no longer lose functionality when a fan controller is introduced.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
