### PR TITLE
Update service domain for local_file from 'camera' to 'local_file'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -377,7 +377,6 @@ omit =
     homeassistant/components/lirc/*
     homeassistant/components/liveboxplaytv/media_player.py
     homeassistant/components/llamalab_automate/notify.py
-    homeassistant/components/local_file/const.py
     homeassistant/components/lockitron/lock.py
     homeassistant/components/logi_circle/__init__.py
     homeassistant/components/logi_circle/camera.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -377,6 +377,7 @@ omit =
     homeassistant/components/lirc/*
     homeassistant/components/liveboxplaytv/media_player.py
     homeassistant/components/llamalab_automate/notify.py
+    homeassistant/components/local_file/const.py
     homeassistant/components/lockitron/lock.py
     homeassistant/components/logi_circle/__init__.py
     homeassistant/components/logi_circle/camera.py

--- a/homeassistant/components/camera/services.yaml
+++ b/homeassistant/components/camera/services.yaml
@@ -68,16 +68,6 @@ record:
       description: (Optional) Target lookback period (in seconds) to include in addition to duration.  Only available if there is currently an active HLS stream.
       example: 4
 
-local_file_update_file_path:
-  description: Update the file_path for a local_file camera.
-  fields:
-    entity_id:
-      description: Name(s) of entities to update.
-      example: 'camera.local_file'
-    file_path:
-      description: Path to the new image file.
-      example: '/images/newimage.jpg'
-
 onvif_ptz:
   description: Pan/Tilt/Zoom service for ONVIF camera.
   fields:

--- a/homeassistant/components/local_file/camera.py
+++ b/homeassistant/components/local_file/camera.py
@@ -13,13 +13,15 @@ from homeassistant.components.camera import (
 )
 from homeassistant.helpers import config_validation as cv
 
-_LOGGER = logging.getLogger(__name__)
+from .const import (
+    CONF_FILE_PATH,
+    DATA_LOCAL_FILE,
+    DEFAULT_NAME,
+    DOMAIN,
+    SERVICE_UPDATE_FILE_PATH,
+)
 
-DOMAIN = "local_file"
-CONF_FILE_PATH = "file_path"
-DATA_LOCAL_FILE = "local_file_cameras"
-DEFAULT_NAME = "Local File"
-SERVICE_UPDATE_FILE_PATH = "update_file_path"
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/local_file/camera.py
+++ b/homeassistant/components/local_file/camera.py
@@ -11,15 +11,15 @@ from homeassistant.components.camera import (
     CAMERA_SERVICE_SCHEMA,
     PLATFORM_SCHEMA,
 )
-from homeassistant.components.camera.const import DOMAIN
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+DOMAIN = "local_file"
 CONF_FILE_PATH = "file_path"
 DATA_LOCAL_FILE = "local_file_cameras"
 DEFAULT_NAME = "Local File"
-SERVICE_UPDATE_FILE_PATH = "local_file_update_file_path"
+SERVICE_UPDATE_FILE_PATH = "update_file_path"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/local_file/const.py
+++ b/homeassistant/components/local_file/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Local File Camera component."""
+DOMAIN = "local_file"
+SERVICE_UPDATE_FILE_PATH = "update_file_path"
+CONF_FILE_PATH = "file_path"
+DATA_LOCAL_FILE = "local_file_cameras"
+DEFAULT_NAME = "Local File"

--- a/homeassistant/components/local_file/services.yaml
+++ b/homeassistant/components/local_file/services.yaml
@@ -1,4 +1,4 @@
-local_file_update_file_path:
+update_file_path:
   description: Use this service to change the file displayed by the camera.
   fields:
     entity_id:

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest import mock
 
-from homeassistant.components.local_file.camera import DOMAIN, SERVICE_UPDATE_FILE_PATH
+from homeassistant.components.local_file.const import DOMAIN, SERVICE_UPDATE_FILE_PATH
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -2,8 +2,7 @@
 import asyncio
 from unittest import mock
 
-from homeassistant.components.camera.const import DOMAIN
-from homeassistant.components.local_file.camera import SERVICE_UPDATE_FILE_PATH
+from homeassistant.components.local_file.camera import DOMAIN, SERVICE_UPDATE_FILE_PATH
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `camera.local_file_update_file_path` by changing the service call to `local_file.update_file_path`. My understanding is that because this is not a service provided by the base `camera` component, it should live in the domain of the `local_file` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `camera.local_file_update_file_path`. I started down this path because of #27289 and based on the introduction [here](https://developers.home-assistant.io/docs/en/dev_101_services.html) and comment [here](https://github.com/home-assistant/home-assistant/issues/27289#issuecomment-539414699), I felt this change made sense. If I am misunderstanding the intent please let me know so that I don't keep moving through these changes, as I have noticed this pattern emerging across a bunch of integrations as I commented [here](https://github.com/home-assistant/home-assistant/issues/27289#issuecomment-555835089). Unfortunately I don't have a device to test most of these integrations.

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11234

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
