### PR TITLE
Move imports to top for opensensemap

### DIFF
--- a/homeassistant/components/opensensemap/air_quality.py
+++ b/homeassistant/components/opensensemap/air_quality.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 import logging
 
+from opensensemap_api import OpenSenseMap
+from opensensemap_api.exceptions import OpenSenseMapError
 import voluptuous as vol
 
 from homeassistant.components.air_quality import PLATFORM_SCHEMA, AirQualityEntity
@@ -26,7 +28,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the openSenseMap air quality platform."""
-    from opensensemap_api import OpenSenseMap
 
     name = config.get(CONF_NAME)
     station_id = config[CONF_STATION_ID]
@@ -88,7 +89,6 @@ class OpenSenseMapData:
     @Throttle(SCAN_INTERVAL)
     async def async_update(self):
         """Get the latest data from the Pi-hole."""
-        from opensensemap_api.exceptions import OpenSenseMapError
 
         try:
             await self.api.get_data()


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
