### PR TITLE
Fix setup of Huawei LTE for which we can't get a MAC address

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -148,7 +148,7 @@ class Router:
     @property
     def device_connections(self) -> Set[Tuple[str, str]]:
         """Get router connections for device registry."""
-        return {(dr.CONNECTION_NETWORK_MAC, self.mac)}
+        return {(dr.CONNECTION_NETWORK_MAC, self.mac)} if self.mac else set()
 
     def update(self) -> None:
         """Update router data."""


### PR DESCRIPTION

## Description:

Don't specify None mac as device connection.

**Related issue (if applicable):** fixes #29188

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
