### PR TITLE
Fix HomeKit linked battery sensor crash

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -96,8 +96,7 @@ class HomeAccessory(Accessory):
         self.debounce = {}
         self._support_battery_level = False
         self._support_battery_charging = True
-        self.linked_battery_sensor = self.config.get(
-            CONF_LINKED_BATTERY_SENSOR)
+        self.linked_battery_sensor = self.config.get(CONF_LINKED_BATTERY_SENSOR)
         self.low_battery_threshold = self.config.get(
             CONF_LOW_BATTERY_THRESHOLD, DEFAULT_LOW_BATTERY_THRESHOLD
         )
@@ -109,8 +108,7 @@ class HomeAccessory(Accessory):
 
         if self.linked_battery_sensor:
             if self.hass.states.get(self.linked_battery_sensor):
-                battery_found = self.hass.states.get(
-                    self.linked_battery_sensor).state
+                battery_found = self.hass.states.get(self.linked_battery_sensor).state
             else:
                 self.linked_battery_sensor = None
                 _LOGGER.warning(

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -96,8 +96,8 @@ class HomeAccessory(Accessory):
         self.debounce = {}
         self._support_battery_level = False
         self._support_battery_charging = True
-        self.linked_battery_sensor = None
-        self.linked_battery_sensor_id = self.config.get(CONF_LINKED_BATTERY_SENSOR)
+        self.linked_battery_sensor = self.config.get(
+            CONF_LINKED_BATTERY_SENSOR)
         self.low_battery_threshold = self.config.get(
             CONF_LOW_BATTERY_THRESHOLD, DEFAULT_LOW_BATTERY_THRESHOLD
         )
@@ -106,19 +106,18 @@ class HomeAccessory(Accessory):
         battery_found = self.hass.states.get(self.entity_id).attributes.get(
             ATTR_BATTERY_LEVEL
         )
-        if self.linked_battery_sensor_id:
-            self.linked_battery_sensor = self.hass.states.get(
-                self.linked_battery_sensor_id
-            )
 
-            if self.linked_battery_sensor is None:
+        if self.linked_battery_sensor:
+            if self.hass.states.get(self.linked_battery_sensor):
+                battery_found = self.hass.states.get(
+                    self.linked_battery_sensor).state
+            else:
+                self.linked_battery_sensor = None
                 _LOGGER.warning(
                     "%s: Battery sensor state missing: %s",
                     self.entity_id,
                     self.linked_battery_sensor,
                 )
-            else:
-                battery_found = self.linked_battery_sensor.state
 
         if battery_found is None:
             return
@@ -148,12 +147,12 @@ class HomeAccessory(Accessory):
         async_track_state_change(self.hass, self.entity_id, self.update_state_callback)
 
         if self.linked_battery_sensor:
-            battery_state = self.hass.states.get(self.linked_battery_sensor_id)
+            battery_state = self.hass.states.get(self.linked_battery_sensor)
             self.hass.async_add_job(
                 self.update_linked_battery, None, None, battery_state
             )
             async_track_state_change(
-                self.hass, self.linked_battery_sensor_id, self.update_linked_battery
+                self.hass, self.linked_battery_sensor, self.update_linked_battery
             )
 
     @ha_callback

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -107,8 +107,9 @@ class HomeAccessory(Accessory):
         )
 
         if self.linked_battery_sensor:
-            if self.hass.states.get(self.linked_battery_sensor):
-                battery_found = self.hass.states.get(self.linked_battery_sensor).state
+            state = self.hass.states.get(self.linked_battery_sensor)
+            if state is not None:
+                battery_found = state.state
             else:
                 self.linked_battery_sensor = None
                 _LOGGER.warning(

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -195,7 +195,7 @@ async def test_linked_battery_sensor(hass, hk_driver, caplog):
         {CONF_LINKED_BATTERY_SENSOR: linked_battery},
     )
     acc.update_state = lambda x: None
-    assert acc.linked_battery_sensor_id == linked_battery
+    assert acc.linked_battery_sensor == linked_battery
 
     await hass.async_add_job(acc.run)
     await hass.async_block_till_done()
@@ -262,7 +262,6 @@ async def test_missing_linked_battery_sensor(hass, hk_driver, caplog):
     )
     acc.update_state = lambda x: None
     assert not acc.linked_battery_sensor
-    assert acc.linked_battery_sensor_id
 
     await hass.async_add_job(acc.run)
     await hass.async_block_till_done()

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -195,7 +195,7 @@ async def test_linked_battery_sensor(hass, hk_driver, caplog):
         {CONF_LINKED_BATTERY_SENSOR: linked_battery},
     )
     acc.update_state = lambda x: None
-    assert acc.linked_battery_sensor == linked_battery
+    assert acc.linked_battery_sensor_id == linked_battery
 
     await hass.async_add_job(acc.run)
     await hass.async_block_till_done()
@@ -243,6 +243,34 @@ async def test_linked_battery_sensor(hass, hk_driver, caplog):
     assert acc._char_battery.value == 100
     assert acc._char_low_battery.value == 0
     assert acc._char_charging.value == 0
+
+
+async def test_missing_linked_battery_sensor(hass, hk_driver, caplog):
+    """Test battery service with mising linked_battery_sensor."""
+    entity_id = "homekit.accessory"
+    linked_battery = "sensor.battery"
+    hass.states.async_set(entity_id, "open")
+    await hass.async_block_till_done()
+
+    acc = HomeAccessory(
+        hass,
+        hk_driver,
+        "Battery Service",
+        entity_id,
+        2,
+        {CONF_LINKED_BATTERY_SENSOR: linked_battery},
+    )
+    acc.update_state = lambda x: None
+    assert not acc.linked_battery_sensor
+    assert acc.linked_battery_sensor_id
+
+    await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
+
+    assert not acc.linked_battery_sensor
+    assert not hasattr(acc, "_char_battery")
+    assert not hasattr(acc, "_char_low_battery")
+    assert not hasattr(acc, "_char_charging")
 
 
 async def test_call_service(hass, hk_driver, events):


### PR DESCRIPTION
Description:

This adds checks in to prevent HomeKit component from crashing when a linked battery sensor is missing or incorrectly configured with a nonexistent `entity_id`. It will also display a warning in the logs when a linked battery sensor is missing, and still allow HomeKit to start;.

**Related issue (if applicable):** fixes #28686

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
