### PR TITLE
Add flux set_state_service configuration to support light platforms that can change properties when light is off

### DIFF
--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -109,8 +109,8 @@ async def async_set_lights_xy(
             service_data[ATTR_TRANSITION] = transition
         try:
             await hass.services.async_call(LIGHT_DOMAIN, service, service_data)
-        except Exception as e:
-            _LOGGER.warning("flux failed to set new xy state: %s", e)
+        except Exception as err:  # pylint:disable=broad-except
+            _LOGGER.warning("flux failed to set new xy state: %s", err)
 
 
 async def async_set_lights_temp(
@@ -131,8 +131,8 @@ async def async_set_lights_temp(
             service_data[ATTR_TRANSITION] = transition
         try:
             await hass.services.async_call(LIGHT_DOMAIN, service, service_data)
-        except Exception as e:
-            _LOGGER.warning("flux failed to set new temp state: %s", e)
+        except Exception as err:  # pylint:disable=broad-except
+            _LOGGER.warning("flux failed to set new temp state: %s", err)
 
 
 async def async_set_lights_rgb(hass, set_state_service, lights, rgb, transition):
@@ -146,8 +146,8 @@ async def async_set_lights_rgb(hass, set_state_service, lights, rgb, transition)
             service_data[ATTR_TRANSITION] = transition
         try:
             await hass.services.async_call(LIGHT_DOMAIN, service, service_data)
-        except Exception as e:
-            _LOGGER.warning("flux failed to set new rgb state: %s", e)
+        except Exception as err:  # pylint:disable=broad-except
+            _LOGGER.warning("flux failed to set new rgb state: %s", err)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -110,7 +110,7 @@ async def async_set_lights_xy(
         try:
             await hass.services.async_call(LIGHT_DOMAIN, service, service_data)
         except Exception as err:  # pylint:disable=broad-except
-            _LOGGER.warning("flux failed to set new xy state: %s", err)
+            _LOGGER.exception("flux failed to set new xy state: %s", err)
 
 
 async def async_set_lights_temp(
@@ -132,7 +132,7 @@ async def async_set_lights_temp(
         try:
             await hass.services.async_call(LIGHT_DOMAIN, service, service_data)
         except Exception as err:  # pylint:disable=broad-except
-            _LOGGER.warning("flux failed to set new temp state: %s", err)
+            _LOGGER.exception("flux failed to set new temp state: %s", err)
 
 
 async def async_set_lights_rgb(hass, set_state_service, lights, rgb, transition):
@@ -147,7 +147,7 @@ async def async_set_lights_rgb(hass, set_state_service, lights, rgb, transition)
         try:
             await hass.services.async_call(LIGHT_DOMAIN, service, service_data)
         except Exception as err:  # pylint:disable=broad-except
-            _LOGGER.warning("flux failed to set new rgb state: %s", err)
+            _LOGGER.exception("flux failed to set new rgb state: %s", err)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Most lights don't have a color when they are off, and the flux component uses light.turn_on with the new properties only when the light is already on.  Platforms such as lifx and my vantage infusion lighting component support a light.{lifx,vantage}_set_state service that works even when the light is off. This changes enables a new config field, set_state_service, that lets you specify the name of such a service and has the flux light setting code use that even when the light is off.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11358

coming soon.

## Example entry for `configuration.yaml` (if applicable):
```
flux:
    ...
    set_state_service: 'lifx_set_state'
    ...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
