### PR TITLE
Move hdmi_cec imports at top-level

### DIFF
--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -4,6 +4,25 @@ from functools import reduce
 import logging
 import multiprocessing
 
+from pycec.cec import CecAdapter
+from pycec.commands import CecCommand, KeyPressCommand, KeyReleaseCommand
+from pycec.const import (
+    ADDR_AUDIOSYSTEM,
+    ADDR_BROADCAST,
+    ADDR_UNREGISTERED,
+    KEY_MUTE_OFF,
+    KEY_MUTE_ON,
+    KEY_MUTE_TOGGLE,
+    KEY_VOLUME_DOWN,
+    KEY_VOLUME_UP,
+    POWER_OFF,
+    POWER_ON,
+    STATUS_PLAY,
+    STATUS_STILL,
+    STATUS_STOP,
+)
+from pycec.network import HDMINetwork, PhysicalAddress
+from pycec.tcp import TcpAdapter
 import voluptuous as vol
 
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER
@@ -155,8 +174,6 @@ def parse_mapping(mapping, parents=None):
         parents = []
     for addr, val in mapping.items():
         if isinstance(addr, (str,)) and isinstance(val, (str,)):
-            from pycec.network import PhysicalAddress
-
             yield (addr, PhysicalAddress(val))
         else:
             cur = parents + [addr]
@@ -168,20 +185,6 @@ def parse_mapping(mapping, parents=None):
 
 def setup(hass: HomeAssistant, base_config):
     """Set up the CEC capability."""
-    from pycec.network import HDMINetwork
-    from pycec.commands import CecCommand, KeyReleaseCommand, KeyPressCommand
-    from pycec.const import (
-        KEY_VOLUME_UP,
-        KEY_VOLUME_DOWN,
-        KEY_MUTE_ON,
-        KEY_MUTE_OFF,
-        KEY_MUTE_TOGGLE,
-        ADDR_AUDIOSYSTEM,
-        ADDR_BROADCAST,
-        ADDR_UNREGISTERED,
-    )
-    from pycec.cec import CecAdapter
-    from pycec.tcp import TcpAdapter
 
     # Parse configuration into a dict of device name to physical address
     # represented as a list of four elements.
@@ -278,8 +281,6 @@ def setup(hass: HomeAssistant, base_config):
 
     def _select_device(call):
         """Select the active device."""
-        from pycec.network import PhysicalAddress
-
         addr = call.data[ATTR_DEVICE]
         if not addr:
             _LOGGER.error("Device not found: %s", call.data[ATTR_DEVICE])
@@ -366,14 +367,6 @@ class CecDevice(Entity):
     def update(self):
         """Update device status."""
         device = self._device
-        from pycec.const import (
-            STATUS_PLAY,
-            STATUS_STOP,
-            STATUS_STILL,
-            POWER_OFF,
-            POWER_ON,
-        )
-
         if device.power_status in [POWER_OFF, 3]:
             self._state = STATE_OFF
         elif device.status == STATUS_PLAY:

--- a/homeassistant/components/hdmi_cec/media_player.py
+++ b/homeassistant/components/hdmi_cec/media_player.py
@@ -1,6 +1,27 @@
 """Support for HDMI CEC devices as media players."""
 import logging
 
+from pycec.commands import CecCommand, KeyPressCommand, KeyReleaseCommand
+from pycec.const import (
+    KEY_BACKWARD,
+    KEY_FORWARD,
+    KEY_MUTE_TOGGLE,
+    KEY_PAUSE,
+    KEY_PLAY,
+    KEY_STOP,
+    KEY_VOLUME_DOWN,
+    KEY_VOLUME_UP,
+    POWER_OFF,
+    POWER_ON,
+    STATUS_PLAY,
+    STATUS_STILL,
+    STATUS_STOP,
+    TYPE_AUDIO,
+    TYPE_PLAYBACK,
+    TYPE_RECORDER,
+    TYPE_TUNER,
+)
+
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     DOMAIN,
@@ -50,8 +71,6 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
 
     def send_keypress(self, key):
         """Send keypress to CEC adapter."""
-        from pycec.commands import KeyPressCommand, KeyReleaseCommand
-
         _LOGGER.debug(
             "Sending keypress %s to device %s", hex(key), hex(self._logical_address)
         )
@@ -60,20 +79,14 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
 
     def send_playback(self, key):
         """Send playback status to CEC adapter."""
-        from pycec.commands import CecCommand
-
         self._device.async_send_command(CecCommand(key, dst=self._logical_address))
 
     def mute_volume(self, mute):
         """Mute volume."""
-        from pycec.const import KEY_MUTE_TOGGLE
-
         self.send_keypress(KEY_MUTE_TOGGLE)
 
     def media_previous_track(self):
         """Go to previous track."""
-        from pycec.const import KEY_BACKWARD
-
         self.send_keypress(KEY_BACKWARD)
 
     def turn_on(self):
@@ -92,8 +105,6 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
 
     def media_stop(self):
         """Stop playback."""
-        from pycec.const import KEY_STOP
-
         self.send_keypress(KEY_STOP)
         self._state = STATE_IDLE
 
@@ -103,8 +114,6 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
 
     def media_next_track(self):
         """Skip to next track."""
-        from pycec.const import KEY_FORWARD
-
         self.send_keypress(KEY_FORWARD)
 
     def media_seek(self, position):
@@ -117,8 +126,6 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
 
     def media_pause(self):
         """Pause playback."""
-        from pycec.const import KEY_PAUSE
-
         self.send_keypress(KEY_PAUSE)
         self._state = STATE_PAUSED
 
@@ -128,22 +135,16 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
 
     def media_play(self):
         """Start playback."""
-        from pycec.const import KEY_PLAY
-
         self.send_keypress(KEY_PLAY)
         self._state = STATE_PLAYING
 
     def volume_up(self):
         """Increase volume."""
-        from pycec.const import KEY_VOLUME_UP
-
         _LOGGER.debug("%s: volume up", self._logical_address)
         self.send_keypress(KEY_VOLUME_UP)
 
     def volume_down(self):
         """Decrease volume."""
-        from pycec.const import KEY_VOLUME_DOWN
-
         _LOGGER.debug("%s: volume down", self._logical_address)
         self.send_keypress(KEY_VOLUME_DOWN)
 
@@ -155,14 +156,6 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
     def update(self):
         """Update device status."""
         device = self._device
-        from pycec.const import (
-            STATUS_PLAY,
-            STATUS_STOP,
-            STATUS_STILL,
-            POWER_OFF,
-            POWER_ON,
-        )
-
         if device.power_status in [POWER_OFF, 3]:
             self._state = STATE_OFF
         elif not self.support_pause:
@@ -180,8 +173,6 @@ class CecPlayerDevice(CecDevice, MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        from pycec.const import TYPE_RECORDER, TYPE_PLAYBACK, TYPE_TUNER, TYPE_AUDIO
-
         if self.type_id == TYPE_RECORDER or self.type == TYPE_PLAYBACK:
             return (
                 SUPPORT_TURN_ON


### PR DESCRIPTION
## Breaking Change:

None

## Description:

**Related issue:** partially fix #27284 + isort

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html