### PR TITLE
Update service domain for bluesound from 'media_player' to 'bluesound'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -83,7 +83,7 @@ omit =
     homeassistant/components/blinkt/light.py
     homeassistant/components/blockchain/sensor.py
     homeassistant/components/bloomsky/*
-    homeassistant/components/bluesound/media_player.py
+    homeassistant/components/bluesound/*
     homeassistant/components/bluetooth_le_tracker/device_tracker.py
     homeassistant/components/bluetooth_tracker/device_tracker.py
     homeassistant/components/bme280/sensor.py

--- a/homeassistant/components/bluesound/const.py
+++ b/homeassistant/components/bluesound/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Bluesound HiFi wireless speakers and audio integrations component."""
+DOMAIN = "bluesound"
+SERVICE_CLEAR_TIMER = "clear_sleep_timer"
+SERVICE_JOIN = "join"
+SERVICE_SET_TIMER = "set_sleep_timer"
+SERVICE_UNJOIN = "unjoin"

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -15,7 +15,6 @@ import xmltodict
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_ENQUEUE,
-    DOMAIN,
     MEDIA_TYPE_MUSIC,
     SUPPORT_CLEAR_PLAYLIST,
     SUPPORT_NEXT_TRACK,
@@ -50,6 +49,13 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
+from .const import (
+    DOMAIN,
+    SERVICE_CLEAR_TIMER,
+    SERVICE_JOIN,
+    SERVICE_SET_TIMER,
+    SERVICE_UNJOIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,10 +68,6 @@ DEFAULT_PORT = 11000
 NODE_OFFLINE_CHECK_TIMEOUT = 180
 NODE_RETRY_INITIATION = timedelta(minutes=3)
 
-SERVICE_CLEAR_TIMER = "bluesound_clear_sleep_timer"
-SERVICE_JOIN = "bluesound_join"
-SERVICE_SET_TIMER = "bluesound_set_sleep_timer"
-SERVICE_UNJOIN = "bluesound_unjoin"
 STATE_GROUPED = "grouped"
 SYNC_STATUS_INTERVAL = timedelta(minutes=5)
 

--- a/homeassistant/components/bluesound/services.yaml
+++ b/homeassistant/components/bluesound/services.yaml
@@ -1,0 +1,30 @@
+join:
+  description: Group player together.
+  fields:
+    master:
+      description: Entity ID of the player that should become the master of the group.
+      example: 'media_player.bluesound_livingroom'
+    entity_id:
+      description: Name(s) of entities that will coordinate the grouping. Platform dependent.
+      example: 'media_player.bluesound_livingroom'
+
+unjoin:
+  description: Unjoin the player from a group.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will be unjoined from their group. Platform dependent.
+      example: 'media_player.bluesound_livingroom'
+
+set_sleep_timer:
+  description: "Set a Bluesound timer. It will increase timer in steps: 15, 30, 45, 60, 90, 0"
+  fields:
+    entity_id:
+      description: Name(s) of entities that will have a timer set.
+      example: 'media_player.bluesound_livingroom'
+
+clear_sleep_timer:
+  description: Clear a Bluesound timer.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will have the timer cleared.
+      example: 'media_player.bluesound_livingroom'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -258,37 +258,6 @@ yamaha_enable_output:
       description: Boolean indicating if port should be enabled or not.
       example: true
 
-bluesound_join:
-  description: Group player together.
-  fields:
-    master:
-      description: Entity ID of the player that should become the master of the group.
-      example: 'media_player.bluesound_livingroom'
-    entity_id:
-      description: Name(s) of entities that will coordinate the grouping. Platform dependent.
-      example: 'media_player.bluesound_livingroom'
-
-bluesound_unjoin:
-  description: Unjoin the player from a group.
-  fields:
-    entity_id:
-      description: Name(s) of entities that will be unjoined from their group. Platform dependent.
-      example: 'media_player.bluesound_livingroom'
-
-bluesound_set_sleep_timer:
-  description: "Set a Bluesound timer. It will increase timer in steps: 15, 30, 45, 60, 90, 0"
-  fields:
-    entity_id:
-      description: Name(s) of entities that will have a timer set.
-      example: 'media_player.bluesound_livingroom'
-
-bluesound_clear_sleep_timer:
-  description: Clear a Bluesound timer.
-  fields:
-    entity_id:
-      description: Name(s) of entities that will have the timer cleared.
-      example: 'media_player.bluesound_livingroom'
-
 songpal_set_sound_setting:
   description: Change sound setting.
 


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `media_player.bluesound_*` services by changing the service calls to be `bluesound.*`. My understanding is that because this is not a service provided by the base `media_player` component, it should live in the domain of the `bluesound` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `media_player.bluesound_*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11300

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
