### PR TITLE
Add generic command functionality to denonavr

### DIFF
--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -1,15 +1,16 @@
 """The denonavr component."""
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL
+from homeassistant.const import ATTR_ENTITY_ID
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import dispatcher_send
 
 DOMAIN = "denonavr"
 
 SERVICE_GET_COMMAND = "get_command"
 ATTR_COMMAND = "command"
 
-CALL_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.comp_entity_ids})
+CALL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids})
 
 GET_COMMAND_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_COMMAND): cv.string})
 
@@ -20,21 +21,12 @@ SERVICE_TO_METHOD = {
 
 def setup(hass, config):
     """Set up the denonavr platform."""
-    hass.data[DOMAIN] = {}
 
     def service_handler(service):
         method = SERVICE_TO_METHOD.get(service.service)
-        params = {
-            key: value for key, value in service.data.items() if key != "entity_id"
-        }
-        entity_ids = service.data.get(ATTR_ENTITY_ID)
-        target_players = []
-        for player in hass.data[DOMAIN]["receivers"]:
-            if entity_ids == ENTITY_MATCH_ALL or player.entity_id in entity_ids:
-                target_players.append(player)
-
-        for player in target_players:
-            getattr(player, method["method"])(**params)
+        data = service.data.copy()
+        data["method"] = method["method"]
+        dispatcher_send(hass, DOMAIN, data)
 
     for service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[service]["schema"]

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -1,6 +1,7 @@
 """The denonavr component."""
 import voluptuous as vol
-from homeassistant.const import ENTITY_MATCH_ALL, ATTR_ENTITY_ID
+
+from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "denonavr"

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -1,1 +1,42 @@
 """The denonavr component."""
+import voluptuous as vol
+from homeassistant.const import ENTITY_MATCH_ALL, ATTR_ENTITY_ID
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN = "denonavr"
+
+SERVICE_GET_COMMAND = "get_command"
+ATTR_COMMAND = "command"
+
+CALL_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.comp_entity_ids})
+
+GET_COMMAND_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_COMMAND): cv.string})
+
+SERVICE_TO_METHOD = {
+    SERVICE_GET_COMMAND: {"method": "get_command", "schema": GET_COMMAND_SCHEMA}
+}
+
+
+def setup(hass, config):
+    """Set up the denonavr platform."""
+    hass.data[DOMAIN] = {}
+
+    def service_handler(service):
+        method = SERVICE_TO_METHOD.get(service.service)
+        params = {
+            key: value for key, value in service.data.items() if key != "entity_id"
+        }
+        entity_ids = service.data.get(ATTR_ENTITY_ID)
+        target_players = []
+        for player in hass.data[DOMAIN]["receivers"]:
+            if entity_ids == ENTITY_MATCH_ALL or player.entity_id in entity_ids:
+                target_players.append(player)
+
+        for player in target_players:
+            getattr(player, method["method"])(**params)
+
+    for service in SERVICE_TO_METHOD:
+        schema = SERVICE_TO_METHOD[service]["schema"]
+        hass.services.register(DOMAIN, service, service_handler, schema=schema)
+
+    return True

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 import homeassistant.helpers.config_validation as cv
+
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -24,16 +24,19 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_HOST,
     CONF_NAME,
     CONF_TIMEOUT,
     CONF_ZONE,
+    ENTITY_MATCH_ALL,
     STATE_OFF,
     STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import DOMAIN
 
@@ -152,7 +155,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             _LOGGER.info("Denon receiver at host %s initialized", host)
 
     # Add all freshly discovered receivers
-    hass.data[DOMAIN]["receivers"] = receivers
     if receivers:
         add_entities(receivers)
 
@@ -192,6 +194,21 @@ class DenonDevice(MediaPlayerDevice):
         self._supported_features_base |= (
             self._sound_mode_support and SUPPORT_SELECT_SOUND_MODE
         )
+
+    async def async_added_to_hass(self):
+        """Register signal handler."""
+        async_dispatcher_connect(self.hass, DOMAIN, self.signal_handler)
+
+    def signal_handler(self, data):
+        """Handle domain-specific signal by calling appropriate method."""
+        entity_ids = data[ATTR_ENTITY_ID]
+        if entity_ids == ENTITY_MATCH_ALL or self.entity_id in entity_ids:
+            params = {
+                key: value
+                for key, value in data.items()
+                if key not in ["entity_id", "method"]
+            }
+            getattr(self, data["method"])(**params)
 
     def update(self):
         """Get the latest status information from device."""

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -421,4 +421,4 @@ class DenonDevice(MediaPlayerDevice):
 
     def get_command(self, command, **kwargs):
         """Send generic command."""
-        return self._receiver.send_get_command(command)
+        self._receiver.send_get_command(command)

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 import homeassistant.helpers.config_validation as cv
+from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -150,6 +151,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             _LOGGER.info("Denon receiver at host %s initialized", host)
 
     # Add all freshly discovered receivers
+    hass.data[DOMAIN]["receivers"] = receivers
     if receivers:
         add_entities(receivers)
 
@@ -398,3 +400,7 @@ class DenonDevice(MediaPlayerDevice):
     def mute_volume(self, mute):
         """Send mute command."""
         return self._receiver.mute(mute)
+
+    def get_command(self, command, **kwargs):
+        """Send generic command."""
+        return self._receiver.send_get_command(command)

--- a/homeassistant/components/denonavr/services.yaml
+++ b/homeassistant/components/denonavr/services.yaml
@@ -1,0 +1,11 @@
+# Describes the format for available webostv services
+
+get_command:
+  description: 'Send a generic http get command.'
+  fields:
+    entity_id:
+      description: Name(s) of the denonavr entities where to run the API method.
+      example: 'media_player.living_room_receiver'
+    command:
+      description: Endpoint of the command, including associated parameters.
+      example: '/goform/formiPhoneAppDirect.xml?RCKSK0410370'

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -146,6 +146,9 @@ datadog==0.15.0
 # homeassistant.components.ssdp
 defusedxml==0.6.0
 
+# homeassistant.components.denonavr
+denonavr==0.7.10
+
 # homeassistant.components.directv
 directpy==0.5
 

--- a/tests/components/denonavr/__init__.py
+++ b/tests/components/denonavr/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the denonavr integration."""

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -21,8 +21,8 @@ def client_fixture():
     ) as mock_client_class, patch(
         "homeassistant.components.denonavr.media_player.denonavr.discover"
     ):
-        mock_client_class.name = NAME
-        mock_client_class.return_value.zones = {"Main": mock_client_class}
+        mock_client_class.return_value.name = NAME
+        mock_client_class.return_value.zones = {"Main": mock_client_class.return_value}
         yield mock_client_class.return_value
 
 
@@ -54,4 +54,4 @@ async def test_get_command(hass, client):
     await hass.services.async_call(DOMAIN, SERVICE_GET_COMMAND, data)
     await hass.async_block_till_done()
 
-    client.zones["Main"].send_get_command.assert_called_with("test")
+    client.send_get_command.assert_called_with("test")

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -1,17 +1,39 @@
 """The tests for the denonavr media player platform."""
-import unittest
-from unittest import mock
+from unittest.mock import MagicMock
 
-from homeassistant.components.denonavr import media_player as denonavr
+from homeassistant.components import media_player
+from homeassistant.components.demo import media_player as demo
+import homeassistant.components.denonavr as denonavr
+from homeassistant.components.denonavr import ATTR_COMMAND, DOMAIN, SERVICE_GET_COMMAND
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.setup import async_setup_component
 
 
-class TestDenonDevice(unittest.TestCase):
-    """Test the DenonDevice class."""
+async def test_setup_demo_platform(hass):
+    """Test setup."""
+    mock = MagicMock()
+    add_entities = mock.MagicMock()
+    await demo.async_setup_platform(hass, {}, add_entities)
+    assert add_entities.call_count == 1
 
-    def setUp(self):
-        """Configure a fake device for each test."""
-        self.device = denonavr.DenonDevice(mock.MagicMock())
 
-    def test_get_command(self):
-        """Test generic command functionality."""
-        self.device.get_command("/goform/formiPhoneAppDirect.xml?RCKSK0410370")
+async def test_get_command(hass):
+    """Test generic command functionality."""
+
+    await hass.async_add_executor_job(denonavr.setup, hass, {})
+
+    assert await async_setup_component(
+        hass,
+        media_player.DOMAIN,
+        {"media_player": {"platform": "manual", "name": "test"}},
+    )
+
+    entity_id = "media_player.test"
+    command = "/goform/formiPhoneAppDirect.xml?RCKSK0410370"
+
+    data = {
+        ATTR_ENTITY_ID: entity_id,
+        ATTR_COMMAND: command,
+    }
+
+    await hass.services.async_call(DOMAIN, SERVICE_GET_COMMAND, data, blocking=True)

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -1,0 +1,26 @@
+"""The tests for the denonavr media player platform."""
+import unittest
+from unittest import mock
+
+from homeassistant.components.denonavr import media_player as denonavr
+
+
+class FakeDenonDevice(denonavr.DenonDevice):
+    """A fake device without the client setup required for the real one."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialise parameters needed for tests with fake values."""
+        self._receiver = mock.MagicMock()
+        self._name = "fake_device"
+
+
+class TestDenonDevice(unittest.TestCase):
+    """Test the LgWebOSDevice class."""
+
+    def setUp(self):
+        """Configure a fake device for each test."""
+        self.device = FakeDenonDevice()
+
+    def test_get_command(self):
+        """Test generic command functionality."""
+        self.device.get_command("/goform/formiPhoneAppDirect.xml?RCKSK0410370")

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -5,21 +5,12 @@ from unittest import mock
 from homeassistant.components.denonavr import media_player as denonavr
 
 
-class FakeDenonDevice(denonavr.DenonDevice):
-    """A fake device without the client setup required for the real one."""
-
-    def __init__(self, *args, **kwargs):
-        """Initialise parameters needed for tests with fake values."""
-        self._receiver = mock.MagicMock()
-        self._name = "fake_device"
-
-
 class TestDenonDevice(unittest.TestCase):
-    """Test the LgWebOSDevice class."""
+    """Test the DenonDevice class."""
 
     def setUp(self):
         """Configure a fake device for each test."""
-        self.device = FakeDenonDevice()
+        self.device = denonavr.DenonDevice(mock.MagicMock())
 
     def test_get_command(self):
         """Test generic command functionality."""


### PR DESCRIPTION
## Description:
Adds generic http get command functionality to denonavr

Replaces https://github.com/home-assistant/home-assistant/pull/28280 since the discussion in https://github.com/home-assistant/architecture/issues/299 seems to disfavour adding generic command functionality to the media_player domain.

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
- alias: Harmony Mute Button
  trigger:
    platform: event
    event_type: keyboard_remote_command_received
    event_data:
      key_code: 113
  action:
  - service: denonavr.get_command
    data:
      entity_id: media_player.denon_avr
      command: "/goform/formiPhoneAppDirect.xml?RCKSK0410370"
```

Corresponding documentation update in https://github.com/home-assistant/home-assistant.io/pull/11598