### PR TITLE
 Add input_datetime reload service.

### DIFF
--- a/homeassistant/components/input_datetime/services.yaml
+++ b/homeassistant/components/input_datetime/services.yaml
@@ -9,3 +9,6 @@ set_datetime:
       example: '"time": "05:30:00"'}
     datetime: {description: The target date & time the entity should be set to. Do not use with date or time.,
       example: '"datetime": "2019-04-22 05:30:00"'}
+
+reload:
+  description: Reload the input_datetime configuration.


### PR DESCRIPTION
## Description:
Add `input_datetime.reload` admin service so new entities could be added without entire HA instance restart

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
