### PR TITLE
move import to top and add service definition for pilight

### DIFF
--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -7,6 +7,8 @@ from datetime import timedelta
 
 import voluptuous as vol
 
+from pilight import pilight
+
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.util import dt as dt_util
 import homeassistant.helpers.config_validation as cv
@@ -18,8 +20,6 @@ from homeassistant.const import (
     CONF_WHITELIST,
     CONF_PROTOCOL,
 )
-
-from pilight import pilight
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -19,6 +19,8 @@ from homeassistant.const import (
     CONF_PROTOCOL,
 )
 
+from pilight import pilight
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SEND_DELAY = "send_delay"
@@ -59,7 +61,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the Pilight component."""
-    from pilight import pilight
 
     host = config[DOMAIN][CONF_HOST]
     port = config[DOMAIN][CONF_PORT]

--- a/homeassistant/components/pilight/services.yaml
+++ b/homeassistant/components/pilight/services.yaml
@@ -1,0 +1,6 @@
+send:
+  description: Send RF code to Pilight device
+  fields:
+    protocol:
+      description: 'Protocol that Pilight recognizes. See https://manual.pilight.org/protocols/index.html for supported protocols and additional parameters that each protocol supports'
+      example: 'lirc'


### PR DESCRIPTION
## Description:
Move pilight import outside of initialization method and add service description for `send`

**Related issue (if applicable):** Related to #27289

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A
