### PR TITLE
Add validator for UUID4 in string format

### DIFF
--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
-                vol.Required(CONF_API_KEY): cv.string,
+                vol.Required(CONF_API_KEY): cv.uuid4_string,
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): cv.time_period,
@@ -49,7 +49,7 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.positive_int, vol.Range(min=1)
                 ),
                 vol.Optional(CONF_STATIONS, default=[]): vol.All(
-                    cv.ensure_list, [cv.string]
+                    cv.ensure_list, [cv.uuid4_string]
                 ),
             }
         )

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -583,6 +583,20 @@ def uuid4_hex(value: Any) -> str:
     return result.hex
 
 
+def uuid4_string(value):
+    """Validate a v4 UUID in string format."""
+    try:
+        result = UUID(value, version=4)
+    except (ValueError, AttributeError, TypeError) as error:
+        raise vol.Invalid("Invalid Version4 UUID", error_message=str(error))
+
+    if str(result) != value.lower():
+        # UUID() will create a uuid4 if input is invalid
+        raise vol.Invalid("Invalid Version4 UUID")
+
+    return str(result)
+
+
 def ensure_list_csv(value: Any) -> List:
     """Ensure that input is a list or make one from comma-separated string."""
     if isinstance(value, str):

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -969,7 +969,7 @@ def test_comp_entity_ids():
 
 
 def test_uuid4_hex(caplog):
-    """Test uuid validation."""
+    """Test hex uuid validation."""
     schema = vol.Schema(cv.uuid4_hex)
 
     for value in ["Not a hex string", "0", 0]:
@@ -987,6 +987,27 @@ def test_uuid4_hex(caplog):
     _hex = uuid.uuid4().hex
     assert schema(_hex) == _hex
     assert schema(_hex.upper()) == _hex
+
+
+def test_uuid4_string(caplog):
+    """Test string uuid validation."""
+    schema = vol.Schema(cv.uuid4_string)
+
+    for value in ["Not a hex string", "0", 0]:
+        with pytest.raises(vol.Invalid):
+            schema(value)
+
+    with pytest.raises(vol.Invalid):
+        # the third block should start with 4
+        schema("a03d31b2-2eee-2acc-bb90-eec40be6ed23")
+
+    with pytest.raises(vol.Invalid):
+        # the fourth block should start with 8-a
+        schema("a03d31b2-2eee-4acc-1b90-eec40be6ed23")
+
+    _str = str(uuid.uuid4())
+    assert schema(_str) == _str
+    assert schema(_str.upper()) == _str
 
 
 def test_key_value_schemas():


### PR DESCRIPTION
## Description:

Add a configuration validator for strings in the UUID4 format, like
e.g. '005056ba-7cb6-4ed2-bceb-92a737c6ad35'

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
