### PR TITLE
Update service domain for wemo from 'fan' to 'wemo'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -768,7 +768,6 @@ omit =
     homeassistant/components/waze_travel_time/sensor.py
     homeassistant/components/webostv/*
     homeassistant/components/wemo/*
-    homeassistant/components/wemo/fan.py
     homeassistant/components/whois/sensor.py
     homeassistant/components/wink/*
     homeassistant/components/wirelesstag/*

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -194,20 +194,3 @@ xiaomi_miio_set_dry_off:
     entity_id:
       description: Name of the xiaomi miio entity.
       example: 'fan.xiaomi_miio_device'
-
-wemo_set_humidity:
-  description: Set the target humidity of WeMo humidifier devices.
-  fields:
-    entity_id:
-      description: Names of the WeMo humidifier entities (1 or more entity_ids are required).
-      example: 'fan.wemo_humidifier'
-    target_humidity:
-      description: Target humidity. This is a float value between 0 and 100, but will be mapped to the humidity levels that WeMo humidifiers support (45, 50, 55, 60, and 100/Max) by rounding the value down to the nearest supported value.
-      example: 56.5
-
-wemo_reset_filter_life:
-  description: Reset the WeMo Humidifier's filter life to 100%.
-  fields:
-    entity_id:
-      description: Names of the WeMo humidifier entities (1 or more entity_ids are required).
-      example: 'fan.wemo_humidifier'

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -11,8 +11,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
-
-DOMAIN = "wemo"
+from .const import DOMAIN
 
 # Mapping from Wemo model_name to component.
 WEMO_MODEL_DISPATCH = {

--- a/homeassistant/components/wemo/const.py
+++ b/homeassistant/components/wemo/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Belkin Wemo component."""
+DOMAIN = "wemo"
+
+SERVICE_SET_HUMIDITY = "set_humidity"
+SERVICE_RESET_FILTER_LIFE = "reset_filter_life"

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.fan import (
-    DOMAIN,
     SUPPORT_SET_SPEED,
     FanEntity,
     SPEED_OFF,
@@ -22,6 +21,7 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.const import ATTR_ENTITY_ID
 
 from . import SUBSCRIPTION_REGISTRY
+from .const import DOMAIN, SERVICE_RESET_FILTER_LIFE, SERVICE_SET_HUMIDITY
 
 SCAN_INTERVAL = timedelta(seconds=10)
 DATA_KEY = "fan.wemo"
@@ -79,8 +79,6 @@ HASS_FAN_SPEED_TO_WEMO = {
     if k not in [WEMO_FAN_LOW, WEMO_FAN_HIGH]
 }
 
-SERVICE_SET_HUMIDITY = "wemo_set_humidity"
-
 SET_HUMIDITY_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
@@ -89,8 +87,6 @@ SET_HUMIDITY_SCHEMA = vol.Schema(
         ),
     }
 )
-
-SERVICE_RESET_FILTER_LIFE = "wemo_reset_filter_life"
 
 RESET_FILTER_LIFE_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.entity_ids})
 

--- a/homeassistant/components/wemo/services.yaml
+++ b/homeassistant/components/wemo/services.yaml
@@ -1,0 +1,16 @@
+set_humidity:
+  description: Set the target humidity of WeMo humidifier devices.
+  fields:
+    entity_id:
+      description: Names of the WeMo humidifier entities (1 or more entity_ids are required).
+      example: 'fan.wemo_humidifier'
+    target_humidity:
+      description: Target humidity. This is a float value between 0 and 100, but will be mapped to the humidity levels that WeMo humidifiers support (45, 50, 55, 60, and 100/Max) by rounding the value down to the nearest supported value.
+      example: 56.5
+
+reset_filter_life:
+  description: Reset the WeMo Humidifier's filter life to 100%.
+  fields:
+    entity_id:
+      description: Names of the WeMo humidifier entities (1 or more entity_ids are required).
+      example: 'fan.wemo_humidifier'

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -12,7 +12,8 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import convert
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_STANDBY, STATE_UNKNOWN
 
-from . import SUBSCRIPTION_REGISTRY, DOMAIN as WEMO_DOMAIN
+from . import SUBSCRIPTION_REGISTRY
+from .const import DOMAIN
 
 SCAN_INTERVAL = timedelta(seconds=10)
 
@@ -96,7 +97,7 @@ class WemoSwitch(SwitchDevice):
     @property
     def device_info(self):
         """Return the device info."""
-        return {"name": self._name, "identifiers": {(WEMO_DOMAIN, self._serialnumber)}}
+        return {"name": self._name, "identifiers": {(DOMAIN, self._serialnumber)}}
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `fan.wemo_*` services by changing the service calls to be `wemo.*`.

## Description:

Update the domain and service name for `wemo.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11309

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
