### PR TITLE
Move imports to top for group

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -7,34 +7,33 @@ import voluptuous as vol
 
 from homeassistant import core as ha
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
+    ATTR_ICON,
+    ATTR_NAME,
     CONF_ICON,
     CONF_NAME,
+    SERVICE_RELOAD,
     STATE_CLOSED,
     STATE_HOME,
+    STATE_LOCKED,
     STATE_NOT_HOME,
     STATE_OFF,
+    STATE_OK,
     STATE_ON,
     STATE_OPEN,
-    STATE_LOCKED,
-    STATE_UNLOCKED,
-    STATE_OK,
     STATE_PROBLEM,
     STATE_UNKNOWN,
-    ATTR_ASSUMED_STATE,
-    SERVICE_RELOAD,
-    ATTR_NAME,
-    ATTR_ICON,
+    STATE_UNLOCKED,
 )
 from homeassistant.core import callback
-from homeassistant.loader import bind_hass
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_state_change
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.typing import HomeAssistantType
-
+from homeassistant.loader import bind_hass
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -4,18 +4,6 @@ from typing import Dict, Optional, Set
 
 import voluptuous as vol
 
-from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
-    ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
-    CONF_ENTITIES,
-    CONF_NAME,
-    STATE_CLOSED,
-)
-from homeassistant.core import callback, State
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
-
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
@@ -41,7 +29,17 @@ from homeassistant.components.cover import (
     SUPPORT_STOP_TILT,
     CoverDevice,
 )
-
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    CONF_ENTITIES,
+    CONF_NAME,
+    STATE_CLOSED,
+)
+from homeassistant.core import State, callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change
 
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -8,20 +8,6 @@ from typing import Any, Callable, Iterator, List, Optional, Tuple, cast
 import voluptuous as vol
 
 from homeassistant.components import light
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
-    CONF_ENTITIES,
-    CONF_NAME,
-    STATE_ON,
-    STATE_UNAVAILABLE,
-)
-from homeassistant.core import CALLBACK_TYPE, State, callback
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-from homeassistant.util import color as color_util
-
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
@@ -42,7 +28,19 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     SUPPORT_WHITE_VALUE,
 )
-
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    CONF_ENTITIES,
+    CONF_NAME,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import CALLBACK_TYPE, State, callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.util import color as color_util
 
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -6,9 +6,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import ATTR_SERVICE
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_MESSAGE,
@@ -16,7 +13,8 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
-
+from homeassistant.const import ATTR_SERVICE
+import homeassistant.helpers.config_validation as cv
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/group/reproduce_state.py
+++ b/homeassistant/components/group/reproduce_state.py
@@ -2,15 +2,16 @@
 from typing import Iterable, Optional
 
 from homeassistant.core import Context, State
+from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.helpers.typing import HomeAssistantType
+
+from . import get_entity_ids
 
 
 async def async_reproduce_states(
     hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
 ) -> None:
     """Reproduce component states."""
-    from . import get_entity_ids
-    from homeassistant.helpers.state import async_reproduce_state
 
     states_copy = []
     for state in states:

--- a/tests/components/group/test_reproduce_state.py
+++ b/tests/components/group/test_reproduce_state.py
@@ -21,7 +21,9 @@ async def test_reproduce_group(hass):
             context=state.context,
         )
 
-    with patch("homeassistant.helpers.state.async_reproduce_state") as fun:
+    with patch(
+        "homeassistant.components.group.reproduce_state.async_reproduce_state"
+    ) as fun:
         fun.return_value = Future()
         fun.return_value.set_result(None)
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
