### PR TITLE
Update service domain for onvif from 'camera' to 'onvif'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -475,6 +475,7 @@ omit =
     homeassistant/components/onewire/sensor.py
     homeassistant/components/onkyo/media_player.py
     homeassistant/components/onvif/camera.py
+    homeassistant/components/onvif/const.py
     homeassistant/components/opencv/*
     homeassistant/components/openevse/sensor.py
     homeassistant/components/openexchangerates/sensor.py

--- a/homeassistant/components/camera/services.yaml
+++ b/homeassistant/components/camera/services.yaml
@@ -77,19 +77,3 @@ local_file_update_file_path:
     file_path:
       description: Path to the new image file.
       example: '/images/newimage.jpg'
-
-onvif_ptz:
-  description: Pan/Tilt/Zoom service for ONVIF camera.
-  fields:
-    entity_id:
-      description: Name(s) of entities to pan, tilt or zoom.
-      example: 'camera.living_room_camera'
-    pan:
-      description: "Direction of pan. Allowed values: LEFT, RIGHT."
-      example: 'LEFT'
-    tilt:
-      description: "Direction of tilt. Allowed values: DOWN, UP."
-      example: 'DOWN'
-    zoom:
-      description: "Zoom. Allowed values: ZOOM_IN, ZOOM_OUT"
-      example: "ZOOM_IN"

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -18,7 +18,6 @@ import voluptuous as vol
 from zeep.exceptions import Fault
 
 from homeassistant.components.camera import PLATFORM_SCHEMA, SUPPORT_STREAM, Camera
-from homeassistant.components.camera.const import DOMAIN
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS, DATA_FFMPEG
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -33,34 +32,31 @@ from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import async_extract_entity_ids
 import homeassistant.util.dt as dt_util
+from .const import (
+    ATTR_PAN,
+    ATTR_TILT,
+    ATTR_ZOOM,
+    CONF_PROFILE,
+    DEFAULT_ARGUMENTS,
+    DEFAULT_NAME,
+    DEFAULT_PASSWORD,
+    DEFAULT_PORT,
+    DEFAULT_PROFILE,
+    DEFAULT_USERNAME,
+    DIR_DOWN,
+    DIR_LEFT,
+    DIR_RIGHT,
+    DIR_UP,
+    DOMAIN,
+    ENTITIES,
+    ONVIF_DATA,
+    PTZ_NONE,
+    SERVICE_PTZ,
+    ZOOM_IN,
+    ZOOM_OUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-DEFAULT_NAME = "ONVIF Camera"
-DEFAULT_PORT = 5000
-DEFAULT_USERNAME = "admin"
-DEFAULT_PASSWORD = "888888"
-DEFAULT_ARGUMENTS = "-pred 1"
-DEFAULT_PROFILE = 0
-
-CONF_PROFILE = "profile"
-
-ATTR_PAN = "pan"
-ATTR_TILT = "tilt"
-ATTR_ZOOM = "zoom"
-
-DIR_UP = "UP"
-DIR_DOWN = "DOWN"
-DIR_LEFT = "LEFT"
-DIR_RIGHT = "RIGHT"
-ZOOM_OUT = "ZOOM_OUT"
-ZOOM_IN = "ZOOM_IN"
-PTZ_NONE = "NONE"
-
-SERVICE_PTZ = "onvif_ptz"
-
-ONVIF_DATA = "onvif"
-ENTITIES = "entities"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Onvif Camera component."""
+"""Constants for the ONVIF Camera component."""
 DOMAIN = "onvif"
 
 DEFAULT_NAME = "ONVIF Camera"

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -1,0 +1,28 @@
+"""Constants for the Onvif Camera component."""
+DOMAIN = "onvif"
+
+DEFAULT_NAME = "ONVIF Camera"
+DEFAULT_PORT = 5000
+DEFAULT_USERNAME = "admin"
+DEFAULT_PASSWORD = "888888"
+DEFAULT_ARGUMENTS = "-pred 1"
+DEFAULT_PROFILE = 0
+
+CONF_PROFILE = "profile"
+
+ATTR_PAN = "pan"
+ATTR_TILT = "tilt"
+ATTR_ZOOM = "zoom"
+
+DIR_UP = "UP"
+DIR_DOWN = "DOWN"
+DIR_LEFT = "LEFT"
+DIR_RIGHT = "RIGHT"
+ZOOM_OUT = "ZOOM_OUT"
+ZOOM_IN = "ZOOM_IN"
+PTZ_NONE = "NONE"
+
+SERVICE_PTZ = "ptz"
+
+ONVIF_DATA = "onvif"
+ENTITIES = "entities"

--- a/homeassistant/components/onvif/services.yaml
+++ b/homeassistant/components/onvif/services.yaml
@@ -1,4 +1,4 @@
-onvif_ptz:
+ptz:
   description: If your ONVIF camera supports PTZ, you will be able to pan, tilt or zoom your camera.
   fields:
     entity_id:


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `camera.onvif_ptz` by changing the service call to `onvif.ptz`. My understanding is that because this is not a service provided by the base `camera` component, it should live in the domain of the `onvif` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `camera.onvif_ptz`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11294

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
