### PR TITLE
Update service domain for econet from 'water_heater' to 'econet'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -178,7 +178,7 @@ omit =
     homeassistant/components/ecobee/notify.py
     homeassistant/components/ecobee/sensor.py
     homeassistant/components/ecobee/weather.py
-    homeassistant/components/econet/water_heater.py
+    homeassistant/components/econet/*
     homeassistant/components/ecovacs/*
     homeassistant/components/eddystone_temperature/sensor.py
     homeassistant/components/edimax/switch.py

--- a/homeassistant/components/econet/const.py
+++ b/homeassistant/components/econet/const.py
@@ -1,0 +1,5 @@
+"""Constants for Econet integration."""
+
+DOMAIN = "econet"
+SERVICE_ADD_VACATION = "add_vacation"
+SERVICE_DELETE_VACATION = "delete_vacation"

--- a/homeassistant/components/econet/services.yaml
+++ b/homeassistant/components/econet/services.yaml
@@ -1,0 +1,19 @@
+add_vacation:
+  description: Add a vacation to your water heater.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'water_heater.econet'
+    start_date:
+      description: The timestamp of when the vacation should start. (Optional, defaults to now)
+      example: 1513186320
+    end_date:
+      description: The timestamp of when the vacation should end.
+      example: 1513445520
+
+delete_vacation:
+  description: Delete your existing vacation from your water heater.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'water_heater.econet'

--- a/homeassistant/components/econet/water_heater.py
+++ b/homeassistant/components/econet/water_heater.py
@@ -6,7 +6,6 @@ from pyeconet.api import PyEcoNet
 import voluptuous as vol
 
 from homeassistant.components.water_heater import (
-    DOMAIN,
     PLATFORM_SCHEMA,
     STATE_ECO,
     STATE_ELECTRIC,
@@ -28,6 +27,8 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
+from .const import DOMAIN, SERVICE_ADD_VACATION, SERVICE_DELETE_VACATION
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_VACATION_START = "next_vacation_start_date"
@@ -40,9 +41,6 @@ ATTR_START_DATE = "start_date"
 ATTR_END_DATE = "end_date"
 
 SUPPORT_FLAGS_HEATER = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
-
-SERVICE_ADD_VACATION = "econet_add_vacation"
-SERVICE_DELETE_VACATION = "econet_delete_vacation"
 
 ADD_VACATION_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/water_heater/services.yaml
+++ b/homeassistant/components/water_heater/services.yaml
@@ -29,23 +29,3 @@ set_operation_mode:
     operation_mode:
       description: New value of operation mode.
       example: eco
-
-econet_add_vacation:
-  description: Add a vacation to your water heater.
-  fields:
-    entity_id:
-      description: Name(s) of entities to change.
-      example: 'water_heater.econet'
-    start_date:
-      description: The timestamp of when the vacation should start. (Optional, defaults to now)
-      example: 1513186320
-    end_date:
-      description: The timestamp of when the vacation should end.
-      example: 1513445520
-
-econet_delete_vacation:
-  description: Delete your existing vacation from your water heater.
-  fields:
-    entity_id:
-      description: Name(s) of entities to change.
-      example: 'water_heater.econet'


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `water_heater.econet_*` services by changing the service calls to be `econet.*`.

## Description:

Update the domain and service name for `econet.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A as the docs already mistakenly indicated that the services were in the econet domain

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
