### PR TITLE
Report device unavailable state through Emulated Hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -56,6 +56,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.util.network import is_local
 
@@ -578,7 +579,7 @@ def entity_to_json(config, entity, state):
                 HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],
                 HUE_API_STATE_HUE: state[STATE_HUE],
                 HUE_API_STATE_SAT: state[STATE_SATURATION],
-                "reachable": True,
+                "reachable": entity.state != STATE_UNAVAILABLE,
             },
             "type": "Dimmable light",
             "name": config.get_entity_name(entity),
@@ -587,7 +588,10 @@ def entity_to_json(config, entity, state):
             "swversion": "123",
         }
     return {
-        "state": {HUE_API_STATE_ON: state[STATE_ON], "reachable": True},
+        "state": {
+            HUE_API_STATE_ON: state[STATE_ON],
+            "reachable": entity.state != STATE_UNAVAILABLE,
+        },
         "type": "On/off light",
         "name": config.get_entity_name(entity),
         "modelid": "HASS321",

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -233,6 +233,26 @@ def test_light_without_brightness_supported(hass_hue, hue_client):
 
 
 @asyncio.coroutine
+@pytest.mark.parametrize(
+    "state,is_reachable",
+    [
+        (const.STATE_UNAVAILABLE, False),
+        (const.STATE_OK, True),
+        (const.STATE_UNKNOWN, True),
+    ],
+)
+def test_reachable_for_state(hass_hue, hue_client, state, is_reachable):
+    """Test that an entity is reported as unreachable if in unavailable state."""
+    entity_id = "light.ceiling_lights"
+
+    hass_hue.states.async_set(entity_id, state)
+
+    state_json = yield from perform_get_light_state(hue_client, entity_id, 200)
+
+    assert state_json["state"]["reachable"] == is_reachable, state_json
+
+
+@asyncio.coroutine
 def test_get_light_state(hass_hue, hue_client):
     """Test the getting of light state."""
     # Turn office light on and set to 127 brightness, and set light color


### PR DESCRIPTION
## Description:

If an entity is in unavailable state in HA, we expose this
as unreachable to Hue clients. This helps when troubleshooting
Hue issues because you can now receive feedback if there is an issue
on the HA side.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
