### PR TITLE
Move imports to top for ecovacs

### DIFF
--- a/homeassistant/components/ecovacs/__init__.py
+++ b/homeassistant/components/ecovacs/__init__.py
@@ -3,6 +3,7 @@ import logging
 import random
 import string
 
+from sucks import EcoVacsAPI, VacBot
 import voluptuous as vol
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
@@ -43,8 +44,6 @@ def setup(hass, config):
     _LOGGER.debug("Creating new Ecovacs component")
 
     hass.data[ECOVACS_DEVICES] = []
-
-    from sucks import EcoVacsAPI, VacBot
 
     ecovacs_api = EcoVacsAPI(
         ECOVACS_API_DEVICEID,

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -1,16 +1,7 @@
 """Support for Ecovacs Ecovacs Vaccums."""
 import logging
 
-from sucks import (
-    Charge,
-    Clean,
-    FAN_SPEED_NORMAL,
-    FAN_SPEED_HIGH,
-    PlaySound,
-    Spot,
-    Stop,
-    VacBotCommand,
-)
+import sucks
 
 from homeassistant.components.vacuum import (
     SUPPORT_BATTERY,
@@ -135,7 +126,7 @@ class EcovacsVacuum(VacuumDevice):
     def return_to_base(self, **kwargs):
         """Set the vacuum cleaner to return to the dock."""
 
-        self.device.run(Charge())
+        self.device.run(sucks.Charge())
 
     @property
     def battery_icon(self):
@@ -161,12 +152,12 @@ class EcovacsVacuum(VacuumDevice):
     def fan_speed_list(self):
         """Get the list of available fan speed steps of the vacuum cleaner."""
 
-        return [FAN_SPEED_NORMAL, FAN_SPEED_HIGH]
+        return [sucks.FAN_SPEED_NORMAL, sucks.FAN_SPEED_HIGH]
 
     def turn_on(self, **kwargs):
         """Turn the vacuum on and start cleaning."""
 
-        self.device.run(Clean())
+        self.device.run(sucks.Clean())
 
     def turn_off(self, **kwargs):
         """Turn the vacuum off stopping the cleaning and returning home."""
@@ -175,27 +166,27 @@ class EcovacsVacuum(VacuumDevice):
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
 
-        self.device.run(Stop())
+        self.device.run(sucks.Stop())
 
     def clean_spot(self, **kwargs):
         """Perform a spot clean-up."""
 
-        self.device.run(Spot())
+        self.device.run(sucks.Spot())
 
     def locate(self, **kwargs):
         """Locate the vacuum cleaner."""
 
-        self.device.run(PlaySound())
+        self.device.run(sucks.PlaySound())
 
     def set_fan_speed(self, fan_speed, **kwargs):
         """Set fan speed."""
         if self.is_on:
 
-            self.device.run(Clean(mode=self.device.clean_status, speed=fan_speed))
+            self.device.run(sucks.Clean(mode=self.device.clean_status, speed=fan_speed))
 
     def send_command(self, command, params=None, **kwargs):
         """Send a command to a vacuum cleaner."""
-        self.device.run(VacBotCommand(command, params))
+        self.device.run(sucks.VacBotCommand(command, params))
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -1,6 +1,17 @@
 """Support for Ecovacs Ecovacs Vaccums."""
 import logging
 
+from sucks import (
+    Charge,
+    Clean,
+    FAN_SPEED_NORMAL,
+    FAN_SPEED_HIGH,
+    PlaySound,
+    Spot,
+    Stop,
+    VacBotCommand,
+)
+
 from homeassistant.components.vacuum import (
     SUPPORT_BATTERY,
     SUPPORT_CLEAN_SPOT,
@@ -123,7 +134,6 @@ class EcovacsVacuum(VacuumDevice):
 
     def return_to_base(self, **kwargs):
         """Set the vacuum cleaner to return to the dock."""
-        from sucks import Charge
 
         self.device.run(Charge())
 
@@ -150,13 +160,11 @@ class EcovacsVacuum(VacuumDevice):
     @property
     def fan_speed_list(self):
         """Get the list of available fan speed steps of the vacuum cleaner."""
-        from sucks import FAN_SPEED_NORMAL, FAN_SPEED_HIGH
 
         return [FAN_SPEED_NORMAL, FAN_SPEED_HIGH]
 
     def turn_on(self, **kwargs):
         """Turn the vacuum on and start cleaning."""
-        from sucks import Clean
 
         self.device.run(Clean())
 
@@ -166,33 +174,27 @@ class EcovacsVacuum(VacuumDevice):
 
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
-        from sucks import Stop
 
         self.device.run(Stop())
 
     def clean_spot(self, **kwargs):
         """Perform a spot clean-up."""
-        from sucks import Spot
 
         self.device.run(Spot())
 
     def locate(self, **kwargs):
         """Locate the vacuum cleaner."""
-        from sucks import PlaySound
 
         self.device.run(PlaySound())
 
     def set_fan_speed(self, fan_speed, **kwargs):
         """Set fan speed."""
         if self.is_on:
-            from sucks import Clean
 
             self.device.run(Clean(mode=self.device.clean_status, speed=fan_speed))
 
     def send_command(self, command, params=None, **kwargs):
         """Send a command to a vacuum cleaner."""
-        from sucks import VacBotCommand
-
         self.device.run(VacBotCommand(command, params))
 
     @property


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
