### PR TITLE
Fix scene applying

### DIFF
--- a/homeassistant/components/alarm_control_panel/reproduce_state.py
+++ b/homeassistant/components/alarm_control_panel/reproduce_state.py
@@ -51,10 +51,6 @@ async def _async_reproduce_state(
         )
         return
 
-    # Return if we are already at the right state.
-    if cur_state.state == state.state:
-        return
-
     service_data = {ATTR_ENTITY_ID: state.entity_id}
 
     if state.state == STATE_ALARM_ARMED_AWAY:

--- a/homeassistant/components/fan/reproduce_state.py
+++ b/homeassistant/components/fan/reproduce_state.py
@@ -50,27 +50,16 @@ async def _async_reproduce_state(
         )
         return
 
-    # Return if we are already at the right state.
-    if cur_state.state == state.state and all(
-        check_attr_equal(cur_state.attributes, state.attributes, attr)
-        for attr in ATTRIBUTES
-    ):
-        return
-
     service_data = {ATTR_ENTITY_ID: state.entity_id}
     service_calls = {}  # service: service_data
 
     if state.state == STATE_ON:
         # The fan should be on
-        if cur_state.state != STATE_ON:
-            # Turn on the fan at first
-            service_calls[SERVICE_TURN_ON] = service_data
+        service_calls[SERVICE_TURN_ON] = service_data
 
         for attr, service in ATTRIBUTES.items():
             # Call services to adjust the attributes
-            if attr in state.attributes and not check_attr_equal(
-                state.attributes, cur_state.attributes, attr
-            ):
+            if attr in state.attributes:
                 data = service_data.copy()
                 data[attr] = state.attributes[attr]
                 service_calls[service] = data

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -87,13 +87,6 @@ async def _async_reproduce_state(
     if any(attr in DEPRECATED_GROUP for attr in state.attributes):
         _LOGGER.warning(DEPRECATION_WARNING)
 
-    # Return if we are already at the right state.
-    if cur_state.state == state.state and all(
-        check_attr_equal(cur_state.attributes, state.attributes, attr)
-        for attr in ATTR_GROUP + COLOR_GROUP
-    ):
-        return
-
     service_data = {ATTR_ENTITY_ID: state.entity_id}
 
     if state.state == STATE_ON:

--- a/homeassistant/components/lock/reproduce_state.py
+++ b/homeassistant/components/lock/reproduce_state.py
@@ -36,10 +36,6 @@ async def _async_reproduce_state(
         )
         return
 
-    # Return if we are already at the right state.
-    if cur_state.state == state.state:
-        return
-
     service_data = {ATTR_ENTITY_ID: state.entity_id}
 
     if state.state == STATE_LOCKED:

--- a/homeassistant/components/switch/reproduce_state.py
+++ b/homeassistant/components/switch/reproduce_state.py
@@ -36,10 +36,6 @@ async def _async_reproduce_state(
         )
         return
 
-    # Return if we are already at the right state.
-    if cur_state.state == state.state:
-        return
-
     service_data = {ATTR_ENTITY_ID: state.entity_id}
 
     if state.state == STATE_ON:

--- a/homeassistant/components/vacuum/reproduce_state.py
+++ b/homeassistant/components/vacuum/reproduce_state.py
@@ -56,34 +56,26 @@ async def _async_reproduce_state(
         )
         return
 
-    # Return if we are already at the right state.
-    if cur_state.state == state.state and cur_state.attributes.get(
-        ATTR_FAN_SPEED
-    ) == state.attributes.get(ATTR_FAN_SPEED):
-        return
-
     service_data = {ATTR_ENTITY_ID: state.entity_id}
 
-    if cur_state.state != state.state:
-        # Wrong state
-        if state.state == STATE_ON:
-            service = SERVICE_TURN_ON
-        elif state.state == STATE_OFF:
-            service = SERVICE_TURN_OFF
-        elif state.state == STATE_CLEANING:
-            service = SERVICE_START
-        elif state.state == STATE_DOCKED or state.state == STATE_RETURNING:
-            service = SERVICE_RETURN_TO_BASE
-        elif state.state == STATE_IDLE:
-            service = SERVICE_STOP
-        elif state.state == STATE_PAUSED:
-            service = SERVICE_PAUSE
+    if state.state == STATE_ON:
+        service = SERVICE_TURN_ON
+    elif state.state == STATE_OFF:
+        service = SERVICE_TURN_OFF
+    elif state.state == STATE_CLEANING:
+        service = SERVICE_START
+    elif state.state == STATE_DOCKED or state.state == STATE_RETURNING:
+        service = SERVICE_RETURN_TO_BASE
+    elif state.state == STATE_IDLE:
+        service = SERVICE_STOP
+    elif state.state == STATE_PAUSED:
+        service = SERVICE_PAUSE
 
-        await hass.services.async_call(
-            DOMAIN, service, service_data, context=context, blocking=True
-        )
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
 
-    if cur_state.attributes.get(ATTR_FAN_SPEED) != state.attributes.get(ATTR_FAN_SPEED):
+    if state.attributes.get(ATTR_FAN_SPEED):
         # Wrong fan speed
         service_data["fan_speed"] = state.attributes[ATTR_FAN_SPEED]
         await hass.services.async_call(

--- a/tests/components/alarm_control_panel/test_reproduce_state.py
+++ b/tests/components/alarm_control_panel/test_reproduce_state.py
@@ -58,7 +58,9 @@ async def test_reproducing_states(hass, caplog):
         hass, "alarm_control_panel", SERVICE_ALARM_TRIGGER
     )
 
-    # These calls should do nothing as entities already in desired state
+    # Even if the target state is the same as the current we still needs
+    # to do the calls, as the current state is just a cache of the real one
+    # and could be out of sync.
     await hass.helpers.state.async_reproduce_state(
         [
             State("alarm_control_panel.entity_armed_away", STATE_ALARM_ARMED_AWAY),
@@ -74,12 +76,12 @@ async def test_reproducing_states(hass, caplog):
         blocking=True,
     )
 
-    assert len(arm_away_calls) == 0
-    assert len(arm_custom_bypass_calls) == 0
-    assert len(arm_home_calls) == 0
-    assert len(arm_night_calls) == 0
-    assert len(disarm_calls) == 0
-    assert len(trigger_calls) == 0
+    assert len(arm_away_calls) == 1
+    assert len(arm_custom_bypass_calls) == 1
+    assert len(arm_home_calls) == 1
+    assert len(arm_night_calls) == 1
+    assert len(disarm_calls) == 1
+    assert len(trigger_calls) == 1
 
     # Test invalid state is handled
     await hass.helpers.state.async_reproduce_state(
@@ -87,12 +89,12 @@ async def test_reproducing_states(hass, caplog):
     )
 
     assert "not_supported" in caplog.text
-    assert len(arm_away_calls) == 0
-    assert len(arm_custom_bypass_calls) == 0
-    assert len(arm_home_calls) == 0
-    assert len(arm_night_calls) == 0
-    assert len(disarm_calls) == 0
-    assert len(trigger_calls) == 0
+    assert len(arm_away_calls) == 1
+    assert len(arm_custom_bypass_calls) == 1
+    assert len(arm_home_calls) == 1
+    assert len(arm_night_calls) == 1
+    assert len(disarm_calls) == 1
+    assert len(trigger_calls) == 1
 
     # Make sure correct services are called
     await hass.helpers.state.async_reproduce_state(
@@ -113,36 +115,36 @@ async def test_reproducing_states(hass, caplog):
         blocking=True,
     )
 
-    assert len(arm_away_calls) == 1
-    assert arm_away_calls[0].domain == "alarm_control_panel"
-    assert arm_away_calls[0].data == {
+    assert len(arm_away_calls) == 2
+    assert arm_away_calls[1].domain == "alarm_control_panel"
+    assert arm_away_calls[1].data == {
         "entity_id": "alarm_control_panel.entity_armed_custom_bypass"
     }
 
-    assert len(arm_custom_bypass_calls) == 1
-    assert arm_custom_bypass_calls[0].domain == "alarm_control_panel"
-    assert arm_custom_bypass_calls[0].data == {
+    assert len(arm_custom_bypass_calls) == 2
+    assert arm_custom_bypass_calls[1].domain == "alarm_control_panel"
+    assert arm_custom_bypass_calls[1].data == {
         "entity_id": "alarm_control_panel.entity_armed_home"
     }
 
-    assert len(arm_home_calls) == 1
-    assert arm_home_calls[0].domain == "alarm_control_panel"
-    assert arm_home_calls[0].data == {
+    assert len(arm_home_calls) == 2
+    assert arm_home_calls[1].domain == "alarm_control_panel"
+    assert arm_home_calls[1].data == {
         "entity_id": "alarm_control_panel.entity_armed_night"
     }
 
-    assert len(arm_night_calls) == 1
-    assert arm_night_calls[0].domain == "alarm_control_panel"
-    assert arm_night_calls[0].data == {
+    assert len(arm_night_calls) == 2
+    assert arm_night_calls[1].domain == "alarm_control_panel"
+    assert arm_night_calls[1].data == {
         "entity_id": "alarm_control_panel.entity_disarmed"
     }
 
-    assert len(disarm_calls) == 1
-    assert disarm_calls[0].domain == "alarm_control_panel"
-    assert disarm_calls[0].data == {"entity_id": "alarm_control_panel.entity_triggered"}
+    assert len(disarm_calls) == 2
+    assert disarm_calls[1].domain == "alarm_control_panel"
+    assert disarm_calls[1].data == {"entity_id": "alarm_control_panel.entity_triggered"}
 
-    assert len(trigger_calls) == 1
-    assert trigger_calls[0].domain == "alarm_control_panel"
-    assert trigger_calls[0].data == {
+    assert len(trigger_calls) == 2
+    assert trigger_calls[1].domain == "alarm_control_panel"
+    assert trigger_calls[1].data == {
         "entity_id": "alarm_control_panel.entity_armed_away"
     }


### PR DESCRIPTION
## Description:
The scene applying got broken, recently. Apparently the code got optimized to not trigger state updates if a current state is matching the target state. Sadly, there is a race condition in that behavior, because a device state in HA is usually just a cache and it is not authoritative. The problem is super visible with devices that have assumed state, but it exist in all types of entities excluding ones fully owned by HA, like for example; automations, groups, input_numbers etc.

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x ] There is no commented out code in this PR.
  - [ x ] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
