### PR TITLE
Update service domain for harmony from 'remote' to 'harmony'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -284,7 +284,7 @@ omit =
     homeassistant/components/hangouts/hangouts_bot.py
     homeassistant/components/hangouts/hangups_utils.py
     homeassistant/components/harman_kardon_avr/media_player.py
-    homeassistant/components/harmony/remote.py
+    homeassistant/components/harmony/*
     homeassistant/components/haveibeenpwned/sensor.py
     homeassistant/components/hdmi_cec/*
     homeassistant/components/heatmiser/climate.py

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -1,4 +1,4 @@
 """Constants for the Harmony component."""
 DOMAIN = "harmony"
-SERVICE_SYNC = "harmony_sync"
-SERVICE_CHANGE_CHANNEL = "harmony_change_channel"
+SERVICE_SYNC = "sync"
+SERVICE_CHANGE_CHANNEL = "change_channel"

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -1,0 +1,4 @@
+"""Constants for the Harmony component."""
+DOMAIN = "harmony"
+SERVICE_SYNC = "harmony_sync"
+SERVICE_CHANGE_CHANNEL = "harmony_change_channel"

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -19,7 +19,6 @@ from homeassistant.components.remote import (
     ATTR_HOLD_SECS,
     ATTR_NUM_REPEATS,
     DEFAULT_DELAY_SECS,
-    DOMAIN,
     PLATFORM_SCHEMA,
 )
 from homeassistant.const import (
@@ -33,6 +32,8 @@ from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import slugify
 
+from .const import DOMAIN, SERVICE_CHANGE_CHANNEL, SERVICE_SYNC
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANNEL = "channel"
@@ -41,9 +42,6 @@ ATTR_CURRENT_ACTIVITY = "current_activity"
 DEFAULT_PORT = 8088
 DEVICES = []
 CONF_DEVICE_CACHE = "harmony_device_cache"
-
-SERVICE_SYNC = "harmony_sync"
-SERVICE_CHANGE_CHANNEL = "harmony_change_channel"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/harmony/services.yaml
+++ b/homeassistant/components/harmony/services.yaml
@@ -1,0 +1,16 @@
+sync:
+  description: Syncs the remote's configuration.
+  fields:
+    entity_id:
+      description: Name(s) of entities to sync.
+      example: 'remote.family_room'
+
+change_channel:
+  description: Sends change channel command to the Harmony HUB
+  fields:
+    entity_id:
+      description: Name(s) of Harmony remote entities to send change channel command to
+      example: 'remote.family_room'
+    channel:
+      description: Channel number to change to
+      example: '200'

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -65,24 +65,6 @@ learn_command:
       description: Timeout, in seconds, for the command to be learned.
       example: '30'
 
-
-harmony_sync:
-  description: Syncs the remote's configuration.
-  fields:
-    entity_id:
-      description: Name(s) of entities to sync.
-      example: 'remote.family_room'
-
-harmony_change_channel:
-  description: Sends change channel command to the Harmony HUB
-  fields:
-    entity_id:
-      description: Name(s) of Harmony remote entities to send change channel command to
-      example: 'remote.family_room'
-    channel:
-      description: Channel number to change to
-      example: '200'
-
 xiaomi_miio_learn_command:
   description: 'Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.'
   fields:


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `remote.harmony_*` services by changing the service calls to be `harmony.*`.

## Description:

Update the domain and service name for `harmony.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11321

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
