### PR TITLE
Change apns service domain and remove unused variable

### DIFF
--- a/homeassistant/components/apns/const.py
+++ b/homeassistant/components/apns/const.py
@@ -1,0 +1,2 @@
+"""Constants for the apns component."""
+DOMAIN = "apns"

--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
-    DOMAIN,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
@@ -19,12 +18,12 @@ from homeassistant.helpers import template as template_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 
+DOMAIN = "apns"
 APNS_DEVICES = "apns.yaml"
 CONF_CERTFILE = "cert_file"
 CONF_TOPIC = "topic"
 CONF_SANDBOX = "sandbox"
 DEVICE_TRACKER_DOMAIN = "device_tracker"
-SERVICE_REGISTER = "apns_register"
 
 ATTR_PUSH_ID = "push_id"
 

--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -17,13 +17,14 @@ from homeassistant.const import ATTR_NAME, CONF_NAME, CONF_PLATFORM
 from homeassistant.helpers import template as template_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 
-DOMAIN = "apns"
+from .const import DOMAIN
+
 APNS_DEVICES = "apns.yaml"
 CONF_CERTFILE = "cert_file"
 CONF_TOPIC = "topic"
 CONF_SANDBOX = "sandbox"
-DEVICE_TRACKER_DOMAIN = "device_tracker"
 
 ATTR_PUSH_ID = "push_id"
 

--- a/tests/components/apns/test_notify.py
+++ b/tests/components/apns/test_notify.py
@@ -121,7 +121,7 @@ class TestApns(unittest.TestCase):
             self._setup_notify()
 
         assert self.hass.services.call(
-            notify.DOMAIN,
+            apns.DOMAIN,
             "apns_test_app",
             {"push_id": "1234", "name": "test device"},
             blocking=True,
@@ -153,7 +153,7 @@ class TestApns(unittest.TestCase):
             self._setup_notify()
 
         assert self.hass.services.call(
-            notify.DOMAIN, "apns_test_app", {"push_id": "1234"}, blocking=True
+            apns.DOMAIN, "apns_test_app", {"push_id": "1234"}, blocking=True
         )
 
         devices = {dev.push_id: dev for dev in written_devices}
@@ -183,7 +183,7 @@ class TestApns(unittest.TestCase):
             self._setup_notify()
 
         assert self.hass.services.call(
-            notify.DOMAIN,
+            apns.DOMAIN,
             "apns_test_app",
             {"push_id": "1234", "name": "updated device 1"},
             blocking=True,
@@ -222,7 +222,7 @@ class TestApns(unittest.TestCase):
             self._setup_notify()
 
         assert self.hass.services.call(
-            notify.DOMAIN,
+            apns.DOMAIN,
             "apns_test_app",
             {"push_id": "1234", "name": "updated device 1"},
             blocking=True,


### PR DESCRIPTION
## Breaking Change:

`apns` custom service moved from `notify` domain to `apns`

Docs: home-assistant/home-assistant.io#11333

## Description:
Service domain change as part of HA wide initiative to move services to proper domains

**Related issue (if applicable):** Related to 27289
