### PR TITLE
sort imports according to PEP8 for demo

### DIFF
--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -4,8 +4,8 @@ import logging
 import time
 
 from homeassistant import bootstrap, config_entries
-import homeassistant.core as ha
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
+import homeassistant.core as ha
 
 DOMAIN = "demo"
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/demo/binary_sensor.py
+++ b/homeassistant/components/demo/binary_sensor.py
@@ -1,5 +1,6 @@
 """Demo platform that has two fake binary sensors."""
 from homeassistant.components.binary_sensor import BinarySensorDevice
+
 from . import DOMAIN
 
 

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -1,9 +1,8 @@
 """Demo platform that has two fake binary sensors."""
 import copy
 
-import homeassistant.util.dt as dt_util
-
 from homeassistant.components.calendar import CalendarEventDevice, get_date
+import homeassistant.util.dt as dt_util
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/demo/climate.py
+++ b/homeassistant/components/demo/climate.py
@@ -1,11 +1,13 @@
 """Demo platform that offers a fake climate device."""
 import logging
+
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
+    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
@@ -18,9 +20,9 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_HUMIDITY,
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
-    HVAC_MODE_AUTO,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+
 from . import DOMAIN
 
 SUPPORT_FLAGS = 0

--- a/homeassistant/components/demo/cover.py
+++ b/homeassistant/components/demo/cover.py
@@ -1,6 +1,4 @@
 """Demo platform for the cover component."""
-from homeassistant.helpers.event import track_utc_time_change
-
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
@@ -8,6 +6,8 @@ from homeassistant.components.cover import (
     SUPPORT_OPEN,
     CoverDevice,
 )
+from homeassistant.helpers.event import track_utc_time_change
+
 from . import DOMAIN
 
 

--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -1,6 +1,4 @@
 """Demo fan platform that has a fake fan."""
-from homeassistant.const import STATE_OFF
-
 from homeassistant.components.fan import (
     SPEED_HIGH,
     SPEED_LOW,
@@ -10,6 +8,7 @@ from homeassistant.components.fan import (
     SUPPORT_SET_SPEED,
     FanEntity,
 )
+from homeassistant.const import STATE_OFF
 
 FULL_SUPPORT = SUPPORT_SET_SPEED | SUPPORT_OSCILLATE | SUPPORT_DIRECTION
 LIMITED_SUPPORT = SUPPORT_SET_SPEED

--- a/homeassistant/components/demo/geo_location.py
+++ b/homeassistant/components/demo/geo_location.py
@@ -5,9 +5,8 @@ from math import cos, pi, radians, sin
 import random
 from typing import Optional
 
-from homeassistant.helpers.event import track_time_interval
-
 from homeassistant.components.geo_location import GeolocationEvent
+from homeassistant.helpers.event import track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/demo/image_processing.py
+++ b/homeassistant/components/demo/image_processing.py
@@ -1,10 +1,10 @@
 """Support for the demo image processing."""
 from homeassistant.components.image_processing import (
-    ImageProcessingFaceEntity,
-    ATTR_CONFIDENCE,
-    ATTR_NAME,
     ATTR_AGE,
+    ATTR_CONFIDENCE,
     ATTR_GENDER,
+    ATTR_NAME,
+    ImageProcessingFaceEntity,
 )
 from homeassistant.components.openalpr_local.image_processing import (
     ImageProcessingAlprEntity,

--- a/homeassistant/components/demo/lock.py
+++ b/homeassistant/components/demo/lock.py
@@ -1,7 +1,6 @@
 """Demo lock platform that has two fake locks."""
-from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
-
 from homeassistant.components.lock import SUPPORT_OPEN, LockDevice
+from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/homeassistant/components/demo/sensor.py
+++ b/homeassistant/components/demo/sensor.py
@@ -1,11 +1,12 @@
 """Demo platform that has a couple of fake sensors."""
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
-    TEMP_CELSIUS,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
+    TEMP_CELSIUS,
 )
 from homeassistant.helpers.entity import Entity
+
 from . import DOMAIN
 
 

--- a/homeassistant/components/demo/switch.py
+++ b/homeassistant/components/demo/switch.py
@@ -1,6 +1,7 @@
 """Demo platform that has two fake switches."""
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
+
 from . import DOMAIN
 
 

--- a/homeassistant/components/demo/water_heater.py
+++ b/homeassistant/components/demo/water_heater.py
@@ -1,12 +1,11 @@
 """Demo platform that offers a fake water heater device."""
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
-
 from homeassistant.components.water_heater import (
     SUPPORT_AWAY_MODE,
     SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_TEMPERATURE,
     WaterHeaterDevice,
 )
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 
 SUPPORT_FLAGS_HEATER = (
     SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE

--- a/tests/components/demo/test_camera.py
+++ b/tests/components/demo/test_camera.py
@@ -4,7 +4,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from homeassistant.components import camera
-from homeassistant.components.camera import STATE_STREAMING, STATE_IDLE
+from homeassistant.components.camera import STATE_IDLE, STATE_STREAMING
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/demo/test_cover.py
+++ b/tests/components/demo/test_cover.py
@@ -4,29 +4,29 @@ from datetime import timedelta
 import pytest
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
+    ATTR_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
-    STATE_OPEN,
-    STATE_OPENING,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    SERVICE_TOGGLE,
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
-    SERVICE_TOGGLE_COVER_TILT,
     SERVICE_OPEN_COVER,
     SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
+    SERVICE_TOGGLE,
+    SERVICE_TOGGLE_COVER_TILT,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
 )
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util

--- a/tests/components/demo/test_fan.py
+++ b/tests/components/demo/test_fan.py
@@ -1,9 +1,9 @@
 """Test cases around the demo fan platform."""
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import fan
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import async_setup_component
 
 from tests.components.fan import common
 

--- a/tests/components/demo/test_geo_location.py
+++ b/tests/components/demo/test_geo_location.py
@@ -4,17 +4,18 @@ from unittest.mock import patch
 
 from homeassistant.components import geo_location
 from homeassistant.components.demo.geo_location import (
-    NUMBER_OF_DEMO_DEVICES,
     DEFAULT_UNIT_OF_MEASUREMENT,
     DEFAULT_UPDATE_INTERVAL,
+    NUMBER_OF_DEMO_DEVICES,
 )
 from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
+
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
     fire_time_changed,
+    get_test_home_assistant,
 )
-import homeassistant.util.dt as dt_util
 
 CONFIG = {geo_location.DOMAIN: [{"platform": "demo"}]}
 

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -4,10 +4,10 @@ import os
 
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import demo
 from homeassistant.components.device_tracker.legacy import YAML_DEVICES
 from homeassistant.helpers.json import JSONEncoder
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/demo/test_light.py
+++ b/tests/components/demo/test_light.py
@@ -1,8 +1,8 @@
 """The tests for the demo light component."""
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import light
+from homeassistant.setup import async_setup_component
 
 from tests.components.light import common
 

--- a/tests/components/demo/test_lock.py
+++ b/tests/components/demo/test_lock.py
@@ -1,8 +1,8 @@
 """The tests for the Demo lock platform."""
 import unittest
 
-from homeassistant.setup import setup_component
 from homeassistant.components import lock
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant, mock_service
 from tests.components.lock import common

--- a/tests/components/demo/test_media_player.py
+++ b/tests/components/demo/test_media_player.py
@@ -1,14 +1,14 @@
 """The tests for the Demo Media player platform."""
+import asyncio
 import unittest
 from unittest.mock import patch
-import asyncio
 
 import pytest
 import voluptuous as vol
 
-from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.media_player as mp
 from homeassistant.helpers.aiohttp_client import DATA_CLIENTSESSION
+from homeassistant.setup import async_setup_component, setup_component
 
 from tests.common import get_test_home_assistant
 from tests.components.media_player import common

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -5,11 +5,11 @@ from unittest.mock import patch
 import pytest
 import voluptuous as vol
 
-import homeassistant.components.notify as notify
-from homeassistant.setup import setup_component
 import homeassistant.components.demo.notify as demo
+import homeassistant.components.notify as notify
 from homeassistant.core import callback
 from homeassistant.helpers import discovery, script
+from homeassistant.setup import setup_component
 
 from tests.common import assert_setup_component, get_test_home_assistant
 from tests.components.notify import common

--- a/tests/components/demo/test_remote.py
+++ b/tests/components/demo/test_remote.py
@@ -2,9 +2,9 @@
 # pylint: disable=protected-access
 import unittest
 
-from homeassistant.setup import setup_component
 import homeassistant.components.remote as remote
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 from tests.components.remote import common

--- a/tests/components/demo/test_stt.py
+++ b/tests/components/demo/test_stt.py
@@ -1,8 +1,8 @@
 """The tests for the demo stt component."""
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import stt
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/demo/test_vacuum.py
+++ b/tests/components/demo/test_vacuum.py
@@ -2,6 +2,15 @@
 import unittest
 
 from homeassistant.components import vacuum
+from homeassistant.components.demo.vacuum import (
+    DEMO_VACUUM_BASIC,
+    DEMO_VACUUM_COMPLETE,
+    DEMO_VACUUM_MINIMAL,
+    DEMO_VACUUM_MOST,
+    DEMO_VACUUM_NONE,
+    DEMO_VACUUM_STATE,
+    FAN_SPEEDS,
+)
 from homeassistant.components.vacuum import (
     ATTR_BATTERY_LEVEL,
     ATTR_COMMAND,
@@ -13,20 +22,11 @@ from homeassistant.components.vacuum import (
     ENTITY_ID_ALL_VACUUMS,
     SERVICE_SEND_COMMAND,
     SERVICE_SET_FAN_SPEED,
-    STATE_DOCKED,
     STATE_CLEANING,
-    STATE_PAUSED,
+    STATE_DOCKED,
     STATE_IDLE,
+    STATE_PAUSED,
     STATE_RETURNING,
-)
-from homeassistant.components.demo.vacuum import (
-    DEMO_VACUUM_BASIC,
-    DEMO_VACUUM_COMPLETE,
-    DEMO_VACUUM_MINIMAL,
-    DEMO_VACUUM_MOST,
-    DEMO_VACUUM_NONE,
-    DEMO_VACUUM_STATE,
-    FAN_SPEEDS,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -39,7 +39,6 @@ from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant, mock_service
 from tests.components.vacuum import common
-
 
 ENTITY_VACUUM_BASIC = "{}.{}".format(DOMAIN, DEMO_VACUUM_BASIC).lower()
 ENTITY_VACUUM_COMPLETE = "{}.{}".format(DOMAIN, DEMO_VACUUM_COMPLETE).lower()

--- a/tests/components/demo/test_water_heater.py
+++ b/tests/components/demo/test_water_heater.py
@@ -4,13 +4,12 @@ import unittest
 import pytest
 import voluptuous as vol
 
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
-from homeassistant.setup import setup_component
 from homeassistant.components import water_heater
+from homeassistant.setup import setup_component
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.common import get_test_home_assistant
 from tests.components.water_heater import common
-
 
 ENTITY_WATER_HEATER = "water_heater.demo_water_heater"
 ENTITY_WATER_HEATER_CELSIUS = "water_heater.demo_water_heater_celsius"


### PR DESCRIPTION

## Description:

I have sorted the imports for the `demo` component according to PEP8 using isort.

This affects:

- `homeassistant/components/demo/__init__.py` 
- `homeassistant/components/demo/binary_sensor.py` 
- `homeassistant/components/demo/calendar.py` 
- `homeassistant/components/demo/climate.py` 
- `homeassistant/components/demo/cover.py` 
- `homeassistant/components/demo/fan.py` 
- `homeassistant/components/demo/geo_location.py` 
- `homeassistant/components/demo/image_processing.py` 
- `homeassistant/components/demo/lock.py` 
- `homeassistant/components/demo/sensor.py` 
- `homeassistant/components/demo/switch.py` 
- `homeassistant/components/demo/water_heater.py` 
- `tests/components/demo/test_camera.py` 
- `tests/components/demo/test_cover.py` 
- `tests/components/demo/test_fan.py` 
- `tests/components/demo/test_geo_location.py` 
- `tests/components/demo/test_init.py` 
- `tests/components/demo/test_light.py` 
- `tests/components/demo/test_lock.py` 
- `tests/components/demo/test_media_player.py` 
- `tests/components/demo/test_notify.py` 
- `tests/components/demo/test_remote.py` 
- `tests/components/demo/test_stt.py` 
- `tests/components/demo/test_vacuum.py` 
- `tests/components/demo/test_water_heater.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
