### PR TITLE
Alexa gracefully handle climate devices without presets

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -752,10 +752,11 @@ class AlexaThermostatController(AlexaCapability):
                 supported_modes.append(thermostat_mode)
 
         preset_modes = self.entity.attributes.get(climate.ATTR_PRESET_MODES)
-        for mode in preset_modes:
-            thermostat_mode = API_THERMOSTAT_PRESETS.get(mode)
-            if thermostat_mode:
-                supported_modes.append(thermostat_mode)
+        if preset_modes:
+            for mode in preset_modes:
+                thermostat_mode = API_THERMOSTAT_PRESETS.get(mode)
+                if thermostat_mode:
+                    supported_modes.append(thermostat_mode)
 
         # Return False for supportsScheduling until supported with event listener in handler.
         configuration = {"supportsScheduling": False}


### PR DESCRIPTION
## Description:

Gracefully handle climate devices without preset modes in Alexa.

Reported by Vassilis on Discord:

```txt
File "/home/nuc/homeassistant/lib/python3.7/site-packages/homeassistant/components/alexa/capabilities.py", line 755, in configuration

    for mode in preset_modes:

TypeError: 'NoneType' object is not iterable
```

**Related issue (if applicable):** fixes #29034

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
