### PR TITLE
sort imports according to PEP8 for config

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -6,11 +6,11 @@ import os
 import voluptuous as vol
 
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.const import EVENT_COMPONENT_LOADED, CONF_ID
+from homeassistant.const import CONF_ID, EVENT_COMPONENT_LOADED
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import ATTR_COMPONENT
-from homeassistant.util.yaml import load_yaml, dump
+from homeassistant.util.yaml import dump, load_yaml
 
 DOMAIN = "config"
 SECTIONS = (

--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -9,7 +9,6 @@ from homeassistant.components.websocket_api.decorators import (
 from homeassistant.core import callback
 from homeassistant.helpers.area_registry import async_get_registry
 
-
 WS_TYPE_LIST = "config/area_registry/list"
 SCHEMA_WS_LIST = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
     {vol.Required("type"): WS_TYPE_LIST}

--- a/homeassistant/components/config/auth.py
+++ b/homeassistant/components/config/auth.py
@@ -3,7 +3,6 @@ import voluptuous as vol
 
 from homeassistant.components import websocket_api
 
-
 WS_TYPE_LIST = "config/auth/list"
 SCHEMA_WS_LIST = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
     {vol.Required("type"): WS_TYPE_LIST}

--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -4,7 +4,6 @@ import voluptuous as vol
 from homeassistant.auth.providers import homeassistant as auth_ha
 from homeassistant.components import websocket_api
 
-
 WS_TYPE_CREATE = "config/auth_provider/homeassistant/create"
 SCHEMA_WS_CREATE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
     {

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -4,8 +4,8 @@ import uuid
 
 from homeassistant.components.automation import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.components.automation.config import async_validate_config_item
-from homeassistant.const import CONF_ID, SERVICE_RELOAD
 from homeassistant.config import AUTOMATION_CONFIG_PATH
+from homeassistant.const import CONF_ID, SERVICE_RELOAD
 import homeassistant.helpers.config_validation as cv
 
 from . import EditIdBasedConfigView

--- a/homeassistant/components/config/core.py
+++ b/homeassistant/components/config/core.py
@@ -2,10 +2,10 @@
 
 import voluptuous as vol
 
+from homeassistant.components import websocket_api
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config import async_check_ha_config_file
-from homeassistant.components import websocket_api
-from homeassistant.const import CONF_UNIT_SYSTEM_METRIC, CONF_UNIT_SYSTEM_IMPERIAL
+from homeassistant.const import CONF_UNIT_SYSTEM_IMPERIAL, CONF_UNIT_SYSTEM_METRIC
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import location
 

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -1,15 +1,15 @@
 """HTTP views to interact with the entity registry."""
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.helpers.entity_registry import async_get_registry
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
 from homeassistant.components.websocket_api.decorators import (
     async_response,
     require_admin,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_registry import async_get_registry
 
 
 async def async_setup(hass):

--- a/homeassistant/components/config/group.py
+++ b/homeassistant/components/config/group.py
@@ -1,7 +1,7 @@
 """Provide configuration end points for Groups."""
 from homeassistant.components.group import DOMAIN, GROUP_SCHEMA
-from homeassistant.const import SERVICE_RELOAD
 from homeassistant.config import GROUP_CONFIG_PATH
+from homeassistant.const import SERVICE_RELOAD
 import homeassistant.helpers.config_validation as cv
 
 from . import EditKeyBasedConfigView

--- a/homeassistant/components/config/scene.py
+++ b/homeassistant/components/config/scene.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 import uuid
 
 from homeassistant.components.scene import DOMAIN, PLATFORM_SCHEMA
-from homeassistant.const import CONF_ID, SERVICE_RELOAD
 from homeassistant.config import SCENE_CONFIG_PATH
+from homeassistant.const import CONF_ID, SERVICE_RELOAD
 import homeassistant.helpers.config_validation as cv
 
 from . import EditIdBasedConfigView

--- a/homeassistant/components/config/script.py
+++ b/homeassistant/components/config/script.py
@@ -1,7 +1,7 @@
 """Provide configuration end points for scripts."""
 from homeassistant.components.script import DOMAIN, SCRIPT_ENTRY_SCHEMA
-from homeassistant.const import SERVICE_RELOAD
 from homeassistant.config import SCRIPT_CONFIG_PATH
+from homeassistant.const import SERVICE_RELOAD
 import homeassistant.helpers.config_validation as cv
 
 from . import EditKeyBasedConfigView

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -2,6 +2,7 @@
 import pytest
 
 from homeassistant.components.config import area_registry
+
 from tests.common import mock_area_registry
 
 

--- a/tests/components/config/test_auth.py
+++ b/tests/components/config/test_auth.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.auth import models as auth_models
 from homeassistant.components.config import auth as auth_config
 
-from tests.common import MockGroup, MockUser, CLIENT_ID
+from tests.common import CLIENT_ID, MockGroup, MockUser
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -8,18 +8,18 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries as core_ce, data_entry_flow
+from homeassistant.components.config import config_entries
 from homeassistant.config_entries import HANDLERS
 from homeassistant.core import callback
-from homeassistant.setup import async_setup_component
-from homeassistant.components.config import config_entries
 from homeassistant.generated import config_flows
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     MockModule,
     mock_coro_func,
-    mock_integration,
     mock_entity_platform,
+    mock_integration,
 )
 
 

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -8,6 +8,7 @@ from homeassistant.components import config
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import CONF_UNIT_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL
 from homeassistant.util import dt as dt_util, location
+
 from tests.common import mock_coro
 
 ORIG_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -2,6 +2,7 @@
 import pytest
 
 from homeassistant.components.config import device_registry
+
 from tests.common import mock_device_registry
 
 

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -3,9 +3,10 @@ from collections import OrderedDict
 
 import pytest
 
-from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.components.config import entity_registry
-from tests.common import mock_registry, MockEntity, MockEntityPlatform
+from homeassistant.helpers.entity_registry import RegistryEntry
+
+from tests.common import MockEntity, MockEntityPlatform, mock_registry
 
 
 @pytest.fixture

--- a/tests/components/config/test_group.py
+++ b/tests/components/config/test_group.py
@@ -1,11 +1,10 @@
 """Test Group config panel."""
 import asyncio
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
-
 
 VIEW_NAME = "api:config:group:config"
 

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -2,11 +2,11 @@
 import asyncio
 from unittest.mock import patch
 
-from homeassistant.const import EVENT_COMPONENT_LOADED
-from homeassistant.setup import async_setup_component, ATTR_COMPONENT
 from homeassistant.components import config
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 
-from tests.common import mock_coro, mock_component
+from tests.common import mock_component, mock_coro
 
 
 @asyncio.coroutine

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -7,10 +7,9 @@ import pytest
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
-
 from homeassistant.components.zwave import DATA_NETWORK, const
-from tests.mock.zwave import MockNode, MockValue, MockEntityValues
 
+from tests.mock.zwave import MockEntityValues, MockNode, MockValue
 
 VIEW_NAME = "api:config:zwave:device_config"
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `config` component according to PEP8 using isort.

This affects:

- `homeassistant/components/config/__init__.py` 
- `homeassistant/components/config/area_registry.py` 
- `homeassistant/components/config/auth.py` 
- `homeassistant/components/config/auth_provider_homeassistant.py` 
- `homeassistant/components/config/automation.py` 
- `homeassistant/components/config/core.py` 
- `homeassistant/components/config/entity_registry.py` 
- `homeassistant/components/config/group.py` 
- `homeassistant/components/config/scene.py` 
- `homeassistant/components/config/script.py` 
- `tests/components/config/test_area_registry.py` 
- `tests/components/config/test_auth.py` 
- `tests/components/config/test_config_entries.py` 
- `tests/components/config/test_core.py` 
- `tests/components/config/test_device_registry.py` 
- `tests/components/config/test_entity_registry.py` 
- `tests/components/config/test_group.py` 
- `tests/components/config/test_init.py` 
- `tests/components/config/test_zwave.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
