### PR TITLE
Move imports to top for kwb

### DIFF
--- a/homeassistant/components/kwb/sensor.py
+++ b/homeassistant/components/kwb/sensor.py
@@ -1,18 +1,19 @@
 """Support for KWB Easyfire."""
 import logging
 
+from pykwb import kwb
 import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
     CONF_DEVICE,
+    CONF_HOST,
     CONF_NAME,
+    CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.helpers.entity import Entity
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,8 +56,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     connection_type = config.get(CONF_TYPE)
     raw = config.get(CONF_RAW)
     client_name = config.get(CONF_NAME)
-
-    from pykwb import kwb
 
     if connection_type == "serial":
         easyfire = kwb.KWBEasyfire(MODE_SERIAL, "", 0, device)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
