### PR TITLE
Add KEF speakers integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -352,6 +352,7 @@ omit =
     homeassistant/components/kankun/switch.py
     homeassistant/components/keba/*
     homeassistant/components/keenetic_ndms2/device_tracker.py
+    homeassistant/components/kef/*
     homeassistant/components/keyboard/*
     homeassistant/components/keyboard_remote/*
     homeassistant/components/kira/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -176,6 +176,7 @@ homeassistant/components/juicenet/* @jesserockz
 homeassistant/components/kaiterra/* @Michsior14
 homeassistant/components/keba/* @dannerph
 homeassistant/components/keenetic_ndms2/* @foxel
+homeassistant/components/kef/* @basnijholt
 homeassistant/components/keyboard_remote/* @bendavid
 homeassistant/components/knx/* @Julius2342
 homeassistant/components/kodi/* @armills

--- a/homeassistant/components/kef/__init__.py
+++ b/homeassistant/components/kef/__init__.py
@@ -1,0 +1,1 @@
+"""The KEF Wireless Speakers component."""

--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "dependencies": [],
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.1.8"]
+  "requirements": ["aiokef==0.2.0"]
 }

--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "dependencies": [],
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.2.0"]
+  "requirements": ["aiokef==0.2.2"]
 }

--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "kef",
+  "name": "KEF",
+  "documentation": "https://www.home-assistant.io/integrations/kef",
+  "dependencies": [],
+  "codeowners": ["@basnijholt"],
+  "requirements": ["aiokef==0.1.8"]
+}

--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "dependencies": [],
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.2.2"]
+  "requirements": ["aiokef==0.2.2", "getmac==0.8.1"]
 }

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
     CONF_TYPE,
     STATE_OFF,
     STATE_ON,
-    STATE_UNKNOWN,
 )
 from homeassistant.helpers import config_validation as cv
 
@@ -145,7 +144,7 @@ class KefMediaPlayer(MediaPlayerDevice):
             ioloop=ioloop,
         )
 
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._muted = None
         self._source = None
         self._volume = None
@@ -181,7 +180,7 @@ class KefMediaPlayer(MediaPlayerDevice):
                 self._state = STATE_OFF
         except (ConnectionRefusedError, ConnectionError, TimeoutError) as err:
             _LOGGER.debug("Error in `update`: %s", err)
-            self._state = STATE_UNKNOWN
+            self._state = None
 
     @property
     def volume_level(self):

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -3,8 +3,9 @@
 import datetime
 import logging
 
-import voluptuous as vol
 from aiokef.aiokef import AsyncKefSpeaker
+import voluptuous as vol
+
 from homeassistant.components.media_player import (
     PLATFORM_SCHEMA,
     SUPPORT_SELECT_SOURCE,

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -1,0 +1,233 @@
+"""Platform for the KEF Wireless Speakers."""
+
+import datetime
+import logging
+
+from aiokef.aiokef import INPUT_SOURCES, AsyncKefSpeaker
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    PLATFORM_SCHEMA,
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_STEP,
+    MediaPlayerDevice,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+)
+from homeassistant.helpers import config_validation as cv
+
+_CONFIGURING = {}
+_LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_NAME = "KEF"
+DEFAULT_PORT = 50001
+DEFAULT_MAX_VOLUME = 0.5
+DEFAULT_VOLUME_STEP = 0.05
+DATA_KEF = "kef"
+
+SCAN_INTERVAL = datetime.timedelta(seconds=30)
+PARALLEL_UPDATES = 0
+
+KEF_LS50_SOURCES = sorted(INPUT_SOURCES.keys())
+
+SUPPORT_KEF = (
+    SUPPORT_VOLUME_SET
+    | SUPPORT_VOLUME_STEP
+    | SUPPORT_VOLUME_MUTE
+    | SUPPORT_SELECT_SOURCE
+    | SUPPORT_TURN_OFF
+    | SUPPORT_TURN_ON
+)
+
+CONF_MAX_VOLUME = "maximum_volume"
+CONF_VOLUME_STEP = "volume_step"
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_MAX_VOLUME, default=DEFAULT_MAX_VOLUME): cv.small_float,
+        vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): cv.small_float,
+    }
+)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the KEF platform."""
+    if DATA_KEF not in hass.data:
+        hass.data[DATA_KEF] = {}
+
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    name = config.get(CONF_NAME)
+    maximum_volume = config.get(CONF_MAX_VOLUME)
+    volume_step = config.get(CONF_VOLUME_STEP)
+
+    _LOGGER.debug(
+        "Setting up %s with host: %s, port: %s, name: %s, sources: %s",
+        DATA_KEF,
+        host,
+        port,
+        name,
+        KEF_LS50_SOURCES,
+    )
+
+    media_player = KefMediaPlayer(
+        name,
+        host,
+        port,
+        maximum_volume=maximum_volume,
+        volume_step=volume_step,
+        sources=KEF_LS50_SOURCES,
+        ioloop=hass.loop,
+    )
+    unique_id = media_player.unique_id
+    if unique_id in hass.data[DATA_KEF]:
+        _LOGGER.debug("%s is already configured.", unique_id)
+    else:
+        hass.data[DATA_KEF][unique_id] = media_player
+        async_add_entities([media_player], update_before_add=True)
+
+
+class KefMediaPlayer(MediaPlayerDevice):
+    """Kef Player Object."""
+
+    def __init__(self, name, host, port, maximum_volume, volume_step, sources, ioloop):
+        """Initialize the media player."""
+        self._name = name
+        self._sources = sources
+        self._speaker = AsyncKefSpeaker(
+            host, port, volume_step, maximum_volume, ioloop=ioloop
+        )
+
+        self._state = STATE_UNKNOWN
+        self._muted = None
+        self._source = None
+        self._volume = None
+        self._is_online = None
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    async def async_update(self):
+        """Update latest state."""
+        _LOGGER.debug("Running async_update")
+        try:
+            self._is_online = await self._speaker.is_online()
+            if self._is_online:
+                (
+                    self._volume,
+                    self._muted,
+                ) = await self._speaker.get_volume_and_is_muted()
+                self._source, is_on = await self._speaker.get_source_and_state()
+                self._state = STATE_ON if is_on else STATE_OFF
+            else:
+                self._muted = None
+                self._source = None
+                self._volume = None
+                self._state = STATE_OFF
+        except (ConnectionRefusedError, ConnectionError, TimeoutError) as err:
+            _LOGGER.debug("Error in `update`: %s", err)
+            self._state = STATE_UNKNOWN
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return self._volume
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self._muted
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_KEF
+
+    @property
+    def source(self):
+        """Name of the current input source."""
+        return self._source
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._sources
+
+    @property
+    def available(self):
+        """Return if the speaker is reachable online."""
+        return self._is_online
+
+    @property
+    def unique_id(self):
+        """Return the device unique id."""
+        return f"{self._speaker.host}:{self._speaker.port}"
+
+    @property
+    def icon(self):
+        """Return the device's icon."""
+        return "mdi:speaker-wireless"
+
+    @property
+    def should_poll(self):
+        """It's possible that the speaker is controlled manually."""
+        return True
+
+    @property
+    def force_update(self):
+        """Force update."""
+        return False
+
+    async def async_turn_off(self):
+        """Turn the media player off."""
+        await self._speaker.turn_off()
+
+    async def async_turn_on(self):
+        """Turn the media player on."""
+        await self._speaker.turn_on()
+
+    async def async_volume_up(self):
+        """Volume up the media player."""
+        await self._speaker.increase_volume()
+
+    async def async_volume_down(self):
+        """Volume down the media player."""
+        await self._speaker.decrease_volume()
+
+    async def async_set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        await self._speaker.set_volume(volume)
+
+    async def async_mute_volume(self, mute):
+        """Mute (True) or unmute (False) media player."""
+        if mute:
+            await self._speaker.mute()
+        else:
+            await self._speaker.unmute()
+
+    async def async_select_source(self, source: str):
+        """Select input source."""
+        if source in self.source_list:
+            await self._speaker.set_source(source)
+        else:
+            raise ValueError(f"Unknown input source: {source}.")

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -34,7 +34,7 @@ DEFAULT_NAME = "KEF"
 DEFAULT_PORT = 50001
 DEFAULT_MAX_VOLUME = 0.5
 DEFAULT_VOLUME_STEP = 0.05
-DATA_KEF = "kef"
+DOMAIN = "kef"
 
 SCAN_INTERVAL = datetime.timedelta(seconds=30)
 PARALLEL_UPDATES = 0
@@ -65,8 +65,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the KEF platform."""
-    if DATA_KEF not in hass.data:
-        hass.data[DATA_KEF] = {}
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
 
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
@@ -76,7 +76,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     _LOGGER.debug(
         "Setting up %s with host: %s, port: %s, name: %s, sources: %s",
-        DATA_KEF,
+        DOMAIN,
         host,
         port,
         name,
@@ -93,10 +93,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         ioloop=hass.loop,
     )
     unique_id = media_player.unique_id
-    if unique_id in hass.data[DATA_KEF]:
+    if unique_id in hass.data[DOMAIN]:
         _LOGGER.debug("%s is already configured.", unique_id)
     else:
-        hass.data[DATA_KEF][unique_id] = media_player
+        hass.data[DOMAIN][unique_id] = media_player
         async_add_entities([media_player], update_before_add=True)
 
 

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -81,11 +81,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     host = config[CONF_HOST]
     speaker_type = config[CONF_TYPE]
-    port = config.get(CONF_PORT)
-    name = config.get(CONF_NAME)
-    maximum_volume = config.get(CONF_MAX_VOLUME)
-    volume_step = config.get(CONF_VOLUME_STEP)
-    inverse_speaker_mode = config.get(CONF_INVERSE_SPEAKER_MODE)
+    port = config[CONF_PORT]
+    name = config[CONF_NAME]
+    maximum_volume = config[CONF_MAX_VOLUME]
+    volume_step = config[CONF_VOLUME_STEP]
+    inverse_speaker_mode = config[CONF_INVERSE_SPEAKER_MODE]
     standby_time = config.get(CONF_STANDBY_TIME)
 
     sources = SOURCES[speaker_type]

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -1,6 +1,6 @@
 """Platform for the KEF Wireless Speakers."""
 
-import datetime
+from datetime import timedelta
 import logging
 
 from aiokef.aiokef import AsyncKefSpeaker
@@ -39,7 +39,7 @@ DEFAULT_INVERSE_SPEAKER_MODE = False
 
 DOMAIN = "kef"
 
-SCAN_INTERVAL = datetime.timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=30)
 PARALLEL_UPDATES = 0
 
 SOURCES = {"LSX": ["Wifi", "Bluetooth", "Aux", "Opt"]}
@@ -113,7 +113,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
     unique_id = media_player.unique_id
     if unique_id in hass.data[DOMAIN]:
-        _LOGGER.debug("%s is already configured.", unique_id)
+        _LOGGER.debug("%s is already configured", unique_id)
     else:
         hass.data[DOMAIN][unique_id] = media_player
         async_add_entities([media_player], update_before_add=True)
@@ -224,16 +224,6 @@ class KefMediaPlayer(MediaPlayerDevice):
     def icon(self):
         """Return the device's icon."""
         return "mdi:speaker-wireless"
-
-    @property
-    def should_poll(self):
-        """It's possible that the speaker is controlled manually."""
-        return True
-
-    @property
-    def force_update(self):
-        """Force update."""
-        return False
 
     async def async_turn_off(self):
         """Turn the media player off."""

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -123,10 +123,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         unique_id=unique_id,
     )
 
-    if unique_id in hass.data[DOMAIN]:
-        _LOGGER.debug("%s is already configured", unique_id)
+    if host in hass.data[DOMAIN]:
+        _LOGGER.debug("%s is already configured", host)
     else:
-        hass.data[DOMAIN][unique_id] = media_player
+        hass.data[DOMAIN][host] = media_player
         async_add_entities([media_player], update_before_add=True)
 
 

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -108,8 +108,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     except ValueError:
         mode = "hostname"
     mac = await hass.async_add_executor_job(partial(get_mac_address, **{mode: host}))
-
-    unique_id = f"kef-{mac}"
+    unique_id = f"kef-{mac}" if mac is not None else None
 
     media_player = KefMediaPlayer(
         name,

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -18,6 +18,8 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import (
     CONF_HOST,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
     CONF_NAME,
     CONF_PORT,
     CONF_TYPE,
@@ -97,6 +99,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         sources,
     )
 
+    latitude = config.data[CONF_LATITUDE]
+    longitude = config.data[CONF_LONGITUDE]
+    unique_id = f"kef-{latitude}-{longitude}"
+
     media_player = KefMediaPlayer(
         name,
         host,
@@ -107,8 +113,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         inverse_speaker_mode,
         sources,
         ioloop=hass.loop,
+        unique_id=unique_id,
     )
-    unique_id = media_player.unique_id
+
     if unique_id in hass.data[DOMAIN]:
         _LOGGER.debug("%s is already configured", unique_id)
     else:
@@ -130,6 +137,7 @@ class KefMediaPlayer(MediaPlayerDevice):
         inverse_speaker_mode,
         sources,
         ioloop,
+        unique_id,
     ):
         """Initialize the media player."""
         self._name = name
@@ -143,6 +151,7 @@ class KefMediaPlayer(MediaPlayerDevice):
             inverse_speaker_mode,
             ioloop=ioloop,
         )
+        self._unique_id = unique_id
 
         self._state = None
         self._muted = None
@@ -215,7 +224,7 @@ class KefMediaPlayer(MediaPlayerDevice):
     @property
     def unique_id(self):
         """Return the device unique id."""
-        return f"{self._speaker.host}:{self._speaker.port}"
+        return self._unique_id
 
     @property
     def icon(self):

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -27,9 +27,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 
-_CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
-
 
 DEFAULT_NAME = "KEF"
 DEFAULT_PORT = 50001

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -172,7 +172,7 @@ aioimaplib==0.7.15
 aiokafka==0.5.1
 
 # homeassistant.components.kef
-aiokef==0.1.8
+aiokef==0.2.0
 
 # homeassistant.components.lifx
 aiolifx==0.6.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -172,7 +172,7 @@ aioimaplib==0.7.15
 aiokafka==0.5.1
 
 # homeassistant.components.kef
-aiokef==0.2.0
+aiokef==0.2.2
 
 # homeassistant.components.lifx
 aiolifx==0.6.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -171,6 +171,9 @@ aioimaplib==0.7.15
 # homeassistant.components.apache_kafka
 aiokafka==0.5.1
 
+# homeassistant.components.kef
+aiokef==0.1.8
+
 # homeassistant.components.lifx
 aiolifx==0.6.7
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -581,6 +581,7 @@ georss_qld_bushfire_alert_client==0.3
 
 # homeassistant.components.braviatv
 # homeassistant.components.huawei_lte
+# homeassistant.components.kef
 # homeassistant.components.nmap_tracker
 getmac==0.8.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -197,6 +197,7 @@ georss_qld_bushfire_alert_client==0.3
 
 # homeassistant.components.braviatv
 # homeassistant.components.huawei_lte
+# homeassistant.components.kef
 # homeassistant.components.nmap_tracker
 getmac==0.8.1
 


### PR DESCRIPTION
## Description:
This PR will add an integration to integrate KEF speakers.
This will work with the [KEF LS50 Wireless](https://international.kef.com/products/ls50-wireless) and [KEF LSX](https://international.kef.com/products/lsx) speakers.
The development of this code happened on [basnijholt/media_player.kef](https://github.com/basnijholt/media_player.kef) and it uses the [`aiokef`](https://github.com/basnijholt/aiokef) package.

Since these are reasonably expensive speakers (~$2300) there might not be many beta testers. However, on the [community forum](https://community.home-assistant.io/t/kef-ls50-wireless/70269) several people have tried to use HA with these speakers. Having it as a component inside HA (vs `custom_component`) will bring it to a bigger audience.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11274

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: kef
    host: 192.168.x.x  # the IP of your speaker
    type: LS50
    name: MyAudiophileSpeaker  # optional, the name in Home Assistant
    maximum_volume: 0.5  # optional, to avoid extremely loud volumes
    volume_step: 0.05  # optional
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
