### PR TITLE
Handle None when trucating long Environment Canada state values

### DIFF
--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -134,8 +134,12 @@ class ECSensor(Entity):
             )
         elif self.sensor_type == "tendency":
             self._state = str(value).capitalize()
-        else:
+        elif value is not None and len(value) > 255:
             self._state = value[:255]
+            _LOGGER.info('Value for %s truncated to 255 characters',
+                         self._unique_id)
+        else:
+            self._state = value
 
         if sensor_data.get("unit") == "C" or self.sensor_type in [
             "wind_chill",

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -136,8 +136,7 @@ class ECSensor(Entity):
             self._state = str(value).capitalize()
         elif value is not None and len(value) > 255:
             self._state = value[:255]
-            _LOGGER.info('Value for %s truncated to 255 characters',
-                         self._unique_id)
+            _LOGGER.info("Value for %s truncated to 255 characters", self._unique_id)
         else:
             self._state = value
 


### PR DESCRIPTION
## Description:

Handles states of `None` when truncating long states, and adds info message.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]