### PR TITLE
Move folder_watcher imports at top-level

### DIFF
--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -3,6 +3,8 @@ import logging
 import os
 
 import voluptuous as vol
+from watchdog.events import PatternMatchingEventHandler
+from watchdog.observers import Observer
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
@@ -50,7 +52,6 @@ def setup(hass, config):
 
 def create_event_handler(patterns, hass):
     """Return the Watchdog EventHandler object."""
-    from watchdog.events import PatternMatchingEventHandler
 
     class EventHandler(PatternMatchingEventHandler):
         """Class for handling Watcher events."""
@@ -99,8 +100,6 @@ class Watcher:
 
     def __init__(self, path, patterns, hass):
         """Initialise the watchdog observer."""
-        from watchdog.observers import Observer
-
         self._observer = Observer()
         self._observer.schedule(
             create_event_handler(patterns, hass), path, recursive=True


### PR DESCRIPTION
## Breaking Change:

None

## Description:

**Related issue:** partially f!x #27284 + isort

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html