### PR TITLE
Add climate hvac_action for ESPHome

### DIFF
--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -3,10 +3,11 @@ import logging
 from typing import List, Optional
 
 from aioesphomeapi import (
+    ClimateAction,
+    ClimateFanMode,
     ClimateInfo,
     ClimateMode,
     ClimateState,
-    ClimateFanMode,
     ClimateSwingMode,
 )
 
@@ -15,32 +16,38 @@ from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_FAN_ONLY,
-    HVAC_MODE_DRY,
-    HVAC_MODE_OFF,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE,
-    SUPPORT_FAN_MODE,
-    SUPPORT_SWING_MODE,
-    PRESET_AWAY,
-    PRESET_HOME,
-    FAN_ON,
-    FAN_OFF,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_DRY,
+    CURRENT_HVAC_FAN,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_OFF,
+    CURRENT_HVAC_IDLE,
     FAN_AUTO,
+    FAN_DIFFUSE,
+    FAN_FOCUS,
+    FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
-    FAN_HIGH,
     FAN_MIDDLE,
-    FAN_FOCUS,
-    FAN_DIFFUSE,
-    SWING_OFF,
+    FAN_OFF,
+    FAN_ON,
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_OFF,
+    PRESET_AWAY,
+    PRESET_HOME,
+    SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_SWING_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_TARGET_TEMPERATURE_RANGE,
     SWING_BOTH,
-    SWING_VERTICAL,
     SWING_HORIZONTAL,
+    SWING_OFF,
+    SWING_VERTICAL,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
@@ -82,6 +89,18 @@ def _climate_modes():
         ClimateMode.HEAT: HVAC_MODE_HEAT,
         ClimateMode.FAN_ONLY: HVAC_MODE_FAN_ONLY,
         ClimateMode.DRY: HVAC_MODE_DRY,
+    }
+
+
+@esphome_map_enum
+def _climate_actions():
+    return {
+        ClimateAction.OFF: CURRENT_HVAC_OFF,
+        ClimateAction.COOLING: CURRENT_HVAC_COOL,
+        ClimateAction.HEATING: CURRENT_HVAC_HEAT,
+        ClimateAction.IDLE: CURRENT_HVAC_IDLE,
+        ClimateAction.DRYING: CURRENT_HVAC_DRY,
+        ClimateAction.FAN: CURRENT_HVAC_FAN,
     }
 
 
@@ -204,6 +223,14 @@ class EsphomeClimateDevice(EsphomeEntity, ClimateDevice):
     def hvac_mode(self) -> Optional[str]:
         """Return current operation ie. heat, cool, idle."""
         return _climate_modes.from_esphome(self._state.mode)
+
+    @esphome_state_property
+    def hvac_action(self) -> Optional[str]:
+        """Return current action."""
+        # HA has no support feature field for hvac_action
+        if not self._static_info.supports_action:
+            return None
+        return _climate_actions.from_esphome(self._state.action)
 
     @esphome_state_property
     def fan_mode(self):

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
   "requirements": [
-    "aioesphomeapi==2.6.0"
+    "aioesphomeapi==2.6.1"
   ],
   "dependencies": [],
   "zeroconf": ["_esphomelib._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -145,7 +145,7 @@ aiobotocore==0.10.4
 aiodns==2.0.0
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.0
+aioesphomeapi==2.6.1
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -53,7 +53,7 @@ aioautomatic==0.6.5
 aiobotocore==0.10.4
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.0
+aioesphomeapi==2.6.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

ESPHome has supported hvac_action (called action in esphome) for some time now. But apparently that field never got added to HA's esphome integration.

This PR adds the hvac_action field to the ESPHome climate entity class. Also aioesphomeapi is bumped to add newer climate action field values (drying, fan).

Also ran isort on the file.

Ref https://github.com/esphome/esphome/pull/859

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
