### PR TITLE
Move imports to top for nsw_fuel_station

### DIFF
--- a/homeassistant/components/nsw_fuel_station/sensor.py
+++ b/homeassistant/components/nsw_fuel_station/sensor.py
@@ -3,11 +3,12 @@ import datetime
 import logging
 from typing import Optional
 
+from nsw_fuel import FuelCheckClient, FuelCheckError
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -52,7 +53,6 @@ NOTIFICATION_TITLE = "NSW Fuel Station Sensor Setup"
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NSW Fuel Station sensor."""
-    from nsw_fuel import FuelCheckClient
 
     station_id = config[CONF_STATION_ID]
     fuel_types = config[CONF_FUEL_TYPES]
@@ -97,7 +97,6 @@ class StationPriceData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update the internal data using the API client."""
-        from nsw_fuel import FuelCheckError
 
         if self._reference_data is None:
             try:

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -87,7 +87,7 @@ class TestNSWFuelStation(unittest.TestCase):
         "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
         new=FuelCheckClientMock,
     )
-    def test_setup(self, mock_nsw_fuel):
+    def test_setup(self):
         """Test the setup with custom settings."""
         with assert_setup_component(1, sensor.DOMAIN):
             assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
@@ -102,7 +102,7 @@ class TestNSWFuelStation(unittest.TestCase):
         "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
         new=FuelCheckClientMock,
     )
-    def test_sensor_values(self, mock_nsw_fuel):
+    def test_sensor_values(self):
         """Test retrieval of sensor values."""
         assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
 

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -84,7 +84,7 @@ class TestNSWFuelStation(unittest.TestCase):
         self.hass.stop()
 
     @patch(
-        "homeassistant.components.nsw_fuel_station.FuelCheckClient",
+        "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
         new=FuelCheckClientMock,
     )
     def test_setup(self, mock_nsw_fuel):
@@ -99,7 +99,7 @@ class TestNSWFuelStation(unittest.TestCase):
             assert state is not None
 
     @patch(
-        "homeassistant.components.nsw_fuel_station.FuelCheckClient",
+        "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
         new=FuelCheckClientMock,
     )
     def test_sensor_values(self, mock_nsw_fuel):

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from homeassistant.components import sensor
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant, assert_setup_component, MockDependency
+from tests.common import get_test_home_assistant, assert_setup_component
 
 VALID_CONFIG = {
     "platform": "nsw_fuel_station",
@@ -83,8 +83,10 @@ class TestNSWFuelStation(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    @MockDependency("nsw_fuel")
-    @patch("nsw_fuel.FuelCheckClient", new=FuelCheckClientMock)
+    @patch(
+        "homeassistant.components.nsw_fuel_station.FuelCheckClient",
+        new=FuelCheckClientMock,
+    )
     def test_setup(self, mock_nsw_fuel):
         """Test the setup with custom settings."""
         with assert_setup_component(1, sensor.DOMAIN):
@@ -96,8 +98,10 @@ class TestNSWFuelStation(unittest.TestCase):
             state = self.hass.states.get("sensor.{}".format(entity_id))
             assert state is not None
 
-    @MockDependency("nsw_fuel")
-    @patch("nsw_fuel.FuelCheckClient", new=FuelCheckClientMock)
+    @patch(
+        "homeassistant.components.nsw_fuel_station.FuelCheckClient",
+        new=FuelCheckClientMock,
+    )
     def test_sensor_values(self, mock_nsw_fuel):
         """Test retrieval of sensor values."""
         assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
