### PR TITLE
Add hvac modes to helper method state_as_number

### DIFF
--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -1,13 +1,19 @@
 """Helpers that help with state related things."""
 import asyncio
+from collections import defaultdict
 import datetime as dt
 import logging
-from collections import defaultdict
 from types import ModuleType, TracebackType
 from typing import Dict, Iterable, List, Optional, Type, Union
 
-from homeassistant.loader import bind_hass, async_get_integration, IntegrationNotFound
-import homeassistant.util.dt as dt_util
+from homeassistant.components.climate.const import (
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
+)
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
 from homeassistant.const import (
     STATE_CLOSED,
@@ -21,6 +27,9 @@ from homeassistant.const import (
     STATE_UNLOCKED,
 )
 from homeassistant.core import Context, State
+from homeassistant.loader import IntegrationNotFound, async_get_integration, bind_hass
+import homeassistant.util.dt as dt_util
+
 from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,6 +127,12 @@ def state_as_number(state: State) -> float:
         STATE_ABOVE_HORIZON,
         STATE_OPEN,
         STATE_HOME,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT_COOL,
+        HVAC_MODE_AUTO,
+        HVAC_MODE_DRY,
+        HVAC_MODE_FAN_ONLY,
     ):
         return 1
     if state.state in (

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -5,21 +5,31 @@ from unittest.mock import patch
 
 import pytest
 
-import homeassistant.core as ha
-from homeassistant.const import SERVICE_TURN_ON, SERVICE_TURN_OFF
-from homeassistant.util import dt as dt_util
-from homeassistant.helpers import state
-from homeassistant.const import (
-    STATE_OPEN,
-    STATE_CLOSED,
-    STATE_LOCKED,
-    STATE_UNLOCKED,
-    STATE_ON,
-    STATE_OFF,
-    STATE_HOME,
-    STATE_NOT_HOME,
+from homeassistant.components.climate.const import (
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
 )
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
+from homeassistant.const import (
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_CLOSED,
+    STATE_HOME,
+    STATE_LOCKED,
+    STATE_NOT_HOME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_OPEN,
+    STATE_UNKNOWN,
+    STATE_UNLOCKED,
+)
+import homeassistant.core as ha
+from homeassistant.helpers import state
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_mock_service
 
@@ -188,12 +198,25 @@ async def test_as_number_states(hass):
     """Test state_as_number with states."""
     zero_states = (
         STATE_OFF,
-        STATE_CLOSED,
         STATE_UNLOCKED,
+        STATE_UNKNOWN,
         STATE_BELOW_HORIZON,
+        STATE_CLOSED,
         STATE_NOT_HOME,
     )
-    one_states = (STATE_ON, STATE_OPEN, STATE_LOCKED, STATE_ABOVE_HORIZON, STATE_HOME)
+    one_states = (
+        STATE_ON,
+        STATE_LOCKED,
+        STATE_ABOVE_HORIZON,
+        STATE_OPEN,
+        STATE_HOME,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT_COOL,
+        HVAC_MODE_AUTO,
+        HVAC_MODE_DRY,
+        HVAC_MODE_FAN_ONLY,
+    )
     for _state in zero_states:
         assert state.state_as_number(ha.State("domain.test", _state, {})) == 0
     for _state in one_states:


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

- added hvac_modes to the state_as_number method to fix conversion error with climate entities
- sorted all imports with `isort`

**Related issue (if applicable):** fixes #29015<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
