### PR TITLE
Move imports to top for mediaroom

### DIFF
--- a/homeassistant/components/mediaroom/media_player.py
+++ b/homeassistant/components/mediaroom/media_player.py
@@ -1,9 +1,10 @@
 """Support for the Mediaroom Set-up-box."""
 import logging
 
+from pymediaroom import PyMediaroomError, Remote, State, install_mediaroom_protocol
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,
@@ -99,7 +100,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         async_add_entities([new_stb])
 
     if not config[CONF_OPTIMISTIC]:
-        from pymediaroom import install_mediaroom_protocol
 
         already_installed = hass.data.get(DISCOVERY_MEDIAROOM, None)
         if not already_installed:
@@ -123,7 +123,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     def set_state(self, mediaroom_state):
         """Map pymediaroom state to HA state."""
-        from pymediaroom import State
 
         state_map = {
             State.OFF: STATE_OFF,
@@ -139,7 +138,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     def __init__(self, host, device_id, optimistic=False, timeout=DEFAULT_TIMEOUT):
         """Initialize the device."""
-        from pymediaroom import Remote
 
         self.host = host
         self.stb = Remote(host)
@@ -184,7 +182,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play media."""
-        from pymediaroom import PyMediaroomError
 
         _LOGGER.debug(
             "STB(%s) Play media: %s (%s)", self.stb.stb_ip, media_id, media_type
@@ -237,7 +234,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_turn_on(self):
         """Turn on the receiver."""
-        from pymediaroom import PyMediaroomError
 
         try:
             self.set_state(await self.stb.turn_on())
@@ -250,7 +246,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_turn_off(self):
         """Turn off the receiver."""
-        from pymediaroom import PyMediaroomError
 
         try:
             self.set_state(await self.stb.turn_off())
@@ -263,7 +258,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_media_play(self):
         """Send play command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             _LOGGER.debug("media_play()")
@@ -277,7 +271,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_media_pause(self):
         """Send pause command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             await self.stb.send_cmd("PlayPause")
@@ -290,7 +283,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_media_stop(self):
         """Send stop command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             await self.stb.send_cmd("Stop")
@@ -303,7 +295,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_media_previous_track(self):
         """Send Program Down command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             await self.stb.send_cmd("ProgDown")
@@ -316,7 +307,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_media_next_track(self):
         """Send Program Up command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             await self.stb.send_cmd("ProgUp")
@@ -329,7 +319,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_volume_up(self):
         """Send volume up command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             await self.stb.send_cmd("VolUp")
@@ -340,7 +329,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_volume_down(self):
         """Send volume up command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             await self.stb.send_cmd("VolDown")
@@ -350,7 +338,6 @@ class MediaroomDevice(MediaPlayerDevice):
 
     async def async_mute_volume(self, mute):
         """Send mute command."""
-        from pymediaroom import PyMediaroomError
 
         try:
             await self.stb.send_cmd("Mute")


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
