### PR TITLE
Add STATE_STANDBY to base media_player and fix state reporting issues

### DIFF
--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     STATE_PAUSED,
     STATE_PLAYING,
     STATE_UNKNOWN,
+    STATE_STANDBY,
 )
 
 from . import TYPES
@@ -190,7 +191,12 @@ class MediaPlayer(HomeAccessory):
         current_state = new_state.state
 
         if self.chars[FEATURE_ON_OFF]:
-            hk_state = current_state not in (STATE_OFF, STATE_UNKNOWN, "None")
+            hk_state = current_state not in (
+                STATE_OFF,
+                STATE_STANDBY,
+                STATE_UNKNOWN,
+                "None",
+            )
             if not self._flag[FEATURE_ON_OFF]:
                 _LOGGER.debug(
                     '%s: Set current state for "on_off" to %s', self.entity_id, hk_state
@@ -390,7 +396,7 @@ class TelevisionMediaPlayer(HomeAccessory):
         current_state = new_state.state
 
         # Power state television
-        hk_state = current_state not in (STATE_OFF, STATE_UNKNOWN)
+        hk_state = current_state not in (STATE_OFF, STATE_STANDBY, STATE_UNKNOWN)
         if not self._flag[CHAR_ACTIVE]:
             _LOGGER.debug(
                 "%s: Set current active state to %s", self.entity_id, hk_state

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -33,8 +33,8 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_PAUSED,
     STATE_PLAYING,
-    STATE_UNKNOWN,
     STATE_STANDBY,
+    STATE_UNKNOWN,
 )
 
 from . import TYPES

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     STATE_IDLE,
     STATE_OFF,
     STATE_PLAYING,
+    STATE_STANDBY,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -165,7 +166,9 @@ def is_on(hass, entity_id=None):
     """
     entity_ids = [entity_id] if entity_id else hass.states.entity_ids(DOMAIN)
     return any(
-        not hass.states.is_state(entity_id, STATE_OFF) for entity_id in entity_ids
+        not hass.states.is_state(entity_id, STATE_OFF)
+        and not hass.states.is_state(entity_id, STATE_STANDBY)
+        for entity_id in entity_ids
     )
 
 

--- a/homeassistant/components/media_player/device_condition.py
+++ b/homeassistant/components/media_player/device_condition.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
+    STATE_STANDBY,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
@@ -23,7 +24,14 @@ from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
 from . import DOMAIN
 
-CONDITION_TYPES = {"is_on", "is_off", "is_idle", "is_paused", "is_playing"}
+CONDITION_TYPES = {
+    "is_on",
+    "is_off",
+    "is_idle",
+    "is_paused",
+    "is_playing",
+    "is_standby",
+}
 
 CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
@@ -91,6 +99,15 @@ async def async_get_conditions(
                 CONF_TYPE: "is_playing",
             }
         )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_standby",
+            }
+        )
 
     return conditions
 
@@ -109,6 +126,8 @@ def async_condition_from_config(
         state = STATE_PAUSED
     elif config[CONF_TYPE] == "is_on":
         state = STATE_ON
+    elif config[CONF_TYPE] == "is_standby":
+        state = STATE_STANDBY
     else:
         state = STATE_OFF
 

--- a/homeassistant/components/media_player/reproduce_state.py
+++ b/homeassistant/components/media_player/reproduce_state.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
+    STATE_STANDBY,
 )
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType
@@ -58,6 +59,8 @@ async def _async_reproduce_states(
     if state.state == STATE_ON:
         await call_service(SERVICE_TURN_ON, [])
     elif state.state == STATE_OFF:
+        await call_service(SERVICE_TURN_OFF, [])
+    elif state.state == STATE_STANDBY:
         await call_service(SERVICE_TURN_OFF, [])
     elif state.state == STATE_PLAYING:
         await call_service(SERVICE_MEDIA_PLAY, [])

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -5,7 +5,13 @@ import logging
 from pyps4_2ndscreen.errors import NotReady, PSDataIncomplete
 import pyps4_2ndscreen.ps4 as pyps4
 
-from homeassistant.components.media_player import ENTITY_IMAGE_URL, MediaPlayerDevice
+from homeassistant.components.media_player import (
+    ENTITY_IMAGE_URL,
+    STATE_IDLE,
+    STATE_PLAYING,
+    STATE_STANDBY,
+    MediaPlayerDevice,
+)
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_TITLE,
@@ -24,9 +30,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_REGION,
     CONF_TOKEN,
-    STATE_IDLE,
-    STATE_PLAYING,
-    STATE_STANDBY,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry, entity_registry
@@ -252,7 +255,7 @@ class PS4Device(MediaPlayerDevice):
         self._media_type = None
         self._source = None
 
-    async def async_get_title_data(self, title_id, name):
+    async def async_get_title_data(self, title_id: str, name: str):
         """Get PS Store Data."""
 
         app_name = None
@@ -455,6 +458,15 @@ class PS4Device(MediaPlayerDevice):
     def source_list(self):
         """List of available input sources."""
         return self._source_list
+
+    def async_toggle(self):
+        """Toggle the power on the media player.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        if self.state == STATE_STANDBY:
+            return self.async_turn_on()
+        return self.async_turn_off()
 
     async def async_turn_off(self):
         """Turn off media player."""

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -66,6 +66,7 @@ from homeassistant.const import (
     STATE_IDLE,
     STATE_OFF,
     STATE_ON,
+    STATE_STANDBY,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import callback
@@ -83,7 +84,7 @@ CONF_COMMANDS = "commands"
 CONF_SERVICE = "service"
 CONF_SERVICE_DATA = "service_data"
 
-OFF_STATES = [STATE_IDLE, STATE_OFF, STATE_UNAVAILABLE]
+OFF_STATES = [STATE_IDLE, STATE_OFF, STATE_STANDBY, STATE_UNAVAILABLE]
 
 ATTRS_SCHEMA = cv.schema_with_slug_keys(cv.string)
 CMD_SCHEMA = cv.schema_with_slug_keys(cv.SERVICE_SCHEMA)

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
+    STATE_STANDBY,
 )
 
 from tests.common import async_mock_service
@@ -69,6 +70,10 @@ async def test_media_player_set_state(hass, hk_driver, events):
     assert acc.chars[FEATURE_TOGGLE_MUTE].value is True
 
     hass.states.async_set(entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert acc.chars[FEATURE_ON_OFF].value is False
+
+    hass.states.async_set(entity_id, STATE_STANDBY)
     await hass.async_block_till_done()
     assert acc.chars[FEATURE_ON_OFF].value is False
 
@@ -186,6 +191,10 @@ async def test_media_player_television(hass, hk_driver, events, caplog):
     assert acc.char_mute.value is True
 
     hass.states.async_set(entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert acc.char_active.value == 0
+
+    hass.states.async_set(entity_id, STATE_STANDBY)
     await hass.async_block_till_done()
     assert acc.char_active.value == 0
 

--- a/tests/components/media_player/test_reproduce_state.py
+++ b/tests/components/media_player/test_reproduce_state.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
+    STATE_STANDBY,
 )
 from homeassistant.core import Context, State
 
@@ -45,6 +46,7 @@ ENTITY_2 = "media_player.test2"
     [
         (SERVICE_TURN_ON, STATE_ON),
         (SERVICE_TURN_OFF, STATE_OFF),
+        (SERVICE_TURN_OFF, STATE_STANDBY),
         (SERVICE_MEDIA_PLAY, STATE_PLAYING),
         (SERVICE_MEDIA_STOP, STATE_IDLE),
         (SERVICE_MEDIA_PAUSE, STATE_PAUSED),

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -10,7 +10,13 @@ import homeassistant.components.input_select as input_select
 import homeassistant.components.media_player as media_player
 import homeassistant.components.switch as switch
 import homeassistant.components.universal.media_player as universal
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_PAUSED, STATE_PLAYING
+from homeassistant.const import (
+    STATE_OFF,
+    STATE_ON,
+    STATE_PAUSED,
+    STATE_PLAYING,
+    STATE_STANDBY,
+)
 
 from tests.common import get_test_home_assistant, mock_service
 
@@ -386,6 +392,12 @@ class TestMediaPlayer(unittest.TestCase):
         assert self.mock_mp_1.entity_id == ump._child_state.entity_id
 
         self.mock_mp_1._state = STATE_OFF
+        self.mock_mp_1.schedule_update_ha_state()
+        self.hass.block_till_done()
+        asyncio.run_coroutine_threadsafe(ump.async_update(), self.hass.loop).result()
+        assert self.mock_mp_2.entity_id == ump._child_state.entity_id
+
+        self.mock_mp_1._state = STATE_STANDBY
         self.mock_mp_1.schedule_update_ha_state()
         self.hass.block_till_done()
         asyncio.run_coroutine_threadsafe(ump.async_update(), self.hass.loop).result()


### PR DESCRIPTION
## Description:
Add STATE_STANDBY to base media_player. Roku and PS4 already uses STATE_STANDBY.

Fixes issue for PS4 when the lovelace media_player card calls service turn_off when power button is pressed if state is standby. This PR is complimentary with home-assistant/home-assistant-polymer#4250, although the actual issue fix is dependent on it. Also fixes incorrect state reporting in Homekit and Universal.

- Add STATE_STANDBY to base media_player.

- Add STATE_STANDBY to Homekit

- Add STATE_STANDBY to Universal

- Also override base media_player.async_toggle for PS4.


**Related issue (if applicable):** fixes #28891


## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
