### PR TITLE
Move imports to top for deconz

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
-from .gateway import get_gateway_from_config_entry, DeconzEntityHandler
+from .gateway import DeconzEntityHandler, get_gateway_from_config_entry
 
 ATTR_ORIENTATION = "orientation"
 ATTR_TILTANGLE = "tiltangle"

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -2,12 +2,12 @@
 import asyncio
 
 import async_timeout
+from pydeconz.errors import RequestError, ResponseError
+from pydeconz.utils import async_discovery, async_get_api_key, async_get_gateway_config
 import voluptuous as vol
 
-from pydeconz.errors import ResponseError, RequestError
-from pydeconz.utils import async_discovery, async_get_api_key, async_get_gateway_config
-
 from homeassistant import config_entries
+from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -170,7 +170,6 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered deCONZ bridge."""
-        from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
 
         if discovery_info[ATTR_MANUFACTURERURL] != DECONZ_MANUFACTURERURL:
             return self.async_abort(reason="not_deconz_bridge")

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -1,11 +1,11 @@
 """Support for deCONZ covers."""
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    CoverDevice,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
-    SUPPORT_STOP,
     SUPPORT_SET_POSITION,
+    SUPPORT_STOP,
+    CoverDevice,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -2,7 +2,6 @@
 import voluptuous as vol
 
 import homeassistant.components.automation.event as event
-
 from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -1,12 +1,12 @@
 """Representation of a deCONZ gateway."""
 import asyncio
-import async_timeout
 
+import async_timeout
 from pydeconz import DeconzSession, errors
 
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import (
@@ -14,8 +14,8 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity_registry import (
-    async_get_registry,
     DISABLED_CONFIG_ENTRY,
+    async_get_registry,
 )
 
 from .const import (
@@ -30,7 +30,6 @@ from .const import (
     NEW_DEVICE,
     SUPPORTED_PLATFORMS,
 )
-
 from .errors import AuthenticationRequired, CannotConnect
 
 

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -29,7 +29,7 @@ from .const import (
     SWITCH_TYPES,
 )
 from .deconz_device import DeconzDevice
-from .gateway import get_gateway_from_config_entry, DeconzEntityHandler
+from .gateway import DeconzEntityHandler, get_gateway_from_config_entry
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.dispatcher import (
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .deconz_event import DeconzEvent
-from .gateway import get_gateway_from_config_entry, DeconzEntityHandler
+from .gateway import DeconzEntityHandler, get_gateway_from_config_entry
 
 ATTR_CURRENT = "current"
 ATTR_POWER = "power"

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -4,7 +4,7 @@ import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 
 from .config_flow import get_master_gateway
-from .const import CONF_BRIDGEID, DOMAIN, _LOGGER
+from .const import _LOGGER, CONF_BRIDGEID, DOMAIN
 
 DECONZ_SERVICES = "deconz_services"
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
