### PR TITLE
Add device condition for water heater

### DIFF
--- a/homeassistant/components/water_heater/device_condition.py
+++ b/homeassistant/components/water_heater/device_condition.py
@@ -48,7 +48,7 @@ async def async_get_conditions(
 ) -> List[Dict[str, str]]:
     """List device conditions for Water heater devices."""
     registry = await entity_registry.async_get_registry(hass)
-    conditions = []
+    conditions: List[dict] = []
 
     # Get all the integrations entities for this device
     for entry in entity_registry.async_entries_for_device(registry, device_id):

--- a/homeassistant/components/water_heater/device_condition.py
+++ b/homeassistant/components/water_heater/device_condition.py
@@ -1,0 +1,151 @@
+"""Provides device automations for Water heater."""
+from typing import Dict, List
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_CONDITION,
+    CONF_DOMAIN,
+    CONF_TYPE,
+    CONF_DEVICE_ID,
+    CONF_ENTITY_ID,
+)
+from homeassistant.components.water_heater import (
+    STATE_OFF,
+    STATE_ECO,
+    STATE_ELECTRIC,
+    STATE_PERFORMANCE,
+    STATE_HIGH_DEMAND,
+    STATE_HEAT_PUMP,
+    STATE_GAS,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import condition, config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from . import DOMAIN
+
+CONDITION_TYPES = {
+    "is_off",
+    "is_eco",
+    "is_electric",
+    "is_performance",
+    "is_high_demand",
+    "is_heat_pump",
+    "is_gas",
+}
+
+CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(CONDITION_TYPES),
+    }
+)
+
+
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> List[Dict[str, str]]:
+    """List device conditions for Water heater devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    conditions = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        # Add conditions for each entity that belongs to this integration
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_off",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_eco",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_electric",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_performance",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_high_demand",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_heat_pump",
+            }
+        )
+        conditions.append(
+            {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "is_gas",
+            }
+        )
+
+    return conditions
+
+
+def async_condition_from_config(
+    config: ConfigType, config_validation: bool
+) -> condition.ConditionCheckerType:
+    """Create a function to test a device condition."""
+    if config_validation:
+        config = CONDITION_SCHEMA(config)
+    if config[CONF_TYPE] == "is_eco":
+        state = STATE_ECO
+    elif config[CONF_TYPE] == "is_electric":
+        state = STATE_ELECTRIC
+    elif config[CONF_TYPE] == "is_performance":
+        state = STATE_PERFORMANCE
+    elif config[CONF_TYPE] == "is_high_demand":
+        state = STATE_HIGH_DEMAND
+    elif config[CONF_TYPE] == "is_heat_pump":
+        state = STATE_HEAT_PUMP
+    elif config[CONF_TYPE] == "is_gas":
+        state = STATE_GAS
+    else:
+        state = STATE_OFF
+
+    def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if an entity is a certain state."""
+        return condition.state(hass, config[ATTR_ENTITY_ID], state)
+
+    return test_is_state

--- a/homeassistant/components/water_heater/device_condition.py
+++ b/homeassistant/components/water_heater/device_condition.py
@@ -56,69 +56,16 @@ async def async_get_conditions(
             continue
 
         # Add conditions for each entity that belongs to this integration
-        conditions.append(
+        conditions += [
             {
                 CONF_CONDITION: "device",
                 CONF_DEVICE_ID: device_id,
                 CONF_DOMAIN: DOMAIN,
                 CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "is_off",
+                CONF_TYPE: conf_type,
             }
-        )
-        conditions.append(
-            {
-                CONF_CONDITION: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "is_eco",
-            }
-        )
-        conditions.append(
-            {
-                CONF_CONDITION: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "is_electric",
-            }
-        )
-        conditions.append(
-            {
-                CONF_CONDITION: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "is_performance",
-            }
-        )
-        conditions.append(
-            {
-                CONF_CONDITION: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "is_high_demand",
-            }
-        )
-        conditions.append(
-            {
-                CONF_CONDITION: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "is_heat_pump",
-            }
-        )
-        conditions.append(
-            {
-                CONF_CONDITION: "device",
-                CONF_DEVICE_ID: device_id,
-                CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "is_gas",
-            }
-        )
+            for conf_type in CONDITION_TYPES
+        ]
 
     return conditions
 

--- a/homeassistant/components/water_heater/strings.json
+++ b/homeassistant/components/water_heater/strings.json
@@ -1,0 +1,13 @@
+{
+  "device_automation": {
+    "condtion_type": {
+      "is_off": "{entity_name} is off",
+      "is_eco": "{entity_name} is in eco mode",
+      "is_electric": "{entity_name} is in electric mode",
+      "is_performance": "{entity_name} is in performance mode",
+      "is_high_demand": "{entity_name} is in high demand mode",
+      "is_heat_pump": "{entity_name} is in heat pump mode",
+      "is_gas": "{entity_name} is in gas only mode"
+    }
+  }
+}

--- a/tests/components/water_heater/test_device_condition.py
+++ b/tests/components/water_heater/test_device_condition.py
@@ -1,0 +1,329 @@
+"""The tests for Water heater device conditions."""
+import pytest
+
+from homeassistant.components.water_heater import (
+    DOMAIN,
+    STATE_OFF,
+    STATE_ECO,
+    STATE_ELECTRIC,
+    STATE_PERFORMANCE,
+    STATE_HIGH_DEMAND,
+    STATE_HEAT_PUMP,
+    STATE_GAS,
+)
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock serivce."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_conditions(hass, device_reg, entity_reg):
+    """Test we get the expected conditions from a water_heater."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_conditions = [
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_off",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_eco",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_electric",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_performance",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_high_demand",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_heat_pump",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "is_gas",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+    ]
+    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    assert_lists_same(conditions, expected_conditions)
+
+
+async def test_if_state(hass, calls):
+    """Test for state conditions."""
+    hass.states.async_set("water_heater.entity", STATE_OFF)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "water_heater.entity",
+                            "type": "is_off",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_off - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event2"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "water_heater.entity",
+                            "type": "is_eco",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_eco - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event3"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "water_heater.entity",
+                            "type": "is_electric",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_electric - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event4"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "water_heater.entity",
+                            "type": "is_performance",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_performance - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event5"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "water_heater.entity",
+                            "type": "is_high_demand",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_high_demand - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event6"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "water_heater.entity",
+                            "type": "is_heat_pump",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_heat_pump - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event7"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": "water_heater.entity",
+                            "type": "is_gas",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_gas - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    hass.bus.async_fire("test_event6")
+    hass.bus.async_fire("test_event7")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "is_off - event - test_event1"
+
+    hass.states.async_set("water_heater.entity", STATE_ECO)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    hass.bus.async_fire("test_event6")
+    hass.bus.async_fire("test_event7")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "is_eco - event - test_event2"
+
+    hass.states.async_set("water_heater.entity", STATE_ELECTRIC)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    hass.bus.async_fire("test_event6")
+    hass.bus.async_fire("test_event7")
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[2].data["some"] == "is_electric - event - test_event3"
+
+    hass.states.async_set("water_heater.entity", STATE_PERFORMANCE)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    hass.bus.async_fire("test_event6")
+    hass.bus.async_fire("test_event7")
+    await hass.async_block_till_done()
+    assert len(calls) == 4
+    assert calls[3].data["some"] == "is_performance - event - test_event4"
+
+    hass.states.async_set("water_heater.entity", STATE_HIGH_DEMAND)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    hass.bus.async_fire("test_event6")
+    hass.bus.async_fire("test_event7")
+    await hass.async_block_till_done()
+    assert len(calls) == 5
+    assert calls[4].data["some"] == "is_high_demand - event - test_event5"
+
+    hass.states.async_set("water_heater.entity", STATE_HEAT_PUMP)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    hass.bus.async_fire("test_event6")
+    hass.bus.async_fire("test_event7")
+    await hass.async_block_till_done()
+    assert len(calls) == 6
+    assert calls[5].data["some"] == "is_heat_pump - event - test_event6"
+
+    hass.states.async_set("water_heater.entity", STATE_GAS)
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    hass.bus.async_fire("test_event5")
+    hass.bus.async_fire("test_event6")
+    hass.bus.async_fire("test_event7")
+    await hass.async_block_till_done()
+    assert len(calls) == 7
+    assert calls[6].data["some"] == "is_gas - event - test_event7"


### PR DESCRIPTION
## Description:

Adds basic device condition support for water_heater integration - off, eco, electric, performance, high demand, heat pump, gas

**Related issue (if applicable):** fixes #27007

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.