### PR TITLE
Move imports to top for yale_smart_alarm

### DIFF
--- a/homeassistant/components/yale_smart_alarm/alarm_control_panel.py
+++ b/homeassistant/components/yale_smart_alarm/alarm_control_panel.py
@@ -2,6 +2,13 @@
 import logging
 
 import voluptuous as vol
+from yalesmartalarmclient.client import (
+    YaleSmartAlarmClient,
+    AuthenticationError,
+    YALE_STATE_DISARM,
+    YALE_STATE_ARM_PARTIAL,
+    YALE_STATE_ARM_FULL,
+)
 
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanel,
@@ -42,8 +49,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     password = config[CONF_PASSWORD]
     area_id = config[CONF_AREA_ID]
 
-    from yalesmartalarmclient.client import YaleSmartAlarmClient, AuthenticationError
-
     try:
         client = YaleSmartAlarmClient(username, password, area_id)
     except AuthenticationError:
@@ -61,12 +66,6 @@ class YaleAlarmDevice(AlarmControlPanel):
         self._name = name
         self._client = client
         self._state = None
-
-        from yalesmartalarmclient.client import (
-            YALE_STATE_DISARM,
-            YALE_STATE_ARM_PARTIAL,
-            YALE_STATE_ARM_FULL,
-        )
 
         self._state_map = {
             YALE_STATE_DISARM: STATE_ALARM_DISARMED,


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
