### PR TITLE
Fix Espalexa being detected as Hue Bridge

### DIFF
--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -230,6 +230,26 @@ async def test_bridge_ssdp_emulated_hue(hass):
     )
 
     assert result["type"] == "abort"
+    assert result["reason"] == "not_hue_bridge"
+
+
+async def test_bridge_ssdp_espalexa(hass):
+    """Test if discovery info is from an Espalexa based device."""
+    flow = config_flow.HueFlowHandler()
+    flow.hass = hass
+    flow.context = {}
+
+    result = await flow.async_step_ssdp(
+        {
+            "name": "Espalexa (0.0.0.0)",
+            "host": "0.0.0.0",
+            "serial": "1234",
+            "manufacturerURL": config_flow.HUE_MANUFACTURERURL,
+        }
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_hue_bridge"
 
 
 async def test_bridge_ssdp_already_configured(hass):


### PR DESCRIPTION
## Description:

ESP firmwares that use the Espalexa library (Like WLED) are discovered by the Hue integration as a bridge using SSDP.

This PR filters Espalexa based devices. Those are filterable by the hardcoded (friendly)name in the library.

<https://github.com/Aircoookie/Espalexa/blob/master/src/Espalexa.h#L226>

**Related issue (if applicable):** fixes #29043

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

**Example entry for `configuration.yaml` (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
