### PR TITLE
Move imports to top for history

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -5,22 +5,23 @@ from itertools import groupby
 import logging
 import time
 
+from sqlalchemy import and_, func
 import voluptuous as vol
 
+from homeassistant.components import recorder, script
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.recorder.models import States
+from homeassistant.components.recorder.util import execute, session_scope
 from homeassistant.const import (
-    HTTP_BAD_REQUEST,
+    ATTR_HIDDEN,
     CONF_DOMAINS,
     CONF_ENTITIES,
     CONF_EXCLUDE,
     CONF_INCLUDE,
+    HTTP_BAD_REQUEST,
 )
-import homeassistant.util.dt as dt_util
-from homeassistant.components import recorder, script
-from homeassistant.components.http import HomeAssistantView
-from homeassistant.const import ATTR_HIDDEN
-from homeassistant.components.recorder.util import session_scope, execute
 import homeassistant.helpers.config_validation as cv
-
+import homeassistant.util.dt as dt_util
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -58,7 +59,6 @@ def get_significant_states(
     thermostat so that we get current temperature in our graphs).
     """
     timer_start = time.perf_counter()
-    from homeassistant.components.recorder.models import States
 
     with session_scope(hass=hass) as session:
         query = session.query(States).filter(
@@ -94,7 +94,6 @@ def get_significant_states(
 
 def state_changes_during_period(hass, start_time, end_time=None, entity_id=None):
     """Return states changes during UTC period start_time - end_time."""
-    from homeassistant.components.recorder.models import States
 
     with session_scope(hass=hass) as session:
         query = session.query(States).filter(
@@ -117,7 +116,6 @@ def state_changes_during_period(hass, start_time, end_time=None, entity_id=None)
 
 def get_last_state_changes(hass, number_of_states, entity_id):
     """Return the last number_of_states."""
-    from homeassistant.components.recorder.models import States
 
     start_time = dt_util.utcnow()
 
@@ -142,7 +140,6 @@ def get_last_state_changes(hass, number_of_states, entity_id):
 
 def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None):
     """Return the states at a specific point in time."""
-    from homeassistant.components.recorder.models import States
 
     if run is None:
         run = recorder.run_information(hass, utc_point_in_time)
@@ -150,8 +147,6 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None)
         # History did not run before utc_point_in_time
         if run is None:
             return []
-
-    from sqlalchemy import and_, func
 
     with session_scope(hass=hass) as session:
         query = session.query(States)
@@ -386,7 +381,6 @@ class Filters:
         * if include and exclude is defined - select the entities specified in
           the include and filter out the ones from the exclude list.
         """
-        from homeassistant.components.recorder.models import States
 
         # specific entities requested - do not in/exclude anything
         if entity_ids is not None:


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
