### PR TITLE
Add service to set netatmo home heating schedule

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -30,6 +30,7 @@ CONF_WEBHOOKS = "webhooks"
 
 SERVICE_ADDWEBHOOK = "addwebhook"
 SERVICE_DROPWEBHOOK = "dropwebhook"
+SERVICE_SETSCHEDULE = "set_schedule"
 
 NETATMO_AUTH = None
 NETATMO_WEBHOOK_URL = None
@@ -86,6 +87,8 @@ CONFIG_SCHEMA = vol.Schema(
 SCHEMA_SERVICE_ADDWEBHOOK = vol.Schema({vol.Optional(CONF_URL): cv.string})
 
 SCHEMA_SERVICE_DROPWEBHOOK = vol.Schema({})
+
+SCHEMA_SERVICE_SETSCHEDULE = vol.Schema({vol.Required("schedule"): cv.string})
 
 
 def setup(hass, config):
@@ -149,6 +152,21 @@ def setup(hass, config):
         SERVICE_DROPWEBHOOK,
         _service_dropwebhook,
         schema=SCHEMA_SERVICE_DROPWEBHOOK,
+    )
+
+    home_data = pyatmo.HomeData(auth)
+
+    def _service_setschedule(service):
+        """Service to change current home schedule."""
+        schedule_name = service.data.get("schedule")
+        home_data.switchHomeSchedule(schedule=schedule_name)
+        _LOGGER.info("Set home schedule to %s", schedule_name)
+
+    hass.services.register(
+        DOMAIN,
+        SERVICE_SETSCHEDULE,
+        _service_setschedule,
+        schema=SCHEMA_SERVICE_SETSCHEDULE,
     )
 
     return True

--- a/homeassistant/components/netatmo/services.yaml
+++ b/homeassistant/components/netatmo/services.yaml
@@ -28,3 +28,10 @@ set_light_off:
     entity_id:
       description: Entity id.
       example: 'camera.living_room'
+
+set_schedule:
+  description: Set the home heating schedule
+  fields:
+    schedule:
+      description: Schedule name
+      example: Standard


### PR DESCRIPTION
## Description:

Add a service to set Netatmo heating schedule.
It will call [this](https://dev.netatmo.com/resources/technical/reference/energy/switchhomeschedule) API endpoint through `pyatmo`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]