### PR TITLE
Update service domain for songpal from 'media_player' to 'songpal'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -637,7 +637,7 @@ omit =
     homeassistant/components/somfy/*
     homeassistant/components/somfy_mylink/*
     homeassistant/components/sonarr/sensor.py
-    homeassistant/components/songpal/media_player.py
+    homeassistant/components/songpal/*
     homeassistant/components/sonos/*
     homeassistant/components/sony_projector/switch.py
     homeassistant/components/spc/*

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -243,17 +243,3 @@ yamaha_enable_output:
     enabled:
       description: Boolean indicating if port should be enabled or not.
       example: true
-
-songpal_set_sound_setting:
-  description: Change sound setting.
-
-  fields:
-    entity_id:
-      description: Target device.
-      example: 'media_player.my_soundbar'
-    name:
-      description: Name of the setting.
-      example: 'nightMode'
-    value:
-      description: Value to set.
-      example: 'on'

--- a/homeassistant/components/songpal/const.py
+++ b/homeassistant/components/songpal/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Songpal component."""
+DOMAIN = "songpal"
+SET_SOUND_SETTING = "set_sound_setting"

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -15,7 +15,6 @@ from songpal import (
 
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
-    DOMAIN,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
@@ -33,6 +32,8 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
+from .const import DOMAIN, SET_SOUND_SETTING
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ENDPOINT = "endpoint"
@@ -41,8 +42,6 @@ PARAM_NAME = "name"
 PARAM_VALUE = "value"
 
 PLATFORM = "songpal"
-
-SET_SOUND_SETTING = "songpal_set_sound_setting"
 
 SUPPORT_SONGPAL = (
     SUPPORT_VOLUME_SET

--- a/homeassistant/components/songpal/services.yaml
+++ b/homeassistant/components/songpal/services.yaml
@@ -1,0 +1,13 @@
+set_sound_setting:
+  description: Change sound setting.
+
+  fields:
+    entity_id:
+      description: Target device.
+      example: 'media_player.my_soundbar'
+    name:
+      description: Name of the setting.
+      example: 'nightMode'
+    value:
+      description: Value to set.
+      example: 'on'


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `media_player.songpal_*` services by changing the service calls to be `songpal.*`.

## Description:

Update the domain and service name for `songpal.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11317

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
