### PR TITLE
Cast the volume_level of a universal media_player to a float

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -255,7 +255,8 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     @property
     def volume_level(self):
         """Volume level of entity specified in attributes or active child."""
-        return float(self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL))
+        level = self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL)
+        return float(level) if level is not None else None
 
     @property
     def is_volume_muted(self):

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -255,8 +255,10 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     @property
     def volume_level(self):
         """Volume level of entity specified in attributes or active child."""
-        level = self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL)
-        return float(level) if level is not None else None
+        try:
+            return float(self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL))
+        except (TypeError, ValueError):
+            return None
 
     @property
     def is_volume_muted(self):

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -255,7 +255,7 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     @property
     def volume_level(self):
         """Volume level of entity specified in attributes or active child."""
-        return self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL)
+        return float(self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL))
 
     @property
     def is_volume_muted(self):

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -539,10 +539,10 @@ class TestMediaPlayer(unittest.TestCase):
 
         ump = universal.UniversalMediaPlayer(self.hass, **config)
 
-        assert "0" == ump.volume_level
+        assert 0 == ump.volume_level
 
         self.hass.states.set(self.mock_volume_id, 100)
-        assert "100" == ump.volume_level
+        assert 100 == ump.volume_level
 
     def test_is_volume_muted_children_and_attr(self):
         """Test is volume muted property w/ children and attrs."""


### PR DESCRIPTION
## Description:
The universal `media_player` can be configured to fetch it's volume from another sensor's state (like from a mqtt source). Since a sensor state is string, the result of the media_player's `volume_level` will also be a string.

This causes issues in other parts of the code (like the google_assistant trait that returns the volume) that expect a volume_level to be a float instead of a string.

Config like this:

```yaml
media_player:
- platform: universal
  name: receiver
  children:
    - media_player.kodi
    - media_player.living_room_chromecast
  commands:
    # ...
  attributes:
    # ...
    volume_level: sensor.avr_volume

sensors:
- platform: mqtt
  name: avr_volume
  state_topic: "media/cec/volume"
  availability_topic: "media/bridge/status"
  value_template: "{{ value_json / 100 | float }}"
```

**Related issue (if applicable):** fixes #29044

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
