### PR TITLE
sort imports according to PEP8 for fan

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -7,15 +7,15 @@ from typing import Optional
 import voluptuous as vol
 
 from homeassistant.components import group
-from homeassistant.const import SERVICE_TURN_ON, SERVICE_TOGGLE, SERVICE_TURN_OFF
-from homeassistant.loader import bind_hass
-from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.const import SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fan/device_action.py
+++ b/homeassistant/components/fan/device_action.py
@@ -1,19 +1,21 @@
 """Provides device automations for Fan."""
-from typing import Optional, List
+from typing import List, Optional
+
 import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
-    SERVICE_TURN_ON,
+    CONF_TYPE,
     SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
 )
-from homeassistant.core import HomeAssistant, Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
+
 from . import DOMAIN
 
 ACTION_TYPES = {"turn_on", "turn_off"}

--- a/homeassistant/components/fan/device_condition.py
+++ b/homeassistant/components/fan/device_condition.py
@@ -1,21 +1,23 @@
 """Provide the device automations for Fan."""
 from typing import Dict, List
+
 import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_CONDITION,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_TYPE,
     STATE_OFF,
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
 from . import DOMAIN
 
 CONDITION_TYPES = {"is_on", "is_off"}

--- a/homeassistant/components/fan/device_trigger.py
+++ b/homeassistant/components/fan/device_trigger.py
@@ -1,21 +1,23 @@
 """Provides device automations for Fan."""
 from typing import List
+
 import voluptuous as vol
 
+from homeassistant.components.automation import AutomationActionType, state
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
-    CONF_DOMAIN,
-    CONF_TYPE,
-    CONF_PLATFORM,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
-    STATE_ON,
+    CONF_PLATFORM,
+    CONF_TYPE,
     STATE_OFF,
+    STATE_ON,
 )
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.components.automation import state, AutomationActionType
-from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+
 from . import DOMAIN
 
 TRIGGER_TYPES = {"turned_on", "turned_off"}

--- a/homeassistant/components/fan/reproduce_state.py
+++ b/homeassistant/components/fan/reproduce_state.py
@@ -6,19 +6,19 @@ from typing import Iterable, Optional
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    STATE_ON,
-    STATE_OFF,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
-    DOMAIN,
     ATTR_DIRECTION,
     ATTR_OSCILLATING,
     ATTR_SPEED,
+    DOMAIN,
     SERVICE_OSCILLATE,
     SERVICE_SET_DIRECTION,
     SERVICE_SET_SPEED,

--- a/tests/components/fan/common.py
+++ b/tests/components/fan/common.py
@@ -5,8 +5,8 @@ components. Instead call the service directly.
 """
 from homeassistant.components.fan import (
     ATTR_DIRECTION,
-    ATTR_SPEED,
     ATTR_OSCILLATING,
+    ATTR_SPEED,
     DOMAIN,
     SERVICE_OSCILLATE,
     SERVICE_SET_DIRECTION,
@@ -14,9 +14,9 @@ from homeassistant.components.fan import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
     ENTITY_MATCH_ALL,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
 )
 
 

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -1,18 +1,18 @@
 """The tests for Fan device actions."""
 import pytest
 
-from homeassistant.components.fan import DOMAIN
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
+from homeassistant.components.fan import DOMAIN
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/fan/test_device_condition.py
+++ b/tests/components/fan/test_device_condition.py
@@ -1,19 +1,19 @@
 """The tests for Fan device conditions."""
 import pytest
 
-from homeassistant.components.fan import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
+from homeassistant.components.fan import DOMAIN
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -1,19 +1,19 @@
 """The tests for Fan device triggers."""
 import pytest
 
-from homeassistant.components.fan import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
+from homeassistant.components.fan import DOMAIN
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -2,8 +2,9 @@
 
 import unittest
 
-from homeassistant.components.fan import FanEntity
 import pytest
+
+from homeassistant.components.fan import FanEntity
 
 
 class BaseFan(FanEntity):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `fan` component according to PEP8 using isort.

This affects:

- `homeassistant/components/fan/__init__.py` 
- `homeassistant/components/fan/device_action.py` 
- `homeassistant/components/fan/device_condition.py` 
- `homeassistant/components/fan/device_trigger.py` 
- `homeassistant/components/fan/reproduce_state.py` 
- `tests/components/fan/common.py` 
- `tests/components/fan/test_device_action.py` 
- `tests/components/fan/test_device_condition.py` 
- `tests/components/fan/test_device_trigger.py` 
- `tests/components/fan/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
