### PR TITLE
Clear miflora sensor state on exception

### DIFF
--- a/homeassistant/components/miflora/sensor.py
+++ b/homeassistant/components/miflora/sensor.py
@@ -106,6 +106,7 @@ class MiFloraSensor(Entity):
         self._icon = icon
         self._name = name
         self._state = None
+        self._available = False
         self.data = []
         self._force_update = force_update
         # Median is used to filter out outliers. median of 3 will filter
@@ -133,6 +134,11 @@ class MiFloraSensor(Entity):
         return self._state
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @property
     def unit_of_measurement(self):
         """Return the units of measurement."""
         return self._unit
@@ -156,17 +162,14 @@ class MiFloraSensor(Entity):
         try:
             _LOGGER.debug("Polling data for %s", self.name)
             data = self.poller.parameter_value(self.parameter)
-        except OSError as ioerr:
-            _LOGGER.info("Polling error %s", ioerr)
-            self._state = None
-            return
-        except BluetoothBackendException as bterror:
-            _LOGGER.info("Polling error %s", bterror)
-            self._state = None
+        except (OSError, BluetoothBackendException) as err:
+            _LOGGER.info("Polling error %s: %s", type(err).__name__, err)
+            self._available = False
             return
 
         if data is not None:
             _LOGGER.debug("%s = %s", self.name, data)
+            self._available = True
             self.data.append(data)
         else:
             _LOGGER.info("Did not receive any data from Mi Flora sensor %s", self.name)

--- a/homeassistant/components/miflora/sensor.py
+++ b/homeassistant/components/miflora/sensor.py
@@ -158,9 +158,11 @@ class MiFloraSensor(Entity):
             data = self.poller.parameter_value(self.parameter)
         except OSError as ioerr:
             _LOGGER.info("Polling error %s", ioerr)
+            self._state = None
             return
         except BluetoothBackendException as bterror:
             _LOGGER.info("Polling error %s", bterror)
+            self._state = None
             return
 
         if data is not None:


### PR DESCRIPTION
## Breaking Change:

Values for a unresponsive device aren't reported any more as if they were valid, so it's possible to send an alert.

## Description:

Report avaiable() = False if querying the device fails. The state is then set to unavailable, so it can be tracked if a miflora device isn't responding any more.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `automations.yaml`:
```yaml
- id: plant_unreachable
  alias: plant unreachable
  trigger:
  - entity_id: sensor.plant_moisture
    for: 01:00:00
    platform: state
    to: unavailable
  action:
...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html

---
Updates:
 changed unknown to unavailable in automations.yaml
