### PR TITLE
Add Post Processing Jobs to NZBGet component

### DIFF
--- a/homeassistant/components/nzbget/sensor.py
+++ b/homeassistant/components/nzbget/sensor.py
@@ -18,6 +18,7 @@ SENSOR_TYPES = {
     "download_rate": ["DownloadRate", "Speed", "MB/s"],
     "download_size": ["DownloadedSizeMB", "Size", "MB"],
     "free_disk_space": ["FreeDiskSpaceMB", "Disk Free", "MB"],
+    "post_job_count": ["PostJobCount", "Post Processing Jobs", "Count"],
     "post_paused": ["PostPaused", "Post Processing Paused", None],
     "remaining_size": ["RemainingSizeMB", "Queue Size", "MB"],
     "uptime": ["UpTimeSec", "Uptime", "min"],

--- a/homeassistant/components/nzbget/sensor.py
+++ b/homeassistant/components/nzbget/sensor.py
@@ -18,7 +18,7 @@ SENSOR_TYPES = {
     "download_rate": ["DownloadRate", "Speed", "MB/s"],
     "download_size": ["DownloadedSizeMB", "Size", "MB"],
     "free_disk_space": ["FreeDiskSpaceMB", "Disk Free", "MB"],
-    "post_job_count": ["PostJobCount", "Post Processing Jobs", "Count"],
+    "post_job_count": ["PostJobCount", "Post Processing Jobs", "Jobs"],
     "post_paused": ["PostPaused", "Post Processing Paused", None],
     "remaining_size": ["RemainingSizeMB", "Queue Size", "MB"],
     "uptime": ["UpTimeSec", "Uptime", "min"],


### PR DESCRIPTION
## Description:

In the current implementation of the NZBGet component there is no way of knowing whether NZBGet is still in the Post Processing phase of a download job. This can be very useful information. For instance when you want to suspend the NZBGet service when all queue items have been completed.

This change adds that additional sensor.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11279

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
