### PR TITLE
Update service domain for todoist from 'calendar' to 'todoist'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -692,6 +692,7 @@ omit =
     homeassistant/components/tile/device_tracker.py
     homeassistant/components/time_date/sensor.py
     homeassistant/components/todoist/calendar.py
+    homeassistant/components/todoist/const.py
     homeassistant/components/tof/sensor.py
     homeassistant/components/tomato/device_tracker.py
     homeassistant/components/toon/*

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -1,26 +1,2 @@
 # Describes the format for available calendar services
 
-todoist_new_task:
-  description: Create a new task and add it to a project.
-  fields:
-    content:
-      description: The name of the task.
-      example: Pick up the mail
-    project:
-      description: The name of the project this task should belong to. Defaults to Inbox.
-      example: Errands
-    labels:
-      description: Any labels that you want to apply to this task, separated by a comma.
-      example: Chores,Deliveries
-    priority:
-      description: The priority of this task, from 1 (normal) to 4 (urgent).
-      example: 2
-    due_date_string:
-      description: The day this task is due, in natural language.
-      example: "tomorrow"
-    due_date_lang:
-      description: The language of due_date_string.
-      example: "en"
-    due_date:
-      description: The day this task is due, in format YYYY-MM-DD.
-      example: "2018-04-01"

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -5,96 +5,48 @@ import logging
 from todoist.api import TodoistAPI
 import voluptuous as vol
 
-from homeassistant.components.calendar import (
-    DOMAIN,
-    PLATFORM_SCHEMA,
-    CalendarEventDevice,
-)
+from homeassistant.components.calendar import PLATFORM_SCHEMA, CalendarEventDevice
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TOKEN
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util import Throttle, dt
 
+from .const import (
+    ALL_DAY,
+    ALL_TASKS,
+    CHECKED,
+    COMPLETED,
+    CONF_PROJECT_DUE_DATE,
+    CONF_EXTRA_PROJECTS,
+    CONF_PROJECT_LABEL_WHITELIST,
+    CONF_PROJECT_WHITELIST,
+    CONTENT,
+    DATETIME,
+    DESCRIPTION,
+    DOMAIN,
+    DUE,
+    DUE_DATE,
+    DUE_DATE_LANG,
+    DUE_DATE_STRING,
+    DUE_DATE_UTC,
+    DUE_DATE_VALID_LANGS,
+    DUE_TODAY,
+    END,
+    ID,
+    LABELS,
+    NAME,
+    OVERDUE,
+    PRIORITY,
+    PROJECT_ID,
+    PROJECT_NAME,
+    PROJECTS,
+    SERVICE_NEW_TASK,
+    START,
+    SUMMARY,
+    TASKS,
+)
+
 _LOGGER = logging.getLogger(__name__)
-
-CONF_EXTRA_PROJECTS = "custom_projects"
-CONF_PROJECT_DUE_DATE = "due_date_days"
-CONF_PROJECT_LABEL_WHITELIST = "labels"
-CONF_PROJECT_WHITELIST = "include_projects"
-
-# Calendar Platform: Does this calendar event last all day?
-ALL_DAY = "all_day"
-# Attribute: All tasks in this project
-ALL_TASKS = "all_tasks"
-# Todoist API: "Completed" flag -- 1 if complete, else 0
-CHECKED = "checked"
-# Attribute: Is this task complete?
-COMPLETED = "completed"
-# Todoist API: What is this task about?
-# Service Call: What is this task about?
-CONTENT = "content"
-# Calendar Platform: Get a calendar event's description
-DESCRIPTION = "description"
-# Calendar Platform: Used in the '_get_date()' method
-DATETIME = "dateTime"
-DUE = "due"
-# Service Call: When is this task due (in natural language)?
-DUE_DATE_STRING = "due_date_string"
-# Service Call: The language of DUE_DATE_STRING
-DUE_DATE_LANG = "due_date_lang"
-# Service Call: The available options of DUE_DATE_LANG
-DUE_DATE_VALID_LANGS = [
-    "en",
-    "da",
-    "pl",
-    "zh",
-    "ko",
-    "de",
-    "pt",
-    "ja",
-    "it",
-    "fr",
-    "sv",
-    "ru",
-    "es",
-    "nl",
-]
-# Attribute: When is this task due?
-# Service Call: When is this task due?
-DUE_DATE = "due_date"
-# Todoist API: Look up a task's due date
-DUE_DATE_UTC = "due_date_utc"
-# Attribute: Is this task due today?
-DUE_TODAY = "due_today"
-# Calendar Platform: When a calendar event ends
-END = "end"
-# Todoist API: Look up a Project/Label/Task ID
-ID = "id"
-# Todoist API: Fetch all labels
-# Service Call: What are the labels attached to this task?
-LABELS = "labels"
-# Todoist API: "Name" value
-NAME = "name"
-# Attribute: Is this task overdue?
-OVERDUE = "overdue"
-# Attribute: What is this task's priority?
-# Todoist API: Get a task's priority
-# Service Call: What is this task's priority?
-PRIORITY = "priority"
-# Todoist API: Look up the Project ID a Task belongs to
-PROJECT_ID = "project_id"
-# Service Call: What Project do you want a Task added to?
-PROJECT_NAME = "project"
-# Todoist API: Fetch all Projects
-PROJECTS = "projects"
-# Calendar Platform: When does a calendar event start?
-START = "start"
-# Calendar Platform: What is the next calendar event about?
-SUMMARY = "summary"
-# Todoist API: Fetch all Tasks
-TASKS = "items"
-
-SERVICE_NEW_TASK = "todoist_new_task"
 
 NEW_TASK_SERVICE_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -28,7 +28,6 @@ from .const import (
     DUE_DATE,
     DUE_DATE_LANG,
     DUE_DATE_STRING,
-    DUE_DATE_UTC,
     DUE_DATE_VALID_LANGS,
     DUE_TODAY,
     END,

--- a/homeassistant/components/todoist/const.py
+++ b/homeassistant/components/todoist/const.py
@@ -44,8 +44,6 @@ DUE_DATE_VALID_LANGS = [
 # Attribute: When is this task due?
 # Service Call: When is this task due?
 DUE_DATE = "due_date"
-# Todoist API: Look up a task's due date
-DUE_DATE_UTC = "due_date_utc"
 # Attribute: Is this task due today?
 DUE_TODAY = "due_today"
 # Calendar Platform: When a calendar event ends

--- a/homeassistant/components/todoist/const.py
+++ b/homeassistant/components/todoist/const.py
@@ -1,0 +1,81 @@
+"""Constants for the Todoist component."""
+CONF_EXTRA_PROJECTS = "custom_projects"
+CONF_PROJECT_DUE_DATE = "due_date_days"
+CONF_PROJECT_LABEL_WHITELIST = "labels"
+CONF_PROJECT_WHITELIST = "include_projects"
+
+# Calendar Platform: Does this calendar event last all day?
+ALL_DAY = "all_day"
+# Attribute: All tasks in this project
+ALL_TASKS = "all_tasks"
+# Todoist API: "Completed" flag -- 1 if complete, else 0
+CHECKED = "checked"
+# Attribute: Is this task complete?
+COMPLETED = "completed"
+# Todoist API: What is this task about?
+# Service Call: What is this task about?
+CONTENT = "content"
+# Calendar Platform: Get a calendar event's description
+DESCRIPTION = "description"
+# Calendar Platform: Used in the '_get_date()' method
+DATETIME = "dateTime"
+DUE = "due"
+# Service Call: When is this task due (in natural language)?
+DUE_DATE_STRING = "due_date_string"
+# Service Call: The language of DUE_DATE_STRING
+DUE_DATE_LANG = "due_date_lang"
+# Service Call: The available options of DUE_DATE_LANG
+DUE_DATE_VALID_LANGS = [
+    "en",
+    "da",
+    "pl",
+    "zh",
+    "ko",
+    "de",
+    "pt",
+    "ja",
+    "it",
+    "fr",
+    "sv",
+    "ru",
+    "es",
+    "nl",
+]
+# Attribute: When is this task due?
+# Service Call: When is this task due?
+DUE_DATE = "due_date"
+# Todoist API: Look up a task's due date
+DUE_DATE_UTC = "due_date_utc"
+# Attribute: Is this task due today?
+DUE_TODAY = "due_today"
+# Calendar Platform: When a calendar event ends
+END = "end"
+# Todoist API: Look up a Project/Label/Task ID
+ID = "id"
+# Todoist API: Fetch all labels
+# Service Call: What are the labels attached to this task?
+LABELS = "labels"
+# Todoist API: "Name" value
+NAME = "name"
+# Attribute: Is this task overdue?
+OVERDUE = "overdue"
+# Attribute: What is this task's priority?
+# Todoist API: Get a task's priority
+# Service Call: What is this task's priority?
+PRIORITY = "priority"
+# Todoist API: Look up the Project ID a Task belongs to
+PROJECT_ID = "project_id"
+# Service Call: What Project do you want a Task added to?
+PROJECT_NAME = "project"
+# Todoist API: Fetch all Projects
+PROJECTS = "projects"
+# Calendar Platform: When does a calendar event start?
+START = "start"
+# Calendar Platform: What is the next calendar event about?
+SUMMARY = "summary"
+# Todoist API: Fetch all Tasks
+TASKS = "items"
+
+DOMAIN = "todoist"
+
+SERVICE_NEW_TASK = "new_task"


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `calendar.todoist_new_task` services by changing the service calls to be `todoist.new_task`. My understanding is that because this is not a service provided by the base `calendar` component, it should live in the domain of the `todoist` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `todoist.new_task`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11306

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
