### PR TITLE
Move imports to top for ffmpeg_motion and ffmpeg_noise

### DIFF
--- a/homeassistant/components/ffmpeg_motion/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_motion/binary_sensor.py
@@ -1,7 +1,7 @@
 """Provides a binary sensor which is a collection of ffmpeg tools."""
 import logging
 
-from haffmpeg.sensor import SensorMotion
+import haffmpeg.sensor as ffmpeg_sensor
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -90,7 +90,9 @@ class FFmpegMotion(FFmpegBinarySensor):
         """Initialize FFmpeg motion binary sensor."""
 
         super().__init__(config)
-        self.ffmpeg = SensorMotion(manager.binary, hass.loop, self._async_callback)
+        self.ffmpeg = ffmpeg_sensor.SensorMotion(
+            manager.binary, hass.loop, self._async_callback
+        )
 
     async def _async_start_ffmpeg(self, entity_ids):
         """Start a FFmpeg instance.

--- a/homeassistant/components/ffmpeg_motion/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_motion/binary_sensor.py
@@ -1,6 +1,7 @@
 """Provides a binary sensor which is a collection of ffmpeg tools."""
 import logging
 
+from haffmpeg.sensor import SensorMotion
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -87,7 +88,6 @@ class FFmpegMotion(FFmpegBinarySensor):
 
     def __init__(self, hass, manager, config):
         """Initialize FFmpeg motion binary sensor."""
-        from haffmpeg.sensor import SensorMotion
 
         super().__init__(config)
         self.ffmpeg = SensorMotion(manager.binary, hass.loop, self._async_callback)

--- a/homeassistant/components/ffmpeg_noise/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_noise/binary_sensor.py
@@ -1,6 +1,7 @@
 """Provides a binary sensor which is a collection of ffmpeg tools."""
 import logging
 
+from haffmpeg.sensor import SensorNoise
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -54,7 +55,6 @@ class FFmpegNoise(FFmpegBinarySensor):
 
     def __init__(self, hass, manager, config):
         """Initialize FFmpeg noise binary sensor."""
-        from haffmpeg.sensor import SensorNoise
 
         super().__init__(config)
         self.ffmpeg = SensorNoise(manager.binary, hass.loop, self._async_callback)

--- a/homeassistant/components/ffmpeg_noise/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_noise/binary_sensor.py
@@ -1,7 +1,7 @@
 """Provides a binary sensor which is a collection of ffmpeg tools."""
 import logging
 
-from haffmpeg.sensor import SensorNoise
+import haffmpeg.sensor as ffmpeg_sensor
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -57,7 +57,9 @@ class FFmpegNoise(FFmpegBinarySensor):
         """Initialize FFmpeg noise binary sensor."""
 
         super().__init__(config)
-        self.ffmpeg = SensorNoise(manager.binary, hass.loop, self._async_callback)
+        self.ffmpeg = ffmpeg_sensor.SensorNoise(
+            manager.binary, hass.loop, self._async_callback
+        )
 
     async def _async_start_ffmpeg(self, entity_ids):
         """Start a FFmpeg instance.


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

- moved all imports to the top

**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
