### PR TITLE
Update service domain for channels from 'media_player' to 'channels'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -109,7 +109,7 @@ omit =
     homeassistant/components/cast/*
     homeassistant/components/cert_expiry/sensor.py
     homeassistant/components/cert_expiry/helper.py
-    homeassistant/components/channels/media_player.py
+    homeassistant/components/channels/*
     homeassistant/components/cisco_ios/device_tracker.py
     homeassistant/components/cisco_mobility_express/device_tracker.py
     homeassistant/components/cisco_webex_teams/notify.py

--- a/homeassistant/components/channels/const.py
+++ b/homeassistant/components/channels/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Channels component."""
+DOMAIN = "channels"
+SERVICE_SEEK_FORWARD = "seek_forward"
+SERVICE_SEEK_BACKWARD = "seek_backward"
+SERVICE_SEEK_BY = "seek_by"

--- a/homeassistant/components/channels/media_player.py
+++ b/homeassistant/components/channels/media_player.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
-    DOMAIN,
     MEDIA_TYPE_CHANNEL,
     MEDIA_TYPE_EPISODE,
     MEDIA_TYPE_MOVIE,
@@ -30,6 +29,8 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN, SERVICE_SEEK_BACKWARD, SERVICE_SEEK_BY, SERVICE_SEEK_FORWARD
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,9 +57,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-SERVICE_SEEK_FORWARD = "channels_seek_forward"
-SERVICE_SEEK_BACKWARD = "channels_seek_backward"
-SERVICE_SEEK_BY = "channels_seek_by"
 
 # Service call validation schemas
 ATTR_SECONDS = "seconds"

--- a/homeassistant/components/channels/services.yaml
+++ b/homeassistant/components/channels/services.yaml
@@ -1,0 +1,23 @@
+seek_forward:
+  description: Seek forward by a set number of seconds.
+  fields:
+    entity_id:
+      description: Name of entity for the instance of Channels to seek in.
+      example: 'media_player.family_room_channels'
+
+seek_backward:
+  description: Seek backward by a set number of seconds.
+  fields:
+    entity_id:
+      description: Name of entity for the instance of Channels to seek in.
+      example: 'media_player.family_room_channels'
+
+seek_by:
+  description: Seek by an inputted number of seconds.
+  fields:
+    entity_id:
+      description: Name of entity for the instance of Channels to seek in.
+      example: 'media_player.family_room_channels'
+    seconds:
+      description: Number of seconds to seek by. Negative numbers seek backwards.
+      example: 120

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -157,30 +157,6 @@ shuffle_set:
       description: True/false for enabling/disabling shuffle.
       example: true
 
-channels_seek_forward:
-  description: Seek forward by a set number of seconds.
-  fields:
-    entity_id:
-      description: Name of entity for the instance of Channels to seek in.
-      example: 'media_player.family_room_channels'
-
-channels_seek_backward:
-  description: Seek backward by a set number of seconds.
-  fields:
-    entity_id:
-      description: Name of entity for the instance of Channels to seek in.
-      example: 'media_player.family_room_channels'
-
-channels_seek_by:
-  description: Seek by an inputted number of seconds.
-  fields:
-    entity_id:
-      description: Name of entity for the instance of Channels to seek in.
-      example: 'media_player.family_room_channels'
-    seconds:
-      description: Number of seconds to seek by. Negative numbers seek backwards.
-      example: 120
-
 soundtouch_play_everywhere:
   description: Play on all Bose Soundtouch devices.
   fields:


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `media_player.channels_*` services by changing the service calls to be `channels.*`.

## Description:

Update the domain and service name for `channels.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11313

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
