### PR TITLE
Update service domain for neato from 'vacuum' to 'neato'

### DIFF
--- a/homeassistant/components/neato/const.py
+++ b/homeassistant/components/neato/const.py
@@ -11,6 +11,8 @@ NEATO_ROBOTS = "neato_robots"
 
 SCAN_INTERVAL_MINUTES = 5
 
+SERVICE_NEATO_CUSTOM_CLEANING = "custom_cleaning"
+
 VALID_VENDORS = ["neato", "vorwerk"]
 
 MODE = {1: "Eco", 2: "Turbo"}

--- a/homeassistant/components/neato/services.yaml
+++ b/homeassistant/components/neato/services.yaml
@@ -1,0 +1,18 @@
+custom_cleaning:
+  description: Zone Cleaning service call specific to Neato Botvacs.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity. [Required]
+      example: 'vacuum.neato'
+    mode:
+      description: "Set the cleaning mode: 1 for eco and 2 for turbo. Defaults to turbo if not set."
+      example: 2
+    navigation:
+      description: "Set the navigation mode: 1 for normal, 2 for extra care, 3 for deep. Defaults to normal if not set."
+      example: 1
+    category:
+      description: "Whether to use a persistent map or not for cleaning (i.e. No go lines): 2 for no map, 4 for map. Default to using map if not set (and fallback to no map if no map is found)."
+      example: 2
+    zone:
+      description: Only supported on the Botvac D7. Name of the zone to clean. Defaults to no zone i.e. complete house cleanup.
+      example: "Kitchen"

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 
 from homeassistant.components.vacuum import (
     ATTR_STATUS,
-    DOMAIN,
     STATE_CLEANING,
     STATE_DOCKED,
     STATE_ERROR,
@@ -40,6 +39,7 @@ from .const import (
     NEATO_PERSISTENT_MAPS,
     NEATO_ROBOTS,
     SCAN_INTERVAL_MINUTES,
+    SERVICE_NEATO_CUSTOM_CLEANING,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -72,8 +72,6 @@ ATTR_LAUNCHED_FROM = "launched_from"
 ATTR_NAVIGATION = "navigation"
 ATTR_CATEGORY = "category"
 ATTR_ZONE = "zone"
-
-SERVICE_NEATO_CUSTOM_CLEANING = "neato_custom_cleaning"
 
 SERVICE_NEATO_CUSTOM_CLEANING_SCHEMA = vol.Schema(
     {
@@ -126,7 +124,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         return entities
 
     hass.services.async_register(
-        DOMAIN,
+        NEATO_DOMAIN,
         SERVICE_NEATO_CUSTOM_CLEANING,
         neato_custom_cleaning_service,
         schema=SERVICE_NEATO_CUSTOM_CLEANING_SCHEMA,

--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -144,22 +144,3 @@ xiaomi_clean_zone:
     repeats:
       description: Number of cleaning repeats for each zone between 1 and 3.
       example: '1'
-
-neato_custom_cleaning:
-  description: Zone Cleaning service call specific to Neato Botvacs.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity. [Required]
-      example: 'vacuum.neato'
-    mode:
-      description: "Set the cleaning mode: 1 for eco and 2 for turbo. Defaults to turbo if not set."
-      example: 2
-    navigation:
-      description: "Set the navigation mode: 1 for normal, 2 for extra care, 3 for deep. Defaults to normal if not set."
-      example: 1
-    category:
-      description: "Whether to use a persistent map or not for cleaning (i.e. No go lines): 2 for no map, 4 for map. Default to using map if not set (and fallback to no map if no map is found)."
-      example: 2
-    zone:
-      description: Only supported on the Botvac D7. Name of the zone to clean. Defaults to no zone i.e. complete house cleanup.
-      example: "Kitchen"


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `vacuum.neato_*` services by changing the service calls to be `neato.*`.

## Description:

Update the domain and service name for `neato.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11322

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
