### PR TITLE
Use hass state for tests rather than direct object

### DIFF
--- a/tests/components/arcam_fmj/conftest.py
+++ b/tests/components/arcam_fmj/conftest.py
@@ -16,6 +16,7 @@ MOCK_TURN_ON = {
     "data": {"entity_id": "switch.test"},
 }
 MOCK_NAME = "dummy"
+MOCK_ENTITY_ID = "media_player.arcam_fmj_1"
 MOCK_CONFIG = DEVICE_SCHEMA({CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT})
 
 
@@ -41,6 +42,10 @@ def state_fixture(client):
     state.client = client
     state.zn = 1
     state.get_power.return_value = True
+    state.get_volume.return_value = 0.0
+    state.get_source_list.return_value = []
+    state.get_incoming_audio_format.return_value = (0, 0)
+    state.get_mute.return_value = None
     return state
 
 
@@ -48,5 +53,7 @@ def state_fixture(client):
 def player_fixture(hass, state):
     """Get standard player."""
     player = ArcamFmj(state, MOCK_NAME, None)
+    player.entity_id = MOCK_ENTITY_ID
+    player.hass = hass
     player.async_schedule_update_ha_state = Mock()
     return player

--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -5,18 +5,10 @@ from arcam.fmj import DecodeMode2CH, DecodeModeMCH, IncomingAudioFormat, SourceC
 from asynctest.mock import ANY, MagicMock, Mock, PropertyMock, patch
 import pytest
 
-from homeassistant.components.arcam_fmj.const import (
-    DOMAIN,
-    SIGNAL_CLIENT_DATA,
-    SIGNAL_CLIENT_STARTED,
-    SIGNAL_CLIENT_STOPPED,
-)
-from homeassistant.components.arcam_fmj.media_player import ArcamFmj
 from homeassistant.components.media_player.const import MEDIA_TYPE_MUSIC
-from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
-from .conftest import MOCK_HOST, MOCK_NAME, MOCK_PORT
+from .conftest import MOCK_HOST, MOCK_NAME, MOCK_PORT, MOCK_ENTITY_ID
 
 MOCK_TURN_ON = {
     "service": "switch.turn_on",
@@ -24,50 +16,69 @@ MOCK_TURN_ON = {
 }
 
 
+async def update(player, force_refresh=False):
+    """Force a update of player and return current state data."""
+    await player.async_update_ha_state(force_refresh=force_refresh)
+    return player.hass.states.get(player.entity_id)
+
+
 async def test_properties(player, state):
     """Test standard properties."""
     assert player.unique_id is None
     assert player.device_info == {
-        "identifiers": {(DOMAIN, MOCK_HOST, MOCK_PORT)},
+        "identifiers": {("arcam_fmj", MOCK_HOST, MOCK_PORT)},
         "model": "FMJ",
         "manufacturer": "Arcam",
     }
     assert not player.should_poll
 
 
-async def test_powered_off(player, state):
+async def test_powered_off(hass, player, state):
     """Test properties in powered off state."""
     state.get_source.return_value = None
     state.get_power.return_value = None
-    assert player.source is None
-    assert player.state == STATE_OFF
+
+    data = await update(player)
+    assert "source" not in data.attributes
+    assert data.state == "off"
 
 
 async def test_powered_on(player, state):
     """Test properties in powered on state."""
     state.get_source.return_value = SourceCodes.PVR
     state.get_power.return_value = True
-    assert player.source == "PVR"
-    assert player.state == STATE_ON
+
+    data = await update(player)
+    assert data.attributes["source"] == "PVR"
+    assert data.state == "on"
 
 
 async def test_supported_features_no_service(player, state):
     """Test support when turn on service exist."""
     state.get_power.return_value = None
-    assert player.supported_features == 68876
+    data = await update(player)
+    assert data.attributes["supported_features"] == 68876
 
     state.get_power.return_value = False
-    assert player.supported_features == 69004
+    data = await update(player)
+    assert data.attributes["supported_features"] == 69004
 
 
 async def test_supported_features_service(hass, state):
     """Test support when turn on service exist."""
+    from homeassistant.components.arcam_fmj.media_player import ArcamFmj
+
     player = ArcamFmj(state, "dummy", MOCK_TURN_ON)
+    player.hass = hass
+    player.entity_id = MOCK_ENTITY_ID
+
     state.get_power.return_value = None
-    assert player.supported_features == 69004
+    data = await update(player)
+    assert data.attributes["supported_features"] == 69004
 
     state.get_power.return_value = False
-    assert player.supported_features == 69004
+    data = await update(player)
+    assert data.attributes["supported_features"] == 69004
 
 
 async def test_turn_on_without_service(player, state):
@@ -83,8 +94,11 @@ async def test_turn_on_without_service(player, state):
 
 async def test_turn_on_with_service(hass, state):
     """Test support when turn on service exist."""
+    from homeassistant.components.arcam_fmj.media_player import ArcamFmj
+
     player = ArcamFmj(state, "dummy", MOCK_TURN_ON)
     player.hass = Mock(HomeAssistant)
+    player.entity_id = MOCK_ENTITY_ID
     with patch(
         "homeassistant.components.arcam_fmj.media_player.async_call_from_config"
     ) as async_call_from_config:
@@ -122,7 +136,7 @@ async def test_name(player):
 
 async def test_update(player, state):
     """Test update."""
-    await player.async_update()
+    await update(player, force_refresh=True)
     state.update.assert_called_with()
 
 
@@ -157,7 +171,8 @@ async def test_select_source(player, state, source, value):
 async def test_source_list(player, state):
     """Test source list."""
     state.get_source_list.return_value = [SourceCodes.BD]
-    assert player.source_list == ["BD"]
+    data = await update(player)
+    assert data.attributes["source_list"] == ["BD"]
 
 
 @pytest.mark.parametrize(
@@ -317,16 +332,28 @@ async def test_media_artist(player, state, source, dls, artist):
 )
 async def test_media_title(player, state, source, channel, title):
     """Test media title."""
+    from homeassistant.components.arcam_fmj.media_player import ArcamFmj
+
     state.get_source.return_value = source
     with patch.object(
         ArcamFmj, "media_channel", new_callable=PropertyMock
     ) as media_channel:
         media_channel.return_value = channel
-        assert player.media_title == title
+        data = await update(player)
+        if title is None:
+            assert "media_title" not in data.attributes
+        else:
+            assert data.attributes["media_title"] == title
 
 
 async def test_added_to_hass(player, state):
     """Test addition to hass."""
+    from homeassistant.components.arcam_fmj.const import (
+        SIGNAL_CLIENT_DATA,
+        SIGNAL_CLIENT_STARTED,
+        SIGNAL_CLIENT_STOPPED,
+    )
+
     connectors = {}
 
     def _connect(signal, fun):


### PR DESCRIPTION
## Description:
This is an initial step to try to address comments in #29335 about using hass core state and functions to test platform behaviour. Instead of doing internal unit test, we do integration tests with hass core.

**Related issue (if applicable):** #29335

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
