### PR TITLE
Bump numpy 1.17.4 / opencv 4.1.2 for Python 3.8

### DIFF
--- a/homeassistant/components/iqvia/manifest.json
+++ b/homeassistant/components/iqvia/manifest.json
@@ -3,12 +3,7 @@
   "name": "IQVIA",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/iqvia",
-  "requirements": [
-    "numpy==1.17.3",
-    "pyiqvia==0.2.1"
-  ],
+  "requirements": ["numpy==1.17.4", "pyiqvia==0.2.1"],
   "dependencies": [],
-  "codeowners": [
-    "@bachya"
-  ]
+  "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/opencv/manifest.json
+++ b/homeassistant/components/opencv/manifest.json
@@ -2,10 +2,7 @@
   "domain": "opencv",
   "name": "Opencv",
   "documentation": "https://www.home-assistant.io/integrations/opencv",
-  "requirements": [
-    "numpy==1.17.3",
-    "opencv-python-headless==4.1.1.26"
-  ],
+  "requirements": ["numpy==1.17.4", "opencv-python-headless==4.1.2.30"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/tensorflow/manifest.json
+++ b/homeassistant/components/tensorflow/manifest.json
@@ -2,11 +2,7 @@
   "domain": "tensorflow",
   "name": "Tensorflow",
   "documentation": "https://www.home-assistant.io/integrations/tensorflow",
-  "requirements": [
-    "tensorflow==1.13.2",
-    "numpy==1.17.3",
-    "protobuf==3.6.1"
-  ],
+  "requirements": ["tensorflow==1.13.2", "numpy==1.17.4", "protobuf==3.6.1"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/trend/manifest.json
+++ b/homeassistant/components/trend/manifest.json
@@ -2,9 +2,7 @@
   "domain": "trend",
   "name": "Trend",
   "documentation": "https://www.home-assistant.io/integrations/trend",
-  "requirements": [
-    "numpy==1.17.3"
-  ],
+  "requirements": ["numpy==1.17.4"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -897,7 +897,7 @@ nuheat==0.3.0
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==1.17.3
+numpy==1.17.4
 
 # homeassistant.components.oasa_telematics
 oasatelematics==0.3
@@ -915,7 +915,7 @@ onkyo-eiscp==1.2.7
 onvif-zeep-async==0.2.0
 
 # homeassistant.components.opencv
-# opencv-python-headless==4.1.1.26
+# opencv-python-headless==4.1.2.30
 
 # homeassistant.components.openevse
 openevsewifi==0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -300,7 +300,7 @@ nuheat==0.3.0
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==1.17.3
+numpy==1.17.4
 
 # homeassistant.components.google
 oauth2client==4.0.0


### PR DESCRIPTION
## Description:

Extend Python3.8 support. Formatting is given with prettier.

