### PR TITLE
Creating a scene by snapshotting entities

### DIFF
--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -57,12 +57,17 @@ def _convert_states(states):
 
 def _ensure_no_intersection(value):
     """Validate that entities and snapshot_entities do not overlap."""
-    if any(
-        entity_id in value[CONF_SNAPSHOT] for entity_id in value[CONF_ENTITIES].keys()
+    if (
+        CONF_SNAPSHOT not in value
+        or CONF_ENTITIES not in value
+        or not any(
+            entity_id in value[CONF_SNAPSHOT]
+            for entity_id in value[CONF_ENTITIES].keys()
+        )
     ):
-        raise vol.Invalid("entities and snapshot_entities must not overlap")
+        return value
 
-    return value
+    raise vol.Invalid("entities and snapshot_entities must not overlap")
 
 
 CONF_SCENE_ID = "scene_id"

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -151,7 +151,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             state = hass.states.get(entity_id)
             if state is None:
                 _LOGGER.warning(
-                    "Entity %s does not exist and therefore cannot be snapshooted",
+                    "Entity %s does not exist and therefore cannot be snapshot",
                     entity_id,
                 )
                 continue

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -61,8 +61,7 @@ def _ensure_no_intersection(value):
         CONF_SNAPSHOT not in value
         or CONF_ENTITIES not in value
         or not any(
-            entity_id in value[CONF_SNAPSHOT]
-            for entity_id in value[CONF_ENTITIES].keys()
+            entity_id in value[CONF_SNAPSHOT] for entity_id in value[CONF_ENTITIES]
         )
     ):
         return value

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -151,7 +151,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             state = hass.states.get(entity_id)
             if state is None:
                 _LOGGER.warning(
-                    "Entity %s does not exist and therefore cannot be snapshotted",
+                    "Entity %s does not exist and therefore cannot be snapshooted",
                     entity_id,
                 )
                 continue

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -56,7 +56,7 @@ def _convert_states(states):
 
 
 CONF_SCENE_ID = "scene_id"
-CONF_SNAPSHOT = "snapshot"
+CONF_SNAPSHOT = "snapshot_entities"
 
 STATES_SCHEMA = vol.All(dict, _convert_states)
 

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -169,7 +169,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             state = hass.states.get(entity_id)
             if state is None:
                 _LOGGER.warning(
-                    "Entity %s does not exist and therefore cannot be snapshot",
+                    "Entity %s does not exist and therefore cannot be snapshotted",
                     entity_id,
                 )
                 continue

--- a/homeassistant/components/scene/services.yaml
+++ b/homeassistant/components/scene/services.yaml
@@ -34,3 +34,8 @@ create:
         light.ceiling:
           state: "on"
           brightness: 200
+    snapshot:
+      description: The entities of which a snapshot is to be taken
+      example:
+        - light.ceiling
+        - light.kitchen

--- a/homeassistant/components/scene/services.yaml
+++ b/homeassistant/components/scene/services.yaml
@@ -34,7 +34,7 @@ create:
         light.ceiling:
           state: "on"
           brightness: 200
-    snapshot:
+    snapshot_entities:
       description: The entities of which a snapshot is to be taken
       example:
         - light.ceiling

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -152,7 +152,7 @@ async def test_snapshot_service(hass, caplog):
     await hass.async_block_till_done()
     assert hass.states.get("scene.hallo_2") is None
     assert (
-        "Entity light.not_existent does not exist and therefore cannot be snapshooted"
+        "Entity light.not_existent does not exist and therefore cannot be snapshot"
         in caplog.text
     )
 

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -135,7 +135,7 @@ async def test_snapshot_service(hass, caplog):
     assert await hass.services.async_call(
         "scene",
         "create",
-        {"scene_id": "hallo", "snapshot": ["light.my_light"]},
+        {"scene_id": "hallo", "snapshot_entities": ["light.my_light"]},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -146,7 +146,7 @@ async def test_snapshot_service(hass, caplog):
     assert await hass.services.async_call(
         "scene",
         "create",
-        {"scene_id": "hallo_2", "snapshot": ["light.not_existent"]},
+        {"scene_id": "hallo_2", "snapshot_entities": ["light.not_existent"]},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -162,7 +162,7 @@ async def test_snapshot_service(hass, caplog):
         {
             "scene_id": "hallo_3",
             "entities": {"light.bed_light": {"state": "on", "brightness": 50}},
-            "snapshot": ["light.my_light"],
+            "snapshot_entities": ["light.my_light"],
         },
         blocking=True,
     )

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -1,9 +1,11 @@
 """Test Home Assistant scenes."""
 from unittest.mock import patch
 
+import pytest
 import voluptuous as vol
 
 from homeassistant.setup import async_setup_component
+
 from tests.common import async_mock_service
 
 
@@ -193,7 +195,7 @@ async def test_ensure_no_intersection(hass):
     """Test that entities and snapshot_entities do not overlap."""
     assert await async_setup_component(hass, "scene", {"scene": {}})
 
-    try:
+    with pytest.raises(vol.MultipleInvalid) as ex:
         assert await hass.services.async_call(
             "scene",
             "create",
@@ -205,7 +207,5 @@ async def test_ensure_no_intersection(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        assert False
-    except vol.MultipleInvalid as ex:
-        assert ex.msg == "entities and snapshot_entities must not overlap"
+    assert "entities and snapshot_entities must not overlap" in str(ex.value)
     assert hass.states.get("scene.hallo") is None

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -64,7 +64,10 @@ async def test_create_service(hass, caplog):
     assert hass.states.get("scene.hallo_2") is not None
 
     assert await hass.services.async_call(
-        "scene", "create", {"scene_id": "hallo"}, blocking=True
+        "scene",
+        "create",
+        {"scene_id": "hallo", "entities": {}, "snapshot_entities": []},
+        blocking=True,
     )
     await hass.async_block_till_done()
     assert "Empty scenes are not allowed" in caplog.text

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -170,7 +170,7 @@ async def test_snapshot_service(hass, caplog):
     await hass.async_block_till_done()
     assert hass.states.get("scene.hallo_2") is None
     assert (
-        "Entity light.not_existent does not exist and therefore cannot be snapshot"
+        "Entity light.not_existent does not exist and therefore cannot be snapshotted"
         in caplog.text
     )
 

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -152,7 +152,7 @@ async def test_snapshot_service(hass, caplog):
     await hass.async_block_till_done()
     assert hass.states.get("scene.hallo_2") is None
     assert (
-        "Entity light.not_existent does not exist and therefore cannot be snapshotted"
+        "Entity light.not_existent does not exist and therefore cannot be snapshooted"
         in caplog.text
     )
 


### PR DESCRIPTION
## Breaking Change:
Nothing breaks

## Description:
It's now possible to create a scene by snapshooting entities. This would be helpful to create a scene on the fly without knowing the current state. Please let me know if this feature is not needed/wanted.

Example use case:
* Turn off the climate while a window is open, restore the previous state as soon as the window closes again.
* Change the light to inform about something, then restore the previous state.

Since we don't know the current state before changing things, we can't create a scene from it at the moment. This PR makes it possible.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11255

## Example service data:
```yaml
scene_id: all_lights
entities:
  light.bed_light: on
snapshot_entities:
  - light.ceiling
  - light.kitchen
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
