### PR TITLE
Fix all entities triggering all observations in bayesian sensor

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -138,10 +138,10 @@ class BayesianBinarySensor(BinarySensorDevice):
         for ind, obs in enumerate(self._observations):
             obs["id"] = ind
             if "entity_id" in obs:
-                self.entity_obs.get(obs.get("entity_id")).append(obs)
+                self.entity_obs[obs["entity_id"]].append(obs)
             if "value_template" in obs:
                 for ent in obs.get(CONF_VALUE_TEMPLATE).extract_entities():
-                    self.entity_obs.get(ent).append(obs)
+                    self.entity_obs[ent].append(obs)
 
         self.watchers = {
             "numeric_state": self._process_numeric_state,

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -141,7 +141,7 @@ class BayesianBinarySensor(BinarySensorDevice):
                 self.entity_obs.get(obs.get("entity_id")).append(obs)
             if "value_template" in obs:
                 for ent in obs.get(CONF_VALUE_TEMPLATE).extract_entities():
-                    self.entity_obs[ent].append(obs)
+                    self.entity_obs.get(ent).append(obs)
 
         self.watchers = {
             "numeric_state": self._process_numeric_state,

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -133,12 +133,12 @@ class BayesianBinarySensor(BinarySensorDevice):
                 to_observe.update(set([obs.get("entity_id")]))
             if "value_template" in obs:
                 to_observe.update(set(obs.get(CONF_VALUE_TEMPLATE).extract_entities()))
-        self.entity_obs = dict.fromkeys(to_observe, [])
+        self.entity_obs = {key: [] for key in to_observe}
 
         for ind, obs in enumerate(self._observations):
             obs["id"] = ind
             if "entity_id" in obs:
-                self.entity_obs[obs["entity_id"]].append(obs)
+                self.entity_obs.get(obs.get("entity_id")).append(obs)
             if "value_template" in obs:
                 for ent in obs.get(CONF_VALUE_TEMPLATE).extract_entities():
                     self.entity_obs[ent].append(obs)


### PR DESCRIPTION
## Description:
Fixed a bug caused in creating a dictionary of entities to observe. Using dict.fromkeys all entities where observed for each observation since the empty list was added by reference. Replaced by dict comprehension. 
Also using this to learn how to commit my work preparing for more substantial changes to this component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

tox basically takes forever, but it finished in the end. It's not very useful for small pull requests such as this one though, it took more than two hours! 
Have also run all tests manually as mentioned in https://developers.home-assistant.io/docs/en/development_testing.html, this was much faster, is this enough for future pull-requests?

(removed all non-applicable checklists)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
