### PR TITLE
sort imports according to PEP8 for automation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -27,12 +27,11 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util.dt import parse_datetime, utcnow
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs, no-warn-return-any

--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -7,8 +7,8 @@ import voluptuous as vol
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
-from homeassistant.const import CONF_PLATFORM
 from homeassistant.config import async_log_exception, config_without_domain
+from homeassistant.const import CONF_PLATFORM
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition, config_per_platform, script
 from homeassistant.loader import IntegrationNotFound

--- a/homeassistant/components/automation/device.py
+++ b/homeassistant/components/automation/device.py
@@ -7,7 +7,6 @@ from homeassistant.components.device_automation import (
 )
 from homeassistant.const import CONF_DOMAIN
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)

--- a/homeassistant/components/automation/event.py
+++ b/homeassistant/components/automation/event.py
@@ -3,10 +3,9 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
-
 
 # mypy: allow-untyped-defs
 

--- a/homeassistant/components/automation/geo_location.py
+++ b/homeassistant/components/automation/geo_location.py
@@ -2,7 +2,6 @@
 import voluptuous as vol
 
 from homeassistant.components.geo_location import DOMAIN
-from homeassistant.core import callback
 from homeassistant.const import (
     CONF_EVENT,
     CONF_PLATFORM,
@@ -10,9 +9,9 @@ from homeassistant.const import (
     CONF_ZONE,
     EVENT_STATE_CHANGED,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import condition, config_validation as cv
 from homeassistant.helpers.config_validation import entity_domain
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/automation/homeassistant.py
+++ b/homeassistant/components/automation/homeassistant.py
@@ -3,9 +3,8 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback, CoreState
-from homeassistant.const import CONF_PLATFORM, CONF_EVENT, EVENT_HOMEASSISTANT_STOP
-
+from homeassistant.const import CONF_EVENT, CONF_PLATFORM, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import CoreState, callback
 
 # mypy: allow-untyped-defs
 

--- a/homeassistant/components/automation/litejet.py
+++ b/homeassistant/components/automation/litejet.py
@@ -3,12 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.helpers.event import track_point_in_utc_time
-
+import homeassistant.util.dt as dt_util
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -3,11 +3,10 @@ import json
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components import mqtt
-from homeassistant.const import CONF_PLATFORM, CONF_PAYLOAD
+from homeassistant.const import CONF_PAYLOAD, CONF_PLATFORM
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-
 
 # mypy: allow-untyped-defs
 

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -4,18 +4,17 @@ import logging
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.const import (
-    CONF_VALUE_TEMPLATE,
-    CONF_PLATFORM,
-    CONF_ENTITY_ID,
-    CONF_BELOW,
     CONF_ABOVE,
+    CONF_BELOW,
+    CONF_ENTITY_ID,
     CONF_FOR,
+    CONF_PLATFORM,
+    CONF_VALUE_TEMPLATE,
 )
-from homeassistant.helpers.event import async_track_state_change, async_track_same_state
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers import condition, config_validation as cv, template
-
+from homeassistant.helpers.event import async_track_same_state, async_track_state_change
 
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs

--- a/homeassistant/components/automation/reproduce_state.py
+++ b/homeassistant/components/automation/reproduce_state.py
@@ -5,10 +5,10 @@ from typing import Iterable, Optional
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    STATE_ON,
-    STATE_OFF,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -6,11 +6,10 @@ from typing import Dict
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE, callback
-from homeassistant.const import MATCH_ALL, CONF_PLATFORM, CONF_FOR
+from homeassistant.const import CONF_FOR, CONF_PLATFORM, MATCH_ALL
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, template
-from homeassistant.helpers.event import async_track_state_change, async_track_same_state
-
+from homeassistant.helpers.event import async_track_same_state, async_track_state_change
 
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs

--- a/homeassistant/components/automation/sun.py
+++ b/homeassistant/components/automation/sun.py
@@ -4,16 +4,15 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import (
     CONF_EVENT,
     CONF_OFFSET,
     CONF_PLATFORM,
     SUN_EVENT_SUNRISE,
 )
-from homeassistant.helpers.event import async_track_sunrise, async_track_sunset
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-
+from homeassistant.helpers.event import async_track_sunrise, async_track_sunset
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -3,13 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM, CONF_FOR
 from homeassistant import exceptions
-from homeassistant.helpers import condition
+from homeassistant.const import CONF_FOR, CONF_PLATFORM, CONF_VALUE_TEMPLATE
+from homeassistant.core import callback
+from homeassistant.helpers import condition, config_validation as cv, template
 from homeassistant.helpers.event import async_track_same_state, async_track_template
-from homeassistant.helpers import config_validation as cv, template
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -3,11 +3,10 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import CONF_AT, CONF_PLATFORM
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_time_change
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/automation/time_pattern.py
+++ b/homeassistant/components/automation/time_pattern.py
@@ -3,11 +3,10 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_time_change
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/automation/webhook.py
+++ b/homeassistant/components/automation/webhook.py
@@ -5,12 +5,11 @@ import logging
 from aiohttp import hdrs
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import CONF_PLATFORM, CONF_WEBHOOK_ID
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from . import DOMAIN as AUTOMATION_DOMAIN
-
 
 # mypy: allow-untyped-defs
 

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -1,17 +1,16 @@
 """Offer zone automation rules."""
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_EVENT,
     CONF_ENTITY_ID,
+    CONF_EVENT,
+    CONF_PLATFORM,
     CONF_ZONE,
     MATCH_ALL,
-    CONF_PLATFORM,
 )
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.core import callback
 from homeassistant.helpers import condition, config_validation as cv, location
-
+from homeassistant.helpers.event import async_track_state_change
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/tests/components/automation/common.py
+++ b/tests/components/automation/common.py
@@ -6,11 +6,11 @@ components. Instead call the service directly.
 from homeassistant.components.automation import DOMAIN, SERVICE_TRIGGER
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
-    SERVICE_TOGGLE,
-    SERVICE_RELOAD,
     ENTITY_MATCH_ALL,
+    SERVICE_RELOAD,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
 )
 from homeassistant.loader import bind_hass
 

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -1,13 +1,12 @@
 """The tests for the Event automation."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 
-from tests.common import mock_component
+from tests.common import async_mock_service, mock_component
 from tests.components.automation import common
-from tests.common import async_mock_service
 
 
 @pytest.fixture

--- a/tests/components/automation/test_geo_location.py
+++ b/tests/components/automation/test_geo_location.py
@@ -5,9 +5,8 @@ from homeassistant.components import automation, zone
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_component
+from tests.common import async_mock_service, mock_component
 from tests.components.automation import common
-from tests.common import async_mock_service
 
 
 @pytest.fixture

--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -1,9 +1,9 @@
 """The tests for the Event automation."""
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
+import homeassistant.components.automation as automation
 from homeassistant.core import CoreState
 from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 
 from tests.common import async_mock_service, mock_coro
 

--- a/tests/components/automation/test_litejet.py
+++ b/tests/components/automation/test_litejet.py
@@ -1,13 +1,14 @@
 """The tests for the litejet component."""
+from datetime import timedelta
 import logging
 from unittest import mock
-from datetime import timedelta
+
 import pytest
 
 from homeassistant import setup
-import homeassistant.util.dt as dt_util
 from homeassistant.components import litejet
 import homeassistant.components.automation as automation
+import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed, async_mock_service
 

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -1,14 +1,16 @@
 """The tests for the MQTT automation."""
-import pytest
 from unittest import mock
 
-from homeassistant.setup import async_setup_component
+import pytest
+
 import homeassistant.components.automation as automation
+from homeassistant.setup import async_setup_component
+
 from tests.common import (
     async_fire_mqtt_message,
-    mock_component,
-    async_mock_service,
     async_mock_mqtt_component,
+    async_mock_service,
+    mock_component,
 )
 from tests.components.automation import common
 

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -1,7 +1,8 @@
 """The tests for numeric state automation."""
 from datetime import timedelta
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.core import Context
@@ -9,10 +10,10 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    mock_component,
-    async_fire_time_changed,
     assert_setup_component,
+    async_fire_time_changed,
     async_mock_service,
+    mock_component,
 )
 from tests.components.automation import common
 

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -1,17 +1,21 @@
 """The test for state automation."""
 from datetime import timedelta
-
-import pytest
 from unittest.mock import patch
 
+import pytest
+
+import homeassistant.components.automation as automation
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-import homeassistant.components.automation as automation
 
-from tests.common import async_fire_time_changed, assert_setup_component, mock_component
+from tests.common import (
+    assert_setup_component,
+    async_fire_time_changed,
+    async_mock_service,
+    mock_component,
+)
 from tests.components.automation import common
-from tests.common import async_mock_service
 
 
 @pytest.fixture

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -1,16 +1,16 @@
 """The tests for the sun automation."""
 from datetime import datetime
-
-import pytest
 from unittest.mock import patch
 
-from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
-from homeassistant.setup import async_setup_component
+import pytest
+
 from homeassistant.components import sun
 import homeassistant.components.automation as automation
+from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed, mock_component, async_mock_service
+from tests.common import async_fire_time_changed, async_mock_service, mock_component
 from tests.components.automation import common
 
 ORIG_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -4,14 +4,18 @@ from unittest import mock
 
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-import homeassistant.components.automation as automation
 
-from tests.common import async_fire_time_changed, assert_setup_component, mock_component
+from tests.common import (
+    assert_setup_component,
+    async_fire_time_changed,
+    async_mock_service,
+    mock_component,
+)
 from tests.components.automation import common
-from tests.common import async_mock_service
 
 
 @pytest.fixture

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -4,12 +4,16 @@ from unittest.mock import patch
 
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-import homeassistant.components.automation as automation
 
-from tests.common import async_fire_time_changed, assert_setup_component, mock_component
-from tests.common import async_mock_service
+from tests.common import (
+    assert_setup_component,
+    async_fire_time_changed,
+    async_mock_service,
+    mock_component,
+)
 
 
 @pytest.fixture

--- a/tests/components/automation/test_time_pattern.py
+++ b/tests/components/automation/test_time_pattern.py
@@ -1,13 +1,12 @@
 """The tests for the time_pattern automation."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-import homeassistant.components.automation as automation
 
-from tests.common import async_fire_time_changed, mock_component
+from tests.common import async_fire_time_changed, async_mock_service, mock_component
 from tests.components.automation import common
-from tests.common import async_mock_service
 
 
 @pytest.fixture

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -1,12 +1,12 @@
 """The tests for the location automation."""
 import pytest
 
+from homeassistant.components import automation, zone
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
-from homeassistant.components import automation, zone
 
-from tests.components.automation import common
 from tests.common import async_mock_service, mock_component
+from tests.components.automation import common
 
 
 @pytest.fixture


### PR DESCRIPTION

## Description:

I have sorted the imports for the `automation` component according to PEP8 using isort.

This affects:

- `homeassistant/components/automation/__init__.py` 
- `homeassistant/components/automation/config.py` 
- `homeassistant/components/automation/device.py` 
- `homeassistant/components/automation/event.py` 
- `homeassistant/components/automation/geo_location.py` 
- `homeassistant/components/automation/homeassistant.py` 
- `homeassistant/components/automation/litejet.py` 
- `homeassistant/components/automation/mqtt.py` 
- `homeassistant/components/automation/numeric_state.py` 
- `homeassistant/components/automation/reproduce_state.py` 
- `homeassistant/components/automation/state.py` 
- `homeassistant/components/automation/sun.py` 
- `homeassistant/components/automation/template.py` 
- `homeassistant/components/automation/time.py` 
- `homeassistant/components/automation/time_pattern.py` 
- `homeassistant/components/automation/webhook.py` 
- `homeassistant/components/automation/zone.py` 
- `tests/components/automation/common.py` 
- `tests/components/automation/test_event.py` 
- `tests/components/automation/test_geo_location.py` 
- `tests/components/automation/test_homeassistant.py` 
- `tests/components/automation/test_litejet.py` 
- `tests/components/automation/test_mqtt.py` 
- `tests/components/automation/test_numeric_state.py` 
- `tests/components/automation/test_state.py` 
- `tests/components/automation/test_sun.py` 
- `tests/components/automation/test_template.py` 
- `tests/components/automation/test_time.py` 
- `tests/components/automation/test_time_pattern.py` 
- `tests/components/automation/test_zone.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
