### PR TITLE
Move imports to top for route53

### DIFF
--- a/homeassistant/components/route53/__init__.py
+++ b/homeassistant/components/route53/__init__.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 import logging
 from typing import List
 
+import boto3
+from ipify import exceptions, get_ip
 import voluptuous as vol
 
 from homeassistant.const import CONF_DOMAIN, CONF_TTL, CONF_ZONE
@@ -72,10 +74,6 @@ def _update_route53(
     records: List[str],
     ttl: int,
 ):
-    import boto3
-    from ipify import get_ip
-    from ipify import exceptions
-
     _LOGGER.debug("Starting update for zone %s", zone)
 
     client = boto3.client(


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
