### PR TITLE
Move imports to top for sisyphus

### DIFF
--- a/homeassistant/components/sisyphus/__init__.py
+++ b/homeassistant/components/sisyphus/__init__.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 
+from sisyphus_control import Table
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP
@@ -29,7 +30,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the sisyphus component."""
-    from sisyphus_control import Table
 
     class SocketIONoiseFilter(logging.Filter):
         """Filters out excessively verbose logs from SocketIO."""
@@ -105,7 +105,6 @@ class TableHolder:
         return await self._table_task
 
     async def _connect_table(self):
-        from sisyphus_control import Table
 
         self._table = await Table.connect(self._host, self._session)
         if self._name is None:

--- a/homeassistant/components/sisyphus/media_player.py
+++ b/homeassistant/components/sisyphus/media_player.py
@@ -2,6 +2,7 @@
 import logging
 
 import aiohttp
+from sisyphus_control import Track
 
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
@@ -140,7 +141,6 @@ class SisyphusPlayer(MediaPlayerDevice):
     @property
     def media_image_url(self):
         """Return the URL for a thumbnail image of the current track."""
-        from sisyphus_control import Track
 
         if self._table.active_track:
             return self._table.active_track.get_thumbnail_url(Track.ThumbnailSize.LARGE)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
