### PR TITLE
Remove cloud dependency from mobile_app

### DIFF
--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -3,15 +3,7 @@
   "name": "Home Assistant Mobile App Support",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
-  "requirements": [
-    "PyNaCl==1.3.0"
-  ],
-  "dependencies": [
-    "cloud",
-    "http",
-    "webhook"
-  ],
-  "codeowners": [
-    "@robbiet480"
-  ]
+  "requirements": ["PyNaCl==1.3.0"],
+  "dependencies": ["http", "webhook"],
+  "codeowners": ["@robbiet480"]
 }

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -4,7 +4,6 @@ import logging
 from aiohttp.web import HTTPBadRequest, Request, Response
 import voluptuous as vol
 
-from homeassistant.components.cloud import CloudNotAvailable, async_remote_ui_url
 from homeassistant.components.frontend import MANIFEST_JSON
 from homeassistant.components.zone.const import DOMAIN as ZONE_DOMAIN
 from homeassistant.const import (
@@ -310,9 +309,10 @@ async def handle_webhook(
         if CONF_CLOUDHOOK_URL in registration:
             resp[CONF_CLOUDHOOK_URL] = registration[CONF_CLOUDHOOK_URL]
 
-        try:
-            resp[CONF_REMOTE_UI_URL] = async_remote_ui_url(hass)
-        except CloudNotAvailable:
-            pass
+        if "cloud" in hass.config.components:
+            try:
+                resp[CONF_REMOTE_UI_URL] = hass.components.cloud.async_remote_ui_url()
+            except hass.components.cloud.CloudNotAvailable:
+                pass
 
         return webhook_response(resp, registration=registration, headers=headers)

--- a/homeassistant/components/mobile_app/websocket_api.py
+++ b/homeassistant/components/mobile_app/websocket_api.py
@@ -1,7 +1,6 @@
 """Websocket API for mobile_app."""
 import voluptuous as vol
 
-from homeassistant.components.cloud import async_delete_cloudhook
 from homeassistant.components.websocket_api import (
     ActiveConnection,
     async_register_command,
@@ -117,6 +116,6 @@ async def websocket_delete_registration(
         return error_message(msg["id"], "internal_error", "Error deleting registration")
 
     if CONF_CLOUDHOOK_URL in registration and "cloud" in hass.config.components:
-        await async_delete_cloudhook(hass, webhook_id)
+        await hass.components.cloud.async_delete_cloudhook(webhook_id)
 
     connection.send_message(result_message(msg["id"], "ok"))


### PR DESCRIPTION
## Breaking Change:
Loading Mobile App no longer causes Cloud integration to be loaded. If you relied on this, add `cloud:` to your configuration.yaml.

## Description:
Guard all calls into cloud integration from mobile_app. 

@MartinHjelmare @pvizeli I guess here too, we could just install `after_dependencies` and it's not a problem 🤷‍♂ 

**Related issue (if applicable):** Fixes #29347

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

