### PR TITLE
sort imports according to PEP8 for axis

### DIFF
--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -1,8 +1,8 @@
 """Axis network device abstraction."""
 
 import asyncio
-import async_timeout
 
+import async_timeout
 import axis
 from axis.streammanager import SIGNAL_PLAYING
 
@@ -21,7 +21,6 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import CONF_CAMERA, CONF_EVENTS, CONF_MODEL, DOMAIN, LOGGER
-
 from .errors import AuthenticationRequired, CannotConnect
 
 

--- a/tests/components/axis/test_binary_sensor.py
+++ b/tests/components/axis/test_binary_sensor.py
@@ -4,9 +4,8 @@ from unittest.mock import Mock
 
 from homeassistant import config_entries
 from homeassistant.components import axis
-from homeassistant.setup import async_setup_component
-
 import homeassistant.components.binary_sensor as binary_sensor
+from homeassistant.setup import async_setup_component
 
 EVENTS = [
     {

--- a/tests/components/axis/test_camera.py
+++ b/tests/components/axis/test_camera.py
@@ -4,10 +4,8 @@ from unittest.mock import Mock
 
 from homeassistant import config_entries
 from homeassistant.components import axis
-from homeassistant.setup import async_setup_component
-
 import homeassistant.components.camera as camera
-
+from homeassistant.setup import async_setup_component
 
 ENTRY_CONFIG = {
     axis.CONF_DEVICE: {

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 from homeassistant.components import axis
 from homeassistant.components.axis import config_flow
 
-from tests.common import mock_coro, MockConfigEntry
+from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_configured_devices(hass):

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -3,10 +3,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from tests.common import mock_coro, MockConfigEntry
-
 from homeassistant.components.axis import device, errors
 from homeassistant.components.axis.camera import AxisCamera
+
+from tests.common import MockConfigEntry, mock_coro
 
 DEVICE_DATA = {
     device.CONF_HOST: "1.2.3.4",

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -1,10 +1,10 @@
 """Test Axis component setup process."""
 from unittest.mock import Mock, patch
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import axis
+from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro, MockConfigEntry
+from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_setup(hass):

--- a/tests/components/axis/test_switch.py
+++ b/tests/components/axis/test_switch.py
@@ -1,12 +1,11 @@
 """Axis switch platform tests."""
 
-from unittest.mock import call as mock_call, Mock
+from unittest.mock import Mock, call as mock_call
 
 from homeassistant import config_entries
 from homeassistant.components import axis
-from homeassistant.setup import async_setup_component
-
 import homeassistant.components.switch as switch
+from homeassistant.setup import async_setup_component
 
 EVENTS = [
     {


### PR DESCRIPTION

## Description:

I have sorted the imports for the `axis` component according to PEP8 using isort.

This affects:

- `homeassistant/components/axis/device.py` 
- `tests/components/axis/test_binary_sensor.py` 
- `tests/components/axis/test_camera.py` 
- `tests/components/axis/test_config_flow.py` 
- `tests/components/axis/test_device.py` 
- `tests/components/axis/test_init.py` 
- `tests/components/axis/test_switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
