### PR TITLE
Add SSL configuration

### DIFF
--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_COVERS,
     CONF_HOST,
     CONF_PORT,
-    CONF_PROTOCOL,
+    CONF_SSL,
     STATE_CLOSING,
     STATE_OPENING,
 )
@@ -34,7 +34,6 @@ CONF_DEVICE_KEY = "device_key"
 
 DEFAULT_NAME = "OpenGarage"
 DEFAULT_PORT = 80
-DEFAULT_PROTOCOL = "http"
 
 STATES_MAP = {0: STATE_CLOSED, 1: STATE_OPEN}
 
@@ -44,9 +43,7 @@ COVER_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): vol.In(
-            ["http", "https"]
-        ),
+        vol.Optional(CONF_SSL, default=False): cv.boolean,
     }
 )
 
@@ -65,7 +62,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             CONF_NAME: device_config.get(CONF_NAME),
             CONF_HOST: device_config.get(CONF_HOST),
             CONF_PORT: device_config.get(CONF_PORT),
-            CONF_PROTOCOL: device_config.get(CONF_PROTOCOL),
+            CONF_SSL: device_config.get(CONF_SSL),
             CONF_DEVICE_KEY: device_config.get(CONF_DEVICE_KEY),
         }
 
@@ -80,7 +77,7 @@ class OpenGarageCover(CoverDevice):
     def __init__(self, args):
         """Initialize the cover."""
         self.opengarage_url = "{}://{}:{}".format(
-            args[CONF_PROTOCOL], args[CONF_HOST], args[CONF_PORT]
+            "https" if args[CONF_SSL] else "http", args[CONF_HOST], args[CONF_PORT]
         )
         self._name = args[CONF_NAME]
         self._device_key = args[CONF_DEVICE_KEY]

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_COVERS,
     CONF_HOST,
     CONF_PORT,
+    CONF_PROTOCOL,
     STATE_CLOSING,
     STATE_OPENING,
 )
@@ -33,6 +34,7 @@ CONF_DEVICE_KEY = "device_key"
 
 DEFAULT_NAME = "OpenGarage"
 DEFAULT_PORT = 80
+DEFAULT_PROTOCOL = "http"
 
 STATES_MAP = {0: STATE_CLOSED, 1: STATE_OPEN}
 
@@ -42,6 +44,9 @@ COVER_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): vol.In(
+            ["http", "https"]
+        ),
     }
 )
 
@@ -60,6 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             CONF_NAME: device_config.get(CONF_NAME),
             CONF_HOST: device_config.get(CONF_HOST),
             CONF_PORT: device_config.get(CONF_PORT),
+            CONF_PROTOCOL: device_config.get(CONF_PROTOCOL),
             CONF_DEVICE_KEY: device_config.get(CONF_DEVICE_KEY),
         }
 
@@ -73,7 +79,9 @@ class OpenGarageCover(CoverDevice):
 
     def __init__(self, args):
         """Initialize the cover."""
-        self.opengarage_url = "http://{}:{}".format(args[CONF_HOST], args[CONF_PORT])
+        self.opengarage_url = "{}://{}:{}".format(
+            args[CONF_PROTOCOL], args[CONF_HOST], args[CONF_PORT]
+        )
         self._name = args[CONF_NAME]
         self._device_key = args[CONF_DEVICE_KEY]
         self._state = None

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     CONF_SSL,
+    CONF_VERIFY_SSL,
     STATE_CLOSING,
     STATE_OPENING,
 )
@@ -44,6 +45,7 @@ COVER_SCHEMA = vol.Schema(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     }
 )
 
@@ -63,6 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             CONF_HOST: device_config.get(CONF_HOST),
             CONF_PORT: device_config.get(CONF_PORT),
             CONF_SSL: device_config.get(CONF_SSL),
+            CONF_VERIFY_SSL: device_config.get(CONF_VERIFY_SSL),
             CONF_DEVICE_KEY: device_config.get(CONF_DEVICE_KEY),
         }
 
@@ -85,6 +88,7 @@ class OpenGarageCover(CoverDevice):
         self._state_before_move = None
         self._device_state_attributes = {}
         self._available = True
+        self._verify_ssl = args[CONF_VERIFY_SSL]
 
     @property
     def name(self):
@@ -160,7 +164,9 @@ class OpenGarageCover(CoverDevice):
         result = -1
         try:
             result = requests.get(
-                f"{self.opengarage_url}/cc?dkey={self._device_key}&click=1", timeout=10
+                f"{self.opengarage_url}/cc?dkey={self._device_key}&click=1",
+                timeout=10,
+                verify=self._verify_ssl,
             ).json()["result"]
         except requests.exceptions.RequestException as ex:
             _LOGGER.error(


### PR DESCRIPTION
## Description:

Allow the OpenGarage integration to configure the transport layer it uses to communicate (HTTP or HTTPS). See issue #29037 

**Related issue (if applicable):** fixes #29037 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11283

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
cover:
  platform: opengarage
  covers:
    garage:
      ssl: true
      verify_ssl: false
      host: garage.example.com
      port: 443
      device_key: opendoor
      name: Right Garage Door
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
