### PR TITLE
Move imports to top for synology

### DIFF
--- a/homeassistant/components/synology/camera.py
+++ b/homeassistant/components/synology/camera.py
@@ -2,18 +2,19 @@
 import logging
 
 import requests
+from synology.surveillance_station import SurveillanceStation
 import voluptuous as vol
 
+from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
 from homeassistant.const import (
     CONF_NAME,
-    CONF_USERNAME,
     CONF_PASSWORD,
-    CONF_URL,
-    CONF_WHITELIST,
-    CONF_VERIFY_SSL,
     CONF_TIMEOUT,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    CONF_WHITELIST,
 )
-from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_web,
     async_get_clientsession,
@@ -44,8 +45,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     timeout = config.get(CONF_TIMEOUT)
 
     try:
-        from synology.surveillance_station import SurveillanceStation
-
         surveillance = SurveillanceStation(
             config.get(CONF_URL),
             config.get(CONF_USERNAME),


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
