### PR TITLE
Move imports to top for enigma2

### DIFF
--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -1,35 +1,36 @@
 """Support for Enigma2 media players."""
 import logging
 
+from openwebif.api import CreateDevice
 import voluptuous as vol
 
 from homeassistant.components.media_player import MediaPlayerDevice
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_TVSHOW,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_TURN_ON,
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_STOP,
     SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
-    SUPPORT_STOP,
-    SUPPORT_SELECT_SOURCE,
     SUPPORT_VOLUME_STEP,
-    MEDIA_TYPE_TVSHOW,
 )
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
-    CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_PORT,
     CONF_SSL,
+    CONF_USERNAME,
     STATE_OFF,
     STATE_ON,
     STATE_PLAYING,
-    CONF_PORT,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,8 +101,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config[CONF_MAC_ADDRESS] = DEFAULT_MAC_ADDRESS
         config[CONF_DEEP_STANDBY] = DEFAULT_DEEP_STANDBY
         config[CONF_SOURCE_BOUQUET] = DEFAULT_SOURCE_BOUQUET
-
-    from openwebif.api import CreateDevice
 
     device = CreateDevice(
         host=config[CONF_HOST],


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
