### PR TITLE
bump herepy to 0.6.3.3

### DIFF
--- a/homeassistant/components/here_travel_time/manifest.json
+++ b/homeassistant/components/here_travel_time/manifest.json
@@ -3,7 +3,7 @@
     "name": "HERE travel time",
     "documentation": "https://www.home-assistant.io/integrations/here_travel_time",
     "requirements": [
-      "herepy==0.6.3.1"
+      "herepy==0.6.3.3"
     ],
     "dependencies": [],
     "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -641,7 +641,7 @@ hdate==0.9.3
 heatmiserV3==0.9.1
 
 # homeassistant.components.here_travel_time
-herepy==0.6.3.1
+herepy==0.6.3.3
 
 # homeassistant.components.hikvisioncam
 hikvision==0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -217,7 +217,7 @@ hbmqtt==0.9.5
 hdate==0.9.3
 
 # homeassistant.components.here_travel_time
-herepy==0.6.3.1
+herepy==0.6.3.3
 
 # homeassistant.components.pi_hole
 hole==0.5.0

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -71,8 +71,8 @@ def _build_mock_url(origin, destination, modes, app_id, app_code, departure):
     """Construct a url for HERE."""
     base_url = "https://route.cit.api.here.com/routing/7.2/calculateroute.json?"
     parameters = {
-        "waypoint0": origin,
-        "waypoint1": destination,
+        "waypoint0": f"geo!{origin}",
+        "waypoint1": f"geo!{destination}",
         "mode": ";".join(str(herepy.RouteMode[mode]) for mode in modes),
         "app_id": app_id,
         "app_code": app_code,


### PR DESCRIPTION
## Description:

Bump herepy to 0.6.3.3 and update tests to meet new structures.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
