### PR TITLE
Move imports to top for zha

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -8,8 +8,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 
 # Loading the config flow file will register the flow
-from . import config_flow  # noqa: F401 pylint: disable=unused-import
 from . import api
+from . import config_flow  # noqa: F401 pylint: disable=unused-import
 from .core import ZHAGateway
 from .core.const import (
     COMPONENTS,
@@ -100,7 +100,7 @@ async def async_setup_entry(hass, config_entry):
     if config.get(CONF_ENABLE_QUIRKS, True):
         # needs to be done here so that the ZHA module is finished loading
         # before zhaquirks is imported
-        import zhaquirks  # noqa: F401 pylint: disable=unused-import
+        import zhaquirks  # noqa: F401 pylint: disable=unused-import, import-outside-toplevel
 
     zha_gateway = ZHAGateway(hass, config, config_entry)
     await zha_gateway.async_initialize()

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -8,8 +8,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 
 # Loading the config flow file will register the flow
-from . import api
 from . import config_flow  # noqa: F401 pylint: disable=unused-import
+from . import api
 from .core import ZHAGateway
 from .core.const import (
     COMPONENTS,

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -16,18 +16,6 @@ import zigpy.exceptions
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-# pylint: disable=wrong-import-position
-from . import closures  # noqa: F401
-from . import general  # noqa: F401
-from . import homeautomation  # noqa: F401
-from . import hvac  # noqa: F401
-from . import lighting  # noqa: F401
-from . import lightlink  # noqa: F401
-from . import manufacturerspecific  # noqa: F401
-from . import measurement  # noqa: F401
-from . import protocol  # noqa: F401
-from . import security  # noqa: F401
-from . import smartenergy  # noqa: F401
 from ..const import (
     CHANNEL_ATTRIBUTE,
     CHANNEL_EVENT_RELAY,
@@ -404,3 +392,17 @@ class EventRelayChannel(ZigbeeChannel):
             self.zha_send_event(
                 self._cluster, self._cluster.server_commands.get(command_id)[0], args
             )
+
+
+# pylint: disable=wrong-import-position, import-outside-toplevel
+from . import closures  # noqa: F401
+from . import general  # noqa: F401
+from . import homeautomation  # noqa: F401
+from . import hvac  # noqa: F401
+from . import lighting  # noqa: F401
+from . import lightlink  # noqa: F401
+from . import manufacturerspecific  # noqa: F401
+from . import measurement  # noqa: F401
+from . import protocol  # noqa: F401
+from . import security  # noqa: F401
+from . import smartenergy  # noqa: F401

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -16,6 +16,18 @@ import zigpy.exceptions
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
+# pylint: disable=wrong-import-position
+from . import closures  # noqa: F401
+from . import general  # noqa: F401
+from . import homeautomation  # noqa: F401
+from . import hvac  # noqa: F401
+from . import lighting  # noqa: F401
+from . import lightlink  # noqa: F401
+from . import manufacturerspecific  # noqa: F401
+from . import measurement  # noqa: F401
+from . import protocol  # noqa: F401
+from . import security  # noqa: F401
+from . import smartenergy  # noqa: F401
 from ..const import (
     CHANNEL_ATTRIBUTE,
     CHANNEL_EVENT_RELAY,
@@ -392,17 +404,3 @@ class EventRelayChannel(ZigbeeChannel):
             self.zha_send_event(
                 self._cluster, self._cluster.server_commands.get(command_id)[0], args
             )
-
-
-# pylint: disable=wrong-import-position
-from . import closures  # noqa: F401
-from . import general  # noqa: F401
-from . import homeautomation  # noqa: F401
-from . import hvac  # noqa: F401
-from . import lighting  # noqa: F401
-from . import lightlink  # noqa: F401
-from . import manufacturerspecific  # noqa: F401
-from . import measurement  # noqa: F401
-from . import protocol  # noqa: F401
-from . import security  # noqa: F401
-from . import smartenergy  # noqa: F401

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -6,6 +6,7 @@ https://home-assistant.io/integrations/zha/
 """
 import logging
 
+from zigpy.exceptions import DeliveryError
 import zigpy.zcl.clusters.hvac as hvac
 
 from homeassistant.core import callback
@@ -35,7 +36,6 @@ class FanChannel(ZigbeeChannel):
 
     async def async_set_speed(self, value) -> None:
         """Set the speed of the fan."""
-        from zigpy.exceptions import DeliveryError
 
         try:
             await self.cluster.write_attributes({"fan_mode": value})

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -18,7 +18,6 @@ from ..const import (
     SIGNAL_ATTR_UPDATED,
 )
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -6,6 +6,7 @@ https://home-assistant.io/integrations/zha/
 """
 import logging
 
+from zigpy.exceptions import DeliveryError
 import zigpy.zcl.clusters.security as security
 
 from homeassistant.core import callback
@@ -149,7 +150,6 @@ class IASZoneChannel(ZigbeeChannel):
         if self._zha_device.manufacturer == "LUMI":
             self.debug("finished IASZoneChannel configuration")
             return
-        from zigpy.exceptions import DeliveryError
 
         self.debug("started IASZoneChannel configuration")
 

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -11,8 +11,8 @@ import logging
 import time
 
 import zigpy.exceptions
-import zigpy.quirks
 from zigpy.profiles import zha, zll
+import zigpy.quirks
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (

--- a/homeassistant/components/zha/core/store.py
+++ b/homeassistant/components/zha/core/store.py
@@ -2,8 +2,7 @@
 # pylint: disable=unused-import
 from collections import OrderedDict
 import logging
-from typing import MutableMapping
-from typing import cast
+from typing import MutableMapping, cast
 
 import attr
 

--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -2,11 +2,11 @@
 import voluptuous as vol
 
 import homeassistant.components.automation.event as event
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 
 from . import DOMAIN
 from .core.helpers import async_get_zha_device


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
