### PR TITLE
Allow negative altitude in location updates

### DIFF
--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -160,7 +160,7 @@ UPDATE_LOCATION_SCHEMA = vol.Schema(
         vol.Required(ATTR_GPS_ACCURACY): cv.positive_int,
         vol.Optional(ATTR_BATTERY): cv.positive_int,
         vol.Optional(ATTR_SPEED): cv.positive_int,
-        vol.Optional(ATTR_ALTITUDE): cv.positive_int,
+        vol.Optional(ATTR_ALTITUDE): vol.Coerce(float),
         vol.Optional(ATTR_COURSE): cv.positive_int,
         vol.Optional(ATTR_VERTICAL_ACCURACY): cv.positive_int,
     }

--- a/tests/components/mobile_app/conftest.py
+++ b/tests/components/mobile_app/conftest.py
@@ -18,7 +18,7 @@ def registry(hass):
 
 
 @pytest.fixture
-async def create_registrations(authed_api_client):
+async def create_registrations(hass, authed_api_client):
     """Return two new registrations."""
     enc_reg = await authed_api_client.post(
         "/api/mobile_app/registrations", json=REGISTER
@@ -33,6 +33,8 @@ async def create_registrations(authed_api_client):
 
     assert clear_reg.status == 201
     clear_reg_json = await clear_reg.json()
+
+    await hass.async_block_till_done()
 
     return (enc_reg_json, clear_reg_json)
 


### PR DESCRIPTION
## Description:
Mobile App did not consider that people could live below sea level 🙈 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
