### PR TITLE
Change darksky incorrect state mapper wind(y)

### DIFF
--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -45,14 +45,14 @@ MAP_CONDITION = {
     "rain": "rainy",
     "snow": "snowy",
     "sleet": "snowy-rainy",
-    "windy": "windy",
+    "wind": "windy",
     "fog": "fog",
     "cloudy": "cloudy",
     "partly-cloudy-day": "partly-cloudy",
     "partly-cloudy-night": "partly-cloudy",
     "hail": "hail",
     "thunderstorm": "lightning",
-    "tornado": "tornado",
+    "tornado": "exceptional",
 }
 
 CONF_UNITS = "units"

--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -48,11 +48,11 @@ MAP_CONDITION = {
     "windy": "windy",
     "fog": "fog",
     "cloudy": "cloudy",
-    "partly-cloudy-day": "partlycloudy",
-    "partly-cloudy-night": "partlycloudy",
+    "partly-cloudy-day": "partly-cloudy",
+    "partly-cloudy-night": "partly-cloudy",
     "hail": "hail",
     "thunderstorm": "lightning",
-    "tornado": None,
+    "tornado": "tornado",
 }
 
 CONF_UNITS = "units"

--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -45,7 +45,7 @@ MAP_CONDITION = {
     "rain": "rainy",
     "snow": "snowy",
     "sleet": "snowy-rainy",
-    "wind": "windy",
+    "windy": "windy",
     "fog": "fog",
     "cloudy": "cloudy",
     "partly-cloudy-day": "partlycloudy",


### PR DESCRIPTION

![Schermafbeelding 2019-12-06 om 16 33 44](https://user-images.githubusercontent.com/33354141/70334815-6a64f500-1846-11ea-9079-af67c99dc256.jpg)
noticed the weather component has state 'windy' today, and hence the mapper should be changed accordingly

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
