### PR TITLE
Move nuki service to nuki domain services.yaml and remove missing service

### DIFF
--- a/homeassistant/components/lock/services.yaml
+++ b/homeassistant/components/lock/services.yaml
@@ -20,23 +20,6 @@ get_usercode:
       description: Code slot to retrieve a code from.
       example: 1
 
-nuki_lock_n_go:
-  description: "Nuki Lock 'n' Go"
-  fields:
-    entity_id:
-      description: Entity id of the Nuki lock.
-      example: 'lock.front_door'
-    unlatch:
-      description: Whether to unlatch the lock.
-      example: false
-
-nuki_unlatch:
-  description: Nuki unlatch.
-  fields:
-    entity_id:
-      description: Entity id of the Nuki lock.
-      example: 'lock.front_door'
-
 lock:
   description: Lock all or specified locks.
   fields:

--- a/homeassistant/components/nuki/services.yaml
+++ b/homeassistant/components/nuki/services.yaml
@@ -1,0 +1,10 @@
+lock_n_go:
+  description: "Nuki Lock 'n' Go"
+  fields:
+    entity_id:
+      description: Entity id of the Nuki lock.
+      example: 'lock.front_door'
+    unlatch:
+      description: Whether to unlatch the lock.
+      example: false
+


### PR DESCRIPTION
## Description:
Move nuki service to the correct services.yaml

**Related issue (if applicable):**Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A