### PR TITLE
Add new supported features to androidtv component

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,8 +3,8 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
-    "adb-shell==0.0.8",
-    "androidtv==0.0.34",
+    "adb-shell==0.0.9",
+    "androidtv==0.0.35",
     "pure-python-adb==0.2.2.dev0"
   ],
   "dependencies": [],

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -55,6 +55,7 @@ SUPPORT_ANDROIDTV = (
     | SUPPORT_TURN_OFF
     | SUPPORT_PREVIOUS_TRACK
     | SUPPORT_NEXT_TRACK
+    | SUPPORT_SELECT_SOURCE
     | SUPPORT_STOP
     | SUPPORT_VOLUME_MUTE
     | SUPPORT_VOLUME_STEP
@@ -199,6 +200,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 aftv,
                 config[CONF_NAME],
                 config[CONF_APPS],
+                config[CONF_GET_SOURCES],
                 config.get(CONF_TURN_ON_COMMAND),
                 config.get(CONF_TURN_OFF_COMMAND),
             )
@@ -287,7 +289,9 @@ def adb_decorator(override_available=False):
 class ADBDevice(MediaPlayerDevice):
     """Representation of an Android TV or Fire TV device."""
 
-    def __init__(self, aftv, name, apps, turn_on_command, turn_off_command):
+    def __init__(
+        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+    ):
         """Initialize the Android TV / Fire TV device."""
         self.aftv = aftv
         self._name = name
@@ -296,6 +300,7 @@ class ADBDevice(MediaPlayerDevice):
         self._app_name_to_id = {
             value: key for key, value in self._app_id_to_name.items()
         }
+        self._get_sources = get_sources
         self._keys = KEYS
 
         self._device_properties = self.aftv.device_properties
@@ -325,6 +330,7 @@ class ADBDevice(MediaPlayerDevice):
         self._adb_response = None
         self._available = True
         self._current_app = None
+        self._sources = None
         self._state = None
 
     @property
@@ -356,6 +362,16 @@ class ADBDevice(MediaPlayerDevice):
     def should_poll(self):
         """Device should be polled."""
         return True
+
+    @property
+    def source(self):
+        """Return the current app."""
+        return self._app_id_to_name.get(self._current_app, self._current_app)
+
+    @property
+    def source_list(self):
+        """Return a list of running apps."""
+        return self._sources
 
     @property
     def state(self):
@@ -409,6 +425,20 @@ class ADBDevice(MediaPlayerDevice):
         self.aftv.media_next_track()
 
     @adb_decorator()
+    def select_source(self, source):
+        """Select input source.
+
+        If the source starts with a '!', then it will close the app instead of
+        opening it.
+        """
+        if isinstance(source, str):
+            if not source.startswith("!"):
+                self.aftv.launch_app(self._app_name_to_id.get(source, source))
+            else:
+                source_ = source[1:].lstrip()
+                self.aftv.stop_app(self._app_name_to_id.get(source_, source_))
+
+    @adb_decorator()
     def adb_command(self, cmd):
         """Send an ADB command to an Android TV / Fire TV device."""
         key = self._keys.get(cmd)
@@ -436,9 +466,13 @@ class ADBDevice(MediaPlayerDevice):
 class AndroidTVDevice(ADBDevice):
     """Representation of an Android TV device."""
 
-    def __init__(self, aftv, name, apps, turn_on_command, turn_off_command):
+    def __init__(
+        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+    ):
         """Initialize the Android TV device."""
-        super().__init__(aftv, name, apps, turn_on_command, turn_off_command)
+        super().__init__(
+            aftv, name, apps, get_sources, turn_on_command, turn_off_command
+        )
 
         self._device = None
         self._is_volume_muted = None
@@ -465,24 +499,27 @@ class AndroidTVDevice(ADBDevice):
         (
             state,
             self._current_app,
+            running_apps,
             self._device,
             self._is_volume_muted,
             self._volume_level,
-        ) = self.aftv.update()
+        ) = self.aftv.update(self._get_sources)
 
         self._state = ANDROIDTV_STATES.get(state)
         if self._state is None:
             self._available = False
 
+        if running_apps:
+            self._sources = [
+                self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
+            ]
+        else:
+            self._sources = None
+
     @property
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._is_volume_muted
-
-    @property
-    def source(self):
-        """Return the current playback device."""
-        return self._device
 
     @property
     def supported_features(self):
@@ -522,10 +559,9 @@ class FireTVDevice(ADBDevice):
         self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
     ):
         """Initialize the Fire TV device."""
-        super().__init__(aftv, name, apps, turn_on_command, turn_off_command)
-
-        self._get_sources = get_sources
-        self._sources = None
+        super().__init__(
+            aftv, name, apps, get_sources, turn_on_command, turn_off_command
+        )
 
     @adb_decorator(override_available=True)
     def update(self):
@@ -559,16 +595,6 @@ class FireTVDevice(ADBDevice):
             self._sources = None
 
     @property
-    def source(self):
-        """Return the current app."""
-        return self._app_id_to_name.get(self._current_app, self._current_app)
-
-    @property
-    def source_list(self):
-        """Return a list of running apps."""
-        return self._sources
-
-    @property
     def supported_features(self):
         """Flag media player features that are supported."""
         return SUPPORT_FIRETV
@@ -577,17 +603,3 @@ class FireTVDevice(ADBDevice):
     def media_stop(self):
         """Send stop (back) command."""
         self.aftv.back()
-
-    @adb_decorator()
-    def select_source(self, source):
-        """Select input source.
-
-        If the source starts with a '!', then it will close the app instead of
-        opening it.
-        """
-        if isinstance(source, str):
-            if not source.startswith("!"):
-                self.aftv.launch_app(self._app_name_to_id.get(source, source))
-            else:
-                source_ = source[1:].lstrip()
-                self.aftv.stop_app(self._app_name_to_id.get(source_, source_))

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -555,14 +555,6 @@ class AndroidTVDevice(ADBDevice):
 class FireTVDevice(ADBDevice):
     """Representation of a Fire TV device."""
 
-    def __init__(
-        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
-    ):
-        """Initialize the Fire TV device."""
-        super().__init__(
-            aftv, name, apps, get_sources, turn_on_command, turn_off_command
-        )
-
     @adb_decorator(override_available=True)
     def update(self):
         """Update the device state and, if necessary, re-connect."""

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -149,5 +149,22 @@ def patch_firetv_update(state, current_app, running_apps):
     )
 
 
-PATCH_LAUNCH_APP = patch("androidtv.firetv.FireTV.launch_app")
-PATCH_STOP_APP = patch("androidtv.firetv.FireTV.stop_app")
+def patch_androidtv_update(
+    state, current_app, running_apps, device, is_volume_muted, volume_level
+):
+    """Patch the `AndroidTV.update()` method."""
+    return patch(
+        "androidtv.androidtv.AndroidTV.update",
+        return_value=(
+            state,
+            current_app,
+            running_apps,
+            device,
+            is_volume_muted,
+            volume_level,
+        ),
+    )
+
+
+PATCH_LAUNCH_APP = patch("androidtv.basetv.BaseTV.launch_app")
+PATCH_STOP_APP = patch("androidtv.basetv.BaseTV.stop_app")


### PR DESCRIPTION
## Description:
The `python-androidtv` module was recently updated to add support for `select_source`. I have updated the corresponding integration and tests to allow the HA integration to take advantage of the update.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
