### PR TITLE
Move imports to top for enocean

### DIFF
--- a/homeassistant/components/enocean/__init__.py
+++ b/homeassistant/components/enocean/__init__.py
@@ -1,11 +1,14 @@
 """Support for EnOcean devices."""
 import logging
 
+from enocean.communicators.serialcommunicator import SerialCommunicator
+from enocean.protocol.packet import Packet, RadioPacket
+from enocean.utils import combine_hex
 import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICE
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +37,6 @@ class EnOceanDongle:
 
     def __init__(self, hass, ser):
         """Initialize the EnOcean dongle."""
-        from enocean.communicators.serialcommunicator import SerialCommunicator
 
         self.__communicator = SerialCommunicator(port=ser, callback=self.callback)
         self.__communicator.start()
@@ -53,7 +55,6 @@ class EnOceanDongle:
         This is the callback function called by python-enocan whenever there
         is an incoming packet.
         """
-        from enocean.protocol.packet import RadioPacket
 
         if isinstance(packet, RadioPacket):
             _LOGGER.debug("Received radio packet: %s", packet)
@@ -76,7 +77,6 @@ class EnOceanDevice(Entity):
 
     def _message_received_callback(self, packet):
         """Handle incoming packets."""
-        from enocean.utils import combine_hex
 
         if packet.sender_int == combine_hex(self.dev_id):
             self.value_changed(packet)
@@ -86,7 +86,6 @@ class EnOceanDevice(Entity):
 
     def send_command(self, data, optional, packet_type):
         """Send a command via the EnOcean dongle."""
-        from enocean.protocol.packet import Packet
 
         packet = Packet(packet_type, data=data, optional=optional)
         self.hass.helpers.dispatcher.dispatcher_send(SIGNAL_SEND_MESSAGE, packet)

--- a/homeassistant/components/enocean/sensor.py
+++ b/homeassistant/components/enocean/sensor.py
@@ -11,8 +11,8 @@ from homeassistant.const import (
     CONF_NAME,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
-    TEMP_CELSIUS,
     POWER_WATT,
+    TEMP_CELSIUS,
 )
 import homeassistant.helpers.config_validation as cv
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
