### PR TITLE
Move imports to top for seventeentrack

### DIFF
--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -1,7 +1,9 @@
 """Support for package tracking sensors from 17track.net."""
-import logging
 from datetime import timedelta
+import logging
 
+from py17track import Client
+from py17track.errors import SeventeenTrackError
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -61,8 +63,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Configure the platform and add the sensors."""
-    from py17track import Client
-    from py17track.errors import SeventeenTrackError
 
     websession = aiohttp_client.async_get_clientsession(hass)
 
@@ -290,7 +290,6 @@ class SeventeenTrackData:
 
     async def _async_update(self):
         """Get updated data from 17track.net."""
-        from py17track.errors import SeventeenTrackError
 
         try:
             packages = await self._client.profile.packages(

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 import logging
 
-from py17track import Client
+from py17track import Client as SeventeenTrackClient
 from py17track.errors import SeventeenTrackError
 import voluptuous as vol
 
@@ -66,7 +66,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     websession = aiohttp_client.async_get_clientsession(hass)
 
-    client = Client(websession)
+    client = SeventeenTrackClient(websession)
 
     try:
         login_result = await client.profile.login(

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -119,7 +119,10 @@ def fixture_mock_py17track():
 @pytest.fixture(autouse=True, name="mock_client")
 def fixture_mock_client(mock_py17track):
     """Mock py17track client."""
-    with mock.patch("py17track.Client", new=ClientMock):
+    with mock.patch(
+        "homeassistant.components.seventeentrack.sensor.SeventeenTrackClient",
+        new=ClientMock,
+    ):
         yield
     ProfileMock.reset()
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
