### PR TITLE
Add quarterly cycle for utility_meter component

### DIFF
--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -5,9 +5,10 @@ HOURLY = "hourly"
 DAILY = "daily"
 WEEKLY = "weekly"
 MONTHLY = "monthly"
+QUARTERLY = "quarterly"
 YEARLY = "yearly"
 
-METER_TYPES = [HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY]
+METER_TYPES = [HOURLY, DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY]
 
 DATA_UTILITY = "utility_meter_data"
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -25,6 +25,7 @@ from .const import (
     DAILY,
     WEEKLY,
     MONTHLY,
+    QUARTERLY,
     YEARLY,
     CONF_SOURCE_SENSOR,
     CONF_METER_TYPE,
@@ -184,6 +185,12 @@ class UtilityMeterSensor(RestoreEntity):
             and now != date(now.year, now.month, 1) + self._period_offset
         ):
             return
+        if (
+            self._period == QUARTERLY
+            and now
+            != date(now.year, (((now.month - 1) // 3) * 3 + 1), 1) + self._period_offset
+        ):
+            return
         if self._period == YEARLY and now != date(now.year, 1, 1) + self._period_offset:
             return
         await self.async_reset_meter(self._tariff_entity)
@@ -209,7 +216,7 @@ class UtilityMeterSensor(RestoreEntity):
                 minute=self._period_offset.seconds // 60,
                 second=self._period_offset.seconds % 60,
             )
-        elif self._period in [DAILY, WEEKLY, MONTHLY, YEARLY]:
+        elif self._period in [DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY]:
             async_track_time_change(
                 self.hass,
                 self._async_reset_meter,

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -243,7 +243,7 @@ async def test_self_reset_monthly(hass):
 async def test_self_reset_quarterly(hass):
     """Test quarterly reset of meter."""
     await _test_self_reset(
-        hass, gen_config("quarterly"), "2017-03-31T23:59:00.000000+00:00"
+        hass, gen_config("quarterly"), "2017-04-31T23:59:00.000000+00:00"
     )
 
 

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -240,6 +240,13 @@ async def test_self_reset_monthly(hass):
     )
 
 
+async def test_self_reset_quarterly(hass):
+    """Test quarterly reset of meter."""
+    await _test_self_reset(
+        hass, gen_config("quarterly"), "2017-12-31T23:59:00.000000+00:00"
+    )
+
+
 async def test_self_reset_yearly(hass):
     """Test yearly reset of meter."""
     await _test_self_reset(

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -243,7 +243,7 @@ async def test_self_reset_monthly(hass):
 async def test_self_reset_quarterly(hass):
     """Test quarterly reset of meter."""
     await _test_self_reset(
-        hass, gen_config("quarterly"), "2017-04-31T23:59:00.000000+00:00"
+        hass, gen_config("quarterly"), "2017-03-31T23:59:00.000000+00:00"
     )
 
 


### PR DESCRIPTION
Many tariff cycles in Australia are 3 monthly (quarterly).
Add quarterly tariff cycle handling to the utility_meter component.

## Description:

Adds a quarterly tariff cycle to utility_meter component.

## Example entry for `configuration.yaml` (if applicable):
```yaml

utility_meter:
  energy:
    source: sensor.energy_in_kwh
    cycle: quarterly

```

## Checklist:
  - [X ] The code change is tested and works locally.
  - [X ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ X] There is no commented out code in this PR.
  - [X ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
