### PR TITLE
Migrate NSW Rural Fire Service integration to async library

### DIFF
--- a/homeassistant/components/nsw_rural_fire_service_feed/const.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/const.py
@@ -1,9 +1,4 @@
 """Define constants for the NSW Rural Fire Service Feeds integration."""
-
-PLATFORMS = "geo_location"
-
-FEED = "feed"
-
 SIGNAL_DELETE_ENTITY = "nsw_rural_fire_service_feed_delete_{}"
 SIGNAL_UPDATE_ENTITY = "nsw_rural_fire_service_feed_update_{}"
 

--- a/homeassistant/components/nsw_rural_fire_service_feed/const.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/const.py
@@ -1,0 +1,10 @@
+"""Define constants for the NSW Rural Fire Service Feeds integration."""
+
+PLATFORMS = "geo_location"
+
+FEED = "feed"
+
+SIGNAL_DELETE_ENTITY = "nsw_rural_fire_service_feed_delete_{}"
+SIGNAL_UPDATE_ENTITY = "nsw_rural_fire_service_feed_update_{}"
+
+SIGNAL_NEW_GEOLOCATION = "nsw_rural_fire_service_feed_new_geolocation_{}"

--- a/homeassistant/components/nsw_rural_fire_service_feed/const.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/const.py
@@ -1,5 +1,0 @@
-"""Define constants for the NSW Rural Fire Service Feeds integration."""
-SIGNAL_DELETE_ENTITY = "nsw_rural_fire_service_feed_delete_{}"
-SIGNAL_UPDATE_ENTITY = "nsw_rural_fire_service_feed_update_{}"
-
-SIGNAL_NEW_GEOLOCATION = "nsw_rural_fire_service_feed_new_geolocation_{}"

--- a/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
@@ -101,7 +101,6 @@ class NswRuralFireServiceFeedEntityManager:
     ):
         """Initialize the Feed Entity Manager."""
         self._hass = hass
-        self._async_add_entities = async_add_entities
         websession = aiohttp_client.async_get_clientsession(hass)
         self._feed_manager = NswRuralFireServiceIncidentsFeedManager(
             websession,
@@ -112,6 +111,7 @@ class NswRuralFireServiceFeedEntityManager:
             filter_radius=radius_in_km,
             filter_categories=categories,
         )
+        self._async_add_entities = async_add_entities
         self._scan_interval = scan_interval
         self._track_time_remove_callback = None
         self.listeners = []
@@ -151,7 +151,7 @@ class NswRuralFireServiceFeedEntityManager:
     async def _generate_entity(self, external_id):
         """Generate new entity."""
         new_entity = NswRuralFireServiceLocationEvent(self, external_id)
-        _LOGGER.debug("Adding geolocation %s", new_entity)
+        # Add new entities to HA.
         self._async_add_entities([new_entity], True)
 
     async def _update_entity(self, external_id):

--- a/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
@@ -67,7 +67,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(
     hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
 ):
-    """Set up the GeoNet NZ Quakes Feed platform."""
+    """Set up the NSW Rural Fire Service Feed platform."""
     scan_interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
     coordinates = (
         config.get(CONF_LATITUDE, hass.config.latitude),

--- a/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
@@ -7,11 +7,6 @@ from aio_geojson_nsw_rfs_incidents import NswRuralFireServiceIncidentsFeedManage
 import voluptuous as vol
 
 from homeassistant.components.geo_location import PLATFORM_SCHEMA, GeolocationEvent
-from homeassistant.components.nsw_rural_fire_service_feed.const import (
-    SIGNAL_DELETE_ENTITY,
-    SIGNAL_NEW_GEOLOCATION,
-    SIGNAL_UPDATE_ENTITY,
-)
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_LOCATION,
@@ -48,6 +43,10 @@ DEFAULT_RADIUS_IN_KM = 20.0
 DEFAULT_UNIT_OF_MEASUREMENT = "km"
 
 SCAN_INTERVAL = timedelta(minutes=5)
+
+SIGNAL_DELETE_ENTITY = "nsw_rural_fire_service_feed_delete_{}"
+SIGNAL_UPDATE_ENTITY = "nsw_rural_fire_service_feed_update_{}"
+SIGNAL_NEW_GEOLOCATION = "nsw_rural_fire_service_feed_new_geolocation_{}"
 
 SOURCE = "nsw_rural_fire_service_feed"
 

--- a/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
+++ b/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nsw rural fire service feed",
   "documentation": "https://www.home-assistant.io/integrations/nsw_rural_fire_service_feed",
   "requirements": [
-    "geojson_client==0.4"
+    "aio_geojson_nsw_rfs_incidents==0.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -129,6 +129,9 @@ aio_geojson_geonetnz_quakes==0.11
 # homeassistant.components.geonetnz_volcano
 aio_geojson_geonetnz_volcano==0.5
 
+# homeassistant.components.nsw_rural_fire_service_feed
+aio_geojson_nsw_rfs_incidents==0.1
+
 # homeassistant.components.ambient_station
 aioambient==0.3.2
 
@@ -550,7 +553,6 @@ geizhals==0.0.9
 geniushub-client==0.6.30
 
 # homeassistant.components.geo_json_events
-# homeassistant.components.nsw_rural_fire_service_feed
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.4
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -40,6 +40,9 @@ aio_geojson_geonetnz_quakes==0.11
 # homeassistant.components.geonetnz_volcano
 aio_geojson_geonetnz_volcano==0.5
 
+# homeassistant.components.nsw_rural_fire_service_feed
+aio_geojson_nsw_rfs_incidents==0.1
+
 # homeassistant.components.ambient_station
 aioambient==0.3.2
 
@@ -171,7 +174,6 @@ foobot_async==0.3.1
 gTTS-token==1.1.3
 
 # homeassistant.components.geo_json_events
-# homeassistant.components.nsw_rural_fire_service_feed
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.4
 

--- a/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
+++ b/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
@@ -1,6 +1,9 @@
 """The tests for the geojson platform."""
 import datetime
-from asynctest.mock import patch, MagicMock, call
+from unittest.mock import ANY
+
+from aio_geojson_nsw_rfs_incidents import NswRuralFireServiceIncidentsFeed
+from asynctest.mock import patch, MagicMock, call, CoroutineMock
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -113,9 +116,9 @@ async def test_setup(hass):
     utcnow = dt_util.utcnow()
     # Patching 'utcnow' to gain more control over the timed update.
     with patch("homeassistant.util.dt.utcnow", return_value=utcnow), patch(
-        "geojson_client.nsw_rural_fire_service_feed." "NswRuralFireServiceFeed"
-    ) as mock_feed:
-        mock_feed.return_value.update.return_value = (
+        "aio_geojson_client.feed.GeoJsonFeed.update", new_callable=CoroutineMock
+    ) as mock_feed_update:
+        mock_feed_update.return_value = (
             "OK",
             [mock_entry_1, mock_entry_2, mock_entry_3],
         )
@@ -187,7 +190,7 @@ async def test_setup(hass):
 
             # Simulate an update - one existing, one new entry,
             # one outdated entry
-            mock_feed.return_value.update.return_value = (
+            mock_feed_update.return_value = (
                 "OK",
                 [mock_entry_1, mock_entry_4, mock_entry_3],
             )
@@ -199,7 +202,7 @@ async def test_setup(hass):
 
             # Simulate an update - empty data, but successful update,
             # so no changes to entities.
-            mock_feed.return_value.update.return_value = "OK_NO_DATA", None
+            mock_feed_update.return_value = "OK_NO_DATA", None
             async_fire_time_changed(hass, utcnow + 2 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
@@ -207,7 +210,7 @@ async def test_setup(hass):
             assert len(all_states) == 3
 
             # Simulate an update - empty data, removes all entities
-            mock_feed.return_value.update.return_value = "ERROR", None
+            mock_feed_update.return_value = "ERROR", None
             async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
@@ -221,9 +224,12 @@ async def test_setup_with_custom_location(hass):
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 20.5, (-31.1, 150.1))
 
     with patch(
-        "geojson_client.nsw_rural_fire_service_feed." "NswRuralFireServiceFeed"
-    ) as mock_feed:
-        mock_feed.return_value.update.return_value = "OK", [mock_entry_1]
+        "aio_geojson_nsw_rfs_incidents.feed_manager.NswRuralFireServiceIncidentsFeed",
+        wraps=NswRuralFireServiceIncidentsFeed,
+    ) as mock_feed_manager, patch(
+        "aio_geojson_client.feed.GeoJsonFeed.update", new_callable=CoroutineMock
+    ) as mock_feed_update:
+        mock_feed_update.return_value = "OK", [mock_entry_1]
 
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(
@@ -238,6 +244,6 @@ async def test_setup_with_custom_location(hass):
             all_states = hass.states.async_all()
             assert len(all_states) == 1
 
-            assert mock_feed.call_args == call(
-                (15.1, 25.2), filter_categories=[], filter_radius=200.0
+            assert mock_feed_manager.call_args == call(
+                ANY, (15.1, 25.2), filter_categories=[], filter_radius=200.0
             )

--- a/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
+++ b/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
@@ -1,4 +1,4 @@
-"""The tests for the geojson platform."""
+"""The tests for the NSW Rural Fire Service Feeds platform."""
 import datetime
 from unittest.mock import ANY
 
@@ -23,6 +23,7 @@ from homeassistant.components.nsw_rural_fire_service_feed.geo_location import (
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -30,7 +31,7 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_RADIUS,
     EVENT_HOMEASSISTANT_START,
-    ATTR_ICON,
+    EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed
@@ -113,8 +114,8 @@ async def test_setup(hass):
     mock_entry_3 = _generate_mock_feed_entry("3456", "Title 3", 25.5, (-31.2, 150.2))
     mock_entry_4 = _generate_mock_feed_entry("4567", "Title 4", 12.5, (-31.3, 150.3))
 
-    utcnow = dt_util.utcnow()
     # Patching 'utcnow' to gain more control over the timed update.
+    utcnow = dt_util.utcnow()
     with patch("homeassistant.util.dt.utcnow", return_value=utcnow), patch(
         "aio_geojson_client.feed.GeoJsonFeed.update", new_callable=CoroutineMock
     ) as mock_feed_update:
@@ -216,6 +217,11 @@ async def test_setup(hass):
 
             all_states = hass.states.async_all()
             assert len(all_states) == 0
+
+            # Artificially trigger update.
+            hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+            # Collect events.
+            await hass.async_block_till_done()
 
 
 async def test_setup_with_custom_location(hass):

--- a/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
+++ b/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
@@ -3,7 +3,7 @@ import datetime
 from unittest.mock import ANY
 
 from aio_geojson_nsw_rfs_incidents import NswRuralFireServiceIncidentsFeed
-from asynctest.mock import patch, MagicMock, call, CoroutineMock
+from asynctest.mock import patch, MagicMock, call
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -117,7 +117,7 @@ async def test_setup(hass):
     # Patching 'utcnow' to gain more control over the timed update.
     utcnow = dt_util.utcnow()
     with patch("homeassistant.util.dt.utcnow", return_value=utcnow), patch(
-        "aio_geojson_client.feed.GeoJsonFeed.update", new_callable=CoroutineMock
+        "aio_geojson_client.feed.GeoJsonFeed.update"
     ) as mock_feed_update:
         mock_feed_update.return_value = (
             "OK",
@@ -233,7 +233,7 @@ async def test_setup_with_custom_location(hass):
         "aio_geojson_nsw_rfs_incidents.feed_manager.NswRuralFireServiceIncidentsFeed",
         wraps=NswRuralFireServiceIncidentsFeed,
     ) as mock_feed_manager, patch(
-        "aio_geojson_client.feed.GeoJsonFeed.update", new_callable=CoroutineMock
+        "aio_geojson_client.feed.GeoJsonFeed.update"
     ) as mock_feed_update:
         mock_feed_update.return_value = "OK", [mock_entry_1]
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This migrates the NSW Rural Fire Service integration to an async library. Functionality and behaviour is exactly the same as before.

Next steps will be to make this a top-level integration and introduce config flow.

**Related issue (if applicable):** addresses #27284 as a side-effect

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
geo_location:
  - platform: nsw_rural_fire_service_feed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
