### PR TITLE
Update service domain for mill from 'climate' to 'mill'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -412,6 +412,7 @@ omit =
     homeassistant/components/miflora/sensor.py
     homeassistant/components/mikrotik/*
     homeassistant/components/mill/climate.py
+    homeassistant/components/mill/const.py
     homeassistant/components/minio/*
     homeassistant/components/mitemp_bt/sensor.py
     homeassistant/components/mjpeg/camera.py

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -72,22 +72,6 @@ set_swing_mode:
     swing_mode:
       description: New value of swing mode.
 
-mill_set_room_temperature:
-  description: Set Mill room temperatures.
-  fields:
-    room_name:
-      description: Name of room to change.
-      example: 'kitchen'
-    away_temp:
-      description: Away temp.
-      example: 12
-    comfort_temp:
-      description: Comfort temp.
-      example: 22
-    sleep_temp:
-      description: Sleep temp.
-      example: 17
-
 nuheat_resume_program:
   description: Resume the programmed schedule.
   fields:

--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
-    DOMAIN,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     SUPPORT_FAN_MODE,
@@ -22,15 +21,18 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-_LOGGER = logging.getLogger(__name__)
+from .const import (
+    ATTR_AWAY_TEMP,
+    ATTR_COMFORT_TEMP,
+    ATTR_ROOM_NAME,
+    ATTR_SLEEP_TEMP,
+    DOMAIN,
+    MAX_TEMP,
+    MIN_TEMP,
+    SERVICE_SET_ROOM_TEMP,
+)
 
-ATTR_AWAY_TEMP = "away_temp"
-ATTR_COMFORT_TEMP = "comfort_temp"
-ATTR_ROOM_NAME = "room_name"
-ATTR_SLEEP_TEMP = "sleep_temp"
-MAX_TEMP = 35
-MIN_TEMP = 5
-SERVICE_SET_ROOM_TEMP = "mill_set_room_temperature"
+_LOGGER = logging.getLogger(__name__)
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
 

--- a/homeassistant/components/mill/const.py
+++ b/homeassistant/components/mill/const.py
@@ -1,0 +1,10 @@
+"""Constants for the Mill heater component."""
+
+ATTR_AWAY_TEMP = "away_temp"
+ATTR_COMFORT_TEMP = "comfort_temp"
+ATTR_ROOM_NAME = "room_name"
+ATTR_SLEEP_TEMP = "sleep_temp"
+MAX_TEMP = 35
+MIN_TEMP = 5
+DOMAIN = "mill"
+SERVICE_SET_ROOM_TEMP = "set_room_temperature"

--- a/homeassistant/components/mill/services.yaml
+++ b/homeassistant/components/mill/services.yaml
@@ -1,0 +1,15 @@
+set_room_temperature:
+  description: Set Mill room temperatures.
+  fields:
+    room_name:
+      description: Name of room to change.
+      example: 'kitchen'
+    away_temp:
+      description: Away temp.
+      example: 12
+    comfort_temp:
+      description: Comfort temp.
+      example: 22
+    sleep_temp:
+      description: Sleep temp.
+      example: 17


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `climate.mill_set_room_temperature` services by changing the service calls to be `mill.set_room_temperature`. My understanding is that because this is not a service provided by the base `climate` component, it should live in the domain of the `mill` component instead. If that's the case, then it also makes sense to update the service name.

## Description:

Update the domain and service name for `mill.set_room_temperature`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11307

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
