### PR TITLE
Update roomba bin state checking

### DIFF
--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -336,7 +336,7 @@ class RoombaVacuum(VacuumDevice):
             self._state_attrs[ATTR_POSITION] = position
 
         # Not all Roombas have a bin full sensor
-        if self._capabilities[CAP_BIN_FULL]:
+        if self._capabilities[CAP_BIN_FULL] or bin_state.get("full") is not None:
             self._state_attrs[ATTR_BIN_FULL] = bin_state.get("full")
 
         # Fan speed mode (Performance, Automatic or Eco)

--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -33,7 +33,6 @@ ATTR_ERROR = "error"
 ATTR_POSITION = "position"
 ATTR_SOFTWARE_VERSION = "software_version"
 
-CAP_BIN_FULL = "bin_full"
 CAP_POSITION = "position"
 CAP_CARPET_BOOST = "carpet_boost"
 
@@ -276,17 +275,13 @@ class RoombaVacuum(VacuumDevice):
 
         # Get the capabilities of our unit
         capabilities = state.get("cap", {})
-        cap_bin_full = capabilities.get("binFullDetect")
         cap_carpet_boost = capabilities.get("carpetBoost")
         cap_pos = capabilities.get("pose")
         # Store capabilities
         self._capabilities = {
-            CAP_BIN_FULL: cap_bin_full == 1,
             CAP_CARPET_BOOST: cap_carpet_boost == 1,
             CAP_POSITION: cap_pos == 1,
         }
-
-        bin_state = state.get("bin", {})
 
         # Roomba software version
         software_version = state.get("softwareVer")
@@ -302,9 +297,12 @@ class RoombaVacuum(VacuumDevice):
 
         # Set properties that are to appear in the GUI
         self._state_attrs = {
-            ATTR_BIN_PRESENT: bin_state.get("present"),
             ATTR_SOFTWARE_VERSION: software_version,
         }
+
+        # Get bin state
+        bin_state = self._get_bin_state(state)
+        self._state_attrs.update(bin_state)
 
         # Only add cleaning time and cleaned area attrs when the vacuum is
         # currently on
@@ -335,10 +333,6 @@ class RoombaVacuum(VacuumDevice):
                 position = f"({pos_x}, {pos_y}, {theta})"
             self._state_attrs[ATTR_POSITION] = position
 
-        # Not all Roombas have a bin full sensor
-        if self._capabilities[CAP_BIN_FULL] or bin_state.get("full") is not None:
-            self._state_attrs[ATTR_BIN_FULL] = bin_state.get("full")
-
         # Fan speed mode (Performance, Automatic or Eco)
         # Not all Roombas expose carpet boost
         if self._capabilities[CAP_CARPET_BOOST]:
@@ -355,3 +349,15 @@ class RoombaVacuum(VacuumDevice):
                     fan_speed = FAN_SPEED_ECO
 
             self._fan_speed = fan_speed
+
+    def _get_bin_state(self, state):
+        bin_raw_state = state.get("bin", {})
+        bin_state = {}
+
+        if bin_raw_state.get("present") is not None:
+            bin_state[ATTR_BIN_PRESENT] = bin_raw_state.get("present")
+
+        if bin_raw_state.get("full") is not None:
+            bin_state[ATTR_BIN_FULL] = bin_raw_state.get("full")
+
+        return bin_state

--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -350,7 +350,8 @@ class RoombaVacuum(VacuumDevice):
 
             self._fan_speed = fan_speed
 
-    def _get_bin_state(self, state):
+    @staticmethod
+    def _get_bin_state(state):
         bin_raw_state = state.get("bin", {})
         bin_state = {}
 


### PR DESCRIPTION
## Description:
Fixed detection is bin full. Refactored part responsible for bin.
Now just grab info from roomba and set in state only available values.
There is no need to check is roomba has capabilities to check is bin is full

**Related issue (if applicable):** fixes #17382 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
