### PR TITLE
Move imports to top for gitter

### DIFF
--- a/homeassistant/components/gitter/sensor.py
+++ b/homeassistant/components/gitter/sensor.py
@@ -1,6 +1,8 @@
 """Support for displaying details about a Gitter.im chat room."""
 import logging
 
+from gitterpy.client import GitterClient
+from gitterpy.errors import GitterRoomError, GitterTokenError
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -30,8 +32,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Gitter sensor."""
-    from gitterpy.client import GitterClient
-    from gitterpy.errors import GitterTokenError
 
     name = config.get(CONF_NAME)
     api_key = config.get(CONF_API_KEY)
@@ -91,7 +91,6 @@ class GitterSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the state."""
-        from gitterpy.errors import GitterRoomError
 
         try:
             data = self._data.user.unread_items(self._room)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
