### PR TITLE
Add attribute for storing one weather warning as a whole

### DIFF
--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -140,6 +140,9 @@ class DwdWeatherWarningsSensor(Entity):
         for event in self._api.data[prefix + "_warnings"]:
             i = i + 1
 
+            # dictionary for the attribute containing the complete warning as json
+            event_json = event.copy()
+
             data[f"warning_{i}_name"] = event["event"]
             data[f"warning_{i}_level"] = event["level"]
             data[f"warning_{i}_type"] = event["type"]
@@ -154,11 +157,15 @@ class DwdWeatherWarningsSensor(Entity):
                 data[f"warning_{i}_start"] = dt_util.as_local(
                     dt_util.utc_from_timestamp(event["start"] / 1000)
                 )
+                event_json["start"] = data[f"warning_{i}_start"]
 
             if event["end"] is not None:
                 data[f"warning_{i}_end"] = dt_util.as_local(
                     dt_util.utc_from_timestamp(event["end"] / 1000)
                 )
+                event_json["end"] = data[f"warning_{i}_end"]
+
+            data[f"warning_{i}"] = event_json
 
         return data
 


### PR DESCRIPTION
## Description:

This adds an attribute to the warning sensors from the [DWD Weather warnings](https://www.home-assistant.io/integrations/dwd_weather_warnings/) component. This new attribute contains the warning as a whole JSON object and thus enables the use of [list-card](https://github.com/iantrich/list-card) to show the list of warnings in the UI easily.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11271

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**  
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.  

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.  
**(There has not been a test for the file in the first place.)**

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
