### PR TITLE
Move imports to top for uvc

### DIFF
--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -4,6 +4,7 @@ import socket
 
 import requests
 import voluptuous as vol
+from uvcclient import nvr, camera as uvc_camera
 
 from homeassistant.const import CONF_PORT, CONF_SSL
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
@@ -38,8 +39,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     password = config[CONF_PASSWORD]
     port = config[CONF_PORT]
     ssl = config[CONF_SSL]
-
-    from uvcclient import nvr
 
     try:
         # Exceptions may be raised in all method calls to the nvr library.
@@ -118,7 +117,6 @@ class UnifiVideoCamera(Camera):
 
     def _login(self):
         """Login to the camera."""
-        from uvcclient import camera as uvc_camera
 
         caminfo = self._nvr.get_camera(self._uuid)
         if self._connect_addr:
@@ -160,7 +158,6 @@ class UnifiVideoCamera(Camera):
 
     def camera_image(self):
         """Return the image of this camera."""
-        from uvcclient import camera as uvc_camera
 
         if not self._camera:
             if not self._login():
@@ -182,7 +179,6 @@ class UnifiVideoCamera(Camera):
 
     def set_motion_detection(self, mode):
         """Set motion detection on or off."""
-        from uvcclient.nvr import NvrError
 
         if mode is True:
             set_mode = "motion"
@@ -192,7 +188,7 @@ class UnifiVideoCamera(Camera):
         try:
             self._nvr.set_recordmode(self._uuid, set_mode)
             self._motion_status = mode
-        except NvrError as err:
+        except nvr.NvrError as err:
             _LOGGER.error("Unable to set recordmode to %s", set_mode)
             _LOGGER.debug(err)
 

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -3,13 +3,13 @@ import logging
 import socket
 
 import requests
+from uvcclient import camera as uvc_camera, nvr
 import voluptuous as vol
-from uvcclient import nvr, camera as uvc_camera
 
+from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
 from homeassistant.const import CONF_PORT, CONF_SSL
-from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
-import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -75,10 +75,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class UnifiVideoCamera(Camera):
     """A Ubiquiti Unifi Video Camera."""
 
-    def __init__(self, nvr, uuid, name, password):
+    def __init__(self, camera, uuid, name, password):
         """Initialize an Unifi camera."""
         super().__init__()
-        self._nvr = nvr
+        self._nvr = camera
         self._uuid = uuid
         self._name = name
         self._password = password


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- moved imports to the top

**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
