### PR TITLE
Inline MQTT paho imports

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -725,6 +725,7 @@ class MQTT:
         """Initialize Home Assistant MQTT client."""
         # We don't import them on the top because some integrations
         # should be able to optionally rely on MQTT.
+        # pylint: disable=import-outside-toplevel
         import paho.mqtt.client as mqtt
 
         self.hass = hass
@@ -788,6 +789,7 @@ class MQTT:
 
         This method is a coroutine.
         """
+        # pylint: disable=import-outside-toplevel
         import paho.mqtt.client as mqtt
 
         result: int = None
@@ -881,6 +883,7 @@ class MQTT:
         Resubscribe to all topics we were subscribed to and publish birth
         message.
         """
+        # pylint: disable=import-outside-toplevel
         import paho.mqtt.client as mqtt
 
         if result_code != mqtt.CONNACK_ACCEPTED:
@@ -974,6 +977,7 @@ class MQTT:
 
 def _raise_on_error(result_code: int) -> None:
     """Raise error if error result."""
+    # pylint: disable=import-outside-toplevel
     import paho.mqtt.client as mqtt
 
     if result_code != 0:
@@ -984,6 +988,7 @@ def _raise_on_error(result_code: int) -> None:
 
 def _match_topic(subscription: str, topic: str) -> bool:
     """Test if topic matches subscription."""
+    # pylint: disable=import-outside-toplevel
     from paho.mqtt.matcher import MQTTMatcher
 
     matcher = MQTTMatcher()

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -16,8 +16,6 @@ from typing import Any, Callable, List, Optional, Union
 import attr
 import requests.certs
 import voluptuous as vol
-import paho.mqtt.client as mqtt
-from paho.mqtt.matcher import MQTTMatcher
 
 from homeassistant import config_entries
 from homeassistant.components import websocket_api
@@ -725,6 +723,10 @@ class MQTT:
         tls_version: Optional[int],
     ) -> None:
         """Initialize Home Assistant MQTT client."""
+        # We don't import them on the top because some integrations
+        # should be able to optionally rely on MQTT.
+        import paho.mqtt.client as mqtt
+
         self.hass = hass
         self.broker = broker
         self.port = port
@@ -786,6 +788,8 @@ class MQTT:
 
         This method is a coroutine.
         """
+        import paho.mqtt.client as mqtt
+
         result: int = None
         try:
             result = await self.hass.async_add_job(
@@ -877,6 +881,8 @@ class MQTT:
         Resubscribe to all topics we were subscribed to and publish birth
         message.
         """
+        import paho.mqtt.client as mqtt
+
         if result_code != mqtt.CONNACK_ACCEPTED:
             _LOGGER.error(
                 "Unable to connect to the MQTT broker: %s",
@@ -968,6 +974,8 @@ class MQTT:
 
 def _raise_on_error(result_code: int) -> None:
     """Raise error if error result."""
+    import paho.mqtt.client as mqtt
+
     if result_code != 0:
         raise HomeAssistantError(
             "Error talking to MQTT: {}".format(mqtt.error_string(result_code))
@@ -976,6 +984,8 @@ def _raise_on_error(result_code: int) -> None:
 
 def _match_topic(subscription: str, topic: str) -> bool:
     """Test if topic matches subscription."""
+    from paho.mqtt.matcher import MQTTMatcher
+
     matcher = MQTTMatcher()
     matcher[subscription] = True
     try:

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 import queue
 
 import voluptuous as vol
-import paho.mqtt.client as mqtt
 
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -126,6 +125,8 @@ class FlowHandler(config_entries.ConfigFlow):
 
 def try_connection(broker, port, username, password, protocol="3.1"):
     """Test if we can connect to an MQTT broker."""
+    import paho.mqtt.client as mqtt
+
     if protocol == "3.1":
         proto = mqtt.MQTTv31
     else:

--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -4,7 +4,6 @@ import logging
 import tempfile
 
 import voluptuous as vol
-from hbmqtt.broker import Broker, BrokerException
 from passlib.apps import custom_app_context
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -37,6 +36,9 @@ def async_start(hass, password, server_config):
 
     This method is a coroutine.
     """
+    # pylint: disable=import-outside-toplevel
+    from hbmqtt.broker import Broker, BrokerException
+
     passwd = tempfile.NamedTemporaryFile()
 
     gen_server_config, client_config = generate_config(hass, passwd, password)

--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -4,7 +4,6 @@ import logging
 import tempfile
 
 import voluptuous as vol
-from passlib.apps import custom_app_context
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
@@ -67,6 +66,9 @@ def async_start(hass, password, server_config):
 
 def generate_config(hass, passwd, password):
     """Generate a configuration based on current Home Assistant instance."""
+    # pylint: disable=import-outside-toplevel
+    from passlib.apps import custom_app_context
+
     config = {
         "listeners": {
             "default": {

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -23,9 +23,7 @@ class TestMQTT:
         "homeassistant.components.mqtt.server.custom_app_context", Mock(return_value="")
     )
     @patch("tempfile.NamedTemporaryFile", Mock(return_value=MagicMock()))
-    @patch(
-        "homeassistant.components.mqtt.server.Broker", Mock(return_value=MagicMock())
-    )
+    @patch("hbmqtt.broker.Broker", Mock(return_value=MagicMock()))
     @patch("hbmqtt.broker.Broker.start", Mock(return_value=mock_coro()))
     @patch("homeassistant.components.mqtt.MQTT")
     def test_creating_config_with_pass_and_no_http_pass(self, mock_mqtt):
@@ -49,9 +47,7 @@ class TestMQTT:
         "homeassistant.components.mqtt.server.custom_app_context", Mock(return_value="")
     )
     @patch("tempfile.NamedTemporaryFile", Mock(return_value=MagicMock()))
-    @patch(
-        "homeassistant.components.mqtt.server.Broker", Mock(return_value=MagicMock())
-    )
+    @patch("hbmqtt.broker.Broker", Mock(return_value=MagicMock()))
     @patch("hbmqtt.broker.Broker.start", Mock(return_value=mock_coro()))
     @patch("homeassistant.components.mqtt.MQTT")
     def test_creating_config_with_pass_and_http_pass(self, mock_mqtt):

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -19,9 +19,7 @@ class TestMQTT:
         """Stop everything that was started."""
         self.hass.stop()
 
-    @patch(
-        "homeassistant.components.mqtt.server.custom_app_context", Mock(return_value="")
-    )
+    @patch("passlib.apps.custom_app_context", Mock(return_value=""))
     @patch("tempfile.NamedTemporaryFile", Mock(return_value=MagicMock()))
     @patch("hbmqtt.broker.Broker", Mock(return_value=MagicMock()))
     @patch("hbmqtt.broker.Broker.start", Mock(return_value=mock_coro()))
@@ -43,9 +41,7 @@ class TestMQTT:
         assert mock_mqtt.mock_calls[1][2]["username"] == "homeassistant"
         assert mock_mqtt.mock_calls[1][2]["password"] == password
 
-    @patch(
-        "homeassistant.components.mqtt.server.custom_app_context", Mock(return_value="")
-    )
+    @patch("passlib.apps.custom_app_context", Mock(return_value=""))
     @patch("tempfile.NamedTemporaryFile", Mock(return_value=MagicMock()))
     @patch("hbmqtt.broker.Broker", Mock(return_value=MagicMock()))
     @patch("hbmqtt.broker.Broker.start", Mock(return_value=mock_coro()))


### PR DESCRIPTION
## Description:
Some integrations rely optionally on MQTT (ie. OwnTracks, MySensors). These could no longer be imported because the MQTT imports would fail (`mqtt` is only an after_dependencies).

**Related issue (if applicable):** fixes #28464

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
