### PR TITLE
Update service domain for html5 from 'notify' to 'html5'

### DIFF
--- a/homeassistant/components/html5/const.py
+++ b/homeassistant/components/html5/const.py
@@ -1,0 +1,3 @@
+"""Constants for the HTML5 component."""
+DOMAIN = "html5"
+SERVICE_DISMISS = "dismiss"

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -34,16 +34,15 @@ from homeassistant.components.notify import (
     ATTR_TARGET,
     ATTR_TITLE,
     ATTR_TITLE_DEFAULT,
-    DOMAIN,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
 
+from .const import DOMAIN, SERVICE_DISMISS
+
 _LOGGER = logging.getLogger(__name__)
 
 REGISTRATIONS_FILE = "html5_push_registrations.conf"
-
-SERVICE_DISMISS = "html5_dismiss"
 
 ATTR_GCM_SENDER_ID = "gcm_sender_id"
 ATTR_GCM_API_KEY = "gcm_api_key"

--- a/homeassistant/components/html5/services.yaml
+++ b/homeassistant/components/html5/services.yaml
@@ -1,0 +1,9 @@
+dismiss:
+  description: Dismiss a html5 notification.
+  fields:
+    target:
+      description: An array of targets. Optional.
+      example: ['my_phone', 'my_tablet']
+    data:
+      description: Extended information of notification. Supports tag. Optional.
+      example: '{ "tag": "tagname" }'

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -16,16 +16,6 @@ notify:
       description: Extended information for notification. Optional depending on the platform.
       example: platform specific
 
-html5_dismiss:
-  description: Dismiss a html5 notification.
-  fields:
-    target:
-      description: An array of targets. Optional.
-      example: ['my_phone', 'my_tablet']
-    data:
-      description: Extended information of notification. Supports tag. Optional.
-      example: '{ "tag": "tagname" }'
-
 apns_register:
   description: Registers a device to receive push notifications.
   fields:


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `notify.html5_*` services by changing the service calls to be `html5.*`.

## Description:

Update the domain and service name for `html5.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11320

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
