### PR TITLE
Added error checking

### DIFF
--- a/homeassistant/components/synologydsm/sensor.py
+++ b/homeassistant/components/synologydsm/sensor.py
@@ -119,24 +119,26 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ]
 
         # Handle all volumes
-        for volume in config.get(CONF_VOLUMES, api.storage.volumes):
-            sensors += [
-                SynoNasStorageSensor(
-                    api, name, variable, _STORAGE_VOL_MON_COND[variable], volume
-                )
-                for variable in monitored_conditions
-                if variable in _STORAGE_VOL_MON_COND
-            ]
+        if api.storage.volumes is not None:
+            for volume in config.get(CONF_VOLUMES, api.storage.volumes):
+                sensors += [
+                    SynoNasStorageSensor(
+                        api, name, variable, _STORAGE_VOL_MON_COND[variable], volume
+                    )
+                    for variable in monitored_conditions
+                    if variable in _STORAGE_VOL_MON_COND
+                ]
 
         # Handle all disks
-        for disk in config.get(CONF_DISKS, api.storage.disks):
-            sensors += [
-                SynoNasStorageSensor(
-                    api, name, variable, _STORAGE_DSK_MON_COND[variable], disk
-                )
-                for variable in monitored_conditions
-                if variable in _STORAGE_DSK_MON_COND
-            ]
+        if api.storage.disks is not None:
+            for disk in config.get(CONF_DISKS, api.storage.disks):
+                sensors += [
+                    SynoNasStorageSensor(
+                        api, name, variable, _STORAGE_DSK_MON_COND[variable], disk
+                    )
+                    for variable in monitored_conditions
+                    if variable in _STORAGE_DSK_MON_COND
+                ]
 
         add_entities(sensors, True)
 


### PR DESCRIPTION
## Description:

Add in error checking in case disks or volumes are empty.

**Related issue (if applicable):** fixes 


## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: synologydsm
    host: IP
    port: PORT
    ssl: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
