### PR TITLE
Show current effect in yeelight device

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -48,6 +48,7 @@ ACTION_STAY = "stay"
 ACTION_OFF = "off"
 
 ACTIVE_MODE_NIGHTLIGHT = "1"
+ACTIVE_COLOR_FLOWING = "1"
 
 NIGHTLIGHT_SWITCH_TYPE_LIGHT = "light"
 
@@ -123,6 +124,7 @@ UPDATE_REQUEST_PROPERTIES = [
     "hue",
     "sat",
     "color_mode",
+    "flowing",
     "bg_power",
     "bg_lmode",
     "bg_flowing",
@@ -251,8 +253,17 @@ class YeelightDevice:
         return self._active_mode is not None
 
     @property
+    def is_color_flow_enabled(self) -> bool:
+        """Return true / false if color flow is currently running."""
+        return self._color_flow == ACTIVE_COLOR_FLOWING
+
+    @property
     def _active_mode(self):
         return self.bulb.last_properties.get("active_mode")
+
+    @property
+    def _color_flow(self):
+        return self.bulb.last_properties.get("flowing")
 
     @property
     def type(self):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -696,7 +696,8 @@ class YeelightGenericLight(Light):
         if effect == EFFECT_STOP:
             self._bulb.stop_flow(light_type=self.light_type)
             return
-        elif effect in self.custom_effects_names:
+
+        if effect in self.custom_effects_names:
             flow = Flow(**self.custom_effects[effect])
         elif effect in EFFECTS_MAP:
             flow = Flow(count=0, transitions=EFFECTS_MAP[effect]())

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -692,7 +692,8 @@ class YeelightGenericLight(Light):
         """Activate effect."""
         if not effect:
             return
-        elif effect == EFFECT_STOP:
+
+        if effect == EFFECT_STOP:
             self._bulb.stop_flow(light_type=self.light_type)
             return
         elif effect in self.custom_effects_names:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -675,46 +675,48 @@ class YeelightGenericLight(Light):
     @_cmd
     def set_effect(self, effect) -> None:
         """Activate effect."""
-        if effect:
-            if effect == EFFECT_STOP:
-                self._bulb.stop_flow(light_type=self.light_type)
-                return
+        if not effect:
+            return
 
-            effects_map = {
-                EFFECT_DISCO: yee_transitions.disco,
-                EFFECT_TEMP: yee_transitions.temp,
-                EFFECT_STROBE: yee_transitions.strobe,
-                EFFECT_STROBE_COLOR: yee_transitions.strobe_color,
-                EFFECT_ALARM: yee_transitions.alarm,
-                EFFECT_POLICE: yee_transitions.police,
-                EFFECT_POLICE2: yee_transitions.police2,
-                EFFECT_CHRISTMAS: yee_transitions.christmas,
-                EFFECT_RGB: yee_transitions.rgb,
-                EFFECT_RANDOM_LOOP: yee_transitions.randomloop,
-                EFFECT_LSD: yee_transitions.lsd,
-                EFFECT_SLOWDOWN: yee_transitions.slowdown,
-            }
+        if effect == EFFECT_STOP:
+            self._bulb.stop_flow(light_type=self.light_type)
+            return
 
-            if effect in self.custom_effects_names:
-                flow = Flow(**self.custom_effects[effect])
-            elif effect in effects_map:
-                flow = Flow(count=0, transitions=effects_map[effect]())
-            elif effect == EFFECT_FAST_RANDOM_LOOP:
-                flow = Flow(
-                    count=0, transitions=yee_transitions.randomloop(duration=250)
-                )
-            elif effect == EFFECT_WHATSAPP:
-                flow = Flow(count=2, transitions=yee_transitions.pulse(37, 211, 102))
-            elif effect == EFFECT_FACEBOOK:
-                flow = Flow(count=2, transitions=yee_transitions.pulse(59, 89, 152))
-            elif effect == EFFECT_TWITTER:
-                flow = Flow(count=2, transitions=yee_transitions.pulse(0, 172, 237))
+        effects_map = {
+            EFFECT_DISCO: yee_transitions.disco,
+            EFFECT_TEMP: yee_transitions.temp,
+            EFFECT_STROBE: yee_transitions.strobe,
+            EFFECT_STROBE_COLOR: yee_transitions.strobe_color,
+            EFFECT_ALARM: yee_transitions.alarm,
+            EFFECT_POLICE: yee_transitions.police,
+            EFFECT_POLICE2: yee_transitions.police2,
+            EFFECT_CHRISTMAS: yee_transitions.christmas,
+            EFFECT_RGB: yee_transitions.rgb,
+            EFFECT_RANDOM_LOOP: yee_transitions.randomloop,
+            EFFECT_LSD: yee_transitions.lsd,
+            EFFECT_SLOWDOWN: yee_transitions.slowdown,
+        }
 
-            try:
-                self._bulb.start_flow(flow, light_type=self.light_type)
-                self._effect = effect
-            except BulbException as ex:
-                _LOGGER.error("Unable to set effect: %s", ex)
+        if effect in self.custom_effects_names:
+            flow = Flow(**self.custom_effects[effect])
+        elif effect in effects_map:
+            flow = Flow(count=0, transitions=effects_map[effect]())
+        elif effect == EFFECT_FAST_RANDOM_LOOP:
+            flow = Flow(
+                count=0, transitions=yee_transitions.randomloop(duration=250)
+            )
+        elif effect == EFFECT_WHATSAPP:
+            flow = Flow(count=2, transitions=yee_transitions.pulse(37, 211, 102))
+        elif effect == EFFECT_FACEBOOK:
+            flow = Flow(count=2, transitions=yee_transitions.pulse(59, 89, 152))
+        elif effect == EFFECT_TWITTER:
+            flow = Flow(count=2, transitions=yee_transitions.pulse(0, 172, 237))
+
+        try:
+            self._bulb.start_flow(flow, light_type=self.light_type)
+            self._effect = effect
+        except BulbException as ex:
+            _LOGGER.error("Unable to set effect: %s", ex)
 
     def turn_on(self, **kwargs) -> None:
         """Turn the bulb on."""

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -552,11 +552,10 @@ class YeelightGenericLight(Light):
         return YEELIGHT_MONO_EFFECT_LIST
 
     @property
-    def state_attributes(self):
-        """Return optional state attributes."""
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
 
-        attributes = super().state_attributes
-        attributes["flowing"] = self.device.is_color_flow_enabled
+        attributes = {"flowing": self.device.is_color_flow_enabled}
         if self.device.is_nightlight_supported:
             attributes["night_light"] = self.device.is_nightlight_enabled
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -141,6 +141,21 @@ MODEL_TO_DEVICE_TYPE = {
     "ceiling4": BulbType.WhiteTempMood,
 }
 
+EFFECTS_MAP = {
+    EFFECT_DISCO: yee_transitions.disco,
+    EFFECT_TEMP: yee_transitions.temp,
+    EFFECT_STROBE: yee_transitions.strobe,
+    EFFECT_STROBE_COLOR: yee_transitions.strobe_color,
+    EFFECT_ALARM: yee_transitions.alarm,
+    EFFECT_POLICE: yee_transitions.police,
+    EFFECT_POLICE2: yee_transitions.police2,
+    EFFECT_CHRISTMAS: yee_transitions.christmas,
+    EFFECT_RGB: yee_transitions.rgb,
+    EFFECT_RANDOM_LOOP: yee_transitions.randomloop,
+    EFFECT_LSD: yee_transitions.lsd,
+    EFFECT_SLOWDOWN: yee_transitions.slowdown,
+}
+
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Range(min=1, max=100))
 
 SERVICE_SCHEMA_SET_MODE = YEELIGHT_SERVICE_SCHEMA.extend(
@@ -677,40 +692,23 @@ class YeelightGenericLight(Light):
         """Activate effect."""
         if not effect:
             return
-
-        if effect == EFFECT_STOP:
+        elif effect == EFFECT_STOP:
             self._bulb.stop_flow(light_type=self.light_type)
             return
-
-        effects_map = {
-            EFFECT_DISCO: yee_transitions.disco,
-            EFFECT_TEMP: yee_transitions.temp,
-            EFFECT_STROBE: yee_transitions.strobe,
-            EFFECT_STROBE_COLOR: yee_transitions.strobe_color,
-            EFFECT_ALARM: yee_transitions.alarm,
-            EFFECT_POLICE: yee_transitions.police,
-            EFFECT_POLICE2: yee_transitions.police2,
-            EFFECT_CHRISTMAS: yee_transitions.christmas,
-            EFFECT_RGB: yee_transitions.rgb,
-            EFFECT_RANDOM_LOOP: yee_transitions.randomloop,
-            EFFECT_LSD: yee_transitions.lsd,
-            EFFECT_SLOWDOWN: yee_transitions.slowdown,
-        }
-
-        if effect in self.custom_effects_names:
+        elif effect in self.custom_effects_names:
             flow = Flow(**self.custom_effects[effect])
-        elif effect in effects_map:
-            flow = Flow(count=0, transitions=effects_map[effect]())
+        elif effect in EFFECTS_MAP:
+            flow = Flow(count=0, transitions=EFFECTS_MAP[effect]())
         elif effect == EFFECT_FAST_RANDOM_LOOP:
-            flow = Flow(
-                count=0, transitions=yee_transitions.randomloop(duration=250)
-            )
+            flow = Flow(count=0, transitions=yee_transitions.randomloop(duration=250))
         elif effect == EFFECT_WHATSAPP:
             flow = Flow(count=2, transitions=yee_transitions.pulse(37, 211, 102))
         elif effect == EFFECT_FACEBOOK:
             flow = Flow(count=2, transitions=yee_transitions.pulse(59, 89, 152))
         elif effect == EFFECT_TWITTER:
             flow = Flow(count=2, transitions=yee_transitions.pulse(0, 172, 237))
+        else:
+            return
 
         try:
             self._bulb.start_flow(flow, light_type=self.light_type)


### PR DESCRIPTION
## Description:
Fixes https://github.com/home-assistant/home-assistant/issues/28901 . It also adds additional attributes, to yeelight light entity. Active mode ( normal / night light ) and color flow ( is device flowing , some effect enabled ). Current effect is only populated, if effect is started from HA. Yeelight doesn't return any current effect, for example if executed from official Yeelight App, so we can only populate it when executed from predefined HA effects list.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/28901

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]