### PR TITLE
Move imports to top for kiwi

### DIFF
--- a/homeassistant/components/kiwi/lock.py
+++ b/homeassistant/components/kiwi/lock.py
@@ -1,21 +1,22 @@
 """Support for the KIWI.KI lock platform."""
 import logging
 
+from kiwiki import KiwiClient, KiwiException
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.lock import LockDevice, PLATFORM_SCHEMA
+from homeassistant.components.lock import PLATFORM_SCHEMA, LockDevice
 from homeassistant.const import (
+    ATTR_ID,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
     CONF_PASSWORD,
     CONF_USERNAME,
-    ATTR_ID,
-    ATTR_LONGITUDE,
-    ATTR_LATITUDE,
     STATE_LOCKED,
     STATE_UNLOCKED,
 )
-from homeassistant.helpers.event import async_call_later
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_call_later
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the KIWI lock platform."""
-    from kiwiki import KiwiClient, KiwiException
 
     try:
         kiwi = KiwiClient(config[CONF_USERNAME], config[CONF_PASSWORD])
@@ -98,7 +98,6 @@ class KiwiLock(LockDevice):
 
     def unlock(self, **kwargs):
         """Unlock the device."""
-        from kiwiki import KiwiException
 
         try:
             self._client.open_door(self.lock_id)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
