### PR TITLE
Update service domain for mysensors from 'switch' to 'mysensors'

### DIFF
--- a/homeassistant/components/mysensors/const.py
+++ b/homeassistant/components/mysensors/const.py
@@ -25,6 +25,8 @@ NODE_CALLBACK = "mysensors_node_callback_{}_{}"
 TYPE = "type"
 UPDATE_DELAY = 0.1
 
+SERVICE_SEND_IR_CODE = "send_ir_code"
+
 BINARY_SENSOR_TYPES = {
     "S_DOOR": {"V_TRIPPED"},
     "S_MOTION": {"V_TRIPPED"},

--- a/homeassistant/components/mysensors/services.yaml
+++ b/homeassistant/components/mysensors/services.yaml
@@ -1,0 +1,9 @@
+send_ir_code:
+  description: Set an IR code as a state attribute for a MySensors IR device switch and turn the switch on.
+  fields:
+    entity_id:
+      description: Name(s) of entities that should have the IR code set and be turned on. Platform dependent.
+      example: 'switch.living_room_1_1'
+    V_IR_SEND:
+      description: IR code to send.
+      example: '0xC284'

--- a/homeassistant/components/mysensors/switch.py
+++ b/homeassistant/components/mysensors/switch.py
@@ -6,8 +6,9 @@ from homeassistant.components import mysensors
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 
+from .const import DOMAIN as MYSENSORS_DOMAIN, SERVICE_SEND_IR_CODE
+
 ATTR_IR_CODE = "V_IR_SEND"
-SERVICE_SEND_IR_CODE = "mysensors_send_ir_code"
 
 SEND_IR_CODE_SERVICE_SCHEMA = vol.Schema(
     {vol.Optional(ATTR_ENTITY_ID): cv.entity_ids, vol.Required(ATTR_IR_CODE): cv.string}
@@ -64,7 +65,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             await device.async_turn_on(**kwargs)
 
     hass.services.async_register(
-        DOMAIN,
+        MYSENSORS_DOMAIN,
         SERVICE_SEND_IR_CODE,
         async_send_ir_code_service,
         schema=SEND_IR_CODE_SERVICE_SCHEMA,

--- a/homeassistant/components/switch/services.yaml
+++ b/homeassistant/components/switch/services.yaml
@@ -21,16 +21,6 @@ toggle:
       description: Name(s) of entities to toggle.
       example: 'switch.living_room'
 
-mysensors_send_ir_code:
-  description: Set an IR code as a state attribute for a MySensors IR device switch and turn the switch on.
-  fields:
-    entity_id:
-      description: Name(s) of entities that should have the IR code set and be turned on. Platform dependent.
-      example: 'switch.living_room_1_1'
-    V_IR_SEND:
-      description: IR code to send.
-      example: '0xC284'
-
 xiaomi_miio_set_wifi_led_on:
   description: Turn the wifi led on.
   fields:


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `switch.mysensors_*` services by changing the service calls to be `mysensors.*`.

## Description:

Update the domain and service name for `mysensors.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11331

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
