### PR TITLE
update demo service domain and service description

### DIFF
--- a/homeassistant/components/demo/const.py
+++ b/homeassistant/components/demo/const.py
@@ -1,3 +1,3 @@
 """Constants for the Demo component."""
 DOMAIN = "demo"
-SERVICE_DEMO = "randomize_device_tracker_data"
+SERVICE_RANDOMIZE_DEVICE_TRACKER_DATA = "randomize_device_tracker_data"

--- a/homeassistant/components/demo/const.py
+++ b/homeassistant/components/demo/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Demo component."""
+DOMAIN = "demo"
+SERVICE_DEMO = "demo"

--- a/homeassistant/components/demo/const.py
+++ b/homeassistant/components/demo/const.py
@@ -1,3 +1,3 @@
 """Constants for the Demo component."""
 DOMAIN = "demo"
-SERVICE_DEMO = "demo"
+SERVICE_DEMO = "randomize_device_tracker_data"

--- a/homeassistant/components/demo/device_tracker.py
+++ b/homeassistant/components/demo/device_tracker.py
@@ -1,7 +1,7 @@
 """Demo platform for the Device tracker component."""
 import random
 
-from .const import DOMAIN, SERVICE_DEMO
+from .const import DOMAIN, SERVICE_RANDOMIZE_DEVICE_TRACKER_DATA
 
 
 def setup_scanner(hass, config, see, discovery_info=None):
@@ -36,6 +36,6 @@ def setup_scanner(hass, config, see, discovery_info=None):
         battery=53,
     )
 
-    hass.services.register(DOMAIN, SERVICE_DEMO, observe)
+    hass.services.register(DOMAIN, SERVICE_RANDOMIZE_DEVICE_TRACKER_DATA, observe)
 
     return True

--- a/homeassistant/components/demo/device_tracker.py
+++ b/homeassistant/components/demo/device_tracker.py
@@ -1,7 +1,7 @@
 """Demo platform for the Device tracker component."""
 import random
 
-from homeassistant.components.device_tracker import DOMAIN
+DOMAIN = "demo"
 
 
 def setup_scanner(hass, config, see, discovery_info=None):

--- a/homeassistant/components/demo/device_tracker.py
+++ b/homeassistant/components/demo/device_tracker.py
@@ -1,7 +1,7 @@
 """Demo platform for the Device tracker component."""
 import random
 
-DOMAIN = "demo"
+from .const import DOMAIN, SERVICE_DEMO
 
 
 def setup_scanner(hass, config, see, discovery_info=None):
@@ -36,6 +36,6 @@ def setup_scanner(hass, config, see, discovery_info=None):
         battery=53,
     )
 
-    hass.services.register(DOMAIN, "demo", observe)
+    hass.services.register(DOMAIN, SERVICE_DEMO, observe)
 
     return True

--- a/homeassistant/components/demo/services.yaml
+++ b/homeassistant/components/demo/services.yaml
@@ -1,2 +1,2 @@
-demo:
+randomize_device_tracker_data:
   description: Demonstrates using a device tracker to see where devices are located

--- a/homeassistant/components/demo/services.yaml
+++ b/homeassistant/components/demo/services.yaml
@@ -1,0 +1,2 @@
+demo:
+  description: Demonstrates using a device tracker to see where devices are located


### PR DESCRIPTION
## Breaking Change:

The `device_tracker.demo` service has been renamed and moved to `demo.randomize_device_tracker_data` under the `demo` domain from `device_tracker` domain.

## Description:
Added service description and moved `demo` to proper domain

**Related issue (if applicable):** Related to #27289
