### PR TITLE
Add name option to season sensor

### DIFF
--- a/homeassistant/components/season/sensor.py
+++ b/homeassistant/components/season/sensor.py
@@ -14,7 +14,7 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = "season"
+DEFAULT_NAME = "Season"
 
 EQUATOR = "equator"
 

--- a/homeassistant/components/season/sensor.py
+++ b/homeassistant/components/season/sensor.py
@@ -7,11 +7,14 @@ import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_TYPE
+from homeassistant.const import CONF_NAME, CONF_TYPE
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "season"
 
 EQUATOR = "equator"
 
@@ -44,7 +47,10 @@ SEASON_ICONS = {
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {vol.Optional(CONF_TYPE, default=TYPE_ASTRONOMICAL): vol.In(VALID_TYPES)}
+    {
+        vol.Optional(CONF_TYPE, default=TYPE_ASTRONOMICAL): vol.In(VALID_TYPES),
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
 )
 
 
@@ -56,6 +62,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     latitude = util.convert(hass.config.latitude, float)
     _type = config.get(CONF_TYPE)
+    name = config.get(CONF_NAME)
 
     if latitude < 0:
         hemisphere = SOUTHERN
@@ -65,7 +72,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         hemisphere = EQUATOR
 
     _LOGGER.debug(_type)
-    add_entities([Season(hass, hemisphere, _type)])
+    add_entities([Season(hass, hemisphere, _type, name)])
 
     return True
 
@@ -105,9 +112,10 @@ def get_season(date, hemisphere, season_tracking_type):
 class Season(Entity):
     """Representation of the current season."""
 
-    def __init__(self, hass, hemisphere, season_tracking_type):
+    def __init__(self, hass, hemisphere, season_tracking_type, name):
         """Initialize the season."""
         self.hass = hass
+        self._name = name
         self.hemisphere = hemisphere
         self.datetime = dt_util.utcnow().replace(tzinfo=None)
         self.type = season_tracking_type
@@ -116,7 +124,7 @@ class Season(Entity):
     @property
     def name(self):
         """Return the name."""
-        return "Season"
+        return self._name
 
     @property
     def state(self):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- add name option to the season sensor so that users can modify its name to their liking

**Related issue (if applicable):** fixes #29298<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11346<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: season
    type: astronomical
    name: myastronomicalsensor
  - platform: season
    type: meteorological
    name: mymeteorologicalsensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
