### PR TITLE
Update service domain for squeezebox from 'media_player' to 'squeezebox'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -645,7 +645,7 @@ omit =
     homeassistant/components/spider/*
     homeassistant/components/spotcrime/sensor.py
     homeassistant/components/spotify/media_player.py
-    homeassistant/components/squeezebox/media_player.py
+    homeassistant/components/squeezebox/*
     homeassistant/components/starline/*
     homeassistant/components/starlingbank/sensor.py
     homeassistant/components/steam_online/sensor.py

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -218,19 +218,6 @@ soundtouch_remove_zone_slave:
       description: Name of slaves entities to remove from the existing zone.
       example: 'media_player.soundtouch_bedroom'
 
-squeezebox_call_method:
-  description: 'Call a Squeezebox JSON/RPC API method.'
-  fields:
-    entity_id:
-      description: Name(s) of the Squeexebox entities where to run the API method.
-      example: 'media_player.squeezebox_radio'
-    command:
-      description: Name of the Squeezebox command.
-      example: 'playlist'
-    parameters:
-      description: Optional array of parameters to be appended to the command. See 'Command Line Interface' official help page from Logitech for details.
-      example: '["loadtracks", "track.titlesearch=highway to hell"]'
-
 yamaha_enable_output:
   description: Enable or disable an output port
   fields:

--- a/homeassistant/components/squeezebox/const.py
+++ b/homeassistant/components/squeezebox/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Squeezebox component."""
+DOMAIN = "squeezebox"
+SERVICE_CALL_METHOD = "call_method"

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -12,7 +12,6 @@ import voluptuous as vol
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_ENQUEUE,
-    DOMAIN,
     MEDIA_TYPE_MUSIC,
     SUPPORT_CLEAR_PLAYLIST,
     SUPPORT_NEXT_TRACK,
@@ -44,6 +43,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util.dt import utcnow
 
+from .const import DOMAIN, SERVICE_CALL_METHOD
+
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 9000
@@ -74,8 +75,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_USERNAME): cv.string,
     }
 )
-
-SERVICE_CALL_METHOD = "squeezebox_call_method"
 
 DATA_SQUEEZEBOX = "squeezebox"
 

--- a/homeassistant/components/squeezebox/services.yaml
+++ b/homeassistant/components/squeezebox/services.yaml
@@ -1,4 +1,4 @@
-squeezebox_call_method:
+call_method:
   description: Call a custom Squeezebox JSONRPC API.
   fields:
     entity_id:
@@ -10,4 +10,3 @@ squeezebox_call_method:
     parameters:
       description: Array of additional parameters to pass to Logitech Media Server (p1, ..., pN in the CLI documentation).
       example: ["loadtracks", "album.titlesearch="]
- 


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `media_player.squeezebox_*` services by changing the service calls to be `squeezebox.*`.

## Description:

Update the domain and service name for `squeezebox.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11315

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
