### PR TITLE
sort imports according to PEP8 for cover

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -6,31 +6,30 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.loader import bind_hass
-from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity import Entity
+from homeassistant.components import group
+from homeassistant.const import (
+    SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
+    SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
+    SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
+    SERVICE_TOGGLE,
+    SERVICE_TOGGLE_COVER_TILT,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+)
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-from homeassistant.components import group
-from homeassistant.const import (
-    SERVICE_OPEN_COVER,
-    SERVICE_CLOSE_COVER,
-    SERVICE_SET_COVER_POSITION,
-    SERVICE_STOP_COVER,
-    SERVICE_TOGGLE,
-    SERVICE_OPEN_COVER_TILT,
-    SERVICE_CLOSE_COVER_TILT,
-    SERVICE_STOP_COVER_TILT,
-    SERVICE_SET_COVER_TILT_POSITION,
-    SERVICE_TOGGLE_COVER_TILT,
-    STATE_OPEN,
-    STATE_CLOSED,
-    STATE_OPENING,
-    STATE_CLOSING,
-)
-
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.loader import bind_hass
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/cover/device_condition.py
+++ b/homeassistant/components/cover/device_condition.py
@@ -1,5 +1,6 @@
 """Provides device automations for Cover."""
 from typing import Any, Dict, List
+
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -8,14 +9,14 @@ from homeassistant.const import (
     CONF_ABOVE,
     CONF_BELOW,
     CONF_CONDITION,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
-    STATE_OPEN,
+    CONF_TYPE,
     STATE_CLOSED,
-    STATE_OPENING,
     STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
@@ -24,8 +25,9 @@ from homeassistant.helpers import (
     entity_registry,
     template,
 )
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
 from . import (
     DOMAIN,
     SUPPORT_CLOSE,

--- a/homeassistant/components/cover/device_trigger.py
+++ b/homeassistant/components/cover/device_trigger.py
@@ -1,30 +1,32 @@
 """Provides device automations for Cover."""
 from typing import List
+
 import voluptuous as vol
 
+from homeassistant.components.automation import (
+    AutomationActionType,
+    numeric_state as numeric_state_automation,
+    state as state_automation,
+)
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     CONF_ABOVE,
     CONF_BELOW,
-    CONF_DOMAIN,
-    CONF_TYPE,
-    CONF_PLATFORM,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
     STATE_CLOSED,
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.components.automation import (
-    state as state_automation,
-    numeric_state as numeric_state_automation,
-    AutomationActionType,
-)
-from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+
 from . import (
     DOMAIN,
     SUPPORT_CLOSE,

--- a/homeassistant/components/cover/intent.py
+++ b/homeassistant/components/cover/intent.py
@@ -2,7 +2,7 @@
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
-from . import DOMAIN, SERVICE_OPEN_COVER, SERVICE_CLOSE_COVER
+from . import DOMAIN, SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 
 INTENT_OPEN_COVER = "HassOpenCover"
 INTENT_CLOSE_COVER = "HassCloseCover"

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -1,26 +1,26 @@
 """The tests for Cover device conditions."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.components.cover import DOMAIN
 from homeassistant.const import (
     CONF_PLATFORM,
-    STATE_OPEN,
     STATE_CLOSED,
-    STATE_OPENING,
     STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
 )
-from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
-    async_get_device_automation_capabilities,
 )
 
 

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -1,6 +1,7 @@
 """The tests for Cover device triggers."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.components.cover import DOMAIN
 from homeassistant.const import (
     CONF_PLATFORM,
@@ -9,18 +10,17 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
-    async_get_device_automation_capabilities,
 )
 
 

--- a/tests/components/cover/test_intent.py
+++ b/tests/components/cover/test_intent.py
@@ -1,11 +1,12 @@
 """The tests for the cover platform."""
 
 from homeassistant.components.cover import (
-    SERVICE_OPEN_COVER,
     SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
     intent as cover_intent,
 )
 from homeassistant.helpers import intent
+
 from tests.common import async_mock_service
 
 

--- a/tests/components/cover/test_reproduce_state.py
+++ b/tests/components/cover/test_reproduce_state.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_OPEN,
 )
 from homeassistant.core import State
+
 from tests.common import async_mock_service
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `cover` component according to PEP8 using isort.

This affects:

- `homeassistant/components/cover/__init__.py` 
- `homeassistant/components/cover/device_condition.py` 
- `homeassistant/components/cover/device_trigger.py` 
- `homeassistant/components/cover/intent.py` 
- `tests/components/cover/test_device_condition.py` 
- `tests/components/cover/test_device_trigger.py` 
- `tests/components/cover/test_intent.py` 
- `tests/components/cover/test_reproduce_state.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
