### PR TITLE
Bump Lightwave to 0.17

### DIFF
--- a/homeassistant/components/lightwave/manifest.json
+++ b/homeassistant/components/lightwave/manifest.json
@@ -3,7 +3,7 @@
   "name": "Lightwave",
   "documentation": "https://www.home-assistant.io/integrations/lightwave",
   "requirements": [
-    "lightwave==0.15"
+    "lightwave==0.17"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -778,7 +778,7 @@ liffylights==0.9.4
 lightify==1.0.7.2
 
 # homeassistant.components.lightwave
-lightwave==0.15
+lightwave==0.17
 
 # homeassistant.components.limitlessled
 limitlessled==1.1.3


### PR DESCRIPTION
## Description:
Bump Lightwave to 0.17 to fix registration problems and improve logging

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
