### PR TITLE
Update service domain for monoprice from 'media_player' to 'monoprice'

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -107,20 +107,6 @@ media_seek:
       description: Position to seek to. The format is platform dependent.
       example: 100
 
-monoprice_snapshot:
-  description: Take a snapshot of the media player zone.
-  fields:
-    entity_id:
-      description: Name(s) of entities that will be snapshot. Platform dependent.
-      example: 'media_player.living_room'
-
-monoprice_restore:
-  description: Restore a snapshot of the media player zone.
-  fields:
-    entity_id:
-      description: Name(s) of entities that will be restored. Platform dependent.
-      example: 'media_player.living_room'
-
 play_media:
   description: Send the media player the command for playing media.
   fields:

--- a/homeassistant/components/monoprice/const.py
+++ b/homeassistant/components/monoprice/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Monoprice 6-Zone Amplifier Media Player component."""
+
+DOMAIN = "monoprice"
+SERVICE_SNAPSHOT = "snapshot"
+SERVICE_RESTORE = "restore"

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
-    DOMAIN,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
@@ -21,6 +20,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 import homeassistant.helpers.config_validation as cv
+from .const import DOMAIN, SERVICE_RESTORE, SERVICE_SNAPSHOT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,9 +41,6 @@ CONF_ZONES = "zones"
 CONF_SOURCES = "sources"
 
 DATA_MONOPRICE = "monoprice"
-
-SERVICE_SNAPSHOT = "snapshot"
-SERVICE_RESTORE = "restore"
 
 # Valid zone ids: 11-16 or 21-26 or 31-36
 ZONE_IDS = vol.All(

--- a/homeassistant/components/monoprice/services.yaml
+++ b/homeassistant/components/monoprice/services.yaml
@@ -1,0 +1,13 @@
+snapshot:
+  description: Take a snapshot of the media player zone.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will be snapshot. Platform dependent.
+      example: 'media_player.living_room'
+
+restore:
+  description: Restore a snapshot of the media player zone.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will be restored. Platform dependent.
+      example: 'media_player.living_room'

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 
 from collections import defaultdict
 from homeassistant.components.media_player.const import (
-    DOMAIN,
     SUPPORT_TURN_ON,
     SUPPORT_TURN_OFF,
     SUPPORT_VOLUME_MUTE,
@@ -19,9 +18,12 @@ import tests.common
 from homeassistant.components.monoprice.media_player import (
     DATA_MONOPRICE,
     PLATFORM_SCHEMA,
-    SERVICE_SNAPSHOT,
-    SERVICE_RESTORE,
     setup_platform,
+)
+from homeassistant.components.monoprice.const import (
+    DOMAIN,
+    SERVICE_RESTORE,
+    SERVICE_SNAPSHOT,
 )
 import pytest
 


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `media_player.snapshot` and `media_player.restore` services by changing the service calls to be `monoprice.snapshot` and `monoprice.restore` respectively. My understanding is that because this is not a service provided by the base `media_player` component, it should live in the domain of the `monoprice` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `media_player.snapshot` and `media_player.restore`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11297

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
