### PR TITLE
Add Huawei LTE reboot and clear traffic statistics services

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -403,7 +403,7 @@ async def async_setup(hass: HomeAssistantType, config) -> bool:
             _LOGGER.error(
                 "%s: more than one router configured, must specify one of URLs %s",
                 service.service,
-                sorted(routers.keys()),
+                sorted(routers),
             )
             return
         if not router:

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -105,7 +105,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-SERVICE_SCHEMA = vol.Schema({vol.Required(CONF_URL): cv.url})
+SERVICE_SCHEMA = vol.Schema({vol.Optional(CONF_URL): cv.url})
 
 CONFIG_ENTRY_PLATFORMS = (
     BINARY_SENSOR_DOMAIN,
@@ -394,7 +394,19 @@ async def async_setup(hass: HomeAssistantType, config) -> bool:
     def service_handler(service) -> None:
         """Apply a service."""
         url = service.data.get(CONF_URL)
-        router = hass.data[DOMAIN].routers.get(url)
+        routers = hass.data[DOMAIN].routers
+        if url:
+            router = routers.get(url)
+        else:
+            if len(routers) == 1:
+                router = next(iter(routers.values()))
+            else:
+                _LOGGER.error(
+                    "%s: more than one router configured, must specify one of URLs %s",
+                    service.service,
+                    sorted(routers.keys()),
+                )
+                return
         if not router:
             _LOGGER.error("%s: router %s unavailable", service.service, url)
             return

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -58,6 +58,7 @@ from .const import (
     KEY_MONITORING_STATUS,
     KEY_MONITORING_TRAFFIC_STATISTICS,
     KEY_WLAN_HOST_LIST,
+    SERVICE_CLEAR_TRAFFIC_STATISTICS,
     UPDATE_OPTIONS_SIGNAL,
     UPDATE_SIGNAL,
 )
@@ -102,6 +103,8 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+SERVICE_SCHEMA = vol.Schema({vol.Required(CONF_URL): cv.url})
 
 CONFIG_ENTRY_PLATFORMS = (
     BINARY_SENSOR_DOMAIN,
@@ -386,6 +389,25 @@ async def async_setup(hass: HomeAssistantType, config) -> bool:
         hass.data[DOMAIN] = HuaweiLteData(hass_config=config, config=domain_config)
     for router_config in config.get(DOMAIN, []):
         domain_config[url_normalize(router_config.pop(CONF_URL))] = router_config
+
+    def service_handler(service) -> None:
+        """Apply a service."""
+        url = service.data.get(CONF_URL)
+        router = hass.data[DOMAIN].routers.get(url)
+        if not router:
+            _LOGGER.error("%s: router %s unavailable", service.service, url)
+            return
+
+        if service.service == SERVICE_CLEAR_TRAFFIC_STATISTICS:
+            result = router.client.monitoring.set_clear_traffic()
+            _LOGGER.debug("%s: %s", service.service, result)
+        else:
+            _LOGGER.error("%s: unsupported service", service.service)
+
+    for service in (SERVICE_CLEAR_TRAFFIC_STATISTICS,):
+        hass.services.async_register(
+            DOMAIN, service, service_handler, schema=SERVICE_SCHEMA,
+        )
 
     for url, router_config in domain_config.items():
         hass.async_create_task(

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -409,7 +409,7 @@ async def async_setup(hass: HomeAssistantType, config) -> bool:
             _LOGGER.error("%s: unsupported service", service.service)
 
     for service in (SERVICE_CLEAR_TRAFFIC_STATISTICS, SERVICE_REBOOT):
-        hass.services.async_register(
+        hass.helpers.service.async_register_admin_service(
             DOMAIN, service, service_handler, schema=SERVICE_SCHEMA,
         )
 

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -59,6 +59,7 @@ from .const import (
     KEY_MONITORING_TRAFFIC_STATISTICS,
     KEY_WLAN_HOST_LIST,
     SERVICE_CLEAR_TRAFFIC_STATISTICS,
+    SERVICE_REBOOT,
     UPDATE_OPTIONS_SIGNAL,
     UPDATE_SIGNAL,
 )
@@ -401,10 +402,13 @@ async def async_setup(hass: HomeAssistantType, config) -> bool:
         if service.service == SERVICE_CLEAR_TRAFFIC_STATISTICS:
             result = router.client.monitoring.set_clear_traffic()
             _LOGGER.debug("%s: %s", service.service, result)
+        elif service.service == SERVICE_REBOOT:
+            result = router.client.device.reboot()
+            _LOGGER.debug("%s: %s", service.service, result)
         else:
             _LOGGER.error("%s: unsupported service", service.service)
 
-    for service in (SERVICE_CLEAR_TRAFFIC_STATISTICS,):
+    for service in (SERVICE_CLEAR_TRAFFIC_STATISTICS, SERVICE_REBOOT):
         hass.services.async_register(
             DOMAIN, service, service_handler, schema=SERVICE_SCHEMA,
         )

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -397,16 +397,15 @@ async def async_setup(hass: HomeAssistantType, config) -> bool:
         routers = hass.data[DOMAIN].routers
         if url:
             router = routers.get(url)
+        elif len(routers) == 1:
+            router = next(iter(routers.values()))
         else:
-            if len(routers) == 1:
-                router = next(iter(routers.values()))
-            else:
-                _LOGGER.error(
-                    "%s: more than one router configured, must specify one of URLs %s",
-                    service.service,
-                    sorted(routers.keys()),
-                )
-                return
+            _LOGGER.error(
+                "%s: more than one router configured, must specify one of URLs %s",
+                service.service,
+                sorted(routers.keys()),
+            )
+            return
         if not router:
             _LOGGER.error("%s: router %s unavailable", service.service, url)
             return

--- a/homeassistant/components/huawei_lte/const.py
+++ b/homeassistant/components/huawei_lte/const.py
@@ -13,6 +13,7 @@ UNIT_SECONDS = "s"
 CONNECTION_TIMEOUT = 10
 
 SERVICE_CLEAR_TRAFFIC_STATISTICS = "clear_traffic_statistics"
+SERVICE_REBOOT = "reboot"
 
 KEY_DEVICE_BASIC_INFORMATION = "device_basic_information"
 KEY_DEVICE_INFORMATION = "device_information"

--- a/homeassistant/components/huawei_lte/const.py
+++ b/homeassistant/components/huawei_lte/const.py
@@ -12,6 +12,8 @@ UNIT_SECONDS = "s"
 
 CONNECTION_TIMEOUT = 10
 
+SERVICE_CLEAR_TRAFFIC_STATISTICS = "clear_traffic_statistics"
+
 KEY_DEVICE_BASIC_INFORMATION = "device_basic_information"
 KEY_DEVICE_INFORMATION = "device_information"
 KEY_DEVICE_SIGNAL = "device_signal"

--- a/homeassistant/components/huawei_lte/services.yaml
+++ b/homeassistant/components/huawei_lte/services.yaml
@@ -4,3 +4,10 @@ clear_traffic_statistics:
     url:
       description: URL of router to clear.
       example: http://192.168.100.1/
+
+reboot:
+  description: Reboot router.
+  fields:
+    url:
+      description: URL of router to reboot.
+      example: http://192.168.100.1/

--- a/homeassistant/components/huawei_lte/services.yaml
+++ b/homeassistant/components/huawei_lte/services.yaml
@@ -1,0 +1,6 @@
+clear_traffic_statistics:
+  description: Clear traffic statistics.
+  fields:
+    url:
+      description: URL of router to clear.
+      example: http://192.168.100.1/

--- a/homeassistant/components/huawei_lte/services.yaml
+++ b/homeassistant/components/huawei_lte/services.yaml
@@ -2,12 +2,12 @@ clear_traffic_statistics:
   description: Clear traffic statistics.
   fields:
     url:
-      description: URL of router to clear.
+      description: URL of router to clear; optional when only one is configured.
       example: http://192.168.100.1/
 
 reboot:
   description: Reboot router.
   fields:
     url:
-      description: URL of router to reboot.
+      description: URL of router to reboot; optional when only one is configured.
       example: http://192.168.100.1/


### PR DESCRIPTION

## Description:

Add Huawei LTE reboot and clear traffic statistics services.
 
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11389

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
