### PR TITLE
Add round to half template method

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -669,6 +669,8 @@ def forgiving_round(value, precision=0, method="common"):
             value = math.ceil(float(value) * multiplier) / multiplier
         elif method == "floor":
             value = math.floor(float(value) * multiplier) / multiplier
+        elif method == "half":
+            value = round(float(value) * 2) / 2
         else:
             # if method is common or something else, use common rounding
             value = round(float(value), precision)

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -227,6 +227,13 @@ def test_rounding_value(hass):
         == "12.8"
     )
 
+    assert (
+        template.Template(
+            '{{ states.sensor.temperature.state | round(1, "half") }}', hass
+        ).async_render()
+        == "13.0"
+    )
+
 
 def test_rounding_value_get_original_value_on_error(hass):
     """Test rounding value get original value on error."""


### PR DESCRIPTION
## Description:

extended the round function to accept "half" as a method which will round a number to the nearest .5 value.

```
2.1 | round(1,"half") => 2.0
2.2 | round(1,"half") => 2.0
2.3 | round(1,"half") => 2.5
2.7 | round(1,"half") => 2.5
2.8 | round(1,"half") => 3.0
```
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11257

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)