### PR TITLE
Move imports to top for ihc

### DIFF
--- a/homeassistant/components/ihc/__init__.py
+++ b/homeassistant/components/ihc/__init__.py
@@ -2,6 +2,8 @@
 import logging
 import os.path
 
+from defusedxml import ElementTree
+from ihcsdk.ihccontroller import IHCController
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
@@ -214,7 +216,6 @@ def setup(hass, config):
 
 def ihc_setup(hass, config, conf, controller_id):
     """Set up the IHC component."""
-    from ihcsdk.ihccontroller import IHCController
 
     url = conf[CONF_URL]
     username = conf[CONF_USERNAME]
@@ -272,7 +273,6 @@ def autosetup_ihc_products(
     hass: HomeAssistantType, config, ihc_controller, controller_id
 ):
     """Auto setup of IHC products from the IHC project file."""
-    from defusedxml import ElementTree
 
     project_xml = ihc_controller.get_project()
     if not project_xml:


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
