### PR TITLE
Move imports to top for satel_integra

### DIFF
--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -2,9 +2,10 @@
 import collections
 import logging
 
+from satel_integra.satel_integra import AsyncSatel
 import voluptuous as vol
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -101,8 +102,6 @@ async def async_setup(hass, config):
     host = conf.get(CONF_HOST)
     port = conf.get(CONF_PORT)
     partitions = conf.get(CONF_DEVICE_PARTITIONS)
-
-    from satel_integra.satel_integra import AsyncSatel
 
     monitored_outputs = collections.OrderedDict(
         list(outputs.items()) + list(switchable_outputs.items())

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -3,6 +3,8 @@ import asyncio
 from collections import OrderedDict
 import logging
 
+from satel_integra.satel_integra import AlarmState
+
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
@@ -82,7 +84,6 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     def _read_alarm_state(self):
         """Read current status of the alarm and translate it into HA status."""
-        from satel_integra.satel_integra import AlarmState
 
         # Default - disarmed:
         hass_alarm_status = STATE_ALARM_DISARMED

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -10,9 +10,9 @@ from . import (
     CONF_ZONE_NAME,
     CONF_ZONE_TYPE,
     CONF_ZONES,
+    DATA_SATEL,
     SIGNAL_OUTPUTS_UPDATED,
     SIGNAL_ZONES_UPDATED,
-    DATA_SATEL,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -9,8 +9,8 @@ from . import (
     CONF_DEVICE_CODE,
     CONF_SWITCHABLE_OUTPUTS,
     CONF_ZONE_NAME,
-    SIGNAL_OUTPUTS_UPDATED,
     DATA_SATEL,
+    SIGNAL_OUTPUTS_UPDATED,
 )
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
