### PR TITLE
Improve WLED white value support for RGBW strips

### DIFF
--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -8,6 +8,7 @@ from homeassistant.components.light import (
     ATTR_HS_COLOR,
     ATTR_RGB_COLOR,
     ATTR_TRANSITION,
+    ATTR_WHITE_VALUE,
     DOMAIN as LIGHT_DOMAIN,
 )
 from homeassistant.components.wled.const import (
@@ -164,7 +165,8 @@ async def test_rgbw_light(
 
     state = hass.states.get("light.wled_rgbw_light")
     assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_HS_COLOR) == (0.0, 64.706)
+    assert state.attributes.get(ATTR_HS_COLOR) == (0.0, 100.0)
+    assert state.attributes.get(ATTR_WHITE_VALUE) == 139
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -177,3 +179,17 @@ async def test_rgbw_light(
     state = hass.states.get("light.wled_rgbw_light")
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_HS_COLOR) == (28.874, 72.522)
+    assert state.attributes.get(ATTR_WHITE_VALUE) == 139
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.wled_rgbw_light", ATTR_WHITE_VALUE: 100},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.wled_rgbw_light")
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_HS_COLOR) == (28.874, 72.522)
+    assert state.attributes.get(ATTR_WHITE_VALUE) == 100


### PR DESCRIPTION
## Description:

This PR implements one of the most requested features I got this month.

The WLED integration used a method to "magically" determine the white value of the RGBW LED strip. This change adds in support for setting a white value when the used LED strip has a white channel.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
