### PR TITLE
Remove the alarm_control_panel CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,6 @@ homeassistant/components/abode/* @shred86
 homeassistant/components/adguard/* @frenck
 homeassistant/components/airly/* @bieniu
 homeassistant/components/airvisual/* @bachya
-homeassistant/components/alarm_control_panel/* @colinodell
 homeassistant/components/alexa/* @home-assistant/cloud @ochlocracy
 homeassistant/components/almond/* @gcampax @balloob
 homeassistant/components/alpha_vantage/* @fabaff

--- a/homeassistant/components/alarm_control_panel/manifest.json
+++ b/homeassistant/components/alarm_control_panel/manifest.json
@@ -4,7 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/alarm_control_panel",
   "requirements": [],
   "dependencies": [],
-  "codeowners": [
-    "@colinodell"
-  ]
+  "codeowners": []
 }


### PR DESCRIPTION
Although I originally contributed the [manual alarm with MQTT control](https://www.home-assistant.io/integrations/manual_mqtt), I no longer use it myself and haven't been following the internal development of HA, so I'm no longer a good person to review any further changes to this component.  I would therefore like to relinquish my CODEOWNER status over this component.