### PR TITLE
Add broadcast target to tplink

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -45,7 +45,9 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [TPLINK_HOST_SCHEMA]
                 ),
                 vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
-                vol.Optional(CONF_DISOVERY_TARGET, default='255.255.255.255'): cv.string,
+                vol.Optional(
+                    CONF_DISOVERY_TARGET, default="255.255.255.255"
+                ): cv.string,
             }
         )
     },
@@ -88,7 +90,9 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigType):
 
     # Add discovered devices
     if config_data is None or config_data[CONF_DISCOVERY]:
-        discovered_devices = await async_discover_devices(hass, static_devices, config_data)
+        discovered_devices = await async_discover_devices(
+            hass, static_devices, config_data
+        )
 
         lights.extend(discovered_devices.lights)
         switches.extend(discovered_devices.switches)

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -12,7 +12,7 @@ from .common import (
     ATTR_CONFIG,
     CONF_DIMMER,
     CONF_DISCOVERY,
-    CONF_TARGET,
+    CONF_DISOVERY_TARGET,
     CONF_LIGHT,
     CONF_SWITCH,
     CONF_STRIP,
@@ -45,7 +45,7 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [TPLINK_HOST_SCHEMA]
                 ),
                 vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
-                vol.Optional(CONF_TARGET, default='255.255.255.255'): cv.string,
+                vol.Optional(CONF_DISOVERY_TARGET, default='255.255.255.255'): cv.string,
             }
         )
     },

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -12,6 +12,7 @@ from .common import (
     ATTR_CONFIG,
     CONF_DIMMER,
     CONF_DISCOVERY,
+    CONF_TARGET,
     CONF_LIGHT,
     CONF_SWITCH,
     CONF_STRIP,
@@ -44,6 +45,7 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [TPLINK_HOST_SCHEMA]
                 ),
                 vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
+                vol.Optional(CONF_TARGET, default='255.255.255.255'): cv.string,
             }
         )
     },
@@ -86,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigType):
 
     # Add discovered devices
     if config_data is None or config_data[CONF_DISCOVERY]:
-        discovered_devices = await async_discover_devices(hass, static_devices)
+        discovered_devices = await async_discover_devices(hass, static_devices, config_data)
 
         lights.extend(discovered_devices.lights)
         switches.extend(discovered_devices.switches)

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -12,7 +12,7 @@ from .common import (
     ATTR_CONFIG,
     CONF_DIMMER,
     CONF_DISCOVERY,
-    CONF_DISOVERY_TARGET,
+    CONF_DISCOVERY_TARGET,
     CONF_LIGHT,
     CONF_SWITCH,
     CONF_STRIP,
@@ -46,7 +46,7 @@ CONFIG_SCHEMA = vol.Schema(
                 ),
                 vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
                 vol.Optional(
-                    CONF_DISOVERY_TARGET, default="255.255.255.255"
+                    CONF_DISCOVERY_TARGET, default="255.255.255.255"
                 ): cv.string,
             }
         )

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_CONFIG = "config"
 CONF_DIMMER = "dimmer"
 CONF_DISCOVERY = "discovery"
+CONF_TARGET = "target"
 CONF_LIGHT = "light"
 CONF_STRIP = "strip"
 CONF_SWITCH = "switch"
@@ -55,22 +56,22 @@ class SmartDevices:
         return False
 
 
-async def async_get_discoverable_devices(hass):
+async def async_get_discoverable_devices(hass, config_data):
     """Return if there are devices that can be discovered."""
 
     def discover():
-        devs = Discover.discover()
+        devs = Discover.discover(target=config_data[CONF_TARGET])
         return devs
 
     return await hass.async_add_executor_job(discover)
 
 
 async def async_discover_devices(
-    hass: HomeAssistantType, existing_devices: SmartDevices
+    hass: HomeAssistantType, existing_devices: SmartDevices, config_data
 ) -> SmartDevices:
     """Get devices through discovery."""
     _LOGGER.debug("Discovering devices")
-    devices = await async_get_discoverable_devices(hass)
+    devices = await async_get_discoverable_devices(hass, config_data)
     _LOGGER.info("Discovered %s TP-Link smart home device(s)", len(devices))
 
     lights = []

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_CONFIG = "config"
 CONF_DIMMER = "dimmer"
 CONF_DISCOVERY = "discovery"
-CONF_TARGET = "target"
+CONF_DISCOVERY_TARGET = "discovery_target"
 CONF_LIGHT = "light"
 CONF_STRIP = "strip"
 CONF_SWITCH = "switch"
@@ -60,7 +60,7 @@ async def async_get_discoverable_devices(hass, config_data):
     """Return if there are devices that can be discovered."""
 
     def discover():
-        devs = Discover.discover(target=config_data[CONF_TARGET])
+        devs = Discover.discover(target=config_data[CONF_DISCOVERY_TARGET])
         return devs
 
     return await hass.async_add_executor_job(discover)


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #29503 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11373

## Example entry for `configuration.yaml` (if applicable):
```yaml
tplink:
  discovery: true
  target: 192.168.1.255
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
