### PR TITLE
sort imports according to PEP8 for yweather

### DIFF
--- a/tests/components/yweather/test_sensor.py
+++ b/tests/components/yweather/test_sensor.py
@@ -1,12 +1,11 @@
 """The tests for the Yahoo weather sensor component."""
 import json
-
 import unittest
 from unittest.mock import patch
 
 from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, load_fixture, MockDependency
+from tests.common import MockDependency, get_test_home_assistant, load_fixture
 
 VALID_CONFIG_MINIMAL = {
     "sensor": {"platform": "yweather", "monitored_conditions": ["weather"]}

--- a/tests/components/yweather/test_weather.py
+++ b/tests/components/yweather/test_weather.py
@@ -1,6 +1,5 @@
 """The tests for the Yahoo weather component."""
 import json
-
 import unittest
 from unittest.mock import patch
 
@@ -11,10 +10,10 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED,
 )
-from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.setup import setup_component
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from tests.common import get_test_home_assistant, load_fixture, MockDependency
+from tests.common import MockDependency, get_test_home_assistant, load_fixture
 
 
 def _yql_queryMock(yql):  # pylint: disable=invalid-name


### PR DESCRIPTION

## Description:

I have sorted the imports for the `yweather` component according to PEP8 using isort.

This affects:

- `tests/components/yweather/test_sensor.py` 
- `tests/components/yweather/test_weather.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
