### PR TITLE
Add user-agent to fix dwd_weather_warnings setup error

### DIFF
--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_MONITORED_CONDITIONS
@@ -185,7 +186,7 @@ class DwdWeatherWarningsAPI:
         )
 
         # a dummy User-Agent is necessary to trick the rest api endpoint (see #29496)
-        headers = {"User-Agent": "HomeAssistant/0.103.0"}
+        headers = {"User-Agent": SERVER_SOFTWARE}
 
         self._rest = RestData("GET", resource, None, headers, None, True)
         self.region_name = region_name

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -184,7 +184,10 @@ class DwdWeatherWarningsAPI:
             "jsonp=loadWarnings",
         )
 
-        self._rest = RestData("GET", resource, None, None, None, True)
+        # a dummy User-Agent is necessary to trick the rest api endpoint (see #29496)
+        headers = {"User-Agent": "HomeAssistant/0.103.0"}
+
+        self._rest = RestData("GET", resource, None, headers, None, True)
         self.region_name = region_name
         self.region_id = None
         self.region_state = None

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
+from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE as HA_USER_AGENT
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_MONITORED_CONDITIONS
@@ -185,8 +185,8 @@ class DwdWeatherWarningsAPI:
             "jsonp=loadWarnings",
         )
 
-        # a dummy User-Agent is necessary to trick the rest api endpoint (see #29496)
-        headers = {"User-Agent": SERVER_SOFTWARE}
+        # a User-Agent is necessary for this rest api endpoint (#29496)
+        headers = {"User-Agent": HA_USER_AGENT}
 
         self._rest = RestData("GET", resource, None, headers, None, True)
         self.region_name = region_name


### PR DESCRIPTION
## Description:
- see https://github.com/home-assistant/home-assistant/issues/29496#issuecomment-562870438
- used rest api endpoint requires a `User-Agent` in the request `header`
- added a dummy user-agent and passed it onto the `RestData` constructor

**Related issue (if applicable):** fixes #29496<home-assistant issue number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: dwd_weather_warnings
    region_name: Hansestadt Hamburg
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
