### PR TITLE
Fix Abode sensor temperature reporting

### DIFF
--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -72,19 +72,19 @@ class AbodeSensor(AbodeDevice):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self._sensor_type == "temp":
+        if self._sensor_type == CONST.TEMP_STATUS_KEY:
             return self._device.temp
-        if self._sensor_type == "humidity":
+        if self._sensor_type == CONST.HUMI_STATUS_KEY:
             return self._device.humidity
-        if self._sensor_type == "lux":
+        if self._sensor_type == CONST.LUX_STATUS_KEY:
             return self._device.lux
 
     @property
     def unit_of_measurement(self):
         """Return the units of measurement."""
-        if self._sensor_type == "temp":
+        if self._sensor_type == CONST.TEMP_STATUS_KEY:
             return self._device.temp_unit
-        if self._sensor_type == "humidity":
+        if self._sensor_type == CONST.HUMI_STATUS_KEY:
             return self._device.humidity_unit
-        if self._sensor_type == "lux":
+        if self._sensor_type == CONST.LUX_STATUS_KEY:
             return self._device.lux_unit


### PR DESCRIPTION
## Description:
Fixes an issue where Abode temp/humidity/lux sensors are not reporting a temperature value. Also includes the use of constants where applicable. Request this to be added to the 102.2 milestone.

**Related issue (if applicable):** fixes #28931

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]