### PR TITLE
Move imports to top for spc

### DIFF
--- a/homeassistant/components/spc/__init__.py
+++ b/homeassistant/components/spc/__init__.py
@@ -1,11 +1,14 @@
 """Support for Vanderbilt (formerly Siemens) SPC alarm systems."""
 import logging
 
+from pyspcwebgw import SpcWebGateway
+from pyspcwebgw.area import Area
+from pyspcwebgw.zone import Zone
 import voluptuous as vol
 
-from homeassistant.helpers import discovery, aiohttp_client
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers import aiohttp_client, discovery
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,11 +36,8 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the SPC component."""
-    from pyspcwebgw import SpcWebGateway
 
     async def async_upate_callback(spc_object):
-        from pyspcwebgw.area import Area
-        from pyspcwebgw.zone import Zone
 
         if isinstance(spc_object, Area):
             async_dispatcher_send(hass, SIGNAL_UPDATE_ALARM.format(spc_object.id))

--- a/homeassistant/components/spc/alarm_control_panel.py
+++ b/homeassistant/components/spc/alarm_control_panel.py
@@ -1,6 +1,8 @@
 """Support for Vanderbilt (formerly Siemens) SPC alarm systems."""
 import logging
 
+from pyspcwebgw.const import AreaMode
+
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
@@ -92,24 +94,20 @@ class SpcAlarm(alarm.AlarmControlPanel):
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
-        from pyspcwebgw.const import AreaMode
 
         await self._api.change_mode(area=self._area, new_mode=AreaMode.UNSET)
 
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
-        from pyspcwebgw.const import AreaMode
 
         await self._api.change_mode(area=self._area, new_mode=AreaMode.PART_SET_A)
 
     async def async_alarm_arm_night(self, code=None):
         """Send arm home command."""
-        from pyspcwebgw.const import AreaMode
 
         await self._api.change_mode(area=self._area, new_mode=AreaMode.PART_SET_B)
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        from pyspcwebgw.const import AreaMode
 
         await self._api.change_mode(area=self._area, new_mode=AreaMode.FULL_SET)

--- a/homeassistant/components/spc/alarm_control_panel.py
+++ b/homeassistant/components/spc/alarm_control_panel.py
@@ -26,7 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 
 def _get_alarm_state(area):
     """Get the alarm state."""
-    from pyspcwebgw.const import AreaMode
 
     if area.verified_alarm:
         return STATE_ALARM_TRIGGERED

--- a/homeassistant/components/spc/binary_sensor.py
+++ b/homeassistant/components/spc/binary_sensor.py
@@ -1,6 +1,8 @@
 """Support for Vanderbilt (formerly Siemens) SPC alarm systems."""
 import logging
 
+from pyspcwebgw.const import ZoneInput
+
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -60,7 +62,6 @@ class SpcBinarySensor(BinarySensorDevice):
     @property
     def is_on(self):
         """Whether the device is switched on."""
-        from pyspcwebgw.const import ZoneInput
 
         return self._zone.input == ZoneInput.OPEN
 

--- a/tests/components/spc/test_init.py
+++ b/tests/components/spc/test_init.py
@@ -13,7 +13,8 @@ async def test_valid_device_config(hass, monkeypatch):
     config = {"spc": {"api_url": "http://localhost/", "ws_url": "ws://localhost/"}}
 
     with patch(
-        "pyspcwebgw.SpcWebGateway.async_load_parameters", return_value=mock_coro(True)
+        "homeassistant.components.spc.SpcWebGateway.async_load_parameters",
+        return_value=mock_coro(True),
     ):
         assert await async_setup_component(hass, "spc", config) is True
 
@@ -23,7 +24,8 @@ async def test_invalid_device_config(hass, monkeypatch):
     config = {"spc": {"api_url": "http://localhost/"}}
 
     with patch(
-        "pyspcwebgw.SpcWebGateway.async_load_parameters", return_value=mock_coro(True)
+        "homeassistant.components.spc.SpcWebGateway.async_load_parameters",
+        return_value=mock_coro(True),
     ):
         assert await async_setup_component(hass, "spc", config) is False
 
@@ -45,11 +47,11 @@ async def test_update_alarm_device(hass):
     area_mock.verified_alarm = False
 
     with patch(
-        "pyspcwebgw.SpcWebGateway.areas", new_callable=PropertyMock
+        "homeassistant.components.spc.SpcWebGateway.areas", new_callable=PropertyMock
     ) as mock_areas:
         mock_areas.return_value = {"1": area_mock}
         with patch(
-            "pyspcwebgw.SpcWebGateway.async_load_parameters",
+            "homeassistant.components.spc.SpcWebGateway.async_load_parameters",
             return_value=mock_coro(True),
         ):
             assert await async_setup_component(hass, "spc", config) is True


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
