### PR TITLE
Move imports to top for scsgate

### DIFF
--- a/homeassistant/components/scsgate/__init__.py
+++ b/homeassistant/components/scsgate/__init__.py
@@ -2,6 +2,10 @@
 import logging
 from threading import Lock
 
+from scsgate.connection import Connection
+from scsgate.messages import ScenarioTriggeredMessage, StateMessage
+from scsgate.reactor import Reactor
+from scsgate.tasks import GetStatusTask
 import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICE, CONF_NAME
@@ -61,11 +65,7 @@ class SCSGate:
         self._device_being_registered = None
         self._device_being_registered_lock = Lock()
 
-        from scsgate.connection import Connection
-
         connection = Connection(device=device, logger=self._logger)
-
-        from scsgate.reactor import Reactor
 
         self._reactor = Reactor(
             connection=connection,
@@ -75,7 +75,6 @@ class SCSGate:
 
     def handle_message(self, message):
         """Handle a messages seen on the bus."""
-        from scsgate.messages import StateMessage, ScenarioTriggeredMessage
 
         self._logger.debug(f"Received message {message}")
         if not isinstance(message, StateMessage) and not isinstance(
@@ -132,7 +131,6 @@ class SCSGate:
 
     def _activate_next_device(self):
         """Start the activation of the first device."""
-        from scsgate.tasks import GetStatusTask
 
         with self._devices_to_register_lock:
             while self._devices_to_register:

--- a/homeassistant/components/scsgate/cover.py
+++ b/homeassistant/components/scsgate/cover.py
@@ -1,10 +1,15 @@
 """Support for SCSGate covers."""
 import logging
 
+from scsgate.tasks import (
+    HaltRollerShutterTask,
+    LowerRollerShutterTask,
+    RaiseRollerShutterTask,
+)
 import voluptuous as vol
 
 from homeassistant.components import scsgate
-from homeassistant.components.cover import CoverDevice, PLATFORM_SCHEMA
+from homeassistant.components.cover import PLATFORM_SCHEMA, CoverDevice
 from homeassistant.const import CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
@@ -69,20 +74,14 @@ class SCSGateCover(CoverDevice):
 
     def open_cover(self, **kwargs):
         """Move the cover."""
-        from scsgate.tasks import RaiseRollerShutterTask
-
         scsgate.SCSGATE.append_task(RaiseRollerShutterTask(target=self._scs_id))
 
     def close_cover(self, **kwargs):
         """Move the cover down."""
-        from scsgate.tasks import LowerRollerShutterTask
-
         scsgate.SCSGATE.append_task(LowerRollerShutterTask(target=self._scs_id))
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        from scsgate.tasks import HaltRollerShutterTask
-
         scsgate.SCSGATE.append_task(HaltRollerShutterTask(target=self._scs_id))
 
     def process_event(self, message):

--- a/homeassistant/components/scsgate/light.py
+++ b/homeassistant/components/scsgate/light.py
@@ -1,10 +1,11 @@
 """Support for SCSGate lights."""
 import logging
 
+from scsgate.tasks import ToggleStatusTask
 import voluptuous as vol
 
 from homeassistant.components import scsgate
-from homeassistant.components.light import Light, PLATFORM_SCHEMA
+from homeassistant.components.light import PLATFORM_SCHEMA, Light
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE, CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
@@ -70,7 +71,6 @@ class SCSGateLight(Light):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(ToggleStatusTask(target=self._scs_id, toggled=True))
 
@@ -79,7 +79,6 @@ class SCSGateLight(Light):
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(
             ToggleStatusTask(target=self._scs_id, toggled=False)

--- a/homeassistant/components/scsgate/switch.py
+++ b/homeassistant/components/scsgate/switch.py
@@ -1,11 +1,13 @@
 """Support for SCSGate switches."""
 import logging
 
+from scsgate.messages import ScenarioTriggeredMessage, StateMessage
+from scsgate.tasks import ToggleStatusTask
 import voluptuous as vol
 
 from homeassistant.components import scsgate
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE, CONF_NAME, CONF_DEVICES
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE, CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
 ATTR_SCENARIO_ID = "scenario_id"
@@ -105,7 +107,6 @@ class SCSGateSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(ToggleStatusTask(target=self._scs_id, toggled=True))
 
@@ -114,7 +115,6 @@ class SCSGateSwitch(SwitchDevice):
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        from scsgate.tasks import ToggleStatusTask
 
         scsgate.SCSGATE.append_task(
             ToggleStatusTask(target=self._scs_id, toggled=False)
@@ -172,7 +172,6 @@ class SCSGateScenarioSwitch:
 
     def process_event(self, message):
         """Handle a SCSGate message related with this switch."""
-        from scsgate.messages import StateMessage, ScenarioTriggeredMessage
 
         if isinstance(message, StateMessage):
             scenario_id = message.bytes[4]


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
