### PR TITLE
Move imports to top for deluge

### DIFF
--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -1,21 +1,22 @@
 """Support for monitoring the Deluge BitTorrent client API."""
 import logging
 
+from deluge_client import DelugeRPCClient, FailedToReconnectException
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_NAME,
-    CONF_PORT,
     CONF_MONITORED_VARIABLES,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
     STATE_IDLE,
 )
-from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 _THROTTLED_REFRESH = None
@@ -46,7 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Deluge sensors."""
-    from deluge_client import DelugeRPCClient
 
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
@@ -103,7 +103,6 @@ class DelugeSensor(Entity):
 
     def update(self):
         """Get the latest data from Deluge and updates the state."""
-        from deluge_client import FailedToReconnectException
 
         try:
             self.data = self.client.call(

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -1,21 +1,22 @@
 """Support for setting the Deluge BitTorrent client in Pause."""
 import logging
 
+from deluge_client import DelugeRPCClient, FailedToReconnectException
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
-    CONF_PORT,
     CONF_PASSWORD,
+    CONF_PORT,
     CONF_USERNAME,
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +36,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Deluge switch."""
-    from deluge_client import DelugeRPCClient
 
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
@@ -95,7 +95,6 @@ class DelugeSwitch(ToggleEntity):
 
     def update(self):
         """Get the latest data from deluge and updates the state."""
-        from deluge_client import FailedToReconnectException
 
         try:
             torrent_list = self.deluge_client.call(


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
