### PR TITLE
sort imports according to PEP8 for binary_sensor

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -5,14 +5,13 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity import Entity
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/binary_sensor/device_condition.py
+++ b/homeassistant/components/binary_sensor/device_condition.py
@@ -1,10 +1,11 @@
 """Implemenet device conditions for binary sensor."""
 from typing import Dict, List
+
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant
 from homeassistant.components.device_automation.const import CONF_IS_OFF, CONF_IS_ON
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, CONF_FOR, CONF_TYPE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition, config_validation as cv
 from homeassistant.helpers.entity_registry import (
     async_entries_for_device,
@@ -13,7 +14,6 @@ from homeassistant.helpers.entity_registry import (
 from homeassistant.helpers.typing import ConfigType
 
 from . import (
-    DOMAIN,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_COLD,
     DEVICE_CLASS_CONNECTIVITY,
@@ -37,6 +37,7 @@ from . import (
     DEVICE_CLASS_SOUND,
     DEVICE_CLASS_VIBRATION,
     DEVICE_CLASS_WINDOW,
+    DOMAIN,
 )
 
 DEVICE_CLASS_NONE = "none"

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -8,11 +8,10 @@ from homeassistant.components.device_automation.const import (
     CONF_TURNED_ON,
 )
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, CONF_FOR, CONF_TYPE
-from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_registry import async_entries_for_device
 
 from . import (
-    DOMAIN,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_COLD,
     DEVICE_CLASS_CONNECTIVITY,
@@ -36,8 +35,8 @@ from . import (
     DEVICE_CLASS_SOUND,
     DEVICE_CLASS_VIBRATION,
     DEVICE_CLASS_WINDOW,
+    DOMAIN,
 )
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -1,23 +1,24 @@
 """The test for binary_sensor device automation."""
 from datetime import timedelta
-import pytest
 from unittest.mock import patch
 
-from homeassistant.components.binary_sensor import DOMAIN, DEVICE_CLASSES
-from homeassistant.components.binary_sensor.device_condition import ENTITY_CONDITIONS
-from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
-from homeassistant.setup import async_setup_component
+import pytest
+
 import homeassistant.components.automation as automation
+from homeassistant.components.binary_sensor import DEVICE_CLASSES, DOMAIN
+from homeassistant.components.binary_sensor.device_condition import ENTITY_CONDITIONS
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
-    async_get_device_automation_capabilities,
 )
 
 

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -1,23 +1,24 @@
 """The test for binary_sensor device automation."""
 from datetime import timedelta
+
 import pytest
 
-from homeassistant.components.binary_sensor import DOMAIN, DEVICE_CLASSES
-from homeassistant.components.binary_sensor.device_trigger import ENTITY_TRIGGERS
-from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
+from homeassistant.components.binary_sensor import DEVICE_CLASSES, DOMAIN
+from homeassistant.components.binary_sensor.device_trigger import ENTITY_TRIGGERS
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
-    async_get_device_automation_capabilities,
 )
 
 

--- a/tests/components/binary_sensor/test_init.py
+++ b/tests/components/binary_sensor/test_init.py
@@ -3,7 +3,7 @@ import unittest
 from unittest import mock
 
 from homeassistant.components import binary_sensor
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
 
 
 class TestBinarySensor(unittest.TestCase):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `binary_sensor` component according to PEP8 using isort.

This affects:

- `homeassistant/components/binary_sensor/__init__.py` 
- `homeassistant/components/binary_sensor/device_condition.py` 
- `homeassistant/components/binary_sensor/device_trigger.py` 
- `tests/components/binary_sensor/test_device_condition.py` 
- `tests/components/binary_sensor/test_device_trigger.py` 
- `tests/components/binary_sensor/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
