### PR TITLE
Fix Plex startup race condition

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_URL,
     CONF_VERIFY_SSL,
+    EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import config_validation as cv
@@ -164,11 +165,15 @@ async def async_setup_entry(hass, entry):
     websocket = PlexWebsocket(
         plex_server.plex_server, update_plex, session=session, verify_ssl=verify_ssl
     )
-    hass.loop.create_task(websocket.listen())
     hass.data[PLEX_DOMAIN][WEBSOCKETS][server_id] = websocket
+
+    async def async_start_websocket_session(_):
+        await websocket.listen()
 
     def close_websocket_session(_):
         websocket.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start_websocket_session)
 
     unsub = hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP, close_websocket_session

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -68,6 +68,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         hass, PLEX_NEW_MP_SIGNAL.format(server_id), async_new_media_players
     )
     hass.data[PLEX_DOMAIN][DISPATCHERS][server_id].append(unsub)
+    _LOGGER.debug("New entity listener created")
 
 
 @callback


### PR DESCRIPTION
## Description:
When starting up, there was a potential race condition where we would attempt to create new `media_player` entities before the listening dispatcher was set up. This delays the connection of the websocket connection until HA is fully started. This ensures the dispatch listener for new `media_player` entities is available when new Plex clients are found during the initial scan.

**Related issues:** fixes #28928 fixes #28491
Possibly a fix for #28485

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
