### PR TITLE
Update service domain for blackbird from 'media_player' to 'blackbird'

### DIFF
--- a/homeassistant/components/blackbird/const.py
+++ b/homeassistant/components/blackbird/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Monoprice Blackbird Matrix Switch component."""
+DOMAIN = "blackbird"
+SERVICE_SETALLZONES = "set_all_zones"

--- a/homeassistant/components/blackbird/media_player.py
+++ b/homeassistant/components/blackbird/media_player.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
-    DOMAIN,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
@@ -23,6 +22,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 import homeassistant.helpers.config_validation as cv
+from .const import DOMAIN, SERVICE_SETALLZONES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +39,6 @@ CONF_SOURCES = "sources"
 
 DATA_BLACKBIRD = "blackbird"
 
-SERVICE_SETALLZONES = "blackbird_set_all_zones"
 ATTR_SOURCE = "source"
 
 BLACKBIRD_SETALLZONES_SCHEMA = MEDIA_PLAYER_SCHEMA.extend(

--- a/homeassistant/components/blackbird/services.yaml
+++ b/homeassistant/components/blackbird/services.yaml
@@ -1,0 +1,10 @@
+set_all_zones:
+  description: Set all Blackbird zones to a single source.
+  fields:
+    entity_id:
+      description: Name of any blackbird zone.
+      example: 'media_player.zone_1'
+    source:
+      description: Name of source to switch to.
+      example: 'Source 1'
+

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -258,37 +258,6 @@ yamaha_enable_output:
       description: Boolean indicating if port should be enabled or not.
       example: true
 
-bluesound_join:
-  description: Group player together.
-  fields:
-    master:
-      description: Entity ID of the player that should become the master of the group.
-      example: 'media_player.bluesound_livingroom'
-    entity_id:
-      description: Name(s) of entities that will coordinate the grouping. Platform dependent.
-      example: 'media_player.bluesound_livingroom'
-
-bluesound_unjoin:
-  description: Unjoin the player from a group.
-  fields:
-    entity_id:
-      description: Name(s) of entities that will be unjoined from their group. Platform dependent.
-      example: 'media_player.bluesound_livingroom'
-
-bluesound_set_sleep_timer:
-  description: "Set a Bluesound timer. It will increase timer in steps: 15, 30, 45, 60, 90, 0"
-  fields:
-    entity_id:
-      description: Name(s) of entities that will have a timer set.
-      example: 'media_player.bluesound_livingroom'
-
-bluesound_clear_sleep_timer:
-  description: Clear a Bluesound timer.
-  fields:
-    entity_id:
-      description: Name(s) of entities that will have the timer cleared.
-      example: 'media_player.bluesound_livingroom'
-
 songpal_set_sound_setting:
   description: Change sound setting.
 
@@ -302,16 +271,6 @@ songpal_set_sound_setting:
     value:
       description: Value to set.
       example: 'on'
-
-blackbird_set_all_zones:
-  description: Set all Blackbird zones to a single source.
-  fields:
-    entity_id:
-      description: Name of any blackbird zone.
-      example: 'media_player.zone_1'
-    source:
-      description: Name of source to switch to.
-      example: 'Source 1'
 
 epson_select_cmode:
   description: Select Color mode of Epson projector

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -258,6 +258,37 @@ yamaha_enable_output:
       description: Boolean indicating if port should be enabled or not.
       example: true
 
+bluesound_join:
+  description: Group player together.
+  fields:
+    master:
+      description: Entity ID of the player that should become the master of the group.
+      example: 'media_player.bluesound_livingroom'
+    entity_id:
+      description: Name(s) of entities that will coordinate the grouping. Platform dependent.
+      example: 'media_player.bluesound_livingroom'
+
+bluesound_unjoin:
+  description: Unjoin the player from a group.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will be unjoined from their group. Platform dependent.
+      example: 'media_player.bluesound_livingroom'
+
+bluesound_set_sleep_timer:
+  description: "Set a Bluesound timer. It will increase timer in steps: 15, 30, 45, 60, 90, 0"
+  fields:
+    entity_id:
+      description: Name(s) of entities that will have a timer set.
+      example: 'media_player.bluesound_livingroom'
+
+bluesound_clear_sleep_timer:
+  description: Clear a Bluesound timer.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will have the timer cleared.
+      example: 'media_player.bluesound_livingroom'
+
 songpal_set_sound_setting:
   description: Change sound setting.
 

--- a/tests/components/blackbird/test_media_player.py
+++ b/tests/components/blackbird/test_media_player.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 
 from collections import defaultdict
 from homeassistant.components.media_player.const import (
-    DOMAIN,
     SUPPORT_TURN_ON,
     SUPPORT_TURN_OFF,
     SUPPORT_SELECT_SOURCE,
@@ -16,9 +15,9 @@ import tests.common
 from homeassistant.components.blackbird.media_player import (
     DATA_BLACKBIRD,
     PLATFORM_SCHEMA,
-    SERVICE_SETALLZONES,
     setup_platform,
 )
+from homeassistant.components.blackbird.const import DOMAIN, SERVICE_SETALLZONES
 import pytest
 
 


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `media_player.blackbird_set_all_zones` services by changing the service calls to be `blackbird.set_all_zones`. My understanding is that because this is not a service provided by the base `media_player` component, it should live in the domain of the `blackbird` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `media_player.blackbird_set_all_zones`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11299

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
