### PR TITLE
Move GoogleConfig initialization into setup of component

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -32,7 +32,7 @@ from .const import (
 )
 from .const import EVENT_COMMAND_RECEIVED, EVENT_SYNC_RECEIVED  # noqa: F401
 from .const import EVENT_QUERY_RECEIVED  # noqa: F401
-from .http import async_register_http
+from .http import GoogleAssistantView, GoogleConfig
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,7 +93,12 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: GOOGLE_ASSISTANT_SCHEMA}, extra=vol.ALLOW_EX
 async def async_setup(hass: HomeAssistant, yaml_config: Dict[str, Any]):
     """Activate Google Actions component."""
     config = yaml_config.get(DOMAIN, {})
-    google_config = async_register_http(hass, config)
+    google_config = GoogleConfig(hass, config)
+
+    hass.http.register_view(GoogleAssistantView(google_config))
+
+    if google_config.should_report_state:
+        google_config.async_enable_report_state()
 
     async def request_sync_service_handler(call: ServiceCall):
         """Handle request sync service calls."""

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -10,7 +10,6 @@ from aiohttp.web import Request, Response
 
 # Typing imports
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.core import callback
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
@@ -223,16 +222,6 @@ class GoogleConfig(AbstractConfig):
             "payload": message,
         }
         await self.async_call_homegraph_api(REPORT_STATE_BASE_URL, data)
-
-
-@callback
-def async_register_http(hass, cfg):
-    """Register HTTP views for Google Assistant."""
-    config = GoogleConfig(hass, cfg)
-    hass.http.register_view(GoogleAssistantView(config))
-    if config.should_report_state:
-        config.async_enable_report_state()
-    return config
 
 
 class GoogleAssistantView(HomeAssistantView):


### PR DESCRIPTION
## Description:
Remove helper function that just introduce complexity in setup

**Related issue (if applicable):** reduces size of #29158 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
