### PR TITLE
sort imports according to PEP8 for command_line

### DIFF
--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -4,15 +4,15 @@ import subprocess
 
 import voluptuous as vol
 
-from homeassistant.components.cover import CoverDevice, PLATFORM_SCHEMA
+from homeassistant.components.cover import PLATFORM_SCHEMA, CoverDevice
 from homeassistant.const import (
     CONF_COMMAND_CLOSE,
     CONF_COMMAND_OPEN,
     CONF_COMMAND_STATE,
     CONF_COMMAND_STOP,
     CONF_COVERS,
-    CONF_VALUE_TEMPLATE,
     CONF_FRIENDLY_NAME,
+    CONF_VALUE_TEMPLATE,
 )
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -4,10 +4,9 @@ import subprocess
 
 import voluptuous as vol
 
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import CONF_COMMAND, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -4,21 +4,20 @@ import subprocess
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.switch import (
-    SwitchDevice,
-    PLATFORM_SCHEMA,
     ENTITY_ID_FORMAT,
+    PLATFORM_SCHEMA,
+    SwitchDevice,
 )
 from homeassistant.const import (
-    CONF_FRIENDLY_NAME,
-    CONF_SWITCHES,
-    CONF_VALUE_TEMPLATE,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
     CONF_COMMAND_STATE,
+    CONF_FRIENDLY_NAME,
+    CONF_SWITCHES,
+    CONF_VALUE_TEMPLATE,
 )
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -1,8 +1,8 @@
 """The tests for the Command line Binary sensor platform."""
 import unittest
 
-from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.components.command_line import binary_sensor as command_line
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import template
 
 from tests.common import get_test_home_assistant

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -5,8 +5,8 @@ from unittest import mock
 
 import pytest
 
-from homeassistant.components.cover import DOMAIN
 import homeassistant.components.command_line.cover as cmd_rs
+from homeassistant.components.cover import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,

--- a/tests/components/command_line/test_notify.py
+++ b/tests/components/command_line/test_notify.py
@@ -4,8 +4,9 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify
+from homeassistant.setup import setup_component
+
 from tests.common import assert_setup_component, get_test_home_assistant
 
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -2,8 +2,9 @@
 import unittest
 from unittest.mock import patch
 
-from homeassistant.helpers.template import Template
 from homeassistant.components.command_line import sensor as command_line
+from homeassistant.helpers.template import Template
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -4,10 +4,10 @@ import os
 import tempfile
 import unittest
 
-from homeassistant.setup import setup_component
-from homeassistant.const import STATE_ON, STATE_OFF
-import homeassistant.components.switch as switch
 import homeassistant.components.command_line.switch as command_line
+import homeassistant.components.switch as switch
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 from tests.components.switch import common


### PR DESCRIPTION

## Description:

I have sorted the imports for the `command_line` component according to PEP8 using isort.

This affects:

- `homeassistant/components/command_line/cover.py` 
- `homeassistant/components/command_line/notify.py` 
- `homeassistant/components/command_line/switch.py` 
- `tests/components/command_line/test_binary_sensor.py` 
- `tests/components/command_line/test_cover.py` 
- `tests/components/command_line/test_notify.py` 
- `tests/components/command_line/test_sensor.py` 
- `tests/components/command_line/test_switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
