### PR TITLE
Bayesian binary sensor delay_on, delay_off and max duration

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -36,6 +36,7 @@ CONF_P_GIVEN_T = "prob_given_true"
 CONF_TO_STATE = "to_state"
 CONF_DELAY_ON = "delay_on"
 CONF_DELAY_OFF = "delay_off"
+CONF_MAX_DURATION = "max_duration"
 
 DEFAULT_NAME = "Bayesian Binary Sensor"
 DEFAULT_PROBABILITY_THRESHOLD = 0.5
@@ -50,6 +51,7 @@ NUMERIC_STATE_SCHEMA = vol.Schema(
         vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float),
         vol.Optional(CONF_DELAY_ON): vol.All(cv.time_period, cv.positive_timedelta),
         vol.Optional(CONF_DELAY_OFF): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_MAX_DURATION): vol.All(cv.time_period, cv.positive_timedelta),
     },
     required=True,
 )
@@ -63,6 +65,7 @@ STATE_SCHEMA = vol.Schema(
         vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float),
         vol.Optional(CONF_DELAY_ON): vol.All(cv.time_period, cv.positive_timedelta),
         vol.Optional(CONF_DELAY_OFF): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_MAX_DURATION): vol.All(cv.time_period, cv.positive_timedelta),
     },
     required=True,
 )
@@ -75,6 +78,7 @@ TEMPLATE_SCHEMA = vol.Schema(
         vol.Optional(CONF_P_GIVEN_F): vol.Coerce(float),
         vol.Optional(CONF_DELAY_ON): vol.All(cv.time_period, cv.positive_timedelta),
         vol.Optional(CONF_DELAY_OFF): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_MAX_DURATION): vol.All(cv.time_period, cv.positive_timedelta),
     },
     required=True,
 )

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -179,7 +179,10 @@ class BayesianBinarySensor(BinarySensorDevice):
                 platform = entity_obs["platform"]
 
                 should_trigger = self.watchers[platform](entity_obs)
-                self._update_current_obs(entity_obs, should_trigger)
+                if (should_trigger and entity_obs["id"] not in self.current_obs) or (
+                    not should_trigger and entity_obs["id"] in self.current_obs
+                ):
+                    self._update_current_obs(entity_obs, should_trigger)
 
         async_track_state_change(
             self.hass, self.entity_obs, async_threshold_sensor_state_listener
@@ -237,6 +240,7 @@ class BayesianBinarySensor(BinarySensorDevice):
                 )
             else:
                 add_to_current_obs()
+
             if max_duration:
                 if delay_on:
                     max_duration = max_duration + delay_on

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -199,6 +199,7 @@ class BayesianBinarySensor(BinarySensorDevice):
         obs_id = entity_observation["id"]
         delay_on = entity_observation.get("delay_on")
         delay_off = entity_observation.get("delay_off")
+        max_duration = entity_observation.get("max_duration")
 
         if entity_observation["platform"] == "template":
             entity_id = entity_observation.get(CONF_VALUE_TEMPLATE).extract_entities()
@@ -236,6 +237,19 @@ class BayesianBinarySensor(BinarySensorDevice):
                 )
             else:
                 add_to_current_obs()
+            if max_duration:
+                if delay_on:
+                    max_duration = max_duration + delay_on
+                async_track_same_state(
+                    self.hass,
+                    max_duration,
+                    pop_from_current_obs,
+                    entity_ids=entity_id,
+                    async_check_same_func=lambda *args: self.watchers[
+                        entity_observation["platform"]
+                    ](entity_observation)
+                    == should_trigger,
+                )
         else:
             if delay_off:
                 period = delay_off

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -19,9 +19,6 @@ from homeassistant.core import callback
 from homeassistant.helpers import condition
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change, async_track_same_state
-import logging
-
-_LOGGER = logging.getLogger(__name__)
 
 ATTR_OBSERVATIONS = "observations"
 ATTR_PROBABILITY = "probability"

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -908,8 +908,8 @@ async def test_state_max_duration(hass):
     )
     assert abs(0.3 - state.attributes.get("probability")) < 1e-7
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -919,8 +919,18 @@ async def test_state_max_duration(hass):
     )
     assert abs(0.5 - state.attributes.get("probability")) < 1e-7
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = newtime + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+    assert [] == state.attributes.get("observations")
+    assert abs(0.2 - state.attributes.get("probability")) < 1e-7
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.test_state", "off")
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -930,8 +940,8 @@ async def test_state_max_duration(hass):
     )
     assert abs(0.25 - state.attributes.get("probability")) < 1e-7
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = newtime + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -941,8 +951,8 @@ async def test_state_max_duration(hass):
     )
     assert abs(0.1 - state.attributes.get("probability")) < 1e-7
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = newtime + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -396,6 +396,75 @@ async def test_state_delay_on(hass):
     assert state.state == "off"
 
 
+async def test_state_delay_off(hass):
+    """Test binary sensor state delay off."""
+    config = {
+        "binary_sensor": {
+            "name": "test",
+            "platform": "bayesian",
+            "observations": [
+                {
+                    "platform": "state",
+                    "entity_id": "sensor.test_state",
+                    "to_state": "on",
+                    "prob_given_true": 0.8,
+                    "prob_given_false": 0.2,
+                    "delay_off": 5,
+                }
+            ],
+            "prior": 0.2,
+            "probability_threshold": 0.3,
+        }
+    }
+    await async_setup_component(hass, "binary_sensor", config)
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    # check with time changes
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+
 async def test_numeric_delay_on(hass):
     """Test binary sensor numeric delay on."""
     config = {
@@ -465,6 +534,75 @@ async def test_numeric_delay_on(hass):
     assert state.state == "off"
 
 
+async def test_numeric_delay_off(hass):
+    """Test binary sensor numeric delay off."""
+    config = {
+        "binary_sensor": {
+            "name": "test",
+            "platform": "bayesian",
+            "observations": [
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.test_state",
+                    "above": 10,
+                    "prob_given_true": 0.8,
+                    "prob_given_false": 0.2,
+                    "delay_off": 5,
+                }
+            ],
+            "prior": 0.2,
+            "probability_threshold": 0.3,
+        }
+    }
+    await async_setup_component(hass, "binary_sensor", config)
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state", 15)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", 5)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    # check with time changes
+    hass.states.async_set("sensor.test_state", 15)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", 5)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", 15)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+
 async def test_template_delay_on(hass):
     """Test binary sensor template delay on."""
     config = {
@@ -523,7 +661,7 @@ async def test_template_delay_on(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    hass.states.async_set("sensor.test_state1", "off")
+    hass.states.async_set("sensor.test_state2", "off")
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -535,3 +673,74 @@ async def test_template_delay_on(hass):
 
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
+
+
+async def test_template_delay_off(hass):
+    """Test binary sensor template delay off."""
+    config = {
+        "binary_sensor": {
+            "name": "test",
+            "platform": "bayesian",
+            "observations": [
+                {
+                    "platform": "template",
+                    "value_template": "{{ is_state('sensor.test_state1', 'on') "
+                    "and is_state('sensor.test_state2', 'on') }}",
+                    "prob_given_true": 0.8,
+                    "prob_given_false": 0.2,
+                    "delay_off": 5,
+                },
+            ],
+            "prior": 0.2,
+            "probability_threshold": 0.3,
+        }
+    }
+    await async_setup_component(hass, "binary_sensor", config)
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state1", "on")
+    hass.states.async_set("sensor.test_state2", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state1", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    # check with time changes
+    hass.states.async_set("sensor.test_state1", "on")
+    hass.states.async_set("sensor.test_state2", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state2", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state2", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -744,3 +744,105 @@ async def test_template_delay_off(hass):
 
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
+
+
+async def test_state_delay_on_off(hass):
+    """Test binary sensor numeric using both delay on and off."""
+    config = {
+        "binary_sensor": {
+            "name": "test",
+            "platform": "bayesian",
+            "observations": [
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.test_state",
+                    "above": 10,
+                    "prob_given_true": 0.8,
+                    "prob_given_false": 0.2,
+                    "delay_on": 5,
+                    "delay_off": 5,
+                }
+            ],
+            "prior": 0.2,
+            "probability_threshold": 0.3,
+        }
+    }
+    await async_setup_component(hass, "binary_sensor", config)
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state", 5)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", 15)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", 5)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    # check with time changes
+    hass.states.async_set("sensor.test_state", 15)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", 5)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", 15)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", 5)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", 15)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -362,8 +362,8 @@ async def test_state_delay_on(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -388,8 +388,8 @@ async def test_state_delay_on(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -431,8 +431,8 @@ async def test_state_delay_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -457,8 +457,8 @@ async def test_state_delay_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = newtime + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -500,8 +500,8 @@ async def test_numeric_delay_on(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -526,8 +526,8 @@ async def test_numeric_delay_on(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -569,8 +569,8 @@ async def test_numeric_delay_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -595,8 +595,8 @@ async def test_numeric_delay_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -640,8 +640,8 @@ async def test_template_delay_on(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -667,8 +667,8 @@ async def test_template_delay_on(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -711,8 +711,8 @@ async def test_template_delay_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -738,8 +738,8 @@ async def test_template_delay_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -782,8 +782,8 @@ async def test_state_delay_on_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -795,8 +795,8 @@ async def test_state_delay_on_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -815,8 +815,8 @@ async def test_state_delay_on_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -840,8 +840,8 @@ async def test_state_delay_on_off(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
+    newtime = dt_util.utcnow() + timedelta(seconds=5)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -878,7 +878,7 @@ async def test_state_max_duration(hass):
                     "to_state": "off",
                     "prob_given_true": 0.52,
                     "prob_given_false": 0.39,
-                    "max_duration": 5,
+                    "max_duration": 3,
                 },
                 {
                     "platform": "state",
@@ -886,7 +886,7 @@ async def test_state_max_duration(hass):
                     "to_state": "off",
                     "prob_given_true": 0.28,
                     "prob_given_false": 0.63,
-                    "delay_on": 5,
+                    "delay_on": 3,
                     "max_duration": 5,
                 },
             ],
@@ -928,7 +928,8 @@ async def test_state_max_duration(hass):
     assert [] == state.attributes.get("observations")
     assert abs(0.2 - state.attributes.get("probability")) < 1e-7
 
-    hass.states.async_set("sensor.test_state", "on")
+    newtime = newtime + timedelta(seconds=1)
+    async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_state", "off")
     await hass.async_block_till_done()
@@ -940,13 +941,13 @@ async def test_state_max_duration(hass):
     )
     assert abs(0.25 - state.attributes.get("probability")) < 1e-7
 
-    newtime = newtime + timedelta(seconds=5)
+    newtime = newtime + timedelta(seconds=3)
     async_fire_time_changed(hass, newtime)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
-    assert [{"prob_false": 0.28, "prob_true": 0.63}] == state.attributes.get(
+    assert [{"prob_false": 0.63, "prob_true": 0.28}] == state.attributes.get(
         "observations"
     )
     assert abs(0.1 - state.attributes.get("probability")) < 1e-7


### PR DESCRIPTION
## Description:
Adds support for 3 new keys for all types. delay_on and delay_off are exactly the same as the template sensor. max_duration does what the name says, an observation will never be on longer than this duration. Together these are here to prevent to have to create many entities for a single bayesian sensor. I have found that once my sensors get more complex I need these functions a lot, so I decided to add them.

I have also added tests for these and have added a test for the template platform which was missing.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11302

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: template
    name: bayesian
    prior: 0.2
    observations:
      - platform: state
        entity_id: input_boolean.test
        to_state: "on"
        prob_given_true: 0.9
        delay_off: 1
      - platform: state
        entity_id: input_boolean.test
        to_state: "off"
        prob_given_true: 0.8
        prob_given_false: 0.2
        max_duration: 5
      - platform: state
        entity_id: input_boolean.test
        to_state: "off"
        delay_on:
          seconds: 5
        prob_given_true: 0.52
        prob_given_false: 0.39
        max_duration: 5
      - platform: state
        entity_id: input_boolean.test
        to_state: "off"
        delay_on:
          seconds: 10
        prob_given_true: 0.01
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
