### PR TITLE
Fix Hue emulation not working for switches

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -572,32 +572,29 @@ def get_entity_state(config, entity):
 def entity_to_json(config, entity, state):
     """Convert an entity to its Hue bridge JSON representation."""
     entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain != light.DOMAIN:
-        return {
-            "state": {
-                HUE_API_STATE_ON: state[STATE_ON],
-                HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],
-                HUE_API_STATE_HUE: state[STATE_HUE],
-                HUE_API_STATE_SAT: state[STATE_SATURATION],
-                "reachable": entity.state != STATE_UNAVAILABLE,
-            },
-            "type": "Dimmable light",
-            "name": config.get_entity_name(entity),
-            "modelid": "HASS123",
-            "uniqueid": entity.entity_id,
-            "swversion": "123",
-        }
-    return {
+
+    data = {
         "state": {
             HUE_API_STATE_ON: state[STATE_ON],
             "reachable": entity.state != STATE_UNAVAILABLE,
         },
-        "type": "On/off light",
         "name": config.get_entity_name(entity),
-        "modelid": "HASS321",
         "uniqueid": entity.entity_id,
         "swversion": "123",
     }
+    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain != light.DOMAIN:
+        data["state"].update(
+            {
+                HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],
+                HUE_API_STATE_HUE: state[STATE_HUE],
+                HUE_API_STATE_SAT: state[STATE_SATURATION],
+            }
+        )
+        data.update({"modelid": "HASS123", "type": "Dimmable light"})
+    else:
+        data.update({"modelid": "HASS321", "type": "On/off light"})
+
+    return data
 
 
 def create_hue_success_response(entity_id, attr, value):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -582,7 +582,14 @@ def entity_to_json(config, entity, state):
         "uniqueid": entity.entity_id,
         "swversion": "123",
     }
-    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain != light.DOMAIN:
+    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain in (
+        # Types of entities for which we can interpret the brightness value
+        script.DOMAIN,
+        climate.DOMAIN,
+        fan.DOMAIN,
+        media_player.DOMAIN,
+        cover.DOMAIN,
+    ):
         data["state"].update(
             {
                 HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],


### PR DESCRIPTION
## Description:

Previously, the Hue emulation would only call something an on/off light
if it was a light and was not dimmable. The problem with this is that
switches, for example, are not dimmable and create confusion if exposed
as a dimmable light.

So the test is changed to only show something as dimmable if it is
a dimmable light, or it is one of the types of entities that we
map the brightness to something else (climate control, fans, media
players or covers)

Thanks to @ts8789 (#27767) / @schiegg for the idea to whitelist only
those domains for which the brightness is interpreted.

This PR differs from #27767 as follows:

- Script entities are left as dimmable instead of converting to on/off. This is because the code supports sending the dimming value to the script and therefore would be a breaking change for existing installs.
- In order to make the code slightly more maintainable (DRY), the items which do not change according to the brightness are combined together into a single assignment
- There is unit test that checks that the switch type is now an on/off switch

**Related issue (if applicable):** fixes #26860

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
