### PR TITLE
Fix Hue linking with non ASCII chars in location

### DIFF
--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -3,6 +3,7 @@ import asyncio
 
 import aiohue
 import async_timeout
+import slugify as unicode_slug
 import voluptuous as vol
 
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -173,24 +174,11 @@ async def get_bridge(hass, host, username=None):
         with async_timeout.timeout(10):
             # Create username if we don't have one
             if not username:
-
-                def cyrillic_to_latin(string):
-                    symbols = (
-                        "абвгдеёзийклмнопрстуфхъыьэАБВГДЕЁЗИЙКЛМНОПРСТУФХЪЫЬЭ",
-                        "abvgdeezijklmnoprstufh'y'eABVGDEEZIJKLMNOPRSTUFH'Y'E",
-                    )
-                    trans_table = {ord(a): ord(b) for a, b in zip(*symbols)}
-                    return string.translate(trans_table)
-
-                def remove_non_ascii(string):
-                    return "".join(i for i in string if ord(i) < 128)
-
-                devicetype = remove_non_ascii(
-                    cyrillic_to_latin(f"home-assistant#{hass.config.location_name}")
+                device_name = unicode_slug.slugify(
+                    hass.config.location_name, max_length=19
                 )
-                await bridge.create_user(
-                    devicetype[:40] if len(devicetype) > 40 else devicetype
-                )
+                await bridge.create_user(f"home-assistant#{device_name}")
+
             # Initialize bridge (and validate our username)
             await bridge.initialize()
 

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -173,7 +173,24 @@ async def get_bridge(hass, host, username=None):
         with async_timeout.timeout(10):
             # Create username if we don't have one
             if not username:
-                await bridge.create_user(f"home-assistant#{hass.config.location_name}")
+
+                def cyrillic_to_latin(string):
+                    symbols = (
+                        "абвгдеёзийклмнопрстуфхъыьэАБВГДЕЁЗИЙКЛМНОПРСТУФХЪЫЬЭ",
+                        "abvgdeezijklmnoprstufh'y'eABVGDEEZIJKLMNOPRSTUFH'Y'E",
+                    )
+                    trans_table = {ord(a): ord(b) for a, b in zip(*symbols)}
+                    return string.translate(trans_table)
+
+                def remove_non_ascii(string):
+                    return "".join(i for i in string if ord(i) < 128)
+
+                devicetype = remove_non_ascii(
+                    cyrillic_to_latin(f"home-assistant#{hass.config.location_name}")
+                )
+                await bridge.create_user(
+                    devicetype[:40] if len(devicetype) > 40 else devicetype
+                )
             # Initialize bridge (and validate our username)
             await bridge.initialize()
 


### PR DESCRIPTION
## Description:
Fixes to long device_type when there are non ASCII chars in the location

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/28323

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
