### PR TITLE
Move imports to top for tahoma

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -1,12 +1,13 @@
 """Support for Tahoma devices."""
 from collections import defaultdict
 import logging
-import voluptuous as vol
-from requests.exceptions import RequestException
 
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_EXCLUDE
-from homeassistant.helpers import discovery
-from homeassistant.helpers import config_validation as cv
+from requests.exceptions import RequestException
+from tahoma_api import Action, TahomaApi
+import voluptuous as vol
+
+from homeassistant.const import CONF_EXCLUDE, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +64,6 @@ TAHOMA_TYPES = {
 
 def setup(hass, config):
     """Activate Tahoma component."""
-    from tahoma_api import TahomaApi
 
     conf = config[DOMAIN]
     username = conf.get(CONF_USERNAME)
@@ -133,7 +133,6 @@ class TahomaDevice(Entity):
 
     def apply_action(self, cmd_name, *args):
         """Apply Action to Device."""
-        from tahoma_api import Action
 
         action = Action(self.tahoma_device.url)
         action.add_command(cmd_name, *args)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
