### PR TITLE
Move imports to top for horizon

### DIFF
--- a/homeassistant/components/horizon/media_player.py
+++ b/homeassistant/components/horizon/media_player.py
@@ -81,12 +81,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class HorizonDevice(MediaPlayerDevice):
     """Representation of a Horizon HD Recorder."""
 
-    def __init__(self, client, name, keys):
+    def __init__(self, client, name, remote_keys):
         """Initialize the remote."""
         self._client = client
         self._name = name
         self._state = None
-        self._keys = keys
+        self._keys = remote_keys
 
     @property
     def name(self):

--- a/homeassistant/components/horizon/media_player.py
+++ b/homeassistant/components/horizon/media_player.py
@@ -2,10 +2,12 @@
 from datetime import timedelta
 import logging
 
+from horimote import Client, keys
+from horimote.exceptions import AuthenticationError
 import voluptuous as vol
 
 from homeassistant import util
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,
@@ -56,8 +58,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Horizon platform."""
-    from horimote import Client, keys
-    from horimote.exceptions import AuthenticationError
 
     host = config[CONF_HOST]
     name = config[CONF_NAME]
@@ -177,7 +177,6 @@ class HorizonDevice(MediaPlayerDevice):
 
     def _send(self, key=None, channel=None):
         """Send a key to the Horizon device."""
-        from horimote.exceptions import AuthenticationError
 
         try:
             if key:


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
