### PR TITLE
Don't escape command parameters

### DIFF
--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -538,8 +538,8 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         """
         Call Squeezebox JSON/RPC method.
 
-        Escaped optional parameters are added to the command to form the list
-        of positional parameters (p0, p1...,  pN) passed to JSON/RPC server.
+        Additional parameters are added to the command to form the list of
+        positional parameters (p0, p1...,  pN) passed to JSON/RPC server.
         """
         all_params = [command]
         if parameters:

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -544,5 +544,5 @@ class SqueezeBoxDevice(MediaPlayerDevice):
         all_params = [command]
         if parameters:
             for parameter in parameters:
-                all_params.append(urllib.parse.quote(parameter, safe="+:=/?"))
+                all_params.append(parameter)
         return self.async_query(*all_params)


### PR DESCRIPTION
## Description:

This removes parameter escaping from `media_player.squeezebox_call_method` since it is not only unnecessary using jsonrpc but also broke the feature.


## Example to reproduce fixed issue
Service `media_player.squeezebox_call_method`
Parameters:
```yaml
entity_id:
  - media_player.schreibtisch
command: show
parameters:
  - line1:20 °C
```

Without this change, the Squeezebox will display `20%20%C2%B0C`.
After applying the commit, the same command results in the display of the expected `20 °C`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
