### PR TITLE
Move imports to top for recswitch

### DIFF
--- a/homeassistant/components/recswitch/switch.py
+++ b/homeassistant/components/recswitch/switch.py
@@ -2,12 +2,12 @@
 
 import logging
 
+from pyrecswitch import RSNetwork, RSNetworkError
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +26,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the device."""
-    from pyrecswitch import RSNetwork
 
     host = config[CONF_HOST]
     mac_address = config[CONF_MAC]
@@ -78,7 +77,6 @@ class RecSwitchSwitch(SwitchDevice):
 
     async def async_set_gpio_status(self, status):
         """Set the switch status."""
-        from pyrecswitch import RSNetworkError
 
         try:
             ret = await self.device.set_gpio_status(status)
@@ -88,7 +86,6 @@ class RecSwitchSwitch(SwitchDevice):
 
     async def async_update(self):
         """Update the current switch status."""
-        from pyrecswitch import RSNetworkError
 
         try:
             ret = await self.device.get_gpio_status()


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
