### PR TITLE
Move ee_brightbox imports at top-level

### DIFF
--- a/homeassistant/components/ee_brightbox/device_tracker.py
+++ b/homeassistant/components/ee_brightbox/device_tracker.py
@@ -1,6 +1,7 @@
 """Support for EE Brightbox router."""
 import logging
 
+from eebrightbox import EEBrightBox, EEBrightBoxException
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -46,8 +47,6 @@ class EEBrightBoxScanner(DeviceScanner):
 
     def check_config(self):
         """Check if provided configuration and credentials are correct."""
-        from eebrightbox import EEBrightBox, EEBrightBoxException
-
         try:
             with EEBrightBox(self.config) as ee_brightbox:
                 return bool(ee_brightbox.get_devices())
@@ -57,8 +56,6 @@ class EEBrightBoxScanner(DeviceScanner):
 
     def scan_devices(self):
         """Scan for devices."""
-        from eebrightbox import EEBrightBox
-
         with EEBrightBox(self.config) as ee_brightbox:
             self.devices = {d["mac"]: d for d in ee_brightbox.get_devices()}
 

--- a/tests/components/ee_brightbox/test_device_tracker.py
+++ b/tests/components/ee_brightbox/test_device_tracker.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 from asynctest import patch
+from eebrightbox import EEBrightBoxException
 import pytest
 
 from homeassistant.components.device_tracker import DOMAIN
@@ -41,8 +42,6 @@ def _configure_mock_get_devices(eebrightbox_mock):
 
 
 def _configure_mock_failed_config_check(eebrightbox_mock):
-    from eebrightbox import EEBrightBoxException
-
     eebrightbox_instance = eebrightbox_mock.return_value
     eebrightbox_instance.__enter__.side_effect = EEBrightBoxException(
         "Failed to connect to the router"
@@ -55,7 +54,7 @@ def mock_dev_track(mock_device_tracker_conf):
     pass
 
 
-@patch("eebrightbox.EEBrightBox")
+@patch("homeassistant.components.ee_brightbox.device_tracker.EEBrightBox")
 async def test_missing_credentials(eebrightbox_mock, hass):
     """Test missing credentials."""
     _configure_mock_get_devices(eebrightbox_mock)
@@ -73,10 +72,10 @@ async def test_missing_credentials(eebrightbox_mock, hass):
     assert hass.states.get("device_tracker.hostnameff") is None
 
 
-@patch("eebrightbox.EEBrightBox")
-async def test_invalid_credentials(eebrightbox_mock, hass):
+@patch("homeassistant.components.ee_brightbox.device_tracker.EEBrightBox")
+async def test_invalid_credentials(config_check_failed, hass):
     """Test invalid credentials."""
-    _configure_mock_failed_config_check(eebrightbox_mock)
+    # _configure_mock_failed_config_check(eebrightbox_mock)
 
     result = await async_setup_component(
         hass,
@@ -93,7 +92,7 @@ async def test_invalid_credentials(eebrightbox_mock, hass):
     assert hass.states.get("device_tracker.hostnameff") is None
 
 
-@patch("eebrightbox.EEBrightBox")
+@patch("homeassistant.components.ee_brightbox.device_tracker.EEBrightBox")
 async def test_get_devices(eebrightbox_mock, hass):
     """Test valid configuration."""
     _configure_mock_get_devices(eebrightbox_mock)

--- a/tests/components/ee_brightbox/test_device_tracker.py
+++ b/tests/components/ee_brightbox/test_device_tracker.py
@@ -73,9 +73,9 @@ async def test_missing_credentials(eebrightbox_mock, hass):
 
 
 @patch("homeassistant.components.ee_brightbox.device_tracker.EEBrightBox")
-async def test_invalid_credentials(config_check_failed, hass):
+async def test_invalid_credentials(eebrightbox_mock, hass):
     """Test invalid credentials."""
-    # _configure_mock_failed_config_check(eebrightbox_mock)
+    _configure_mock_failed_config_check(eebrightbox_mock)
 
     result = await async_setup_component(
         hass,


### PR DESCRIPTION
## Breaking Change:

None

## Description:

**Related issue:** partially f!x #27284 + isort

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html