### PR TITLE
Fix neato device info

### DIFF
--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -165,7 +165,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         _LOGGER.debug("Running Neato Vacuums update")
         try:
             if self._robot_stats is None:
-                self._robot_stats = self.robot.get_robot_info().json()
+                self._robot_stats = self.robot.get_general_info().json().get("data")
         except NeatoRobotException:
             _LOGGER.warning("Couldn't fetch robot information of %s", self._name)
 
@@ -319,10 +319,9 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         """Device info for neato robot."""
         info = {"identifiers": {(NEATO_DOMAIN, self._robot_serial)}, "name": self._name}
         if self._robot_stats:
-            info["manufacturer"] = self._robot_stats["data"]["mfg_name"]
-            info["model"] = self._robot_stats["data"]["modelName"]
-        if self._state:
-            info["sw_version"] = self._state["meta"]["firmware"]
+            info["manufacturer"] = self._robot_stats["battery"]["vendor"]
+            info["model"] = self._robot_stats["model"]
+            info["sw_version"] = self._robot_stats["firmware"]
 
     def start(self):
         """Start cleaning or resume cleaning."""


### PR DESCRIPTION
## Breaking Change:

Maybe there are some minor changes since we use other sources to fill in `device_info`. But I can't imagine a use-case that could be broken by this change.

## Description:
An endpoint of neao's API broke some time ago. There is a workaround where the error is caught (#29156). Now we use a different endpoint to fetch device information. We are now using `get_general_info()` instead of `get_robot_info()` as the last one is intended for debugging purposes.

Please include this in the next release once it has been accepted.

**Related issue (if applicable):** fixes #29239

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
