### PR TITLE
Fix mobile app device identifiers

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -76,14 +76,9 @@ async def async_setup_entry(hass, entry):
 
     device_registry = await dr.async_get_registry(hass)
 
-    identifiers = {
-        (ATTR_DEVICE_ID, registration[ATTR_DEVICE_ID]),
-        (CONF_WEBHOOK_ID, registration[CONF_WEBHOOK_ID]),
-    }
-
     device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers=identifiers,
+        identifiers={(DOMAIN, registration[ATTR_DEVICE_ID])},
         manufacturer=registration[ATTR_MANUFACTURER],
         model=registration[ATTR_MODEL],
         name=registration[ATTR_DEVICE_NAME],

--- a/tests/components/mobile_app/test_entity.py
+++ b/tests/components/mobile_app/test_entity.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from homeassistant.helpers import device_registry
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -63,6 +65,9 @@ async def test_sensor(hass, create_registrations, webhook_client):
 
     updated_entity = hass.states.get("sensor.battery_state")
     assert updated_entity.state == "123"
+
+    dev_reg = await device_registry.async_get_registry(hass)
+    assert len(dev_reg.devices) == len(create_registrations)
 
 
 async def test_sensor_must_register(hass, create_registrations, webhook_client):


### PR DESCRIPTION
## Description:
Mobile app was not registering consistent device identifiers.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant-android/issues/65

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
