### PR TITLE
Fix ikea lights on deconz

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -152,7 +152,7 @@ class DeconzLight(DeconzDevice, Light):
 
         if ATTR_TRANSITION in kwargs:
             data["transitiontime"] = int(kwargs[ATTR_TRANSITION] * 10)
-        elif self._device.manufacturer.startswith("IKEA"):
+        elif self._device.manufacturer and self._device.manufacturer.startswith("IKEA"):
             data["transitiontime"] = 0
 
         if ATTR_FLASH in kwargs:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -152,7 +152,7 @@ class DeconzLight(DeconzDevice, Light):
 
         if ATTR_TRANSITION in kwargs:
             data["transitiontime"] = int(kwargs[ATTR_TRANSITION] * 10)
-        elif self._device.manufacturer and self._device.manufacturer.startswith("IKEA"):
+        elif "IKEA" in (self._device.manufacturer or ""):
             data["transitiontime"] = 0
 
         if ATTR_FLASH in kwargs:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -152,6 +152,8 @@ class DeconzLight(DeconzDevice, Light):
 
         if ATTR_TRANSITION in kwargs:
             data["transitiontime"] = int(kwargs[ATTR_TRANSITION] * 10)
+        elif self._device.manufacturer.startswith("IKEA"):
+            data["transitiontime"] = 0
 
         if ATTR_FLASH in kwargs:
             if kwargs[ATTR_FLASH] == FLASH_SHORT:


### PR DESCRIPTION
## Description:

Fix ikea lights with deCONZ. I think that is fine because on Hue we have also manifactor specifics fix inside. With new state handling, it breaks ikea because of default transision inside deconz API.

Full story: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/894

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
