### PR TITLE
Move imports to top for pushetta

### DIFF
--- a/homeassistant/components/pushetta/notify.py
+++ b/homeassistant/components/pushetta/notify.py
@@ -1,10 +1,8 @@
 """Pushetta platform for notify component."""
 import logging
 
+from pushetta import Pushetta, exceptions as PushettaExceptions
 import voluptuous as vol
-
-from homeassistant.const import CONF_API_KEY
-import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.notify import (
     ATTR_TITLE,
@@ -12,6 +10,8 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_API_KEY
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,7 +44,6 @@ class PushettaNotificationService(BaseNotificationService):
 
     def __init__(self, api_key, channel_name, send_test_msg):
         """Initialize the service."""
-        from pushetta import Pushetta
 
         self._api_key = api_key
         self._channel_name = channel_name
@@ -56,15 +55,14 @@ class PushettaNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        from pushetta import exceptions
 
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
 
         try:
             self.pushetta.pushMessage(self._channel_name, f"{title} {message}")
-        except exceptions.TokenValidationError:
+        except PushettaExceptions.TokenValidationError:
             _LOGGER.error("Please check your access token")
             self.is_valid = False
-        except exceptions.ChannelNotFoundError:
+        except PushettaExceptions.ChannelNotFoundError:
             _LOGGER.error("Channel '%s' not found", self._channel_name)
             self.is_valid = False

--- a/homeassistant/components/pushetta/notify.py
+++ b/homeassistant/components/pushetta/notify.py
@@ -1,7 +1,7 @@
 """Pushetta platform for notify component."""
 import logging
 
-from pushetta import Pushetta, exceptions as PushettaExceptions
+from pushetta import Pushetta, exceptions as pushetta_exceptions
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -60,9 +60,9 @@ class PushettaNotificationService(BaseNotificationService):
 
         try:
             self.pushetta.pushMessage(self._channel_name, f"{title} {message}")
-        except PushettaExceptions.TokenValidationError:
+        except pushetta_exceptions.TokenValidationError:
             _LOGGER.error("Please check your access token")
             self.is_valid = False
-        except PushettaExceptions.ChannelNotFoundError:
+        except pushetta_exceptions.ChannelNotFoundError:
             _LOGGER.error("Channel '%s' not found", self._channel_name)
             self.is_valid = False


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
