### PR TITLE
sort imports according to PEP8 for components

### DIFF
--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -11,7 +11,6 @@ import logging
 
 from homeassistant.core import split_entity_id
 
-
 # mypy: allow-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -3,13 +3,13 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.setup import async_setup_component
-from homeassistant.components.websocket_api.http import URL
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
     TYPE_AUTH_OK,
     TYPE_AUTH_REQUIRED,
 )
+from homeassistant.components.websocket_api.http import URL
+from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `components` component according to PEP8 using isort.

This affects:

- `homeassistant/components/__init__.py` 
- `tests/components/conftest.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
