### PR TITLE
Neato reduce API calls

### DIFF
--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -21,7 +21,6 @@ from .const import (
     NEATO_MAP_DATA,
     NEATO_PERSISTENT_MAPS,
     NEATO_ROBOTS,
-    SCAN_INTERVAL_MINUTES,
     VALID_VENDORS,
 )
 
@@ -161,7 +160,7 @@ class NeatoHub:
         self.logged_in = True
         _LOGGER.debug("Successfully connected to Neato API")
 
-    @Throttle(timedelta(minutes=SCAN_INTERVAL_MINUTES))
+    @Throttle(timedelta(minutes=1))
     def update_robots(self):
         """Update the robot states."""
         _LOGGER.debug("Running HUB.update_robots %s", self._hass.data.get(NEATO_ROBOTS))

--- a/homeassistant/components/neato/sensor.py
+++ b/homeassistant/components/neato/sensor.py
@@ -41,22 +41,14 @@ class NeatoSensor(Entity):
     def __init__(self, neato, robot):
         """Initialize Neato sensor."""
         self.robot = robot
-        self.neato = neato
-        self._available = self.neato.logged_in if self.neato is not None else False
+        self._available = neato.logged_in if neato is not None else False
         self._robot_name = f"{self.robot.name} {BATTERY}"
         self._robot_serial = self.robot.serial
         self._state = None
 
     def update(self):
         """Update Neato Sensor."""
-        if self.neato is None:
-            _LOGGER.error("Error while updating sensor")
-            self._state = None
-            self._available = False
-            return
-
         try:
-            self.neato.update_robots()
             self._state = self.robot.state
         except NeatoRobotException as ex:
             if self._available:

--- a/homeassistant/components/neato/switch.py
+++ b/homeassistant/components/neato/switch.py
@@ -45,8 +45,7 @@ class NeatoConnectedSwitch(ToggleEntity):
         """Initialize the Neato Connected switches."""
         self.type = switch_type
         self.robot = robot
-        self.neato = neato
-        self._available = self.neato.logged_in if self.neato is not None else False
+        self._available = neato.logged_in if neato is not None else False
         self._robot_name = f"{self.robot.name} {SWITCH_TYPES[self.type][0]}"
         self._state = None
         self._schedule_state = None
@@ -55,15 +54,8 @@ class NeatoConnectedSwitch(ToggleEntity):
 
     def update(self):
         """Update the states of Neato switches."""
-        if self.neato is None:
-            _LOGGER.error("Error while updating switches")
-            self._state = None
-            self._available = False
-            return
-
         _LOGGER.debug("Running switch update")
         try:
-            self.neato.update_robots()
             self._state = self.robot.state
         except NeatoRobotException as ex:
             if self._available:  # Print only once when available

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -313,13 +313,12 @@ class NeatoConnectedVacuum(StateVacuumDevice):
     @property
     def device_info(self):
         """Device info for neato robot."""
-        return {
-            "identifiers": {(NEATO_DOMAIN, self._robot_serial)},
-            "name": self._name,
-            "manufacturer": self._robot_stats["data"]["mfg_name"],
-            "model": self._robot_stats["data"]["modelName"],
-            "sw_version": self._state["meta"]["firmware"],
-        }
+        info = {"identifiers": {(NEATO_DOMAIN, self._robot_serial)}, "name": self._name}
+        if self._robot_stats:
+            info["manufacturer"] = self._robot_stats["data"]["mfg_name"]
+            info["model"] = self._robot_stats["data"]["modelName"]
+        if self._state:
+            info["sw_version"] = self._state["meta"]["firmware"]
 
     def start(self):
         """Start cleaning or resume cleaning."""

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -166,6 +166,10 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         try:
             if self._robot_stats is None:
                 self._robot_stats = self.robot.get_robot_info().json()
+        except NeatoRobotException:
+            _LOGGER.warning("Couldn't fetch robot information of %s", self._name)
+
+        try:
             self._state = self.robot.state
         except NeatoRobotException as ex:
             if self._available:  # print only once when available

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -137,8 +137,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
     def __init__(self, neato, robot, mapdata, persistent_maps):
         """Initialize the Neato Connected Vacuum."""
         self.robot = robot
-        self.neato = neato
-        self._available = self.neato.logged_in if self.neato is not None else False
+        self._available = neato.logged_in if neato is not None else False
         self._mapdata = mapdata
         self._name = f"{self.robot.name}"
         self._robot_has_map = self.robot.has_persistent_maps
@@ -163,17 +162,10 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
     def update(self):
         """Update the states of Neato Vacuums."""
-        if self.neato is None:
-            _LOGGER.error("Error while updating vacuum")
-            self._state = None
-            self._available = False
-            return
-
         _LOGGER.debug("Running Neato Vacuums update")
         try:
             if self._robot_stats is None:
                 self._robot_stats = self.robot.get_robot_info().json()
-            self.neato.update_robots()
             self._state = self.robot.state
         except NeatoRobotException as ex:
             if self._available:  # print only once when available


### PR DESCRIPTION
## Breaking Change:
Nothing breaks

## Description:
The neato integration does a lot of unnecessary api calls. We try to reduce them by caching requested data. This let us reduce the maximal number of updates.

**Related issue (if applicable):** related to: #29035

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
