### PR TITLE
Move imports to top for fido

### DIFF
--- a/homeassistant/components/fido/sensor.py
+++ b/homeassistant/components/fido/sensor.py
@@ -7,21 +7,23 @@ https://www.fido.ca/pages/#/my-account/wireless
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.fido/
 """
-import logging
 from datetime import timedelta
+import logging
 
+from pyfido import FidoClient
+from pyfido.client import PyFidoError
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_USERNAME,
-    CONF_PASSWORD,
-    CONF_NAME,
     CONF_MONITORED_VARIABLES,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -147,7 +149,6 @@ class FidoData:
 
     def __init__(self, username, password, httpsession):
         """Initialize the data object."""
-        from pyfido import FidoClient
 
         self.client = FidoClient(username, password, REQUESTS_TIMEOUT, httpsession)
         self.data = {}
@@ -155,7 +156,6 @@ class FidoData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Get the latest data from Fido."""
-        from pyfido.client import PyFidoError
 
         try:
             await self.client.fetch_data()

--- a/tests/components/fido/test_sensor.py
+++ b/tests/components/fido/test_sensor.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.fido import sensor as fido
@@ -66,29 +66,25 @@ def fake_async_add_entities(component, update_before_add=False):
 @asyncio.coroutine
 def test_fido_sensor(loop, hass):
     """Test the Fido number sensor."""
-    sys.modules["pyfido"] = MagicMock()
-    sys.modules["pyfido.client"] = MagicMock()
-    sys.modules["pyfido.client.PyFidoError"] = PyFidoErrorMock
-    import pyfido.client
-
-    pyfido.FidoClient = FidoClientMock
-    pyfido.client.PyFidoError = PyFidoErrorMock
-    config = {
-        "sensor": {
-            "platform": "fido",
-            "name": "fido",
-            "username": "myusername",
-            "password": "password",
-            "monitored_variables": ["balance", "data_remaining"],
+    with patch(
+        "homeassistant.components.fido.sensor.FidoClient", new=FidoClientMock
+    ), patch("homeassistant.components.fido.sensor.PyFidoError", new=PyFidoErrorMock):
+        config = {
+            "sensor": {
+                "platform": "fido",
+                "name": "fido",
+                "username": "myusername",
+                "password": "password",
+                "monitored_variables": ["balance", "data_remaining"],
+            }
         }
-    }
-    with assert_setup_component(1):
-        yield from async_setup_component(hass, "sensor", config)
-    state = hass.states.get("sensor.fido_1112223344_balance")
-    assert state.state == "160.12"
-    assert state.attributes.get("number") == "1112223344"
-    state = hass.states.get("sensor.fido_1112223344_data_remaining")
-    assert state.state == "100.33"
+        with assert_setup_component(1):
+            yield from async_setup_component(hass, "sensor", config)
+        state = hass.states.get("sensor.fido_1112223344_balance")
+        assert state.state == "160.12"
+        assert state.attributes.get("number") == "1112223344"
+        state = hass.states.get("sensor.fido_1112223344_data_remaining")
+        assert state.state == "100.33"
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
