### PR TITLE
Move imports to top for http

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -26,7 +26,6 @@ from .real_ip import setup_real_ip
 from .static import CACHE_HEADERS, CachingStaticResource
 from .view import HomeAssistantView  # noqa: F401
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 DOMAIN = "http"

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -11,7 +11,6 @@ from homeassistant.util import dt as dt_util
 
 from .const import KEY_AUTHENTICATED, KEY_HASS_USER, KEY_REAL_IP
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -17,7 +17,6 @@ from homeassistant.util.yaml import dump
 
 from .const import KEY_REAL_IP
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/http/cors.py
+++ b/homeassistant/components/http/cors.py
@@ -1,10 +1,9 @@
 """Provide CORS support for the HTTP component."""
+from aiohttp.hdrs import ACCEPT, AUTHORIZATION, CONTENT_TYPE, ORIGIN
 from aiohttp.web_urldispatcher import Resource, ResourceRoute, StaticResource
-from aiohttp.hdrs import ACCEPT, CONTENT_TYPE, ORIGIN, AUTHORIZATION
 
 from homeassistant.const import HTTP_HEADER_X_REQUESTED_WITH
 from homeassistant.core import callback
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -23,6 +22,7 @@ def setup_cors(app, origins):
     """Set up CORS."""
     # This import should remain here. That way the HTTP integration can always
     # be imported by other integrations without it's requirements being installed.
+    # pylint: disable=import-outside-toplevel
     import aiohttp_cors
 
     cors = aiohttp_cors.setup(

--- a/homeassistant/components/http/data_validator.py
+++ b/homeassistant/components/http/data_validator.py
@@ -4,7 +4,6 @@ import logging
 
 import voluptuous as vol
 
-
 # mypy: allow-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -8,7 +8,6 @@ from homeassistant.core import callback
 
 from .const import KEY_REAL_IP
 
-
 # mypy: allow-untyped-defs
 
 

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -3,9 +3,8 @@ from pathlib import Path
 
 from aiohttp import hdrs
 from aiohttp.web import FileResponse
-from aiohttp.web_exceptions import HTTPNotFound, HTTPForbidden
+from aiohttp.web_exceptions import HTTPForbidden, HTTPNotFound
 from aiohttp.web_urldispatcher import StaticResource
-
 
 # mypy: allow-untyped-defs
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
