### PR TITLE
Reduce Plex connection timeout to avoid config flow timeouts

### DIFF
--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -77,7 +77,7 @@ class PlexServer:
             self.server_choice = (
                 self._server_name if self._server_name else available_servers[0][0]
             )
-            self._plex_server = account.resource(self.server_choice).connect()
+            self._plex_server = account.resource(self.server_choice).connect(timeout=10)
 
         def _connect_with_url():
             session = None

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -30,7 +30,7 @@ class MockResource:
         self.provides = ["server"]
         self._mock_plex_server = MockPlexServer(index)
 
-    def connect(self):
+    def connect(self, timeout):
         """Mock the resource connect method."""
         return self._mock_plex_server
 


### PR DESCRIPTION
## Description:
Config flows could time out if many connection options were available for a Plex server and the default timeout of 30s was used.

**Related issue (if applicable):** fixes #28564

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
