### PR TITLE
Deconz - follow library improvements

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -26,10 +26,10 @@ SUPPORTED_PLATFORMS = [
     "switch",
 ]
 
-NEW_GROUP = "group"
-NEW_LIGHT = "light"
-NEW_SCENE = "scene"
-NEW_SENSOR = "sensor"
+NEW_GROUP = "groups"
+NEW_LIGHT = "lights"
+NEW_SCENE = "scenes"
+NEW_SENSOR = "sensors"
 
 NEW_DEVICE = {
     NEW_GROUP: "deconz_new_group_{}",

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -4,7 +4,7 @@ import asyncio
 import async_timeout
 from pydeconz import DeconzSession, errors
 
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
@@ -42,13 +42,13 @@ def get_gateway_from_config_entry(hass, config_entry):
 class DeconzGateway:
     """Manages a single deCONZ gateway."""
 
-    def __init__(self, hass, config_entry):
+    def __init__(self, hass, config_entry) -> None:
         """Initialize the system."""
         self.hass = hass
         self.config_entry = config_entry
+
         self.available = True
         self.api = None
-
         self.deconz_ids = {}
         self.events = []
         self.listeners = []
@@ -77,7 +77,7 @@ class DeconzGateway:
             CONF_ALLOW_DECONZ_GROUPS, DEFAULT_ALLOW_DECONZ_GROUPS
         )
 
-    async def async_update_device_registry(self):
+    async def async_update_device_registry(self) -> None:
         """Update device registry."""
         device_registry = await self.hass.helpers.device_registry.async_get_registry()
         device_registry.async_get_or_create(
@@ -90,7 +90,7 @@ class DeconzGateway:
             sw_version=self.api.config.swversion,
         )
 
-    async def async_setup(self):
+    async def async_setup(self) -> bool:
         """Set up a deCONZ gateway."""
         hass = self.hass
 
@@ -105,8 +105,8 @@ class DeconzGateway:
         except CannotConnect:
             raise ConfigEntryNotReady
 
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.error("Error connecting with deCONZ gateway")
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.error("Error connecting with deCONZ gateway: %s", err)
             return False
 
         for component in SUPPORTED_PLATFORMS:
@@ -124,7 +124,7 @@ class DeconzGateway:
         return True
 
     @staticmethod
-    async def async_new_address(hass, entry):
+    async def async_new_address(hass, entry) -> None:
         """Handle signals of gateway getting new address.
 
         This is a static method because a class method (bound method),
@@ -137,23 +137,23 @@ class DeconzGateway:
             gateway.api.start()
 
     @property
-    def signal_reachable(self):
+    def signal_reachable(self) -> str:
         """Gateway specific event to signal a change in connection status."""
         return f"deconz-reachable-{self.bridgeid}"
 
     @callback
-    def async_connection_status_callback(self, available):
+    def async_connection_status_callback(self, available) -> None:
         """Handle signals of gateway connection status."""
         self.available = available
         async_dispatcher_send(self.hass, self.signal_reachable, True)
 
     @property
-    def signal_options_update(self):
+    def signal_options_update(self) -> str:
         """Event specific per deCONZ entry to signal new options."""
         return f"deconz-options-{self.bridgeid}"
 
     @staticmethod
-    async def async_options_updated(hass, entry):
+    async def async_options_updated(hass, entry) -> None:
         """Triggered by config entry options updates."""
         gateway = get_gateway_from_config_entry(hass, entry)
 
@@ -161,12 +161,12 @@ class DeconzGateway:
         async_dispatcher_send(hass, gateway.signal_options_update, registry)
 
     @callback
-    def async_signal_new_device(self, device_type):
+    def async_signal_new_device(self, device_type) -> str:
         """Gateway specific event to signal new device."""
         return NEW_DEVICE[device_type].format(self.bridgeid)
 
     @callback
-    def async_add_device_callback(self, device_type, device):
+    def async_add_device_callback(self, device_type, device) -> None:
         """Handle event of new device creation in deCONZ."""
         if not isinstance(device, list):
             device = [device]
@@ -175,7 +175,7 @@ class DeconzGateway:
         )
 
     @callback
-    def shutdown(self, event):
+    def shutdown(self, event) -> None:
         """Wrap the call to deconz.close.
 
         Used as an argument to EventBus.async_listen_once.
@@ -206,20 +206,21 @@ class DeconzGateway:
 
 async def get_gateway(
     hass, config, async_add_device_callback, async_connection_status_callback
-):
+) -> DeconzSession:
     """Create a gateway object and verify configuration."""
     session = aiohttp_client.async_get_clientsession(hass)
 
     deconz = DeconzSession(
-        hass.loop,
         session,
-        **config,
+        config[CONF_HOST],
+        config[CONF_PORT],
+        config[CONF_API_KEY],
         async_add_device=async_add_device_callback,
         connection_status=async_connection_status_callback,
     )
     try:
         with async_timeout.timeout(10):
-            await deconz.async_load_parameters()
+            await deconz.initialize()
         return deconz
 
     except errors.Unauthorized:
@@ -234,7 +235,7 @@ async def get_gateway(
 class DeconzEntityHandler:
     """Platform entity handler to help with updating disabled by."""
 
-    def __init__(self, gateway):
+    def __init__(self, gateway) -> None:
         """Create an entity handler."""
         self.gateway = gateway
         self._entities = []
@@ -246,12 +247,12 @@ class DeconzEntityHandler:
         )
 
     @callback
-    def add_entity(self, entity):
+    def add_entity(self, entity) -> None:
         """Add a new entity to handler."""
         self._entities.append(entity)
 
     @callback
-    def update_entity_registry(self, entity_registry):
+    def update_entity_registry(self, entity_registry) -> None:
         """Update entity registry disabled by status."""
         for entity in self._entities:
 

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
   "requirements": [
-    "pydeconz==64"
+    "pydeconz==65"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -4,7 +4,15 @@ import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 
 from .config_flow import get_master_gateway
-from .const import _LOGGER, CONF_BRIDGEID, DOMAIN
+from .const import (
+    _LOGGER,
+    CONF_BRIDGEID,
+    DOMAIN,
+    NEW_GROUP,
+    NEW_LIGHT,
+    NEW_SCENE,
+    NEW_SENSOR,
+)
 
 DECONZ_SERVICES = "deconz_services"
 
@@ -105,7 +113,7 @@ async def async_configure_service(hass, data):
             _LOGGER.error("Could not find the entity %s", entity_id)
             return
 
-    await gateway.api.async_put_state(field, data)
+    await gateway.api.request("put", field, json=data)
 
 
 async def async_refresh_devices_service(hass, data):
@@ -119,10 +127,10 @@ async def async_refresh_devices_service(hass, data):
     scenes = set(gateway.api.scenes.keys())
     sensors = set(gateway.api.sensors.keys())
 
-    await gateway.api.async_load_parameters()
+    await gateway.api.refresh_state()
 
     gateway.async_add_device_callback(
-        "group",
+        NEW_GROUP,
         [
             group
             for group_id, group in gateway.api.groups.items()
@@ -131,7 +139,7 @@ async def async_refresh_devices_service(hass, data):
     )
 
     gateway.async_add_device_callback(
-        "light",
+        NEW_LIGHT,
         [
             light
             for light_id, light in gateway.api.lights.items()
@@ -140,7 +148,7 @@ async def async_refresh_devices_service(hass, data):
     )
 
     gateway.async_add_device_callback(
-        "scene",
+        NEW_SCENE,
         [
             scene
             for scene_id, scene in gateway.api.scenes.items()
@@ -149,7 +157,7 @@ async def async_refresh_devices_service(hass, data):
     )
 
     gateway.async_add_device_callback(
-        "sensor",
+        NEW_SENSOR,
         [
             sensor
             for sensor_id, sensor in gateway.api.sensors.items()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1180,7 +1180,7 @@ pydaikin==1.6.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==64
+pydeconz==65
 
 # homeassistant.components.delijn
 pydelijn==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -406,7 +406,7 @@ pycoolmasternet==0.0.4
 pydaikin==1.6.1
 
 # homeassistant.components.deconz
-pydeconz==64
+pydeconz==65
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -95,7 +95,14 @@ async def test_binary_sensors(hass):
     vibration_sensor = hass.states.get("binary_sensor.vibration_sensor")
     assert vibration_sensor.state == "on"
 
-    gateway.api.sensors["1"].async_update({"state": {"presence": True}})
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"presence": True},
+    }
+    gateway.api.async_event_handler(state_changed_event)
     await hass.async_block_till_done()
 
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
@@ -143,14 +150,14 @@ async def test_add_new_binary_sensor(hass):
     )
     assert len(gateway.deconz_ids) == 0
 
-    state_added = {
+    state_added_event = {
         "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
         "sensor": deepcopy(SENSORS["1"]),
     }
-    gateway.api.async_event_handler(state_added)
+    gateway.api.async_event_handler(state_added_event)
     await hass.async_block_till_done()
 
     assert "binary_sensor.presence_sensor" in gateway.deconz_ids

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -73,16 +73,23 @@ async def test_cover(hass):
     level_controllable_cover = hass.states.get("cover.level_controllable_cover")
     assert level_controllable_cover.state == "open"
 
-    level_controllable_cover_device = gateway.api.lights["1"]
-
-    level_controllable_cover_device.async_update({"state": {"on": True}})
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "lights",
+        "id": "1",
+        "state": {"on": True},
+    }
+    gateway.api.async_event_handler(state_changed_event)
     await hass.async_block_till_done()
 
     level_controllable_cover = hass.states.get("cover.level_controllable_cover")
     assert level_controllable_cover.state == "closed"
 
+    level_controllable_cover_device = gateway.api.lights["1"]
+
     with patch.object(
-        level_controllable_cover_device, "_async_set_callback", return_value=True
+        level_controllable_cover_device, "_request", return_value=True
     ) as set_callback:
         await hass.services.async_call(
             cover.DOMAIN,
@@ -91,10 +98,10 @@ async def test_cover(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/1/state", {"on": False})
+        set_callback.assert_called_with("put", "/lights/1/state", json={"on": False})
 
     with patch.object(
-        level_controllable_cover_device, "_async_set_callback", return_value=True
+        level_controllable_cover_device, "_request", return_value=True
     ) as set_callback:
         await hass.services.async_call(
             cover.DOMAIN,
@@ -103,10 +110,12 @@ async def test_cover(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/1/state", {"on": True, "bri": 255})
+        set_callback.assert_called_with(
+            "put", "/lights/1/state", json={"on": True, "bri": 255}
+        )
 
     with patch.object(
-        level_controllable_cover_device, "_async_set_callback", return_value=True
+        level_controllable_cover_device, "_request", return_value=True
     ) as set_callback:
         await hass.services.async_call(
             cover.DOMAIN,
@@ -115,7 +124,7 @@ async def test_cover(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/1/state", {"bri_inc": 0})
+        set_callback.assert_called_with("put", "/lights/1/state", json={"bri_inc": 0})
 
     await gateway.async_reset()
 

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -41,7 +41,7 @@ async def test_setup_entry_fails(hass):
         deconz.config_flow.CONF_PORT: ENTRY1_PORT,
         deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
     }
-    with patch("pydeconz.DeconzSession.async_load_parameters", side_effect=Exception):
+    with patch("pydeconz.DeconzSession.initialize", side_effect=Exception):
         await deconz.async_setup_entry(hass, entry)
 
 
@@ -54,7 +54,7 @@ async def test_setup_entry_no_available_bridge(hass):
         deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
     }
     with patch(
-        "pydeconz.DeconzSession.async_load_parameters", side_effect=asyncio.TimeoutError
+        "pydeconz.DeconzSession.initialize", side_effect=asyncio.TimeoutError
     ), pytest.raises(ConfigEntryNotReady):
         await deconz.async_setup_entry(hass, entry)
 

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -117,17 +117,22 @@ async def test_lights_and_groups(hass):
     empty_group = hass.states.get("light.empty_group")
     assert empty_group is None
 
-    rgb_light_device = gateway.api.lights["1"]
-
-    rgb_light_device.async_update({"state": {"on": False}})
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "lights",
+        "id": "1",
+        "state": {"on": False},
+    }
+    gateway.api.async_event_handler(state_changed_event)
     await hass.async_block_till_done()
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light.state == "off"
 
-    with patch.object(
-        rgb_light_device, "_async_set_callback", return_value=True
-    ) as set_callback:
+    rgb_light_device = gateway.api.lights["1"]
+
+    with patch.object(rgb_light_device, "_request", return_value=True) as set_callback:
         await hass.services.async_call(
             light.DOMAIN,
             light.SERVICE_TURN_ON,
@@ -143,8 +148,9 @@ async def test_lights_and_groups(hass):
         )
         await hass.async_block_till_done()
         set_callback.assert_called_with(
+            "put",
             "/lights/1/state",
-            {
+            json={
                 "ct": 2500,
                 "bri": 200,
                 "transitiontime": 50,
@@ -153,9 +159,7 @@ async def test_lights_and_groups(hass):
             },
         )
 
-    with patch.object(
-        rgb_light_device, "_async_set_callback", return_value=True
-    ) as set_callback:
+    with patch.object(rgb_light_device, "_request", return_value=True) as set_callback:
         await hass.services.async_call(
             light.DOMAIN,
             light.SERVICE_TURN_ON,
@@ -169,13 +173,12 @@ async def test_lights_and_groups(hass):
         )
         await hass.async_block_till_done()
         set_callback.assert_called_with(
+            "put",
             "/lights/1/state",
-            {"xy": (0.411, 0.351), "alert": "lselect", "effect": "none"},
+            json={"xy": (0.411, 0.351), "alert": "lselect", "effect": "none"},
         )
 
-    with patch.object(
-        rgb_light_device, "_async_set_callback", return_value=True
-    ) as set_callback:
+    with patch.object(rgb_light_device, "_request", return_value=True) as set_callback:
         await hass.services.async_call(
             light.DOMAIN,
             light.SERVICE_TURN_OFF,
@@ -184,12 +187,12 @@ async def test_lights_and_groups(hass):
         )
         await hass.async_block_till_done()
         set_callback.assert_called_with(
-            "/lights/1/state", {"bri": 0, "transitiontime": 50, "alert": "select"}
+            "put",
+            "/lights/1/state",
+            json={"bri": 0, "transitiontime": 50, "alert": "select"},
         )
 
-    with patch.object(
-        rgb_light_device, "_async_set_callback", return_value=True
-    ) as set_callback:
+    with patch.object(rgb_light_device, "_request", return_value=True) as set_callback:
         await hass.services.async_call(
             light.DOMAIN,
             light.SERVICE_TURN_OFF,
@@ -197,7 +200,9 @@ async def test_lights_and_groups(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/1/state", {"alert": "lselect"})
+        set_callback.assert_called_with(
+            "put", "/lights/1/state", json={"alert": "lselect"}
+        )
 
     await gateway.async_reset()
 

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -60,14 +60,12 @@ async def test_scenes(hass):
 
     group_scene = gateway.api.groups["1"].scenes["1"]
 
-    with patch.object(
-        group_scene, "_async_set_state_callback", return_value=True
-    ) as set_callback:
+    with patch.object(group_scene, "_request", return_value=True) as set_callback:
         await hass.services.async_call(
             "scene", "turn_on", {"entity_id": "scene.light_group_scene"}, blocking=True
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/groups/1/scenes/1/recall", {})
+        set_callback.assert_called_with("put", "/groups/1/scenes/1/recall", json={})
 
     await gateway.async_reset()
 

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -143,8 +143,23 @@ async def test_sensors(hass):
     consumption_sensor = hass.states.get("sensor.consumption_sensor")
     assert consumption_sensor.state == "0.002"
 
-    gateway.api.sensors["1"].async_update({"state": {"lightlevel": 2000}})
-    gateway.api.sensors["4"].async_update({"config": {"battery": 75}})
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"lightlevel": 2000},
+    }
+    gateway.api.async_event_handler(state_changed_event)
+
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "4",
+        "config": {"battery": 75},
+    }
+    gateway.api.async_event_handler(state_changed_event)
     await hass.async_block_till_done()
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
@@ -219,14 +234,14 @@ async def test_add_new_sensor(hass):
     )
     assert len(gateway.deconz_ids) == 0
 
-    state_added = {
+    state_added_event = {
         "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
         "sensor": deepcopy(SENSORS["1"]),
     }
-    gateway.api.async_event_handler(state_added)
+    gateway.api.async_event_handler(state_added_event)
     await hass.async_block_till_done()
 
     assert "sensor.light_level_sensor" in gateway.deconz_ids

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -104,14 +104,14 @@ async def test_configure_service_with_field(hass):
         deconz.services.SERVICE_DATA: {"on": True, "attr1": 10, "attr2": 20},
     }
 
-    with patch(
-        "pydeconz.DeconzSession.async_put_state", return_value=Mock(True)
-    ) as put_state:
+    with patch("pydeconz.DeconzSession.request", return_value=Mock(True)) as put_state:
         await hass.services.async_call(
             deconz.DOMAIN, deconz.services.SERVICE_CONFIGURE_DEVICE, service_data=data
         )
         await hass.async_block_till_done()
-        put_state.assert_called_with("/light/2", {"on": True, "attr1": 10, "attr2": 20})
+        put_state.assert_called_with(
+            "put", "/light/2", json={"on": True, "attr1": 10, "attr2": 20}
+        )
 
 
 async def test_configure_service_with_entity(hass):
@@ -127,14 +127,14 @@ async def test_configure_service_with_entity(hass):
         deconz.services.SERVICE_DATA: {"on": True, "attr1": 10, "attr2": 20},
     }
 
-    with patch(
-        "pydeconz.DeconzSession.async_put_state", return_value=Mock(True)
-    ) as put_state:
+    with patch("pydeconz.DeconzSession.request", return_value=Mock(True)) as put_state:
         await hass.services.async_call(
             deconz.DOMAIN, deconz.services.SERVICE_CONFIGURE_DEVICE, service_data=data
         )
         await hass.async_block_till_done()
-        put_state.assert_called_with("/light/1", {"on": True, "attr1": 10, "attr2": 20})
+        put_state.assert_called_with(
+            "put", "/light/1", json={"on": True, "attr1": 10, "attr2": 20}
+        )
 
 
 async def test_configure_service_with_entity_and_field(hass):
@@ -151,15 +151,13 @@ async def test_configure_service_with_entity_and_field(hass):
         deconz.services.SERVICE_DATA: {"on": True, "attr1": 10, "attr2": 20},
     }
 
-    with patch(
-        "pydeconz.DeconzSession.async_put_state", return_value=Mock(True)
-    ) as put_state:
+    with patch("pydeconz.DeconzSession.request", return_value=Mock(True)) as put_state:
         await hass.services.async_call(
             deconz.DOMAIN, deconz.services.SERVICE_CONFIGURE_DEVICE, service_data=data
         )
         await hass.async_block_till_done()
         put_state.assert_called_with(
-            "/light/1/state", {"on": True, "attr1": 10, "attr2": 20}
+            "put", "/light/1/state", json={"on": True, "attr1": 10, "attr2": 20}
         )
 
 
@@ -191,9 +189,7 @@ async def test_configure_service_with_faulty_entity(hass):
         deconz.services.SERVICE_DATA: {},
     }
 
-    with patch(
-        "pydeconz.DeconzSession.async_put_state", return_value=Mock(True)
-    ) as put_state:
+    with patch("pydeconz.DeconzSession.request", return_value=Mock(True)) as put_state:
         await hass.services.async_call(
             deconz.DOMAIN, deconz.services.SERVICE_CONFIGURE_DEVICE, service_data=data
         )
@@ -211,7 +207,7 @@ async def test_service_refresh_devices(hass):
     data = {deconz.CONF_BRIDGEID: BRIDGEID}
 
     with patch(
-        "pydeconz.DeconzSession.async_get_state",
+        "pydeconz.DeconzSession.request",
         return_value={"groups": GROUP, "lights": LIGHT, "sensors": SENSOR},
     ):
         await hass.services.async_call(

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -85,11 +85,22 @@ async def test_switches(hass):
     warning_device = hass.states.get("switch.warning_device")
     assert warning_device.state == "on"
 
-    on_off_switch_device = gateway.api.lights["1"]
-    warning_device_device = gateway.api.lights["3"]
-
-    on_off_switch_device.async_update({"state": {"on": False}})
-    warning_device_device.async_update({"state": {"alert": None}})
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "lights",
+        "id": "1",
+        "state": {"on": False},
+    }
+    gateway.api.async_event_handler(state_changed_event)
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "lights",
+        "id": "3",
+        "state": {"alert": None},
+    }
+    gateway.api.async_event_handler(state_changed_event)
     await hass.async_block_till_done()
 
     on_off_switch = hass.states.get("switch.on_off_switch")
@@ -98,8 +109,10 @@ async def test_switches(hass):
     warning_device = hass.states.get("switch.warning_device")
     assert warning_device.state == "off"
 
+    on_off_switch_device = gateway.api.lights["1"]
+
     with patch.object(
-        on_off_switch_device, "_async_set_callback", return_value=True
+        on_off_switch_device, "_request", return_value=True
     ) as set_callback:
         await hass.services.async_call(
             switch.DOMAIN,
@@ -108,10 +121,10 @@ async def test_switches(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/1/state", {"on": True})
+        set_callback.assert_called_with("put", "/lights/1/state", json={"on": True})
 
     with patch.object(
-        on_off_switch_device, "_async_set_callback", return_value=True
+        on_off_switch_device, "_request", return_value=True
     ) as set_callback:
         await hass.services.async_call(
             switch.DOMAIN,
@@ -120,10 +133,12 @@ async def test_switches(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/1/state", {"on": False})
+        set_callback.assert_called_with("put", "/lights/1/state", json={"on": False})
+
+    warning_device_device = gateway.api.lights["3"]
 
     with patch.object(
-        warning_device_device, "_async_set_callback", return_value=True
+        warning_device_device, "_request", return_value=True
     ) as set_callback:
         await hass.services.async_call(
             switch.DOMAIN,
@@ -132,10 +147,12 @@ async def test_switches(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/3/state", {"alert": "lselect"})
+        set_callback.assert_called_with(
+            "put", "/lights/3/state", json={"alert": "lselect"}
+        )
 
     with patch.object(
-        warning_device_device, "_async_set_callback", return_value=True
+        warning_device_device, "_request", return_value=True
     ) as set_callback:
         await hass.services.async_call(
             switch.DOMAIN,
@@ -144,7 +161,9 @@ async def test_switches(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("/lights/3/state", {"alert": "none"})
+        set_callback.assert_called_with(
+            "put", "/lights/3/state", json={"alert": "none"}
+        )
 
     await gateway.async_reset()
 


### PR DESCRIPTION
Dont pass in loop to DeconzSession
Services will use new refresh state method
Change tests to use the full update mechanism of pydeconz

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
