### PR TITLE
Move imports to top for soundtouch

### DIFF
--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -101,9 +101,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             return
 
         remote_config = {"id": "ha.component.soundtouch", "host": host, "port": port}
-        soundtouch_device = SoundTouchDevice(None, remote_config)
-        hass.data[DATA_SOUNDTOUCH].append(soundtouch_device)
-        add_entities([soundtouch_device])
+        bose_soundtouch_device = SoundTouchDevice(None, remote_config)
+        hass.data[DATA_SOUNDTOUCH].append(bose_soundtouch_device)
+        add_entities([bose_soundtouch_device])
     else:
         name = config.get(CONF_NAME)
         remote_config = {
@@ -111,9 +111,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             "port": config.get(CONF_PORT),
             "host": config.get(CONF_HOST),
         }
-        soundtouch_device = SoundTouchDevice(name, remote_config)
-        hass.data[DATA_SOUNDTOUCH].append(soundtouch_device)
-        add_entities([soundtouch_device])
+        bose_soundtouch_device = SoundTouchDevice(name, remote_config)
+        hass.data[DATA_SOUNDTOUCH].append(bose_soundtouch_device)
+        add_entities([bose_soundtouch_device])
 
     def service_handle(service):
         """Handle the applying of a service."""

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -101,9 +101,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             return
 
         remote_config = {"id": "ha.component.soundtouch", "host": host, "port": port}
-        bose_soundtouch_device = SoundTouchDevice(None, remote_config)
-        hass.data[DATA_SOUNDTOUCH].append(bose_soundtouch_device)
-        add_entities([bose_soundtouch_device])
+        bose_soundtouch_entity = SoundTouchDevice(None, remote_config)
+        hass.data[DATA_SOUNDTOUCH].append(bose_soundtouch_entity)
+        add_entities([bose_soundtouch_entity])
     else:
         name = config.get(CONF_NAME)
         remote_config = {
@@ -111,9 +111,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             "port": config.get(CONF_PORT),
             "host": config.get(CONF_HOST),
         }
-        bose_soundtouch_device = SoundTouchDevice(name, remote_config)
-        hass.data[DATA_SOUNDTOUCH].append(bose_soundtouch_device)
-        add_entities([bose_soundtouch_device])
+        bose_soundtouch_entity = SoundTouchDevice(name, remote_config)
+        hass.data[DATA_SOUNDTOUCH].append(bose_soundtouch_entity)
+        add_entities([bose_soundtouch_entity])
 
     def service_handle(service):
         """Handle the applying of a service."""

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -2,6 +2,7 @@
 import logging
 import re
 
+from libsoundtouch import soundtouch_device
 import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
@@ -184,7 +185,6 @@ class SoundTouchDevice(MediaPlayerDevice):
 
     def __init__(self, name, config):
         """Create Soundtouch Entity."""
-        from libsoundtouch import soundtouch_device
 
         self._device = soundtouch_device(config["host"], config["port"])
         if name is None:

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -148,7 +148,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         logging.disable(logging.NOTSET)
         self.hass.stop()
 
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=None)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=None,
+    )
     def test_ensure_setup_config(self, mocked_soundtouch_device):
         """Test setup OK with custom config."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -158,7 +161,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         assert all_devices[0].config["port"] == 8090
         assert mocked_soundtouch_device.call_count == 1
 
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=None)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=None,
+    )
     def test_ensure_setup_discovery(self, mocked_soundtouch_device):
         """Test setup with discovery."""
         new_device = {
@@ -174,7 +180,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         assert all_devices[0].config["host"] == "192.168.1.1"
         assert mocked_soundtouch_device.call_count == 1
 
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=None)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=None,
+    )
     def test_ensure_setup_discovery_no_duplicate(self, mocked_soundtouch_device):
         """Test setup OK if device already exists."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -203,7 +212,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
 
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_update(self, mocked_soundtouch_device, mocked_status, mocked_volume):
         """Test update device state."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -218,7 +230,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusPlaying
     )
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_playing_media(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -240,7 +255,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusUnknown
     )
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_playing_unknown_media(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -257,7 +275,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         "libsoundtouch.device.SoundTouchDevice.status",
         side_effect=MockStatusPlayingRadio,
     )
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_playing_radio(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -277,7 +298,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
 
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume", side_effect=MockVolume)
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_get_volume_level(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -293,7 +317,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusStandby
     )
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_get_state_off(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -309,7 +336,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusPause
     )
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_get_state_pause(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -325,7 +355,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         "libsoundtouch.device.SoundTouchDevice.volume", side_effect=MockVolumeMuted
     )
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_is_muted(self, mocked_soundtouch_device, mocked_status, mocked_volume):
         """Test device volume is muted."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -346,7 +379,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.power_off")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_should_turn_off(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_power_off
     ):
@@ -362,7 +398,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.power_on")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_should_turn_on(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_power_on
     ):
@@ -378,7 +417,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume_up")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_volume_up(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_volume_up
     ):
@@ -394,7 +436,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume_down")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_volume_down(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_volume_down
     ):
@@ -410,7 +455,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.set_volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_set_volume_level(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_set_volume
     ):
@@ -426,7 +474,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.mute")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_mute(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_mute
     ):
@@ -442,7 +493,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.play")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_play(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_play
     ):
@@ -458,7 +512,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.pause")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_pause(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_pause
     ):
@@ -474,7 +531,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.play_pause")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_play_pause_play(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_play_pause
     ):
@@ -491,7 +551,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.next_track")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_next_previous_track(
         self,
         mocked_soundtouch_device,
@@ -519,7 +582,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     )
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_play_media(
         self,
         mocked_soundtouch_device,
@@ -544,7 +610,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.play_url")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_play_media_url(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_play_url
     ):
@@ -560,7 +629,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.create_zone")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_play_everywhere(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_create_zone
     ):
@@ -605,7 +677,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.create_zone")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_create_zone(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_create_zone
     ):
@@ -649,7 +724,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.remove_zone_slave")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_remove_zone_slave(
         self,
         mocked_soundtouch_device,
@@ -697,7 +775,10 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.add_zone_slave")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch(
+        "homeassistant.components.soundtouch.media_player.soundtouch_device",
+        side_effect=_mock_soundtouch_device,
+    )
     def test_add_zone_slave(
         self,
         mocked_soundtouch_device,

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -148,7 +148,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         logging.disable(logging.NOTSET)
         self.hass.stop()
 
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=None)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=None)
     def test_ensure_setup_config(self, mocked_soundtouch_device):
         """Test setup OK with custom config."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -158,7 +158,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         assert all_devices[0].config["port"] == 8090
         assert mocked_soundtouch_device.call_count == 1
 
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=None)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=None)
     def test_ensure_setup_discovery(self, mocked_soundtouch_device):
         """Test setup with discovery."""
         new_device = {
@@ -174,7 +174,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         assert all_devices[0].config["host"] == "192.168.1.1"
         assert mocked_soundtouch_device.call_count == 1
 
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=None)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=None)
     def test_ensure_setup_discovery_no_duplicate(self, mocked_soundtouch_device):
         """Test setup OK if device already exists."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -203,7 +203,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
 
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_update(self, mocked_soundtouch_device, mocked_status, mocked_volume):
         """Test update device state."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -218,7 +218,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusPlaying
     )
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_playing_media(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -240,7 +240,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusUnknown
     )
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_playing_unknown_media(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -257,7 +257,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         "libsoundtouch.device.SoundTouchDevice.status",
         side_effect=MockStatusPlayingRadio,
     )
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_playing_radio(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -277,7 +277,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
 
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume", side_effect=MockVolume)
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_get_volume_level(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -293,7 +293,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusStandby
     )
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_get_state_off(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -309,7 +309,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch(
         "libsoundtouch.device.SoundTouchDevice.status", side_effect=MockStatusPause
     )
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_get_state_pause(
         self, mocked_soundtouch_device, mocked_status, mocked_volume
     ):
@@ -325,7 +325,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         "libsoundtouch.device.SoundTouchDevice.volume", side_effect=MockVolumeMuted
     )
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_is_muted(self, mocked_soundtouch_device, mocked_status, mocked_volume):
         """Test device volume is muted."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -335,7 +335,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
         all_devices = self.hass.data[soundtouch.DATA_SOUNDTOUCH]
         assert all_devices[0].is_volume_muted is True
 
-    @mock.patch("libsoundtouch.soundtouch_device")
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device")
     def test_media_commands(self, mocked_soundtouch_device):
         """Test supported media commands."""
         soundtouch.setup_platform(self.hass, default_component(), mock.MagicMock())
@@ -346,7 +346,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.power_off")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_should_turn_off(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_power_off
     ):
@@ -362,7 +362,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.power_on")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_should_turn_on(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_power_on
     ):
@@ -378,7 +378,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume_up")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_volume_up(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_volume_up
     ):
@@ -394,7 +394,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume_down")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_volume_down(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_volume_down
     ):
@@ -410,7 +410,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.set_volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_set_volume_level(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_set_volume
     ):
@@ -426,7 +426,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.mute")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_mute(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_mute
     ):
@@ -442,7 +442,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.play")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_play(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_play
     ):
@@ -458,7 +458,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.pause")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_pause(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_pause
     ):
@@ -474,7 +474,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.play_pause")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_play_pause_play(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_play_pause
     ):
@@ -491,7 +491,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.next_track")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_next_previous_track(
         self,
         mocked_soundtouch_device,
@@ -519,7 +519,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     )
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_play_media(
         self,
         mocked_soundtouch_device,
@@ -544,7 +544,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.play_url")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_play_media_url(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_play_url
     ):
@@ -560,7 +560,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.create_zone")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_play_everywhere(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_create_zone
     ):
@@ -605,7 +605,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.create_zone")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_create_zone(
         self, mocked_soundtouch_device, mocked_status, mocked_volume, mocked_create_zone
     ):
@@ -649,7 +649,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.remove_zone_slave")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_remove_zone_slave(
         self,
         mocked_soundtouch_device,
@@ -697,7 +697,7 @@ class TestSoundtouchMediaPlayer(unittest.TestCase):
     @mock.patch("libsoundtouch.device.SoundTouchDevice.add_zone_slave")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.volume")
     @mock.patch("libsoundtouch.device.SoundTouchDevice.status")
-    @mock.patch("libsoundtouch.soundtouch_device", side_effect=_mock_soundtouch_device)
+    @mock.patch("homeassistant.components.soundtouch.media_player.soundtouch_device", side_effect=_mock_soundtouch_device)
     def test_add_zone_slave(
         self,
         mocked_soundtouch_device,


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
