### PR TITLE
Treat BaseException as over-general

### DIFF
--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -44,7 +44,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 "WHOIS lookup for %s didn't contain an expiration date", domain
             )
             return
-    except whois.BaseException as ex:
+    except whois.BaseException as ex:  # pylint: disable=broad-except
         _LOGGER.error("Exception %s occurred during WHOIS lookup for %s", ex, domain)
         return
 
@@ -96,7 +96,7 @@ class WhoisSensor(Entity):
         """Get the current WHOIS data for the domain."""
         try:
             response = self.whois(self._domain)
-        except whois.BaseException as ex:
+        except whois.BaseException as ex:  # pylint: disable=broad-except
             _LOGGER.error("Exception %s occurred during WHOIS lookup", ex)
             self._empty_state_and_attributes()
             return

--- a/pylintrc
+++ b/pylintrc
@@ -64,4 +64,4 @@ ignored-classes=_CountingAttr
 expected-line-ending-format=LF
 
 [EXCEPTIONS]
-overgeneral-exceptions=Exception,HomeAssistantError
+overgeneral-exceptions=BaseException,Exception,HomeAssistantError


### PR DESCRIPTION
## Description:

To follow pylint's defaults.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
