### PR TITLE
Move imports to top for homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -5,15 +5,14 @@ import homekit
 from homekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import Entity
 
 # We need an import from .config_flow, without it .config_flow is never loaded.
 from .config_flow import HomekitControllerFlowHandler  # noqa: F401
-from .connection import get_accessory_information, HKDevice
-from .const import CONTROLLER, ENTITY_MAP, KNOWN_DEVICES
-from .const import DOMAIN
+from .connection import HKDevice, get_accessory_information
+from .const import CONTROLLER, DOMAIN, ENTITY_MAP, KNOWN_DEVICES
 from .storage import EntityMapStorage
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -4,20 +4,20 @@ import logging
 from homekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.climate import (
-    ClimateDevice,
-    DEFAULT_MIN_HUMIDITY,
     DEFAULT_MAX_HUMIDITY,
+    DEFAULT_MIN_HUMIDITY,
+    ClimateDevice,
 )
 from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT_COOL,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
-    CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_COOL,
-    SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -1,17 +1,17 @@
 """Config flow to configure homekit_controller."""
-import os
 import json
 import logging
+import os
 
 import homekit
+from homekit.controller.ip_implementation import IpPairing
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import callback
 
+from .connection import get_accessory_name, get_bridge_information
 from .const import DOMAIN, KNOWN_DEVICES
-from .connection import get_bridge_information, get_accessory_name
-
 
 HOMEKIT_IGNORE = ["Home Assistant Bridge"]
 HOMEKIT_DIR = ".homekit"
@@ -194,7 +194,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
     async def async_import_legacy_pairing(self, discovery_props, pairing_data):
         """Migrate a legacy pairing to config entries."""
-        from homekit.controller.ip_implementation import IpPairing
 
         hkid = discovery_props["id"]
 

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -3,18 +3,18 @@ import asyncio
 import datetime
 import logging
 
+from homekit.controller.ip_implementation import IpPairing
 from homekit.exceptions import (
     AccessoryDisconnectedError,
     AccessoryNotFoundError,
     EncryptionError,
 )
-from homekit.model.services import ServicesTypes
 from homekit.model.characteristics import CharacteristicsTypes
+from homekit.model.services import ServicesTypes
 
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, ENTITY_MAP
-
+from .const import DOMAIN, ENTITY_MAP, HOMEKIT_ACCESSORY_DISPATCH
 
 DEFAULT_SCAN_INTERVAL = datetime.timedelta(seconds=60)
 RETRY_INTERVAL = 60  # seconds
@@ -57,7 +57,6 @@ class HKDevice:
 
     def __init__(self, hass, config_entry, pairing_data):
         """Initialise a generic HomeKit device."""
-        from homekit.controller.ip_implementation import IpPairing
 
         self.hass = hass
         self.config_entry = config_entry

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -11,8 +11,8 @@ from homeassistant.components.cover import (
     SUPPORT_OPEN,
     SUPPORT_OPEN_TILT,
     SUPPORT_SET_POSITION,
-    SUPPORT_STOP,
     SUPPORT_SET_TILT_POSITION,
+    SUPPORT_STOP,
     CoverDevice,
 )
 from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -1,7 +1,7 @@
 """Helpers for HomeKit data stored in HA storage."""
 
-from homeassistant.helpers.storage import Store
 from homeassistant.core import callback
+from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
 

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -250,7 +250,9 @@ async def setup_test_accessories(hass, accessories):
 
     config_entry.add_to_hass(hass)
 
-    pairing_cls_loc = "homekit.controller.ip_implementation.IpPairing"
+    pairing_cls_loc = (
+        "homeassistant.components.homekit_controller.config_flow.IpPairing"
+    )
     with mock.patch(pairing_cls_loc) as pairing_cls:
         pairing_cls.return_value = pairing
         await config_entry.async_setup(hass)

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -250,9 +250,7 @@ async def setup_test_accessories(hass, accessories):
 
     config_entry.add_to_hass(hass)
 
-    pairing_cls_loc = (
-        "homeassistant.components.homekit_controller.config_flow.IpPairing"
-    )
+    pairing_cls_loc = "homeassistant.components.homekit_controller.connection.IpPairing"
     with mock.patch(pairing_cls_loc) as pairing_cls:
         pairing_cls.return_value = pairing
         await config_entry.async_setup(hass)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -154,7 +154,9 @@ async def test_ecobee3_setup_connection_failure(hass):
     # make sure the IpPairing mock is in place or we'll try to connect to
     # a real device. Normally this mocking is done by the helper in
     # setup_test_accessories.
-    pairing_cls_loc = "homekit.controller.ip_implementation.IpPairing"
+    pairing_cls_loc = (
+        "homeassistant.components.homekit_controller.config_flow.IpPairing"
+    )
     with mock.patch(pairing_cls_loc) as pairing_cls:
         pairing_cls.return_value = pairing
         await time_changed(hass, 5 * 60)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -154,9 +154,7 @@ async def test_ecobee3_setup_connection_failure(hass):
     # make sure the IpPairing mock is in place or we'll try to connect to
     # a real device. Normally this mocking is done by the helper in
     # setup_test_accessories.
-    pairing_cls_loc = (
-        "homeassistant.components.homekit_controller.config_flow.IpPairing"
-    )
+    pairing_cls_loc = "homeassistant.components.homekit_controller.connection.IpPairing"
     with mock.patch(pairing_cls_loc) as pairing_cls:
         pairing_cls.return_value = pairing
         await time_changed(hass, 5 * 60)

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -554,7 +554,9 @@ async def test_import_works(hass):
 
     flow = _setup_flow_handler(hass)
 
-    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+    pairing_cls_imp = (
+        "homeassistant.components.homekit_controller.config_flow.IpPairing"
+    )
 
     with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
@@ -694,7 +696,9 @@ async def test_parse_new_homekit_json(hass):
 
     flow = _setup_flow_handler(hass)
 
-    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+    pairing_cls_imp = (
+        "homeassistant.components.homekit_controller.config_flow.IpPairing"
+    )
 
     with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
@@ -742,7 +746,9 @@ async def test_parse_old_homekit_json(hass):
 
     flow = _setup_flow_handler(hass)
 
-    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+    pairing_cls_imp = (
+        "homeassistant.components.homekit_controller.config_flow.IpPairing"
+    )
 
     with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
@@ -798,7 +804,9 @@ async def test_parse_overlapping_homekit_json(hass):
 
     flow = _setup_flow_handler(hass)
 
-    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+    pairing_cls_imp = (
+        "homeassistant.components.homekit_controller.config_flow.IpPairing"
+    )
 
     with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** #27284 <home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
