### PR TITLE
Bump verisure to vsure 1.5.4 and jsonpath 0.82

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import threading
 from datetime import timedelta
+
 from jsonpath import jsonpath
 import verisure
 

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -3,8 +3,8 @@
   "name": "Verisure",
   "documentation": "https://www.home-assistant.io/integrations/verisure",
   "requirements": [
-    "jsonpath==0.75",
-    "vsure==1.5.2"
+    "jsonpath==0.82",
+    "vsure==1.5.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -719,7 +719,7 @@ iperf3==0.1.11
 ipify==1.0.0
 
 # homeassistant.components.verisure
-jsonpath==0.75
+jsonpath==0.82
 
 # homeassistant.components.kodi
 jsonrpc-async==0.6
@@ -1977,7 +1977,7 @@ volkszaehler==0.1.2
 volvooncall==0.8.7
 
 # homeassistant.components.verisure
-vsure==1.5.2
+vsure==1.5.4
 
 # homeassistant.components.vasttrafik
 vtjp==0.1.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -251,7 +251,7 @@ iaqualink==0.3.0
 influxdb==5.2.3
 
 # homeassistant.components.verisure
-jsonpath==0.75
+jsonpath==0.82
 
 # homeassistant.scripts.keyring
 keyring==19.2.0
@@ -608,7 +608,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.verisure
-vsure==1.5.2
+vsure==1.5.4
 
 # homeassistant.components.vultr
 vultr==0.1.2


### PR DESCRIPTION
## Description:
Update to vsure 1.5.4 and jsonpath 0.82
This will give verisure better error messages

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
No related issue

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
No documentation needed

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
