### PR TITLE
Switch iperf3 to generate a new client every time it runs a test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -162,6 +162,7 @@ homeassistant/components/input_text/* @home-assistant/core
 homeassistant/components/integration/* @dgomes
 homeassistant/components/intent/* @home-assistant/core
 homeassistant/components/ios/* @robbiet480
+homeassistant/components/iperf3/* @rohankapoorcom
 homeassistant/components/ipma/* @dgomes
 homeassistant/components/iqvia/* @bachya
 homeassistant/components/irish_rail_transport/* @ttroy50

--- a/homeassistant/components/iperf3/__init__.py
+++ b/homeassistant/components/iperf3/__init__.py
@@ -120,7 +120,7 @@ class Iperf3Data:
         self.data = {ATTR_DOWNLOAD: None, ATTR_UPLOAD: None, ATTR_VERSION: None}
 
     def create_client(self):
-        """Creates a new iperf3 client to use for measurement."""
+        """Create a new iperf3 client to use for measurement."""
         client = iperf3.Client()
         client.duration = self._host[CONF_DURATION]
         client.server_hostname = self._host[CONF_HOST]

--- a/homeassistant/components/iperf3/__init__.py
+++ b/homeassistant/components/iperf3/__init__.py
@@ -85,17 +85,7 @@ async def async_setup(hass, config):
 
     conf = config[DOMAIN]
     for host in conf[CONF_HOSTS]:
-        host_name = host[CONF_HOST]
-
-        client = iperf3.Client()
-        client.duration = host[CONF_DURATION]
-        client.server_hostname = host_name
-        client.port = host[CONF_PORT]
-        client.num_streams = host[CONF_PARALLEL]
-        client.protocol = host[CONF_PROTOCOL]
-        client.verbose = False
-
-        data = hass.data[DOMAIN][host_name] = Iperf3Data(hass, client)
+        data = hass.data[DOMAIN][host[CONF_HOST]] = Iperf3Data(hass, host)
 
         if not conf[CONF_MANUAL]:
             async_track_time_interval(hass, data.update, conf[CONF_SCAN_INTERVAL])
@@ -123,26 +113,37 @@ async def async_setup(hass, config):
 class Iperf3Data:
     """Get the latest data from iperf3."""
 
-    def __init__(self, hass, client):
+    def __init__(self, hass, host):
         """Initialize the data object."""
         self._hass = hass
-        self._client = client
+        self._host = host
         self.data = {ATTR_DOWNLOAD: None, ATTR_UPLOAD: None, ATTR_VERSION: None}
+
+    def create_client(self):
+        """Creates a new iperf3 client to use for measurement."""
+        client = iperf3.Client()
+        client.duration = self._host[CONF_DURATION]
+        client.server_hostname = self._host[CONF_HOST]
+        client.port = self._host[CONF_PORT]
+        client.num_streams = self._host[CONF_PARALLEL]
+        client.protocol = self._host[CONF_PROTOCOL]
+        client.verbose = False
+        return client
 
     @property
     def protocol(self):
         """Return the protocol used for this connection."""
-        return self._client.protocol
+        return self._host[CONF_PROTOCOL]
 
     @property
     def host(self):
         """Return the host connected to."""
-        return self._client.server_hostname
+        return self._host[CONF_HOST]
 
     @property
     def port(self):
         """Return the port on the host connected to."""
-        return self._client.port
+        return self._host[CONF_PORT]
 
     def update(self, now=None):
         """Get the latest data from iperf3."""
@@ -165,9 +166,10 @@ class Iperf3Data:
 
     def _run_test(self, test_type):
         """Run and return the iperf3 data."""
-        self._client.reverse = test_type == ATTR_DOWNLOAD
+        client = self.create_client()
+        client.reverse = test_type == ATTR_DOWNLOAD
         try:
-            result = self._client.run()
+            result = client.run()
         except (AttributeError, OSError, ValueError) as error:
             _LOGGER.error("Iperf3 error: %s", error)
             return None

--- a/homeassistant/components/iperf3/manifest.json
+++ b/homeassistant/components/iperf3/manifest.json
@@ -6,5 +6,7 @@
     "iperf3==0.1.11"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@rohankapoorcom"
+  ]
 }


### PR DESCRIPTION
## Description:
Generates a new Iperf3 client every time one is needed, rather than re-using the existing one. There is a race condition in the existing implementation because both the upload/download sensors start updating at the same time using the same client. Rather than saving and reusing two unique clients, it seems better to regenerate when we need to use one. Thanks to @dooz127 for tracing down the root cause.

I also added myself to CODEOWNERS for iperf3 since I have been maintaining it.

**Related issue (if applicable):** fixes #22163

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
iperf3:
  hosts:
    - host: bouygues.iperf.fr
  monitored_conditions:
    - download
    - upload
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
