### PR TITLE
Move imports to top for xiaomi_tv

### DIFF
--- a/homeassistant/components/xiaomi_tv/media_player.py
+++ b/homeassistant/components/xiaomi_tv/media_player.py
@@ -2,6 +2,7 @@
 import logging
 
 import voluptuous as vol
+import pymitv
 
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
@@ -29,7 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Xiaomi TV platform."""
-    from pymitv import Discover
 
     # If a hostname is set. Discovery is skipped.
     host = config.get(CONF_HOST)
@@ -37,14 +37,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if host is not None:
         # Check if there's a valid TV at the IP address.
-        if not Discover().check_ip(host):
+        if not pymitv.Discover().check_ip(host):
             _LOGGER.error("Could not find Xiaomi TV with specified IP: %s", host)
         else:
             # Register TV with Home Assistant.
             add_entities([XiaomiTV(host, name)])
     else:
         # Otherwise, discover TVs on network.
-        add_entities(XiaomiTV(tv, DEFAULT_NAME) for tv in Discover().scan())
+        add_entities(XiaomiTV(tv, DEFAULT_NAME) for tv in pymitv.Discover().scan())
 
 
 class XiaomiTV(MediaPlayerDevice):
@@ -52,11 +52,9 @@ class XiaomiTV(MediaPlayerDevice):
 
     def __init__(self, ip, name):
         """Receive IP address and name to construct class."""
-        # Import pymitv library.
-        from pymitv import TV
 
         # Initialize the Xiaomi TV.
-        self._tv = TV(ip)
+        self._tv = pymitv.TV(ip)
         # Default name value, only to be overridden by user.
         self._name = name
         self._state = STATE_OFF


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
