### PR TITLE
Fix netatmo manual config

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -547,13 +547,18 @@ class NetatmoData:
         self.data = {}
         self.station_data = self.data_class(self.auth)
         self.station = station
+        self.station_id = None
+        if station:
+            station_data = self.station_data.stationByName(self.station)
+            if station_data:
+                self.station_id = station_data.get("_id")
         self._next_update = time()
         self._update_in_progress = threading.Lock()
 
     def get_module_infos(self):
         """Return all modules available on the API as a dict."""
-        if self.station is not None:
-            return self.station_data.getModules(station=self.station)
+        if self.station_id is not None:
+            return self.station_data.getModules(station_id=self.station_id)
         return self.station_data.getModules()
 
     def update(self):
@@ -579,7 +584,7 @@ class NetatmoData:
                 return
 
             data = self.station_data.lastData(
-                station=self.station, exclude=3600, byId=True
+                station=self.station_id, exclude=3600, byId=True
             )
             if not data:
                 self._next_update = time() + NETATMO_UPDATE_INTERVAL


### PR DESCRIPTION
## Breaking Change:

## Description:
The switch to using IDs rather than names caused the manual config to break. This will fix it.

**Related issue (if applicable):** fixes #28918 and fixes #28677

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
