### PR TITLE
Make conversation and intent context aware

### DIFF
--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -10,7 +10,7 @@ from aiohttp import ClientSession, ClientError
 from pyalmond import AlmondLocalAuth, AbstractAlmondWebAuth, WebAlmondAPI
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, CoreState
+from homeassistant.core import HomeAssistant, CoreState, Context
 from homeassistant.const import CONF_TYPE, CONF_HOST, EVENT_HOMEASSISTANT_START
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.auth.const import GROUP_ID_ADMIN
@@ -277,7 +277,7 @@ class AlmondAgent(conversation.AbstractConversationAgent):
         return True
 
     async def async_process(
-        self, text: str, conversation_id: Optional[str] = None
+        self, text: str, context: Context, conversation_id: Optional[str] = None
     ) -> intent.IntentResponse:
         """Process a sentence."""
         response = await self.api.async_converse_text(text, conversation_id)

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -2,6 +2,7 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from homeassistant.core import Context
 from homeassistant.helpers import intent
 
 
@@ -23,6 +24,6 @@ class AbstractConversationAgent(ABC):
 
     @abstractmethod
     async def async_process(
-        self, text: str, conversation_id: Optional[str] = None
+        self, text: str, context: Context, conversation_id: Optional[str] = None
     ) -> intent.IntentResponse:
         """Process a sentence."""

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -109,7 +109,7 @@ class DefaultAgent(AbstractConversationAgent):
             async_register(self.hass, intent_type, sentences)
 
     async def async_process(
-        self, text: str, conversation_id: Optional[str] = None
+        self, text: str, context: core.Context, conversation_id: Optional[str] = None
     ) -> intent.IntentResponse:
         """Process a sentence."""
         intents = self.hass.data[DOMAIN]
@@ -127,4 +127,5 @@ class DefaultAgent(AbstractConversationAgent):
                     intent_type,
                     {key: {"value": value} for key, value in match.groupdict().items()},
                     text,
+                    context,
                 )

--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -43,7 +43,8 @@ class HomeAssistantView:
 
         return Context(user_id=user.id)
 
-    def json(self, result, status_code=200, headers=None):
+    @staticmethod
+    def json(result, status_code=200, headers=None):
         """Return a JSON response."""
         try:
             msg = json.dumps(

--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -34,8 +34,8 @@ class HomeAssistantView:
     requires_auth = True
     cors_allowed = False
 
-    # pylint: disable=no-self-use
-    def context(self, request):
+    @staticmethod
+    def context(request):
         """Generate a context from a request."""
         user = request.get("hass_user")
         if user is None:

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -80,7 +80,9 @@ class ScriptIntentHandler(intent.IntentHandler):
 
         if action is not None:
             if is_async_action:
-                intent_obj.hass.async_create_task(action.async_run(slots))
+                intent_obj.hass.async_create_task(
+                    action.async_run(slots, intent_obj.context)
+                )
             else:
                 await action.async_run(slots)
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -232,7 +232,9 @@ class SetIntentHandler(intent.IntentHandler):
             service_data[ATTR_BRIGHTNESS_PCT] = slots["brightness"]["value"]
             speech_parts.append("{}% brightness".format(slots["brightness"]["value"]))
 
-        await hass.services.async_call(DOMAIN, SERVICE_TURN_ON, service_data)
+        await hass.services.async_call(
+            DOMAIN, SERVICE_TURN_ON, service_data, context=intent_obj.context
+        )
 
         response = intent_obj.create_response()
 

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Iterable, Optional
 import voluptuous as vol
 
 from homeassistant.const import ATTR_SUPPORTED_FEATURES
-from homeassistant.core import callback, State, T
+from homeassistant.core import callback, State, T, Context
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
@@ -53,6 +53,7 @@ async def async_handle(
     intent_type: str,
     slots: Optional[_SlotsType] = None,
     text_input: Optional[str] = None,
+    context: Optional[Context] = None,
 ) -> "IntentResponse":
     """Handle an intent."""
     handler: IntentHandler = hass.data.get(DATA_KEY, {}).get(intent_type)
@@ -60,7 +61,10 @@ async def async_handle(
     if handler is None:
         raise UnknownIntent(f"Unknown intent {intent_type}")
 
-    intent = Intent(hass, platform, intent_type, slots or {}, text_input)
+    if context is None:
+        context = Context()
+
+    intent = Intent(hass, platform, intent_type, slots or {}, text_input, context)
 
     try:
         _LOGGER.info("Triggering intent handler %s", handler)
@@ -196,7 +200,10 @@ class ServiceIntentHandler(IntentHandler):
         state = async_match_state(hass, slots["name"]["value"])
 
         await hass.services.async_call(
-            self.domain, self.service, {ATTR_ENTITY_ID: state.entity_id}
+            self.domain,
+            self.service,
+            {ATTR_ENTITY_ID: state.entity_id},
+            context=intent_obj.context,
         )
 
         response = intent_obj.create_response()
@@ -207,7 +214,7 @@ class ServiceIntentHandler(IntentHandler):
 class Intent:
     """Hold the intent."""
 
-    __slots__ = ["hass", "platform", "intent_type", "slots", "text_input"]
+    __slots__ = ["hass", "platform", "intent_type", "slots", "text_input", "context"]
 
     def __init__(
         self,
@@ -216,6 +223,7 @@ class Intent:
         intent_type: str,
         slots: _SlotsType,
         text_input: Optional[str],
+        context: Context,
     ) -> None:
         """Initialize an intent."""
         self.hass = hass
@@ -223,6 +231,7 @@ class Intent:
         self.intent_type = intent_type
         self.slots = slots
         self.text_input = text_input
+        self.context = context
 
     @callback
     def create_response(self) -> "IntentResponse":


### PR DESCRIPTION
## Description:
Make conversation integration and intent helpers context aware.

Also moved around and renamed some internal code in the conversation integration so it makes more sense.

Changes the conversation agent signature by adding the `context` parameter.

CC @synesthesiam 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
