### PR TITLE
sort imports according to PEP8 for ads

### DIFF
--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -1,14 +1,13 @@
 """Support for Automation Device Specification (ADS)."""
-import threading
-import struct
-import logging
-import ctypes
-from collections import namedtuple
 import asyncio
+from collections import namedtuple
+import ctypes
+import logging
+import struct
+import threading
+
 import async_timeout
-
 import pyads
-
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/ads/binary_sensor.py
+++ b/homeassistant/components/ads/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
-from . import CONF_ADS_VAR, DATA_ADS, AdsEntity, STATE_KEY_STATE
+from . import CONF_ADS_VAR, DATA_ADS, STATE_KEY_STATE, AdsEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ads/cover.py
+++ b/homeassistant/components/ads/cover.py
@@ -4,25 +4,25 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    PLATFORM_SCHEMA,
-    SUPPORT_OPEN,
-    SUPPORT_CLOSE,
-    SUPPORT_STOP,
-    SUPPORT_SET_POSITION,
     ATTR_POSITION,
     DEVICE_CLASSES_SCHEMA,
+    PLATFORM_SCHEMA,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    SUPPORT_STOP,
     CoverDevice,
 )
-from homeassistant.const import CONF_NAME, CONF_DEVICE_CLASS
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
 from . import (
     CONF_ADS_VAR,
     CONF_ADS_VAR_POSITION,
     DATA_ADS,
-    AdsEntity,
-    STATE_KEY_STATE,
     STATE_KEY_POSITION,
+    STATE_KEY_STATE,
+    AdsEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/ads/light.py
+++ b/homeassistant/components/ads/light.py
@@ -16,9 +16,9 @@ from . import (
     CONF_ADS_VAR,
     CONF_ADS_VAR_BRIGHTNESS,
     DATA_ADS,
-    AdsEntity,
     STATE_KEY_BRIGHTNESS,
     STATE_KEY_STATE,
+    AdsEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/ads/sensor.py
+++ b/homeassistant/components/ads/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT
 import homeassistant.helpers.config_validation as cv
 
-from . import CONF_ADS_FACTOR, CONF_ADS_TYPE, CONF_ADS_VAR, AdsEntity, STATE_KEY_STATE
+from . import CONF_ADS_FACTOR, CONF_ADS_TYPE, CONF_ADS_VAR, STATE_KEY_STATE, AdsEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ads/switch.py
+++ b/homeassistant/components/ads/switch.py
@@ -3,11 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
-from . import CONF_ADS_VAR, DATA_ADS, AdsEntity, STATE_KEY_STATE
+from . import CONF_ADS_VAR, DATA_ADS, STATE_KEY_STATE, AdsEntity
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `ads` component according to PEP8 using isort.

This affects:

- `homeassistant/components/ads/__init__.py` 
- `homeassistant/components/ads/binary_sensor.py` 
- `homeassistant/components/ads/cover.py` 
- `homeassistant/components/ads/light.py` 
- `homeassistant/components/ads/sensor.py` 
- `homeassistant/components/ads/switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
