### PR TITLE
Use TADO_MODE for temperature overrides in tado climate component.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -303,6 +303,7 @@ homeassistant/components/switchmate/* @danielhiversen
 homeassistant/components/syncthru/* @nielstron
 homeassistant/components/synology_srm/* @aerialls
 homeassistant/components/syslog/* @fabaff
+homeassistant/components/tado/* @michaelarnauts
 homeassistant/components/tahoma/* @philklei
 homeassistant/components/tautulli/* @ludeeus
 homeassistant/components/tellduslive/* @fredrike

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -117,7 +117,7 @@ class TadoDataStore:
         return self.tado.getCapabilities(tado_id)
 
     def get_me(self):
-        """Wrap for getMet()."""
+        """Wrap for getMe()."""
         return self.tado.getMe()
 
     def reset_zone_overlay(self, zone_id):

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -48,22 +48,22 @@ FAN_MAP_TADO = {"HIGH": FAN_HIGH, "MIDDLE": FAN_MIDDLE, "LOW": FAN_LOW}
 
 HVAC_MAP_TADO_HEAT = {
     "MANUAL": HVAC_MODE_HEAT,
-    "TIMER": HVAC_MODE_AUTO,
-    "TADO_MODE": HVAC_MODE_AUTO,
+    "TIMER": HVAC_MODE_HEAT,
+    "TADO_MODE": HVAC_MODE_HEAT,
     "SMART_SCHEDULE": HVAC_MODE_AUTO,
     "OFF": HVAC_MODE_OFF,
 }
 HVAC_MAP_TADO_COOL = {
     "MANUAL": HVAC_MODE_COOL,
-    "TIMER": HVAC_MODE_AUTO,
-    "TADO_MODE": HVAC_MODE_AUTO,
+    "TIMER": HVAC_MODE_COOL,
+    "TADO_MODE": HVAC_MODE_COOL,
     "SMART_SCHEDULE": HVAC_MODE_AUTO,
     "OFF": HVAC_MODE_OFF,
 }
 HVAC_MAP_TADO_HEAT_COOL = {
     "MANUAL": HVAC_MODE_HEAT_COOL,
-    "TIMER": HVAC_MODE_AUTO,
-    "TADO_MODE": HVAC_MODE_AUTO,
+    "TIMER": HVAC_MODE_HEAT_COOL,
+    "TADO_MODE": HVAC_MODE_HEAT_COOL,
     "SMART_SCHEDULE": HVAC_MODE_AUTO,
     "OFF": HVAC_MODE_OFF,
 }
@@ -325,7 +325,7 @@ class TadoClimate(ClimateDevice):
         if temperature is None:
             return
 
-        self._current_operation = CONST_OVERLAY_MANUAL
+        self._current_operation = CONST_OVERLAY_TADO_MODE
         self._overlay_mode = None
         self._target_temp = temperature
         self._control_heating()
@@ -339,11 +339,11 @@ class TadoClimate(ClimateDevice):
         elif hvac_mode == HVAC_MODE_AUTO:
             mode = CONST_MODE_SMART_SCHEDULE
         elif hvac_mode == HVAC_MODE_HEAT:
-            mode = CONST_OVERLAY_MANUAL
+            mode = CONST_OVERLAY_TADO_MODE
         elif hvac_mode == HVAC_MODE_COOL:
-            mode = CONST_OVERLAY_MANUAL
+            mode = CONST_OVERLAY_TADO_MODE
         elif hvac_mode == HVAC_MODE_HEAT_COOL:
-            mode = CONST_OVERLAY_MANUAL
+            mode = CONST_OVERLAY_TADO_MODE
 
         self._current_operation = mode
         self._overlay_mode = None

--- a/homeassistant/components/tado/manifest.json
+++ b/homeassistant/components/tado/manifest.json
@@ -6,5 +6,7 @@
     "python-tado==0.2.9"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@michaelarnauts"
+  ]
 }


### PR DESCRIPTION
## Breaking Change:

Temperature overrides are now cancelled when the schedule dictates that the temperature should be lowered (or raised, depending on your climate), like during the night. The current behavior caused my house to be heated during the night a few times since I forgot to set set the mode back to auto, after changing the temperature during a cold evening. This restores the behavior like it was before the big Climate 1.0 PR from Home Assistant 0.95 and makes it consistent with the Tado device and Tado App.

## Description:

Since the "Climate 1.0 PR", when you make a temperature override, the operation mode is switched to "Manual", making the smart schedules that you could create in the app useless, since they will never apply anymore until you manually switch back to auto. The default behaviour of the Tado Mobile app and the Tado device is to use "Tado Mode", meaning that the override is only valid until the next schedule change.

This has been reported here https://community.home-assistant.io/t/setup-failed-for-tado/105570/175 and here https://github.com/home-assistant/home-assistant/issues/25714

### Current behavior:
* Changing the temperature from Home Assistant sets the mode in Tado to "Manual". The schedule will not be used anymore, for example to set the temperature lower during the night, until you set the mode back to "Auto" mode yourself.
* When changing the temperature from the Tado app or the device, the state remains in "Auto", but when you do the same from Home Assistant, the state is set to "Manual". This is inconsistent behaviour. 
* A workaround that is now suggested is to create an automation to set the mode back to "Auto" when you want the schedule to change the temperature, but this requires you to recreate the schedule you already have as a Home Assistant automation, forcing you to setup your schedule twice. I don't like this workaround.

### New behavior:
* Changing the temperature from Home Assistant sets the mode in tado to "Tado Mode". The schedule will still be used to change the temperature. This is the pre 0.95 behavior, and also matches the default behaviour of the tado device and the tado app.

Asking for feedback from @ejaviga @andersonshatch @wmalgadey since you've all recently contributed to the Tado component.

**Related issue (if applicable):** fixes #25714

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
