### PR TITLE
Support MR1100 (Nighthawk M1) with netgear_lte

### DIFF
--- a/homeassistant/components/netgear_lte/manifest.json
+++ b/homeassistant/components/netgear_lte/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netgear lte",
   "documentation": "https://www.home-assistant.io/integrations/netgear_lte",
   "requirements": [
-    "eternalegypt==0.0.10"
+    "eternalegypt==0.0.11"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -493,7 +493,7 @@ epson-projector==0.1.3
 epsonprinter==0.0.9
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.10
+eternalegypt==0.0.11
 
 # homeassistant.components.keyboard_remote
 # evdev==1.1.2


### PR DESCRIPTION
## Description:

Changelog: https://github.com/amelchio/eternalegypt/releases/tag/v0.0.11

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
