### PR TITLE
Add alarm switches to sonos component

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -5,6 +5,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TIME, CONF_HOSTS
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -173,7 +174,8 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up Sonos from a config entry."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, MP_DOMAIN)
-    )
+    for domain in [MP_DOMAIN, SWITCH_DOMAIN]:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, domain)
+        )
     return True

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -1,0 +1,216 @@
+"""Switch for Sonos alarms."""
+from datetime import timedelta
+import logging
+
+import socket
+import pysonos
+from pysonos import alarms
+from pysonos.exceptions import SoCoException
+
+from homeassistant.components.switch import SwitchDevice
+
+from . import (
+    ATTR_INCLUDE_LINKED_ZONES,
+    ATTR_TIME,
+    ATTR_VOLUME,
+    CONF_ADVERTISE_ADDR,
+    CONF_INTERFACE_ADDR,
+    CONF_HOSTS,
+    DOMAIN as SONOS_DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=30)
+DISCOVERY_INTERVAL = 60
+
+ATTR_DURATION = "duration"
+ATTR_PLAY_MODE = "play_mode"
+ATTR_RECURRENCE = "recurrence"
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the Sonos platform. Obsolete."""
+    _LOGGER.error(
+        "Loading Sonos alarms by switch platform config is no longer supported"
+    )
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Sonos from a config entry."""
+
+    config = hass.data[SONOS_DOMAIN].get("media_player", {})
+    _LOGGER.debug("Reached async_setup_entry of alarm, config=%s", config)
+
+    advertise_addr = config.get(CONF_ADVERTISE_ADDR)
+    if advertise_addr:
+        pysonos.config.EVENT_ADVERTISE_IP = advertise_addr
+
+    def _discovery(now=None):
+        """Discover players from network or configuration."""
+        hosts = config.get(CONF_HOSTS)
+        _LOGGER.debug(hosts)
+        alarm_list = []
+
+        def _discovered_alarm(soco):
+            """Handle a (re)discovered player."""
+            try:
+                _LOGGER.debug("Reached _discovered_player, soco=%s", soco)
+                for one_alarm in alarms.get_alarms(soco):
+                    if one_alarm.zone == soco and one_alarm not in alarm_list:
+                        _LOGGER.debug("Adding new alarm")
+                        alarm_list.append(one_alarm)
+                        hass.add_job(
+                            async_add_entities,
+                            [SonosAlarmSwitch(soco, one_alarm._alarm_id)],
+                        )
+            except SoCoException as ex:
+                _LOGGER.debug("SoCoException, ex=%s", ex)
+
+        if hosts:
+            for host in hosts:
+                try:
+                    _LOGGER.debug("Testing %s", host)
+                    player = pysonos.SoCo(socket.gethostbyname(host))
+                    if player.is_visible:
+                        # Make sure that the player is available
+                        _ = player.volume
+
+                        _discovered_alarm(player)
+                except (OSError, SoCoException) as ex:
+                    _LOGGER.debug("Exception %s", ex)
+                    if now is None:
+                        _LOGGER.warning("Failed to initialize '%s'", host)
+
+            _LOGGER.debug("Tested all hosts")
+            hass.helpers.event.call_later(DISCOVERY_INTERVAL, _discovery)
+        else:
+            _LOGGER.debug("Starting discovery thread")
+            pysonos.discover_thread(
+                _discovered_alarm,
+                interval=DISCOVERY_INTERVAL,
+                interface_addr=config.get(CONF_INTERFACE_ADDR),
+            )
+
+    _LOGGER.debug("Adding discovery job")
+    hass.async_add_executor_job(_discovery)
+
+
+class SonosAlarmSwitch(SwitchDevice):
+    """Switch class for Sonos alarms."""
+
+    def __init__(self, soco, id):
+        """Init Sonos alarms switch."""
+        self._icon = "mdi:alarm"
+        self._soco = soco
+        self._id = id
+        self._is_available = True
+        speaker_info = self._soco.get_speaker_info(True)
+        self._unique_id = "{}-{}".format(soco.uid, self._id)
+        self._name = "{} Alarm {}".format(speaker_info["zone_name"], self._id)
+        self._model = speaker_info["model_name"]
+
+        self.alarm = None
+        for one_alarm in alarms.get_alarms(self._soco):
+            # pylint: disable=protected-access
+            if one_alarm._alarm_id == id:
+                self.alarm = one_alarm
+
+        self._is_on = self.alarm.enabled
+        self._attributes = {
+            ATTR_TIME: str(self.alarm.start_time),
+            ATTR_VOLUME: str(self.alarm.volume),
+            ATTR_DURATION: str(self.alarm.duration),
+            ATTR_INCLUDE_LINKED_ZONES: str(self.alarm.include_linked_zones),
+            ATTR_RECURRENCE: str(self.alarm.recurrence),
+            ATTR_PLAY_MODE: str(self.alarm.play_mode),
+        }
+        super().__init__()
+
+    async def async_update(self, now=None):
+        """Retrieve latest state."""
+        _LOGGER.debug("updating alarms")
+        try:
+            alarms.get_alarms(self._soco)
+            self._is_on = self.alarm.enabled
+            self._attributes[ATTR_TIME] = str(self.alarm.start_time)
+            self._attributes[ATTR_DURATION] = str(self.alarm.duration)
+            self._attributes[ATTR_RECURRENCE] = str(self.alarm.recurrence)
+            self._attributes[ATTR_VOLUME] = str(self.alarm.volume)
+            self._attributes[ATTR_PLAY_MODE] = str(self.alarm.play_mode)
+            self._attributes[ATTR_INCLUDE_LINKED_ZONES] = str(
+                self.alarm.include_linked_zones
+            )
+            self._is_available = True
+            _LOGGER.debug("successfully updated alarms")
+        except SoCoException as exc:
+            _LOGGER.error(
+                "Home Assistant couldnt update the state of the alarm {}".format(exc),
+                exc_info=True,
+            )
+            self._is_available = False
+
+    @property
+    def name(self):
+        """Return name of Sonos alarm switch."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return icon of Sonos alarm switch."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self):
+        """Return attributes of Sonos alarm switch."""
+        return self._attributes
+
+    @property
+    def is_on(self):
+        """Return state of Sonos alarm switch."""
+        return self._is_on
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def device_info(self):
+        """Return information about the device."""
+        return {
+            "identifiers": {(SONOS_DOMAIN, self._unique_id)},
+            "name": self._name,
+            "model": self._model.replace("Sonos ", ""),
+            "manufacturer": "Sonos",
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return unavailability of alarm switch."""
+        return self._is_available
+
+    def turn_on(self, **kwargs) -> None:
+        """Turn alarm switch on."""
+        if self.handle_switch_on_off(turn_on=True):
+            self._is_on = True
+
+    def turn_off(self, **kwargs) -> None:
+        """Turn alarm switch off."""
+        if self.handle_switch_on_off(turn_on=False):
+            self._is_on = False
+
+    def handle_switch_on_off(self, turn_on: bool) -> bool:
+        """Handle turn on/off of alarm switch."""
+        # pylint: disable=import-error
+        try:
+            self.alarm.enabled = turn_on
+            self.alarm.save()
+            self._is_available = True
+            return True
+        except SoCoException as exc:
+            _LOGGER.error(
+                "Home Assistant couldnt switch the alarm {}".format(exc), exc_info=True
+            )
+            self._is_available = False
+            return False

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -61,8 +61,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         _LOGGER.debug("Adding new alarm")
                         alarm_list.append(one_alarm)
                         hass.add_job(
-                            async_add_entities,
-                            [SonosAlarmSwitch(soco, one_alarm._alarm_id)],
+                            async_add_entities, [SonosAlarmSwitch(soco, one_alarm)],
                         )
             except SoCoException as ex:
                 _LOGGER.debug("SoCoException, ex=%s", ex)
@@ -99,11 +98,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class SonosAlarmSwitch(SwitchDevice):
     """Switch class for Sonos alarms."""
 
-    def __init__(self, soco, id):
+    def __init__(self, soco, alarm):
         """Init Sonos alarms switch."""
         self._icon = "mdi:alarm"
         self._soco = soco
-        self._id = id
+        self._id = alarm._alarm_id
         self._is_available = True
         speaker_info = self._soco.get_speaker_info(True)
         self._unique_id = "{}-{}".format(soco.uid, self._id)
@@ -113,7 +112,7 @@ class SonosAlarmSwitch(SwitchDevice):
         self.alarm = None
         for one_alarm in alarms.get_alarms(self._soco):
             # pylint: disable=protected-access
-            if one_alarm._alarm_id == id:
+            if one_alarm._alarm_id == self._id:
                 self.alarm = one_alarm
 
         self._is_on = self.alarm.enabled
@@ -145,7 +144,8 @@ class SonosAlarmSwitch(SwitchDevice):
             _LOGGER.debug("successfully updated alarms")
         except SoCoException as exc:
             _LOGGER.error(
-                "Home Assistant couldnt update the state of the alarm {}".format(exc),
+                "Home Assistant couldnt update the state of the alarm %s",
+                exc,
                 exc_info=True,
             )
             self._is_available = False
@@ -210,7 +210,7 @@ class SonosAlarmSwitch(SwitchDevice):
             return True
         except SoCoException as exc:
             _LOGGER.error(
-                "Home Assistant couldnt switch the alarm {}".format(exc), exc_info=True
+                "Home Assistant couldnt switch the alarm %s", exc, exc_info=True
             )
             self._is_available = False
             return False

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -126,7 +126,7 @@ class SonosAlarmSwitch(SwitchDevice):
         }
         super().__init__()
 
-    async def async_update(self, now=None):
+    def update(self, now=None):
         """Retrieve latest state."""
         _LOGGER.debug("updating alarms")
         try:


### PR DESCRIPTION
## Breaking Change:
adding automatically discovered switches for sonos alarms to sonos integration

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
many people control their sonos alarms using home assistant. However up until now, it was not possible to retreave the the actual alarm state. The sonos component only exposed a service to update the alarm states.

This pull request adds automatically discovered switches for every sonos alarm.

It will only affect those users who actually use sonos alarms.

**Related issue (if applicable):** 
Discussions about sonos alarms:
https://community.home-assistant.io/t/alarm-clock-with-sonos-philips-hue/23421
https://community.home-assistant.io/t/how-to-read-sonos-alarm-state-and-time/98998
https://community.home-assistant.io/t/control-sonos-alarm-with-philips-hue-dimmer/98730

Documentation PR: home-assistant/home-assistant.io#11277

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
