### PR TITLE
Use new toon token authentication with toonapilib 4.1.0

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -6,7 +6,7 @@ from functools import partial
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_TOKEN, CONF_SCAN_INTERVAL
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
@@ -15,8 +15,6 @@ from homeassistant.helpers.dispatcher import dispatcher_send, async_dispatcher_c
 
 from . import config_flow  # noqa: F401
 from .const import (
-    CONF_CLIENT_ID,
-    CONF_CLIENT_SECRET,
     CONF_DISPLAY,
     CONF_TENANT,
     DATA_TOON_CLIENT,
@@ -34,8 +32,6 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
-                vol.Required(CONF_CLIENT_ID): cv.string,
-                vol.Required(CONF_CLIENT_SECRET): cv.string,
                 vol.Required(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): vol.All(cv.time_period, cv.positive_timedelta),
@@ -70,10 +66,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigType) -> bool:
     toon = await hass.async_add_executor_job(
         partial(
             Toon,
-            entry.data[CONF_USERNAME],
-            entry.data[CONF_PASSWORD],
-            conf[CONF_CLIENT_ID],
-            conf[CONF_CLIENT_SECRET],
+            entry.data[CONF_TOKEN],
             tenant_id=entry.data[CONF_TENANT],
             display_common_name=entry.data[CONF_DISPLAY],
         )

--- a/homeassistant/components/toon/const.py
+++ b/homeassistant/components/toon/const.py
@@ -8,8 +8,6 @@ DATA_TOON_CLIENT = "toon_client"
 DATA_TOON_CONFIG = "toon_config"
 DATA_TOON_UPDATED = "toon_updated"
 
-CONF_CLIENT_ID = "client_id"
-CONF_CLIENT_SECRET = "client_secret"
 CONF_DISPLAY = "display"
 CONF_TENANT = "tenant"
 

--- a/homeassistant/components/toon/manifest.json
+++ b/homeassistant/components/toon/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/toon",
   "requirements": [
-    "toonapilib==3.2.4"
+    "toonapilib==4.1.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/toon/strings.json
+++ b/homeassistant/components/toon/strings.json
@@ -6,8 +6,7 @@
         "title": "Link your Toon account",
         "description": "Authenticate with your Eneco Toon account (not the developer account).",
         "data": {
-          "username": "Username",
-          "password": "Password",
+          "token": "Token",
           "tenant": "Tenant"
         }
       },
@@ -20,12 +19,10 @@
       }
     },
     "error": {
-      "credentials": "The provided credentials are invalid.",
+      "token": "The provided token is invalid.",
       "display_exists": "The selected display is already configured."
     },
     "abort": {
-      "client_id": "The client ID from the configuration is invalid.",
-      "client_secret": "The client secret from the configuration is invalid.",
       "unknown_auth_fail": "Unexpected error occured, while authenticating.",
       "no_agreements": "This account has no Toon displays.",
       "no_app": "You need to configure Toon before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/toon/)."


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Toon will be enabling a new authentication mechanism since the first of December 2019 and will invalidate the old way of authenticating. The underlying toonapilib library has implemented this new authentication mechanism and this MR is trying to update the component to match for that.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11340
## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
