### PR TITLE
Truncate too long states and log warning

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -60,7 +60,6 @@ from homeassistant import loader
 from homeassistant.exceptions import (
     HomeAssistantError,
     InvalidEntityFormatError,
-    InvalidStateError,
     Unauthorized,
     ServiceNotFound,
 )
@@ -68,11 +67,7 @@ from homeassistant.util.async_ import run_callback_threadsafe, fire_coroutine_th
 from homeassistant import util
 import homeassistant.util.dt as dt_util
 from homeassistant.util import location, slugify
-from homeassistant.util.unit_system import (
-    UnitSystem,
-    IMPERIAL_SYSTEM,
-    METRIC_SYSTEM,
-)
+from homeassistant.util.unit_system import UnitSystem, IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 # Typing imports that create a circular dependency
 # pylint: disable=using-constant-test
@@ -729,7 +724,7 @@ class State:
             _LOGGER.warning(
                 "Invalid state encountered for entity id: %s. "
                 "State truncated to max length of 255 characters.",
-                entity_id
+                entity_id,
             )
             state = state[:255]
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -118,8 +118,8 @@ def valid_entity_id(entity_id: str) -> bool:
     return "." in entity_id and slugify(entity_id) == entity_id.replace(".", "_", 1)
 
 
-def valid_state(state: str) -> bool:
-    """Test if a state is valid."""
+def valid_state_length(state: str) -> bool:
+    """Test if a state is less than 256 characters."""
     return len(state) < 256
 
 
@@ -725,13 +725,13 @@ class State:
                 ).format(entity_id)
             )
 
-        if not valid_state(state):
-            raise InvalidStateError(
-                (
-                    "Invalid state encountered for entity id: {}. "
-                    "State max length is 255 characters."
-                ).format(entity_id)
+        if not valid_state_length(state):
+            _LOGGER.warning(
+                "Invalid state encountered for entity id: %s. "
+                "State truncated to max length of 255 characters.",
+                entity_id
             )
+            state = state[:255]
 
         self.entity_id = entity_id.lower()
         self.state = state

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -36,10 +36,6 @@ class ConfigEntryNotReady(HomeAssistantError):
     """Error to indicate that config entry is not ready."""
 
 
-class InvalidStateError(HomeAssistantError):
-    """When an invalid state is encountered."""
-
-
 class Unauthorized(HomeAssistantError):
     """When an action is unauthorized."""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,7 +14,7 @@ import pytz
 import pytest
 
 import homeassistant.core as ha
-from homeassistant.exceptions import InvalidEntityFormatError, InvalidStateError
+from homeassistant.exceptions import InvalidEntityFormatError
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.const import (
@@ -474,9 +474,6 @@ def test_state_init():
     """Test state.init."""
     with pytest.raises(InvalidEntityFormatError):
         ha.State("invalid_entity_format", "test_state")
-
-    with pytest.raises(InvalidStateError):
-        ha.State("domain.long_state", "t" * 256)
 
 
 def test_state_domain():


### PR DESCRIPTION
## Description:

If an entity's state is longer than 255 characters, truncate it and log a warning instead of raising an error.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]