### PR TITLE
Bumped supported Apprise version to 0.8.2

### DIFF
--- a/homeassistant/components/apprise/manifest.json
+++ b/homeassistant/components/apprise/manifest.json
@@ -3,7 +3,7 @@
   "name": "Apprise",
   "documentation": "https://www.home-assistant.io/components/apprise",
   "requirements": [
-    "apprise==0.8.1"
+    "apprise==0.8.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -227,7 +227,7 @@ apcaccess==0.0.13
 apns2==0.3.0
 
 # homeassistant.components.apprise
-apprise==0.8.1
+apprise==0.8.2
 
 # homeassistant.components.aprs
 aprslib==0.6.46

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -87,7 +87,7 @@ androidtv==0.0.34
 apns2==0.3.0
 
 # homeassistant.components.apprise
-apprise==0.8.1
+apprise==0.8.2
 
 # homeassistant.components.aprs
 aprslib==0.6.46


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Bumped the version of Apprise to v0.8.2 which includes a few new services, bug-fixes and most importantly [a Discord issue that was affecting a lot of users](https://github.com/caronc/apprise/issues/179).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

