### PR TITLE
Nilu integration code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -210,6 +210,7 @@ homeassistant/components/ness_alarm/* @nickw444
 homeassistant/components/nest/* @awarecan
 homeassistant/components/netdata/* @fabaff
 homeassistant/components/nextbus/* @vividboarder
+homeassistant/components/nilu/* @hfurubotten
 homeassistant/components/nissan_leaf/* @filcole
 homeassistant/components/nmbs/* @thibmaek
 homeassistant/components/no_ip/* @fabaff

--- a/homeassistant/components/nilu/manifest.json
+++ b/homeassistant/components/nilu/manifest.json
@@ -6,5 +6,7 @@
     "niluclient==0.1.2"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@hfurubotten"
+  ]
 }


### PR DESCRIPTION
## Description:

Add myself as code owner of `nilu` integration as I maintain the client library it uses.

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
