### PR TITLE
Rendering complex template objects to leave non-template values alone

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -489,8 +489,9 @@ def template_complex(value):
         for key, element in return_value.items():
             return_value[key] = template_complex(element)
         return return_value
-
-    return template(value)
+    if isinstance(value, str):
+        return template(value)
+    return value
 
 
 def datetime(value):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -69,7 +69,9 @@ def render_complex(value, variables=None):
         return [render_complex(item, variables) for item in value]
     if isinstance(value, dict):
         return {key: render_complex(item, variables) for key, item in value.items()}
-    return value.async_render(variables)
+    if isinstance(value, Template):
+        return value.async_render(variables)
+    return value
 
 
 def extract_entities(

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -395,7 +395,7 @@ def test_template_complex():
     """Test template_complex validator."""
     schema = vol.Schema(cv.template_complex)
 
-    for value in (None, "{{ partial_print }", "{% if True %}Hello"):
+    for value in ("{{ partial_print }", "{% if True %}Hello"):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
@@ -419,6 +419,10 @@ def test_template_complex():
         {"test": 1, "test2": "{{ beer }}"},
         ["{{ beer }}", 1],
     )
+
+    # Ensure we don't mutate non-string types that cannot be templates.
+    for value in (1, True, None):
+        assert schema(value) == value
 
 
 def test_time_zone():

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1796,3 +1796,10 @@ def test_length_of_states(hass):
 
     tpl = template.Template("{{ states.sensor | length }}", hass)
     assert tpl.async_render() == "2"
+
+
+def test_render_complex_handling_non_template_values(hass):
+    """Test that we can render non-template fields."""
+    assert template.render_complex(
+        {True: 1, False: template.Template("{{ hello }}", hass)}, {"hello": 2}
+    ) == {True: 1, False: "2"}


### PR DESCRIPTION
## Description:
Rendering complex template objects will now leave non-string values alone, since they can never be templates to begin with.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
