### PR TITLE
Move imports to top for homeworks

### DIFF
--- a/homeassistant/components/homeworks/__init__.py
+++ b/homeassistant/components/homeworks/__init__.py
@@ -1,6 +1,7 @@
 """Support for Lutron Homeworks Series 4 and 8 systems."""
 import logging
 
+from pyhomeworks.pyhomeworks import HW_BUTTON_PRESSED, HW_BUTTON_RELEASED, Homeworks
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -65,7 +66,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, base_config):
     """Start Homeworks controller."""
-    from pyhomeworks.pyhomeworks import Homeworks
 
     def hw_callback(msg_type, values):
         """Dispatch state changes."""
@@ -138,7 +138,6 @@ class HomeworksKeypadEvent:
     @callback
     def _update_callback(self, msg_type, values):
         """Fire events if button is pressed or released."""
-        from pyhomeworks.pyhomeworks import HW_BUTTON_PRESSED, HW_BUTTON_RELEASED
 
         if msg_type == HW_BUTTON_PRESSED:
             event = EVENT_BUTTON_PRESS

--- a/homeassistant/components/homeworks/light.py
+++ b/homeassistant/components/homeworks/light.py
@@ -1,6 +1,8 @@
 """Support for Lutron Homeworks lights."""
 import logging
 
+from pyhomeworks.pyhomeworks import HW_LIGHT_CHANGED
+
 from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
@@ -93,7 +95,6 @@ class HomeworksLight(HomeworksDevice, Light):
     @callback
     def _update_callback(self, msg_type, values):
         """Process device specific messages."""
-        from pyhomeworks.pyhomeworks import HW_LIGHT_CHANGED
 
         if msg_type == HW_LIGHT_CHANGED:
             self._level = int((values[1] * 255.0) / 100.0)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
