### PR TITLE
Move imports to top for websocket_api

### DIFF
--- a/homeassistant/components/websocket_api/__init__.py
+++ b/homeassistant/components/websocket_api/__init__.py
@@ -4,7 +4,6 @@ from homeassistant.loader import bind_hass
 
 from . import commands, connection, const, decorators, http, messages
 
-
 # mypy: allow-untyped-calls, allow-untyped-defs
 
 DOMAIN = const.DOMAIN

--- a/homeassistant/components/websocket_api/auth.py
+++ b/homeassistant/components/websocket_api/auth.py
@@ -3,12 +3,11 @@ import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 from homeassistant.auth.models import RefreshToken, User
-from homeassistant.components.http.ban import process_wrong_login, process_success_login
+from homeassistant.components.http.ban import process_success_login, process_wrong_login
 from homeassistant.const import __version__
 
 from .connection import ActiveConnection
 from .error import Disconnect
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.service import async_get_all_descriptions
 
 from . import const, decorators, messages
-from .permissions import SUBSCRIBE_WHITELIST
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 
@@ -45,6 +44,9 @@ def handle_subscribe_events(hass, connection, msg):
 
     Async friendly.
     """
+    # Circular dep
+    # pylint: disable=import-outside-toplevel
+    from .permissions import SUBSCRIBE_WHITELIST
 
     event_type = msg["event_type"]
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -2,15 +2,15 @@
 import voluptuous as vol
 
 from homeassistant.auth.permissions.const import POLICY_READ
-from homeassistant.const import MATCH_ALL, EVENT_TIME_CHANGED, EVENT_STATE_CHANGED
-from homeassistant.core import callback, DOMAIN as HASS_DOMAIN
-from homeassistant.exceptions import Unauthorized, ServiceNotFound, HomeAssistantError
+from homeassistant.const import EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL
+from homeassistant.core import DOMAIN as HASS_DOMAIN, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceNotFound, Unauthorized
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.service import async_get_all_descriptions
 
 from . import const, decorators, messages
-
+from .permissions import SUBSCRIBE_WHITELIST
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 
@@ -45,7 +45,6 @@ def handle_subscribe_events(hass, connection, msg):
 
     Async friendly.
     """
-    from .permissions import SUBSCRIBE_WHITELIST
 
     event_type = msg["event_type"]
 

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -4,11 +4,10 @@ from typing import Any, Callable, Dict, Hashable
 
 import voluptuous as vol
 
-from homeassistant.core import callback, Context
+from homeassistant.core import Context, callback
 from homeassistant.exceptions import Unauthorized
 
 from . import const, messages
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -3,6 +3,7 @@ import asyncio
 from concurrent import futures
 from functools import partial
 import json
+
 from homeassistant.helpers.json import JSONEncoder
 
 DOMAIN = "websocket_api"

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -7,7 +7,6 @@ from homeassistant.exceptions import Unauthorized
 
 from . import messages
 
-
 # mypy: allow-untyped-calls, allow-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -4,27 +4,26 @@ from contextlib import suppress
 import logging
 from typing import Optional
 
-from aiohttp import web, WSMsgType
+from aiohttp import WSMsgType, web
 import async_timeout
 
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
-from homeassistant.components.http import HomeAssistantView
 
+from .auth import AuthPhase, auth_required_message
 from .const import (
-    MAX_PENDING_MSG,
     CANCELLATION_ERRORS,
-    URL,
+    DATA_CONNECTIONS,
     ERR_UNKNOWN_ERROR,
+    JSON_DUMP,
+    MAX_PENDING_MSG,
     SIGNAL_WEBSOCKET_CONNECTED,
     SIGNAL_WEBSOCKET_DISCONNECTED,
-    DATA_CONNECTIONS,
-    JSON_DUMP,
+    URL,
 )
-from .auth import AuthPhase, auth_required_message
 from .error import Disconnect
 from .messages import error_message
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -6,7 +6,6 @@ from homeassistant.helpers import config_validation as cv
 
 from . import const
 
-
 # mypy: allow-untyped-defs
 
 # Minimal requirements of a message

--- a/homeassistant/components/websocket_api/permissions.py
+++ b/homeassistant/components/websocket_api/permissions.py
@@ -2,22 +2,22 @@
 
 Separate file to avoid circular imports.
 """
+from homeassistant.components.frontend import EVENT_PANELS_UPDATED
+from homeassistant.components.lovelace import EVENT_LOVELACE_UPDATED
+from homeassistant.components.persistent_notification import (
+    EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
+)
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
+    EVENT_CORE_CONFIG_UPDATE,
     EVENT_SERVICE_REGISTERED,
     EVENT_SERVICE_REMOVED,
     EVENT_STATE_CHANGED,
     EVENT_THEMES_UPDATED,
-    EVENT_CORE_CONFIG_UPDATE,
 )
-from homeassistant.components.persistent_notification import (
-    EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
-)
-from homeassistant.components.lovelace import EVENT_LOVELACE_UPDATED
 from homeassistant.helpers.area_registry import EVENT_AREA_REGISTRY_UPDATED
 from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
-from homeassistant.components.frontend import EVENT_PANELS_UPDATED
 
 # These are events that do not contain any sensitive data
 # Except for state_changed, which is handled accordingly.

--- a/homeassistant/components/websocket_api/sensor.py
+++ b/homeassistant/components/websocket_api/sensor.py
@@ -4,11 +4,10 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 
 from .const import (
+    DATA_CONNECTIONS,
     SIGNAL_WEBSOCKET_CONNECTED,
     SIGNAL_WEBSOCKET_DISCONNECTED,
-    DATA_CONNECTIONS,
 )
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
