### PR TITLE
Update bluetooth_tracker service name and domain from 'device_tracker' to 'bluetooth_tracker'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -85,7 +85,7 @@ omit =
     homeassistant/components/bloomsky/*
     homeassistant/components/bluesound/*
     homeassistant/components/bluetooth_le_tracker/device_tracker.py
-    homeassistant/components/bluetooth_tracker/device_tracker.py
+    homeassistant/components/bluetooth_tracker/*
     homeassistant/components/bme280/sensor.py
     homeassistant/components/bme680/sensor.py
     homeassistant/components/bmw_connected_drive/*

--- a/homeassistant/components/bluetooth_tracker/const.py
+++ b/homeassistant/components/bluetooth_tracker/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Bluetooth Tracker component."""
+DOMAIN = "bluetooth_tracker"
+SERVICE_UPDATE = "update"

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -13,7 +13,6 @@ from homeassistant.components.device_tracker.const import (
     CONF_SCAN_INTERVAL,
     CONF_TRACK_NEW,
     DEFAULT_TRACK_NEW,
-    DOMAIN,
     SCAN_INTERVAL,
     SOURCE_TYPE_BLUETOOTH,
 )
@@ -25,6 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
 
+from .const import DOMAIN, SERVICE_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -184,8 +184,6 @@ async def async_setup_scanner(
     hass.async_create_task(update_bluetooth())
     async_track_time_interval(hass, update_bluetooth, interval)
 
-    hass.services.async_register(
-        DOMAIN, "bluetooth_tracker_update", handle_manual_update_bluetooth
-    )
+    hass.services.async_register(DOMAIN, SERVICE_UPDATE, handle_manual_update_bluetooth)
 
     return True

--- a/homeassistant/components/bluetooth_tracker/services.yaml
+++ b/homeassistant/components/bluetooth_tracker/services.yaml
@@ -1,0 +1,2 @@
+update:
+  description: Trigger manual tracker update


### PR DESCRIPTION
## Breaking Change:
The custom service name and domain for `bluetooth_tracker` changes from `device_tracker` to `bluetooth_tracker` domain

## Description:
As part of the effort to move custom services to their own domain

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
