### PR TITLE
Support climate.set* for Tado Water Heaters

### DIFF
--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -103,6 +103,7 @@ def create_climate_device(tado, hass, zone, name, zone_id):
 
     unit = TEMP_CELSIUS
     ac_device = capabilities["type"] == "AIR_CONDITIONING"
+    hot_water_device = capabilities["type"] == "HOT_WATER"
     ac_support_heat = False
 
     if ac_device:
@@ -134,6 +135,7 @@ def create_climate_device(tado, hass, zone, name, zone_id):
         hass.config.units.temperature(max_temp, unit),
         step,
         ac_device,
+        hot_water_device,
         ac_support_heat,
     )
 
@@ -157,6 +159,7 @@ class TadoClimate(ClimateDevice):
         max_temp,
         step,
         ac_device,
+        hot_water_device,
         ac_support_heat,
         tolerance=0.3,
     ):
@@ -168,6 +171,7 @@ class TadoClimate(ClimateDevice):
         self.zone_id = zone_id
 
         self._ac_device = ac_device
+        self._hot_water_device = hot_water_device
         self._ac_support_heat = ac_support_heat
         self._cooling = False
 
@@ -518,6 +522,21 @@ class TadoClimate(ClimateDevice):
                 None,
                 "AIR_CONDITIONING",
                 "COOL",
+            )
+        elif self._hot_water_device:
+            _LOGGER.info(
+                "Switching mytado.com to %s mode for zone %s (%d). Temp (%s) - HOT_WATER",
+                self._current_operation,
+                self.zone_name,
+                self.zone_id,
+                self._target_temp,
+            )
+            self._store.set_zone_overlay(
+                self.zone_id,
+                self._current_operation,
+                self._target_temp,
+                None,
+                "HOT_WATER",
             )
         else:
             _LOGGER.info(


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- added support for setting a tado hot water device via `climate.set*`
- reference to [documentation guide](https://shkspr.mobi/blog/2019/02/tado-api-guide-updated-for-2019/) -> `Turn on Hot Water`

**Related issue (if applicable):** fixes #29013<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
