### PR TITLE
Fix Huawei LTE empty WiFi host list handling

### DIFF
--- a/homeassistant/components/huawei_lte/manifest.json
+++ b/homeassistant/components/huawei_lte/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/huawei_lte",
   "requirements": [
     "getmac==0.8.1",
-    "huawei-lte-api==1.4.3",
+    "huawei-lte-api==1.4.4",
     "stringcase==1.2.0",
     "url-normalize==1.4.1"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -678,7 +678,7 @@ horimote==0.4.1
 httplib2==0.10.3
 
 # homeassistant.components.huawei_lte
-huawei-lte-api==1.4.3
+huawei-lte-api==1.4.4
 
 # homeassistant.components.hydrawise
 hydrawiser==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -242,7 +242,7 @@ homematicip==0.10.13
 httplib2==0.10.3
 
 # homeassistant.components.huawei_lte
-huawei-lte-api==1.4.3
+huawei-lte-api==1.4.4
 
 # homeassistant.components.iaqualink
 iaqualink==0.3.0


### PR DESCRIPTION
## Description:

Fixes an issue with an empty WiFi clients listing with some router models and scenarios.

The issue essentially makes the integration inoperable in affected setups, so a point release with this would be welcome. Not sure what's the proper way to ask it.

https://github.com/Salamek/huawei-lte-api/releases/tag/1.4.4

**Related issue (if applicable):** fixes #28922

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
