### PR TITLE
Move imports to top for switcher_kis

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta
 from logging import getLogger
 from typing import Dict, Optional
 
+from aioswitcher.api import SwitcherV2Api
+from aioswitcher.bridge import SwitcherV2Bridge
 import voluptuous as vol
 
 from homeassistant.auth.permissions.const import POLICY_EDIT
@@ -88,7 +90,6 @@ async def _validate_edit_permission(
 
 async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
     """Set up the switcher component."""
-    from aioswitcher.bridge import SwitcherV2Bridge
 
     phone_id = config[DOMAIN][CONF_PHONE_ID]
     device_id = config[DOMAIN][CONF_DEVICE_ID]
@@ -122,7 +123,6 @@ async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
 
         async def async_set_auto_off_service(service: ServiceCallType) -> None:
             """Use for handling setting device auto-off service calls."""
-            from aioswitcher.api import SwitcherV2Api
 
             await _validate_edit_permission(
                 hass, service.context, service.data[CONF_ENTITY_ID]

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -1,7 +1,16 @@
 """Home Assistant Switcher Component Switch platform."""
 
 from logging import getLogger
-from typing import Callable, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Dict
+
+from aioswitcher.api import SwitcherV2Api
+from aioswitcher.consts import (
+    COMMAND_OFF,
+    COMMAND_ON,
+    STATE_OFF as SWITCHER_STATE_OFF,
+    STATE_ON as SWITCHER_STATE_ON,
+    WAITING_TEXT,
+)
 
 from homeassistant.components.switch import ATTR_CURRENT_POWER_W, SwitchDevice
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -70,7 +79,6 @@ class SwitcherControl(SwitchDevice):
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
-        from aioswitcher.consts import STATE_ON as SWITCHER_STATE_ON
 
         return self._state == SWITCHER_STATE_ON
 
@@ -82,7 +90,6 @@ class SwitcherControl(SwitchDevice):
     @property
     def device_state_attributes(self) -> Dict:
         """Return the optional state attributes."""
-        from aioswitcher.consts import WAITING_TEXT
 
         attribs = {}
 
@@ -96,10 +103,6 @@ class SwitcherControl(SwitchDevice):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        from aioswitcher.consts import (
-            STATE_OFF as SWITCHER_STATE_OFF,
-            STATE_ON as SWITCHER_STATE_ON,
-        )
 
         return self._state in [SWITCHER_STATE_ON, SWITCHER_STATE_OFF]
 
@@ -135,13 +138,6 @@ class SwitcherControl(SwitchDevice):
 
     async def _control_device(self, send_on: bool) -> None:
         """Turn the entity on or off."""
-        from aioswitcher.api import SwitcherV2Api
-        from aioswitcher.consts import (
-            COMMAND_OFF,
-            COMMAND_ON,
-            STATE_OFF as SWITCHER_STATE_OFF,
-            STATE_ON as SWITCHER_STATE_ON,
-        )
 
         response: "SwitcherV2ControlResponseMSG" = None
         async with SwitcherV2Api(

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -25,6 +25,7 @@ from . import (
     SIGNAL_SWITCHER_DEVICE_UPDATE,
 )
 
+# pylint: disable=ungrouped-imports
 if TYPE_CHECKING:
     from aioswitcher.devices import SwitcherV2Device
     from aioswitcher.api.messages import SwitcherV2ControlResponseMSG

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -103,10 +103,22 @@ def mock_bridge_fixture() -> Generator[None, Any, None]:
     mock_bridge = CoroutineMock()
 
     patchers = [
-        patch("aioswitcher.bridge.SwitcherV2Bridge.start", new=mock_bridge),
-        patch("aioswitcher.bridge.SwitcherV2Bridge.stop", new=mock_bridge),
-        patch("aioswitcher.bridge.SwitcherV2Bridge.queue", get=mock_queue),
-        patch("aioswitcher.bridge.SwitcherV2Bridge.running", return_value=True),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Bridge.start",
+            new=mock_bridge,
+        ),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Bridge.stop",
+            new=mock_bridge,
+        ),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Bridge.queue",
+            get=mock_queue,
+        ),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Bridge.running",
+            return_value=True,
+        ),
     ]
 
     for patcher in patchers:
@@ -127,9 +139,18 @@ def mock_failed_bridge_fixture() -> Generator[None, Any, None]:
         raise RuntimeError
 
     patchers = [
-        patch("aioswitcher.bridge.SwitcherV2Bridge.start", return_value=None),
-        patch("aioswitcher.bridge.SwitcherV2Bridge.stop", return_value=None),
-        patch("aioswitcher.bridge.SwitcherV2Bridge.queue", get=mock_queue),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Bridge.start",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Bridge.stop",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Bridge.queue",
+            get=mock_queue,
+        ),
     ]
 
     for patcher in patchers:
@@ -147,8 +168,13 @@ def mock_api_fixture() -> Generator[CoroutineMock, Any, None]:
     mock_api = CoroutineMock()
 
     patchers = [
-        patch("aioswitcher.api.SwitcherV2Api.connect", new=mock_api),
-        patch("aioswitcher.api.SwitcherV2Api.disconnect", new=mock_api),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Api.connect", new=mock_api
+        ),
+        patch(
+            "homeassistant.components.switcher_kis.SwitcherV2Api.disconnect",
+            new=mock_api,
+        ),
     ]
 
     for patcher in patchers:


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
