### PR TITLE
add services.yaml description for nuimo_component service

### DIFF
--- a/homeassistant/components/nuimo_controller/services.yaml
+++ b/homeassistant/components/nuimo_controller/services.yaml
@@ -1,0 +1,18 @@
+led_matrix:
+  description: Sends an LED Matrix to your display
+  fields:
+    matrix:
+      description: "A string representation of the matrix to be displayed. See the SDK documentation for more info: https://github.com/getSenic/nuimo-linux-python#write-to-nuimos-led-matrix"
+      example:
+              '........
+              0000000.
+              .000000.
+              ..00000.
+              .0.0000.
+              .00.000.
+              .000000.
+              .000000.
+              ........'
+    interval:
+      description: Display interval in seconds
+      example: 0.5


### PR DESCRIPTION
## Description:
Add service and field descriptions for nuimo_component

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
