### PR TITLE
Drop < 0.97 Huawei LTE sensor unique id migration workaround

### DIFF
--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DOMAIN as SENSOR_DOMAIN,
 )
-from homeassistant.helpers import entity_registry
 
 from . import HuaweiLteBaseEntity
 from .const import (
@@ -169,23 +168,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             sensors.append(
                 HuaweiLteSensor(router, key, item, SENSOR_META.get((key, item), {}))
             )
-
-    # Pre-0.97 unique id migration. Old ones used the device serial number
-    # (see comments in HuaweiLteData._setup_lte for more info), as well as
-    # had a bug that joined the path str with periods, not the path components,
-    # resulting e.g. *_device_signal.sinr to end up as
-    # *_d.e.v.i.c.e._.s.i.g.n.a.l...s.i.n.r
-    entreg = await entity_registry.async_get_registry(hass)
-    for entid, ent in entreg.entities.items():
-        if ent.platform != DOMAIN:
-            continue
-        for sensor in sensors:
-            oldsuf = ".".join(f"{sensor.key}.{sensor.item}")
-            if ent.unique_id.endswith(f"_{oldsuf}"):
-                entreg.async_update_entity(entid, new_unique_id=sensor.unique_id)
-                _LOGGER.debug(
-                    "Updated entity %s unique id to %s", entid, sensor.unique_id
-                )
 
     async_add_entities(sensors, True)
 


### PR DESCRIPTION

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
