### PR TITLE
Add alexa check for "name" channelMetadata attribute

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1144,21 +1144,25 @@ async def async_api_changechannel(hass, config, directive, context):
     """Process a change channel request."""
     channel = "0"
     entity = directive.entity
-    payload = directive.payload["channel"]
+    channel_payload = directive.payload["channel"]
+    metadata_payload = directive.payload["channelMetadata"]
     payload_name = "number"
 
-    if "number" in payload:
-        channel = payload["number"]
+    if "number" in channel_payload:
+        channel = channel_payload["number"]
         payload_name = "number"
-    elif "callSign" in payload:
-        channel = payload["callSign"]
+    elif "callSign" in channel_payload:
+        channel = channel_payload["callSign"]
         payload_name = "callSign"
-    elif "affiliateCallSign" in payload:
-        channel = payload["affiliateCallSign"]
+    elif "affiliateCallSign" in channel_payload:
+        channel = channel_payload["affiliateCallSign"]
         payload_name = "affiliateCallSign"
-    elif "uri" in payload:
-        channel = payload["uri"]
+    elif "uri" in channel_payload:
+        channel = channel_payload["uri"]
         payload_name = "uri"
+    elif "name" in metadata_payload:
+        channel = metadata_payload["name"]
+        payload_name = "name"
 
     data = {
         ATTR_ENTITY_ID: entity.entity_id,

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1162,7 +1162,7 @@ async def async_api_changechannel(hass, config, directive, context):
         payload_name = "uri"
     elif "name" in metadata_payload:
         channel = metadata_payload["name"]
-        payload_name = "name"
+        payload_name = "callSign"
 
     data = {
         ATTR_ENTITY_ID: entity.entity_id,

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -935,7 +935,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.play_media",
         hass,
-        payload={"channel": {"number": 24}},
+        payload={"channel": {"number": "24"}, "channelMetadata": {"name": ""}},
     )
 
     call, _ = await assert_request_calls_service(
@@ -944,7 +944,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.play_media",
         hass,
-        payload={"channel": {"callSign": "ABC"}},
+        payload={"channel": {"callSign": "ABC"}, "channelMetadata": {"name": ""}},
     )
 
     call, _ = await assert_request_calls_service(
@@ -953,7 +953,7 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.play_media",
         hass,
-        payload={"channel": {"affiliateCallSign": "ABC"}},
+        payload={"channel": {"number": ""}, "channelMetadata": {"name": "ABC"}},
     )
 
     call, _ = await assert_request_calls_service(
@@ -962,7 +962,19 @@ async def test_media_player(hass):
         "media_player#test",
         "media_player.play_media",
         hass,
-        payload={"channel": {"uri": "ABC"}},
+        payload={
+            "channel": {"affiliateCallSign": "ABC"},
+            "channelMetadata": {"name": ""},
+        },
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ChannelController",
+        "ChangeChannel",
+        "media_player#test",
+        "media_player.play_media",
+        hass,
+        payload={"channel": {"uri": "ABC"}, "channelMetadata": {"name": ""}},
     )
 
     call, _ = await assert_request_calls_service(


### PR DESCRIPTION
## Breaking Change:
None
## Description:
Add  a check for "name" channelMetadata attribute, This attribute will be used as the default channel name to send to the media_player when no channel number is found. This attribute gets filled when the user says Alexa, tune to "\<channelname\>" 

**Related issue (if applicable):** fixes #29274


`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
