### PR TITLE
Move imports to top for gpmdp

### DIFF
--- a/homeassistant/components/gpmdp/media_player.py
+++ b/homeassistant/components/gpmdp/media_player.py
@@ -5,8 +5,9 @@ import socket
 import time
 
 import voluptuous as vol
+from websocket import _exceptions, create_connection
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_NEXT_TRACK,
@@ -65,8 +66,6 @@ def request_configuration(hass, config, url, add_entities_callback):
         )
 
         return
-    from websocket import create_connection
-
     websocket = create_connection((url), timeout=1)
     websocket.send(
         json.dumps(
@@ -81,7 +80,6 @@ def request_configuration(hass, config, url, add_entities_callback):
     def gpmdp_configuration_callback(callback_data):
         """Handle configuration changes."""
         while True:
-            from websocket import _exceptions
 
             try:
                 msg = json.loads(websocket.recv())
@@ -174,7 +172,6 @@ class GPMDP(MediaPlayerDevice):
 
     def __init__(self, name, url, code):
         """Initialize the media player."""
-        from websocket import create_connection
 
         self._connection = create_connection
         self._url = url
@@ -210,7 +207,6 @@ class GPMDP(MediaPlayerDevice):
 
     def send_gpmdp_msg(self, namespace, method, with_id=True):
         """Send ws messages to GPMDP and verify request id in response."""
-        from websocket import _exceptions
 
         try:
             websocket = self.get_ws()


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
