### PR TITLE
sort imports according to PEP8 for airly

### DIFF
--- a/homeassistant/components/airly/air_quality.py
+++ b/homeassistant/components/airly/air_quality.py
@@ -1,9 +1,9 @@
 """Support for the Airly air_quality service."""
 from homeassistant.components.air_quality import (
-    AirQualityEntity,
     ATTR_AQI,
-    ATTR_PM_10,
     ATTR_PM_2_5,
+    ATTR_PM_10,
+    AirQualityEntity,
 )
 from homeassistant.const import CONF_NAME
 

--- a/homeassistant/components/airly/config_flow.py
+++ b/homeassistant/components/airly/config_flow.py
@@ -1,14 +1,14 @@
 """Adds config flow for Airly."""
-import async_timeout
-import voluptuous as vol
 from airly import Airly
 from airly.exceptions import AirlyError
+import async_timeout
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 
 from .const import DEFAULT_NAME, DOMAIN, NO_AIRLY_SENSORS
 

--- a/tests/components/airly/test_config_flow.py
+++ b/tests/components/airly/test_config_flow.py
@@ -5,11 +5,11 @@ from airly.exceptions import AirlyError
 from asynctest import patch
 
 from homeassistant import data_entry_flow
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.components.airly import config_flow
 from homeassistant.components.airly.const import DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 
-from tests.common import load_fixture, MockConfigEntry
+from tests.common import MockConfigEntry, load_fixture
 
 CONFIG = {
     CONF_NAME: "abcd",


### PR DESCRIPTION

## Description:

I have sorted the imports for the `airly` component according to PEP8 using isort.

This affects:

- `homeassistant/components/airly/air_quality.py` 
- `homeassistant/components/airly/config_flow.py` 
- `tests/components/airly/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
