### PR TITLE
Bump plexwebsocket to 0.0.6

### DIFF
--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -6,7 +6,7 @@
   "requirements": [
     "plexapi==3.3.0",
     "plexauth==0.0.5",
-    "plexwebsocket==0.0.5"
+    "plexwebsocket==0.0.6"
   ],
   "dependencies": [
     "http"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -990,7 +990,7 @@ plexapi==3.3.0
 plexauth==0.0.5
 
 # homeassistant.components.plex
-plexwebsocket==0.0.5
+plexwebsocket==0.0.6
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -330,7 +330,7 @@ plexapi==3.3.0
 plexauth==0.0.5
 
 # homeassistant.components.plex
-plexwebsocket==0.0.5
+plexwebsocket==0.0.6
 
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm


### PR DESCRIPTION
## Description:
Adds reconnection back-off logic instead of a fixed timer.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
