### PR TITLE
Bump georss_generic_client to 0.3

### DIFF
--- a/homeassistant/components/geo_rss_events/manifest.json
+++ b/homeassistant/components/geo_rss_events/manifest.json
@@ -3,7 +3,7 @@
   "name": "Geo RSS events",
   "documentation": "https://www.home-assistant.io/integrations/geo_rss_events",
   "requirements": [
-    "georss_generic_client==0.2"
+    "georss_generic_client==0.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -563,7 +563,7 @@ geojson_client==0.4
 geopy==1.19.0
 
 # homeassistant.components.geo_rss_events
-georss_generic_client==0.2
+georss_generic_client==0.3
 
 # homeassistant.components.ign_sismologia
 georss_ign_sismologia_client==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -181,7 +181,7 @@ geojson_client==0.4
 geopy==1.19.0
 
 # homeassistant.components.geo_rss_events
-georss_generic_client==0.2
+georss_generic_client==0.3
 
 # homeassistant.components.ign_sismologia
 georss_ign_sismologia_client==0.2


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Bump georss_generic_client to v0.3.
This addresses an issue with RSS feeds that start with a byte order mark which was not handled correctly, and prevented the XML to be parsed.

**Related issue (if applicable):** fixes #29376

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: geo_rss_events
    name: GDACS
    latitude: -7.7321
    longitude: 111.3823
    radius: 2000
    url: https://www.gdacs.org/xml/rss.xml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
