### PR TITLE
Delete configurator service per balloob's comment

### DIFF
--- a/homeassistant/components/configurator/__init__.py
+++ b/homeassistant/components/configurator/__init__.py
@@ -37,7 +37,6 @@ DOMAIN = "configurator"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
-SERVICE_CONFIGURE = "configure"
 STATE_CONFIGURE = "configure"
 STATE_CONFIGURED = "configured"
 
@@ -145,9 +144,6 @@ class Configurator:
         self.hass = hass
         self._cur_id = 0
         self._requests = {}
-        hass.services.async_register(
-            DOMAIN, SERVICE_CONFIGURE, self.async_handle_service_call
-        )
 
     @async_callback
     def async_request_config(
@@ -219,20 +215,6 @@ class Configurator:
             self.hass.states.async_remove(entity_id)
 
         self.hass.bus.async_listen_once(EVENT_TIME_CHANGED, deferred_remove)
-
-    async def async_handle_service_call(self, call):
-        """Handle a configure service call."""
-        request_id = call.data.get(ATTR_CONFIGURE_ID)
-
-        if not self._validate_request_id(request_id):
-            return
-
-        # pylint: disable=unused-variable
-        entity_id, fields, callback = self._requests[request_id]
-
-        # field validation goes here?
-        if callback:
-            await self.hass.async_add_job(callback, call.data.get(ATTR_FIELDS, {}))
 
     def _generate_unique_id(self):
         """Generate a unique configurator ID."""


### PR DESCRIPTION
## Breaking Change:

`configurator`'s service will no longer be available after this change

## Description:
See here: https://github.com/home-assistant/home-assistant/issues/27289#issuecomment-559336493

**Related issue (if applicable):** Related to https://github.com/home-assistant/home-assistant/issues/27289#issuecomment-559336493

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
