### PR TITLE
Move imports to top for zoneminder

### DIFF
--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -2,18 +2,19 @@
 import logging
 
 import voluptuous as vol
+from zoneminder.zm import ZoneMinder
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
+    ATTR_ID,
+    ATTR_NAME,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PATH,
     CONF_SSL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
-    ATTR_NAME,
-    ATTR_ID,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +52,6 @@ SET_RUN_STATE_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the ZoneMinder component."""
-    from zoneminder.zm import ZoneMinder
 
     hass.data[DOMAIN] = {}
 

--- a/homeassistant/components/zoneminder/sensor.py
+++ b/homeassistant/components/zoneminder/sensor.py
@@ -2,6 +2,7 @@
 import logging
 
 import voluptuous as vol
+from zoneminder.monitor import TimePeriod
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_MONITORED_CONDITIONS
@@ -95,7 +96,6 @@ class ZMSensorEvents(Entity):
 
     def __init__(self, monitor, include_archived, sensor_type):
         """Initialize event sensor."""
-        from zoneminder.monitor import TimePeriod
 
         self._monitor = monitor
         self._include_archived = include_archived

--- a/homeassistant/components/zoneminder/switch.py
+++ b/homeassistant/components/zoneminder/switch.py
@@ -2,6 +2,7 @@
 import logging
 
 import voluptuous as vol
+from zoneminder.monitor import MonitorState
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import CONF_COMMAND_OFF, CONF_COMMAND_ON
@@ -21,7 +22,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder switch platform."""
-    from zoneminder.monitor import MonitorState
 
     on_state = MonitorState(config.get(CONF_COMMAND_ON))
     off_state = MonitorState(config.get(CONF_COMMAND_OFF))


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
