### PR TITLE
Fix somfy switch inherit from SwitchDevice instead of ToggleEntity

### DIFF
--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -7,7 +7,7 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
 )
-from homeassistant.components.somfy import DOMAIN, SomfyEntity, DEVICES, API
+from . import DOMAIN, SomfyEntity, DEVICES, API
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/somfy/switch.py
+++ b/homeassistant/components/somfy/switch.py
@@ -2,8 +2,8 @@
 from pymfy.api.devices.camera_protect import CameraProtect
 from pymfy.api.devices.category import Category
 
-from homeassistant.components.somfy import DOMAIN, SomfyEntity, DEVICES, API
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components.switch import SwitchDevice
+from . import DOMAIN, SomfyEntity, DEVICES, API
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -22,7 +22,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(await hass.async_add_executor_job(get_shutters), True)
 
 
-class SomfyCameraShutter(SomfyEntity, ToggleEntity):
+class SomfyCameraShutter(SomfyEntity, SwitchDevice):
     """Representation of a Somfy Camera Shutter device."""
 
     def __init__(self, device, api):


### PR DESCRIPTION
## Description:
See https://github.com/home-assistant/home-assistant/pull/29057#pullrequestreview-324167718

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
