### PR TITLE
Add protection via try-catch to Sigfox message parsing

### DIFF
--- a/homeassistant/components/sigfox/sensor.py
+++ b/homeassistant/components/sigfox/sensor.py
@@ -126,7 +126,11 @@ class SigfoxDevice(Entity):
         url = urljoin(API_URL, device_url)
         response = requests.get(url, auth=self._auth, timeout=10)
         data = json.loads(response.text)["data"][0]
-        payload = bytes.fromhex(data["data"]).decode("utf-8")
+        try:
+            payload = bytes.fromhex(data['data']).decode('utf-8')
+        except UnicodeDecodeError:
+            # take it as it is it can be raw binary data
+            payload = data['data']
         lat = data["rinfos"][0]["lat"]
         lng = data["rinfos"][0]["lng"]
         snr = data["snr"]


### PR DESCRIPTION
Protect bytes.fromhex(data['data']).decode('utf-8') with a try/except, the message can contain raw binary data.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
