### PR TITLE
Add new properties and services for V3 SimpliSafe systems

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -187,7 +187,7 @@ async def async_setup_entry(hass, config_entry):
         )
 
     @callback
-    def verify_system_exists(func):
+    def verify_system_exists(coro):
         """Log an error if a service call uses an invalid system ID."""
 
         async def decorator(call):
@@ -196,13 +196,13 @@ async def async_setup_entry(hass, config_entry):
             if system_id not in systems:
                 _LOGGER.error("Unknown system ID in service call: %s", system_id)
                 return
-            await func(call)
+            await coro(call)
 
         return decorator
 
     @callback
-    def v3_only(func):
-        """Log an error if the decorated function is performed on a v2 system."""
+    def v3_only(coro):
+        """Log an error if the decorated coroutine is called with a v2 system."""
 
         async def decorator(call):
             """Decorate."""
@@ -210,7 +210,7 @@ async def async_setup_entry(hass, config_entry):
             if system.version != 3:
                 _LOGGER.error("Service only available on V3 systems")
                 return
-            await func(call)
+            await coro(call)
 
         return decorator
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -215,7 +215,7 @@ async def async_setup_entry(hass, config_entry):
             coroutines, this, too, is a coroutine.
             """
             system = systems[int(call.data[ATTR_SYSTEM_ID])]
-            if system.version == 2:
+            if system.version != 3:
                 _LOGGER.error("Service only available on V3 systems")
                 return
             await func(call)

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -278,7 +278,7 @@ async def async_setup_entry(hass, config_entry):
     @verify_system_exists
     @v3_only
     @_verify_domain_control
-    async def set_light(call):
+    async def set_armed_light(call):
         """Turn the base station light on/off."""
         system = systems[call.data[ATTR_SYSTEM_ID]]
         try:
@@ -320,7 +320,7 @@ async def async_setup_entry(hass, config_entry):
         ("remove_pin", remove_pin, SERVICE_REMOVE_PIN_SCHEMA),
         ("set_alarm_duration", set_alarm_duration, SERVICE_SET_DELAY_SCHEMA),
         ("set_delay", set_delay, SERVICE_SET_DELAY_SCHEMA),
-        ("set_light", set_light, SERVICE_SET_LIGHT_SCHEMA),
+        ("set_armed_light", set_armed_light, SERVICE_SET_LIGHT_SCHEMA),
         ("set_pin", set_pin, SERVICE_SET_PIN_SCHEMA),
         ("set_volume_property", set_volume_property, SERVICE_SET_VOLUME_SCHEMA),
     ]:

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -191,11 +191,7 @@ async def async_setup_entry(hass, config_entry):
         """Log an error if a service call uses an invalid system ID."""
 
         async def decorator(call):
-            """Decorate.
-
-            Note that since verify_domain_control is used and it only decorates
-            coroutines, this, too, is a coroutine.
-            """
+            """Decorate."""
             system_id = int(call.data[ATTR_SYSTEM_ID])
             if system_id not in systems:
                 _LOGGER.error("Unknown system ID in service call: %s", system_id)
@@ -209,11 +205,7 @@ async def async_setup_entry(hass, config_entry):
         """Log an error if the decorated function is performed on a v2 system."""
 
         async def decorator(call):
-            """Decorate.
-
-            Note that since verify_domain_control is used and it only decorates
-            coroutines, this, too, is a coroutine.
-            """
+            """Decorate."""
             system = systems[int(call.data[ATTR_SYSTEM_ID])]
             if system.version != 3:
                 _LOGGER.error("Service only available on V3 systems")

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -4,6 +4,7 @@ import re
 
 from simplipy.entity import EntityTypes
 from simplipy.system import SystemStates
+from simplipy.system.v3 import LevelMap as V3Volume
 
 from homeassistant.components.alarm_control_panel import (
     FORMAT_NUMBER,
@@ -24,14 +25,23 @@ from .const import DATA_CLIENT, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ALARM_ACTIVE = "alarm_active"
+ATTR_ALARM_DURATION = "alarm_duration"
+ATTR_ALARM_VOLUME = "alarm_volume"
 ATTR_BATTERY_BACKUP_POWER_LEVEL = "battery_backup_power_level"
+ATTR_CHIME_VOLUME = "chime_volume"
+ATTR_ENTRY_DELAY_AWAY = "entry_delay_away"
+ATTR_ENTRY_DELAY_HOME = "entry_delay_home"
+ATTR_EXIT_DELAY_AWAY = "exit_delay_away"
+ATTR_EXIT_DELAY_HOME = "exit_delay_home"
 ATTR_GSM_STRENGTH = "gsm_strength"
 ATTR_LAST_EVENT_INFO = "last_event_info"
 ATTR_LAST_EVENT_SENSOR_NAME = "last_event_sensor_name"
 ATTR_LAST_EVENT_SENSOR_TYPE = "last_event_sensor_type"
 ATTR_LAST_EVENT_TIMESTAMP = "last_event_timestamp"
 ATTR_LAST_EVENT_TYPE = "last_event_type"
+ATTR_LIGHT = "light"
 ATTR_RF_JAMMING = "rf_jamming"
+ATTR_VOICE_PROMPT_VOLUME = "voice_prompt_volume"
 ATTR_WALL_POWER_LEVEL = "wall_power_level"
 ATTR_WIFI_STRENGTH = "wifi_strength"
 
@@ -66,14 +76,27 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
 
         # Some properties only exist for V2 or V3 systems:
         for prop in (
+            ATTR_ALARM_DURATION,
+            ATTR_ALARM_VOLUME,
             ATTR_BATTERY_BACKUP_POWER_LEVEL,
+            ATTR_CHIME_VOLUME,
+            ATTR_ENTRY_DELAY_AWAY,
+            ATTR_ENTRY_DELAY_HOME,
+            ATTR_EXIT_DELAY_AWAY,
+            ATTR_EXIT_DELAY_HOME,
             ATTR_GSM_STRENGTH,
+            ATTR_LIGHT,
             ATTR_RF_JAMMING,
+            ATTR_VOICE_PROMPT_VOLUME,
             ATTR_WALL_POWER_LEVEL,
             ATTR_WIFI_STRENGTH,
         ):
             if hasattr(system, prop):
-                self._attrs[prop] = getattr(system, prop)
+                value = getattr(system, prop)
+                if isinstance(value, V3Volume):
+                    self._attrs[prop] = value.name
+                else:
+                    self._attrs[prop] = value
 
     @property
     def changed_by(self):

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -4,7 +4,6 @@ import re
 
 from simplipy.entity import EntityTypes
 from simplipy.system import SystemStates
-from simplipy.system.v3 import LevelMap as V3Volume
 
 from homeassistant.components.alarm_control_panel import (
     FORMAT_NUMBER,
@@ -74,29 +73,25 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         self._simplisafe = simplisafe
         self._state = None
 
-        # Some properties only exist for V2 or V3 systems:
-        for prop in (
-            ATTR_ALARM_DURATION,
-            ATTR_ALARM_VOLUME,
-            ATTR_BATTERY_BACKUP_POWER_LEVEL,
-            ATTR_CHIME_VOLUME,
-            ATTR_ENTRY_DELAY_AWAY,
-            ATTR_ENTRY_DELAY_HOME,
-            ATTR_EXIT_DELAY_AWAY,
-            ATTR_EXIT_DELAY_HOME,
-            ATTR_GSM_STRENGTH,
-            ATTR_LIGHT,
-            ATTR_RF_JAMMING,
-            ATTR_VOICE_PROMPT_VOLUME,
-            ATTR_WALL_POWER_LEVEL,
-            ATTR_WIFI_STRENGTH,
-        ):
-            if hasattr(system, prop):
-                value = getattr(system, prop)
-                if isinstance(value, V3Volume):
-                    self._attrs[prop] = value.name
-                else:
-                    self._attrs[prop] = value
+        if self._system.version == 3:
+            self._attrs.update(
+                {
+                    ATTR_ALARM_DURATION: self._system.alarm_duration,
+                    ATTR_ALARM_VOLUME: self._system.alarm_volume.name,
+                    ATTR_BATTERY_BACKUP_POWER_LEVEL: self._system.battery_backup_power_level,
+                    ATTR_CHIME_VOLUME: self._system.chime_volume.name,
+                    ATTR_ENTRY_DELAY_AWAY: self._system.entry_delay_away,
+                    ATTR_ENTRY_DELAY_HOME: self._system.entry_delay_home,
+                    ATTR_EXIT_DELAY_AWAY: self._system.exit_delay_away,
+                    ATTR_EXIT_DELAY_HOME: self._system.exit_delay_home,
+                    ATTR_GSM_STRENGTH: self._system.gsm_strength,
+                    ATTR_LIGHT: self._system.light,
+                    ATTR_RF_JAMMING: self._system.rf_jamming,
+                    ATTR_VOICE_PROMPT_VOLUME: self._system.voice_prompt_volume.name,
+                    ATTR_WALL_POWER_LEVEL: self._system.wall_power_level,
+                    ATTR_WIFI_STRENGTH: self._system.wifi_strength,
+                }
+            )
 
     @property
     def changed_by(self):
@@ -174,7 +169,6 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         last_event = self._simplisafe.last_event_data[self._system.system_id]
         self._attrs.update(
             {
-                ATTR_ALARM_ACTIVE: self._system.alarm_going_off,
                 ATTR_LAST_EVENT_INFO: last_event["info"],
                 ATTR_LAST_EVENT_SENSOR_NAME: last_event["sensorName"],
                 ATTR_LAST_EVENT_SENSOR_TYPE: EntityTypes(last_event["sensorType"]).name,

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -73,6 +73,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         self._simplisafe = simplisafe
         self._state = None
 
+        self._attrs.update({ATTR_ALARM_ACTIVE: self._system.alarm_going_off})
         if self._system.version == 3:
             self._attrs.update(
                 {

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
   "requirements": [
-    "simplisafe-python==5.3.4"
+    "simplisafe-python==5.3.5"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
   "requirements": [
-    "simplisafe-python==5.2.0"
+    "simplisafe-python==5.3.4"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -10,11 +10,83 @@ remove_pin:
     label_or_pin:
       description: The label/value to remove.
       example: Test PIN
+set_alarm_duration:
+  description: "Set the duration (in seconds) of an active alarm"
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    seconds:
+      description: The number of seconds to sound the alarm
+      example: 120
+set_alarm_volume:
+  description: "Set the volume of an active alarm"
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    volume:
+      description: "A volume (off, low, medium, high)"
+      example: low
+set_chime_volume:
+  description: "Set the volume of the door chime"
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    volume:
+      description: "A volume (off, low, medium, high)"
+      example: low
+set_entry_delay_away:
+  description: 'Set the entry delay duration ("away" mode).'
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    seconds:
+      description: "The number of seconds to delay"
+      example: 120
+set_entry_delay_home:
+  description: 'Set the entry delay duration ("home" mode).'
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    seconds:
+      description: "The number of seconds to delay"
+      example: 120
+set_exit_delay_away:
+  description: 'Set the exit delay duration ("away" mode).'
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    seconds:
+      description: "The number of seconds to delay"
+      example: 120
+set_exit_delay_home:
+  description: 'Set the exit delay duration ("home" mode).'
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    seconds:
+      description: "The number of seconds to delay"
+      example: 120
+set_light:
+  description: "Turn the base station light on/off"
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    light_state:
+      description: "True for on, False for off"
+      example: "True"
 set_pin:
   description: Set/update a PIN
   fields:
     system_id:
-      description: The SimpliSafe system ID to affect.
+      description: The SimpliSafe system ID to affect
       example: 123987
     label:
       description: The label of the PIN
@@ -22,3 +94,12 @@ set_pin:
     pin:
       description: The value of the PIN
       example: 1256
+set_voice_prompt_volume:
+  description: "Set the volume of the voice prompt"
+  fields:
+    system_id:
+      description: The SimpliSafe system ID to affect
+      example: 123987
+    volume:
+      description: "A volume (off, low, medium, high)"
+      example: low

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -19,57 +19,20 @@ set_alarm_duration:
     seconds:
       description: The number of seconds to sound the alarm
       example: 120
-set_alarm_volume:
-  description: "Set the volume of an active alarm"
+set_delay:
+  description: >
+    Set a duration for how long the base station should delay when transitioning
+    between states
   fields:
     system_id:
       description: The SimpliSafe system ID to affect
       example: 123987
-    volume:
-      description: "A volume (off, low, medium, high)"
-      example: low
-set_chime_volume:
-  description: "Set the volume of the door chime"
-  fields:
-    system_id:
-      description: The SimpliSafe system ID to affect
-      example: 123987
-    volume:
-      description: "A volume (off, low, medium, high)"
-      example: low
-set_entry_delay_away:
-  description: 'Set the entry delay duration ("away" mode).'
-  fields:
-    system_id:
-      description: The SimpliSafe system ID to affect
-      example: 123987
-    seconds:
-      description: "The number of seconds to delay"
-      example: 120
-set_entry_delay_home:
-  description: 'Set the entry delay duration ("home" mode).'
-  fields:
-    system_id:
-      description: The SimpliSafe system ID to affect
-      example: 123987
-    seconds:
-      description: "The number of seconds to delay"
-      example: 120
-set_exit_delay_away:
-  description: 'Set the exit delay duration ("away" mode).'
-  fields:
-    system_id:
-      description: The SimpliSafe system ID to affect
-      example: 123987
-    seconds:
-      description: "The number of seconds to delay"
-      example: 120
-set_exit_delay_home:
-  description: 'Set the exit delay duration ("home" mode).'
-  fields:
-    system_id:
-      description: The SimpliSafe system ID to affect
-      example: 123987
+    arrival_state:
+      description: The target "arrival" state (away, home)
+      example: away
+    transition:
+      description: The system state transition to affect (entry, exit)
+      example: exit
     seconds:
       description: "The number of seconds to delay"
       example: 120
@@ -79,7 +42,7 @@ set_light:
     system_id:
       description: The SimpliSafe system ID to affect
       example: 123987
-    light_state:
+    armed_light_state:
       description: "True for on, False for off"
       example: "True"
 set_pin:
@@ -94,12 +57,15 @@ set_pin:
     pin:
       description: The value of the PIN
       example: 1256
-set_voice_prompt_volume:
-  description: "Set the volume of the voice prompt"
+set_volume_property:
+  description: Set a level for one of the base station's various volumes
   fields:
     system_id:
       description: The SimpliSafe system ID to affect
       example: 123987
+    volume_property:
+      description: The volume property to set (alarm, chime, voice_prompt)
+      example: voice_prompt
     volume:
       description: "A volume (off, low, medium, high)"
       example: low

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1788,7 +1788,7 @@ shodan==1.20.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.3.4
+simplisafe-python==5.3.5
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1788,7 +1788,7 @@ shodan==1.20.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.2.0
+simplisafe-python==5.3.4
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -556,7 +556,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.3.4
+simplisafe-python==5.3.5
 
 # homeassistant.components.sleepiq
 sleepyq==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -556,7 +556,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==5.2.0
+simplisafe-python==5.3.4
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
## Description:

Based on user request, this PR adds several new attributes to V3 `alarm_control_panel` entities:

* `alarm_duration`: the number of seconds the alarm will sound when triggered
* `alarm_volume`: the current volume of the siren (`off`, `low`, `medium`, and `high`)
* `chime_volume`: the current volume of the door chime (`off`, `low`, `medium`, and `high`)
* `entry_delay_away`: the delay duration (in seconds) when returning to a house in "away" mode
* `entry_delay_home`: the delay duration (in seconds) when returning to a house in "home" mode
* `exit_delay_away`: the delay duration (in seconds) when leaving a house in "away" mode
* `exit_delay_home`: the delay duration (in seconds) when leaving a house in "home" mode
* `light`: the current status of the base station light (`True` for on, `False` for off)
* `voice_prompt_volume`: the current volume of the voice prompt (`off`, `low`, `medium`, and `high`)

Additionally, the PR adds service calls so that these properties can be modified on the fly.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11281

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret ss_username
      password: !secret ss_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
