### PR TITLE
Re-authorize Huawei LTE on login required error

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -151,7 +151,7 @@ class Router:
         return {(dr.CONNECTION_NETWORK_MAC, self.mac)} if self.mac else set()
 
     def _get_data(self, key: str, func: Callable[[None], Any]) -> None:
-        if not self.subscriptions[key]:
+        if not self.subscriptions.get(key):
             return
         _LOGGER.debug("Getting %s for subscribers %s", key, self.subscriptions[key])
         try:

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -174,11 +174,11 @@ class Router:
                         )
                     else:
                         _LOGGER.debug("...failed")
-                else:
-                    _LOGGER.info(
-                        "%s requires authorization, excluding from future updates", key
-                    )
-                    self.subscriptions.pop(key)
+                    return
+                _LOGGER.info(
+                    "%s requires authorization, excluding from future updates", key
+                )
+                self.subscriptions.pop(key)
             finally:
                 _LOGGER.debug("%s=%s", key, self.data.get(key))
 

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -150,50 +150,53 @@ class Router:
         """Get router connections for device registry."""
         return {(dr.CONNECTION_NETWORK_MAC, self.mac)} if self.mac else set()
 
+    def _get_data(self, key: str, func: Callable[[None], Any]) -> None:
+        if not self.subscriptions[key]:
+            return
+        _LOGGER.debug("Getting %s for subscribers %s", key, self.subscriptions[key])
+        try:
+            self.data[key] = func()
+        except ResponseErrorNotSupportedException:
+            _LOGGER.info(
+                "%s not supported by device, excluding from future updates", key
+            )
+            self.subscriptions.pop(key)
+        except ResponseErrorLoginRequiredException:
+            if isinstance(self.connection, AuthorizedConnection):
+                _LOGGER.debug("Trying to authorize again...")
+                if self.connection.enforce_authorized_connection():
+                    _LOGGER.debug(
+                        "...success, %s will be updated by a future periodic run", key,
+                    )
+                else:
+                    _LOGGER.debug("...failed")
+                return
+            _LOGGER.info(
+                "%s requires authorization, excluding from future updates", key
+            )
+            self.subscriptions.pop(key)
+        finally:
+            _LOGGER.debug("%s=%s", key, self.data.get(key))
+
     def update(self) -> None:
         """Update router data."""
 
-        def get_data(key: str, func: Callable[[None], Any]) -> None:
-            if not self.subscriptions[key]:
-                return
-            _LOGGER.debug("Getting %s for subscribers %s", key, self.subscriptions[key])
-            try:
-                self.data[key] = func()
-            except ResponseErrorNotSupportedException:
-                _LOGGER.info(
-                    "%s not supported by device, excluding from future updates", key
-                )
-                self.subscriptions.pop(key)
-            except ResponseErrorLoginRequiredException:
-                if isinstance(self.connection, AuthorizedConnection):
-                    _LOGGER.debug("Trying to authorize again...")
-                    if self.connection.enforce_authorized_connection():
-                        _LOGGER.debug(
-                            "...success, %s will be updated by a future periodic run",
-                            key,
-                        )
-                    else:
-                        _LOGGER.debug("...failed")
-                    return
-                _LOGGER.info(
-                    "%s requires authorization, excluding from future updates", key
-                )
-                self.subscriptions.pop(key)
-            finally:
-                _LOGGER.debug("%s=%s", key, self.data.get(key))
-
-        get_data(KEY_DEVICE_INFORMATION, self.client.device.information)
+        self._get_data(KEY_DEVICE_INFORMATION, self.client.device.information)
         if self.data.get(KEY_DEVICE_INFORMATION):
             # Full information includes everything in basic
             self.subscriptions.pop(KEY_DEVICE_BASIC_INFORMATION, None)
-        get_data(KEY_DEVICE_BASIC_INFORMATION, self.client.device.basic_information)
-        get_data(KEY_DEVICE_SIGNAL, self.client.device.signal)
-        get_data(KEY_DIALUP_MOBILE_DATASWITCH, self.client.dial_up.mobile_dataswitch)
-        get_data(KEY_MONITORING_STATUS, self.client.monitoring.status)
-        get_data(
+        self._get_data(
+            KEY_DEVICE_BASIC_INFORMATION, self.client.device.basic_information
+        )
+        self._get_data(KEY_DEVICE_SIGNAL, self.client.device.signal)
+        self._get_data(
+            KEY_DIALUP_MOBILE_DATASWITCH, self.client.dial_up.mobile_dataswitch
+        )
+        self._get_data(KEY_MONITORING_STATUS, self.client.monitoring.status)
+        self._get_data(
             KEY_MONITORING_TRAFFIC_STATISTICS, self.client.monitoring.traffic_statistics
         )
-        get_data(KEY_WLAN_HOST_LIST, self.client.wlan.host_list)
+        self._get_data(KEY_WLAN_HOST_LIST, self.client.wlan.host_list)
 
         self.signal_update()
 

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -165,10 +165,20 @@ class Router:
                 )
                 self.subscriptions.pop(key)
             except ResponseErrorLoginRequiredException:
-                _LOGGER.info(
-                    "%s requires authorization, excluding from future updates", key
-                )
-                self.subscriptions.pop(key)
+                if isinstance(self.connection, AuthorizedConnection):
+                    _LOGGER.debug("Trying to authorize again...")
+                    if self.connection.enforce_authorized_connection():
+                        _LOGGER.debug(
+                            "...success, %s will be updated by a future periodic run",
+                            key,
+                        )
+                    else:
+                        _LOGGER.debug("...failed")
+                else:
+                    _LOGGER.info(
+                        "%s requires authorization, excluding from future updates", key
+                    )
+                    self.subscriptions.pop(key)
             finally:
                 _LOGGER.debug("%s=%s", key, self.data.get(key))
 


### PR DESCRIPTION
## Description:

Try re-authorizing on login required error instead of immediately giving up.

**Related issue (if applicable):**  Fixes #29531

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
