### PR TITLE
Update service domain for facebox from 'image_processing' to 'facebox'

### DIFF
--- a/homeassistant/components/facebox/const.py
+++ b/homeassistant/components/facebox/const.py
@@ -1,0 +1,4 @@
+"""Constants for the Facebox component."""
+
+DOMAIN = "facebox"
+SERVICE_TEACH_FACE = "teach_face"

--- a/homeassistant/components/facebox/image_processing.py
+++ b/homeassistant/components/facebox/image_processing.py
@@ -15,7 +15,6 @@ from homeassistant.components.image_processing import (
     CONF_SOURCE,
     CONF_ENTITY_ID,
     CONF_NAME,
-    DOMAIN,
 )
 from homeassistant.const import (
     CONF_IP_ADDRESS,
@@ -26,6 +25,8 @@ from homeassistant.const import (
     HTTP_OK,
     HTTP_UNAUTHORIZED,
 )
+
+from .const import DOMAIN, SERVICE_TEACH_FACE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +39,6 @@ FACEBOX_NAME = "name"
 CLASSIFIER = "facebox"
 DATA_FACEBOX = "facebox_classifiers"
 FILE_PATH = "file_path"
-SERVICE_TEACH_FACE = "facebox_teach_face"
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/facebox/services.yaml
+++ b/homeassistant/components/facebox/services.yaml
@@ -1,0 +1,12 @@
+teach_face:
+  description: Teach facebox a face using a file.
+  fields:
+    entity_id:
+      description: The facebox entity to teach.
+      example: 'image_processing.facebox'
+    name:
+      description: The name of the face to teach.
+      example: 'my_name'
+    file_path:
+      description: The path to the image file.
+      example: '/images/my_image.jpg'

--- a/homeassistant/components/image_processing/services.yaml
+++ b/homeassistant/components/image_processing/services.yaml
@@ -6,16 +6,3 @@ scan:
     entity_id:
       description: Name(s) of entities to scan immediately.
       example: 'image_processing.alpr_garage'
-
-facebox_teach_face:
-  description: Teach facebox a face using a file.
-  fields:
-    entity_id:
-      description: The facebox entity to teach.
-      example: 'image_processing.facebox'
-    name:
-      description: The name of the face to teach.
-      example: 'my_name'
-    file_path:
-      description: The path to the image file.
-      example: '/images/my_image.jpg'

--- a/tests/components/facebox/test_image_processing.py
+++ b/tests/components/facebox/test_image_processing.py
@@ -261,7 +261,7 @@ async def test_teach_service(
             fb.FILE_PATH: MOCK_FILE_PATH,
         }
         await hass.services.async_call(
-            ip.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
+            fb.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
         )
         await hass.async_block_till_done()
 
@@ -275,7 +275,7 @@ async def test_teach_service(
             fb.FILE_PATH: MOCK_FILE_PATH,
         }
         await hass.services.async_call(
-            ip.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
+            fb.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
         )
         await hass.async_block_till_done()
         assert "AuthenticationError on facebox" in caplog.text
@@ -290,7 +290,7 @@ async def test_teach_service(
             fb.FILE_PATH: MOCK_FILE_PATH,
         }
         await hass.services.async_call(
-            ip.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
+            fb.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
         )
         await hass.async_block_till_done()
         assert MOCK_ERROR_NO_FACE in caplog.text
@@ -305,7 +305,7 @@ async def test_teach_service(
             fb.FILE_PATH: MOCK_FILE_PATH,
         }
         await hass.services.async_call(
-            ip.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
+            fb.DOMAIN, fb.SERVICE_TEACH_FACE, service_data=data
         )
         await hass.async_block_till_done()
         assert "ConnectionError: Is facebox running?" in caplog.text


### PR DESCRIPTION
## Breaking Change:

This change breaks existing service call references to the `image_processing.facebox_*` services by changing the service calls to be `facebox.*`.

## Description:

Update the domain and service name for `facebox.*`. See this comment for context: https://github.com/home-assistant/home-assistant/pull/28890#issuecomment-558485691

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11323

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
