### PR TITLE
Stop Plex config flow imports where more user input needed

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -80,7 +80,10 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Validate a provided configuration."""
         errors = {}
         self.current_login = server_config
-        is_importing = self.context["source"] == config_entries.SOURCE_IMPORT
+        is_importing = (
+            self.context["source"]  # pylint: disable=no-member
+            == config_entries.SOURCE_IMPORT
+        )
 
         plex_server = PlexServer(self.hass, server_config)
         try:

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -80,12 +80,14 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Validate a provided configuration."""
         errors = {}
         self.current_login = server_config
+        is_importing = self.context["source"] == config_entries.SOURCE_IMPORT
 
         plex_server = PlexServer(self.hass, server_config)
         try:
             await self.hass.async_add_executor_job(plex_server.connect)
 
         except NoServersFound:
+            _LOGGER.error("No servers linked to Plex account")
             errors["base"] = "no_servers"
         except (plexapi.exceptions.BadRequest, plexapi.exceptions.Unauthorized):
             _LOGGER.error("Invalid credentials provided, config not created")
@@ -98,6 +100,11 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "not_found"
 
         except ServerNotSpecified as available_servers:
+            if is_importing:
+                _LOGGER.warning(
+                    "Imported configuration has multiple available Plex servers. Specify server in configuration or add a new Integration."
+                )
+                return self.async_abort(reason="non-interactive")
             self.available_servers = available_servers.args[0]
             return await self.async_step_select_server()
 
@@ -106,12 +113,17 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="unknown")
 
         if errors:
+            if is_importing:
+                return self.async_abort(reason="non-interactive")
             return self.async_show_form(step_id="start_website_auth", errors=errors)
 
         server_id = plex_server.machine_identifier
 
         for entry in self._async_current_entries():
             if entry.data[CONF_SERVER_IDENTIFIER] == server_id:
+                _LOGGER.debug(
+                    "Plex server already configured: %s", entry.data[CONF_SERVER]
+                )
                 return self.async_abort(reason="already_configured")
 
         url = plex_server.url_in_use

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -25,6 +25,7 @@
             "already_in_progress": "Plex is being configured",
             "discovery_no_file": "No legacy config file found",
             "invalid_import": "Imported configuration is invalid",
+            "non-interactive": "Non-interactive import",
             "token_request_timeout": "Timed out obtaining token",
             "unknown": "Failed for unknown reason"
         }

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -178,9 +178,8 @@ async def test_import_bad_hostname(hass):
                 CONF_URL: f"http://{MOCK_SERVERS[0][CONF_HOST]}:{MOCK_SERVERS[0][CONF_PORT]}",
             },
         )
-        assert result["type"] == "form"
-        assert result["step_id"] == "start_website_auth"
-        assert result["errors"]["base"] == "not_found"
+        assert result["type"] == "abort"
+        assert result["reason"] == "non-interactive"
 
 
 async def test_unknown_exception(hass):
@@ -384,12 +383,14 @@ async def test_already_configured(hass):
     mock_plex_server = MockPlexServer()
 
     flow = init_config_flow(hass)
+    flow.context = {"source": "import"}
     MockConfigEntry(
         domain=config_flow.DOMAIN,
         data={
+            config_flow.CONF_SERVER: MOCK_SERVERS[0][config_flow.CONF_SERVER],
             config_flow.CONF_SERVER_IDENTIFIER: MOCK_SERVERS[0][
                 config_flow.CONF_SERVER_IDENTIFIER
-            ]
+            ],
         },
     ).add_to_hass(hass)
 
@@ -530,3 +531,20 @@ async def test_callback_view(hass, aiohttp_client):
 
         resp = await client.get(forward_url)
         assert resp.status == 200
+
+
+async def test_multiple_servers_with_import(hass):
+    """Test importing a config with multiple servers available."""
+
+    with patch(
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount(servers=2)
+    ), asynctest.patch("plexauth.PlexAuth.initiate_auth"), asynctest.patch(
+        "plexauth.PlexAuth.token", return_value=MOCK_TOKEN
+    ):
+        result = await hass.config_entries.flow.async_init(
+            config_flow.DOMAIN,
+            context={"source": "import"},
+            data={CONF_TOKEN: MOCK_TOKEN},
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == "non-interactive"


### PR DESCRIPTION
## Description:
When importing a Plex config from `configuration.yaml`, additional user input is sometimes required. This can leave a config flow initiated from an import half-completed which is confusing to users. This aborts imports with a warning if they cannot be completed automatically without additional user input.

This also solves an issue reported which makes an already-imported `configuration.yaml` entry appear to trigger an integration discovery, even when `discovery` was disabled.

**Related issue (if applicable):** fixes #27816

## Example entry for `configuration.yaml` (if applicable):
```yaml
plex:
  token: <SECRET_TOKEN>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
