### PR TITLE
Implement ComponentNotReady exception

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -34,6 +34,10 @@ class ConfigEntryNotReady(HomeAssistantError):
     """Error to indicate that config entry is not ready."""
 
 
+class ComponentNotReady(HomeAssistantError):
+    """Error to indicate that component is not ready."""
+
+
 class InvalidStateError(HomeAssistantError):
     """When an invalid state is encountered."""
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -2,15 +2,13 @@
 import asyncio
 import logging.handlers
 from timeit import default_timer as timer
-
 from types import ModuleType
-from typing import Awaitable, Callable, Optional, Dict, List
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-from homeassistant import requirements, core, loader, config as conf_util
+from homeassistant import config as conf_util, core, loader, requirements
 from homeassistant.config import async_notify_setup_error
 from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
 from homeassistant.exceptions import ComponentNotReady, HomeAssistantError
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +85,7 @@ async def _async_process_dependencies(
 
 
 async def _async_setup_component(
-    hass: core.HomeAssistant, domain: str, config: Dict, tries=0
+    hass: core.HomeAssistant, domain: str, config: Dict, tries: int = 0
 ) -> bool:
     """Set up a component for Home Assistant.
 
@@ -185,7 +183,7 @@ async def _async_setup_component(
             "Component %s not ready yet. Retrying in %d seconds.", domain, wait_time,
         )
 
-        async def setup_again(now):
+        async def setup_again(now: Any) -> None:
             """Run setup again."""
             await _async_setup_component(hass, domain, config, tries)
 


### PR DESCRIPTION
## Description:
This change adds a `ComponentNotReady` exception, related to the `PlatformNotReady` or the `ConfigEntryNotReady` exceptions. This exception can be raised from the setup of the component so Home Assistant will retry to setup it again.

When developing an integration with a bridge, it is recommended to connect with the bridge from the Component, and use dispatcher to notify the platforms of new data. When the bridge is unreachable during startup (due to temporary network issues for example), there is no way to retry this later.

A test has been added to test this behavior.

Helps #29528

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
