### PR TITLE
Handle offline state of SAJ inverters (fixes #29007)

### DIFF
--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import CALLBACK_TYPE, callback
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_call_later
@@ -88,13 +89,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         )
         return
 
-    if done:
-        for sensor in sensor_def:
-            hass_sensors.append(
-                SAJsensor(saj.serialnumber, sensor, inverter_name=config.get(CONF_NAME))
-            )
+    if not done:
+        raise PlatformNotReady
 
-        async_add_entities(hass_sensors)
+    for sensor in sensor_def:
+        hass_sensors.append(
+            SAJsensor(saj.serialnumber, sensor, inverter_name=config.get(CONF_NAME))
+        )
+
+    async_add_entities(hass_sensors)
 
     async def async_saj():
         """Update all the SAJ sensors."""

--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -39,12 +39,12 @@ UNIT_OF_MEASUREMENT_HOURS = "h"
 INVERTER_TYPES = ["ethernet", "wifi"]
 
 SAJ_UNIT_MAPPINGS = {
-    "W": POWER_WATT,
-    "kWh": ENERGY_KILO_WATT_HOUR,
+    "": None,
     "h": UNIT_OF_MEASUREMENT_HOURS,
     "kg": MASS_KILOGRAMS,
+    "kWh": ENERGY_KILO_WATT_HOUR,
+    "W": POWER_WATT,
     "°C": TEMP_CELSIUS,
-    "": None,
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -59,7 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up SAJ sensors."""
+    """Set up the SAJ sensors."""
 
     remove_interval_update = None
     wifi = config[CONF_TYPE] == INVERTER_TYPES[1]
@@ -81,7 +81,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         saj = pysaj.SAJ(config[CONF_HOST], **kwargs)
         done = await saj.read(sensor_def)
     except pysaj.UnauthorizedException:
-        _LOGGER.error("Username and/or password is wrong.")
+        _LOGGER.error("Username and/or password is wrong")
         return
     except pysaj.UnexpectedResponseException as err:
         _LOGGER.error(
@@ -170,7 +170,7 @@ class SAJsensor(Entity):
     """Representation of a SAJ sensor."""
 
     def __init__(self, serialnumber, pysaj_sensor, inverter_name=None):
-        """Initialize the sensor."""
+        """Initialize the SAJ sensor."""
         self._sensor = pysaj_sensor
         self._inverter_name = inverter_name
         self._serialnumber = serialnumber


### PR DESCRIPTION
## Description:
When inverter is offline, for example due to darkness, and HA is restarted at that moment the sensors are not available and do not come available automatically when the inverter is back online at day.
In this case a restart of HA is needed to get it working again.
The fix implements the PlatformNotReady exception to retry until the inverter is online at daylight.

**Related issue (if applicable):** fixes #29007 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
