### PR TITLE
Update service domain for envisalink from 'alarm_control_panel' to 'envisalink'

### DIFF
--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -60,16 +60,6 @@ alarm_trigger:
       description: An optional code to trigger the alarm control panel with.
       example: 1234
 
-envisalink_alarm_keypress:
-  description: Send custom keypresses to the alarm.
-  fields:
-    entity_id:
-      description: Name of the alarm control panel to trigger.
-      example: 'alarm_control_panel.downstairs'
-    keypress:
-      description: 'String to send to the alarm panel (1-6 characters).'
-      example: '*71'
-
 alarmdecoder_alarm_toggle_chime:
   description: Send the alarm the toggle chime command.
   fields:

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -3,7 +3,10 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.components.alarm_control_panel as alarm
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanel,
+    FORMAT_NUMBER,
+)
 from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
     SUPPORT_ALARM_ARM_HOME,
@@ -29,6 +32,7 @@ from . import (
     CONF_PANIC,
     CONF_PARTITIONNAME,
     DATA_EVL,
+    DOMAIN,
     PARTITION_SCHEMA,
     SIGNAL_KEYPAD_UPDATE,
     SIGNAL_PARTITION_UPDATE,
@@ -37,7 +41,7 @@ from . import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_ALARM_KEYPRESS = "envisalink_alarm_keypress"
+SERVICE_ALARM_KEYPRESS = "alarm_keypress"
 ATTR_KEYPRESS = "keypress"
 ALARM_KEYPRESS_SCHEMA = vol.Schema(
     {
@@ -83,7 +87,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             device.async_alarm_keypress(keypress)
 
     hass.services.async_register(
-        alarm.DOMAIN,
+        DOMAIN,
         SERVICE_ALARM_KEYPRESS,
         alarm_keypress_handler,
         schema=ALARM_KEYPRESS_SCHEMA,
@@ -92,7 +96,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     return True
 
 
-class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
+class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanel):
     """Representation of an Envisalink-based alarm panel."""
 
     def __init__(
@@ -124,7 +128,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
         """Regex for code format or None if no code is required."""
         if self._code:
             return None
-        return alarm.FORMAT_NUMBER
+        return FORMAT_NUMBER
 
     @property
     def state(self):

--- a/homeassistant/components/envisalink/services.yaml
+++ b/homeassistant/components/envisalink/services.yaml
@@ -1,5 +1,15 @@
 # Describes the format for available Envisalink services.
 
+alarm_keypress:
+  description: Send custom keypresses to the alarm.
+  fields:
+    entity_id:
+      description: Name of the alarm control panel to trigger.
+      example: 'alarm_control_panel.downstairs'
+    keypress:
+      description: 'String to send to the alarm panel (1-6 characters).'
+      example: '*71'
+
 invoke_custom_function:
   description: >
     Allows users with DSC panels to trigger a PGM output (1-4).


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `alarm_control_panel.envisalink_alarm_keypress` services by changing the service calls to be `envisalink.alarm_keypress`. My understanding is that because this is not a service provided by the base `alarm_control_panel` component, it should live in the domain of the `envisalink` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `envisalink.alarm_keypress`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11303

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
