### PR TITLE
Move imports to top for lutron

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -1,11 +1,12 @@
 """Component for interacting with a Lutron RadioRA 2 system."""
 import logging
 
+from pylutron import Button, Lutron
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import ATTR_ID, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
@@ -36,7 +37,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, base_config):
     """Set up the Lutron component."""
-    from pylutron import Lutron
 
     hass.data[LUTRON_BUTTONS] = []
     hass.data[LUTRON_CONTROLLER] = None
@@ -147,7 +147,6 @@ class LutronButton:
 
     def button_callback(self, button, context, event, params):
         """Fire an event about a button being pressed or released."""
-        from pylutron import Button
 
         # Events per button type:
         #   RaiseLower -> pressed/released

--- a/homeassistant/components/lutron/binary_sensor.py
+++ b/homeassistant/components/lutron/binary_sensor.py
@@ -2,8 +2,8 @@
 from pylutron import OccupancyGroup
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice,
     DEVICE_CLASS_OCCUPANCY,
+    BinarySensorDevice,
 )
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice


### PR DESCRIPTION
## Breaking change

N/A - works with both legacy and new backend formats.

## Proposed change

Refactors grid energy configuration from legacy format to unified grid connection objects (like batteries). Each grid connection is now a single object with import/export/power together.

Adds reusable `ha-energy-power-config` component shared between grid and battery dialogs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml

```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: 
- Link to documentation pull request: 
- Link to core pull request: https://github.com/home-assistant/core/pull/162200