### PR TITLE
Update pyjuicenet dependency

### DIFF
--- a/homeassistant/components/juicenet/manifest.json
+++ b/homeassistant/components/juicenet/manifest.json
@@ -3,7 +3,7 @@
   "name": "Juicenet",
   "documentation": "https://www.home-assistant.io/integrations/juicenet",
   "requirements": [
-    "python-juicenet==0.1.5"
+    "python-juicenet==0.1.6"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1553,7 +1553,7 @@ python-izone==1.1.1
 python-join-api==0.0.4
 
 # homeassistant.components.juicenet
-python-juicenet==0.1.5
+python-juicenet==0.1.6
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3


### PR DESCRIPTION
## Description:
Throw an error using a message from the API.
This case happens when an invalid token is used.

**Related issue (if applicable):** fixes #28926

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
