### PR TITLE
Move imports to top for pjlink

### DIFF
--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -1,9 +1,11 @@
 """Support for controlling projector via the PJLink protocol."""
 import logging
 
+from pypjlink import MUTE_AUDIO, Projector
+from pypjlink.projector import ProjectorError
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
@@ -90,7 +92,6 @@ class PjLinkDevice(MediaPlayerDevice):
 
     def projector(self):
         """Create PJLink Projector instance."""
-        from pypjlink import Projector
 
         projector = Projector.from_address(self._host, self._port, self._encoding)
         projector.authenticate(self._password)
@@ -98,7 +99,6 @@ class PjLinkDevice(MediaPlayerDevice):
 
     def update(self):
         """Get the latest state from the device."""
-        from pypjlink.projector import ProjectorError
 
         with self.projector() as projector:
             try:
@@ -171,8 +171,6 @@ class PjLinkDevice(MediaPlayerDevice):
     def mute_volume(self, mute):
         """Mute (true) of unmute (false) media player."""
         with self.projector() as projector:
-            from pypjlink import MUTE_AUDIO
-
             projector.set_mute(MUTE_AUDIO, mute)
 
     def select_source(self, source):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
