### PR TITLE
Upgrade keyring to 19.3.0 and keyrings.alt to 3.2.0

### DIFF
--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -5,10 +5,8 @@ import os
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-
 # mypy: allow-untyped-defs
-
-REQUIREMENTS = ["keyring==19.2.0", "keyrings.alt==3.1.1"]
+REQUIREMENTS = ["keyring==19.3.0", "keyrings.alt==3.2.0"]
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -742,10 +742,10 @@ kaiterra-async-client==0.0.2
 keba-kecontact==0.2.0
 
 # homeassistant.scripts.keyring
-keyring==19.2.0
+keyring==19.3.0
 
 # homeassistant.scripts.keyring
-keyrings.alt==3.1.1
+keyrings.alt==3.2.0
 
 # homeassistant.components.kiwi
 kiwiki-client==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -259,10 +259,10 @@ influxdb==5.2.3
 jsonpath==0.82
 
 # homeassistant.scripts.keyring
-keyring==19.2.0
+keyring==19.3.0
 
 # homeassistant.scripts.keyring
-keyrings.alt==3.1.1
+keyrings.alt==3.2.0
 
 # homeassistant.components.dyson
 libpurecool==0.5.0


### PR DESCRIPTION
Changelog: https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1930

```bash
$ hass --script keyring set http
INFO:homeassistant.util.package:Attempting install of keyring==19.3.0
INFO:homeassistant.util.package:Attempting install of keyrings.alt==3.2.0
Please enter the secret for http: 
Secret http set successfully


$ hass --script keyring get http
Secret http=test123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
