### PR TITLE
Update rfxtrx component so it can be run as a custom_component

### DIFF
--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -3,16 +3,6 @@ import logging
 
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
-from . import (
-    get_pt2262_deviceid,
-    RECEIVED_EVT_SUBSCRIBERS,
-    apply_received_command,
-    RFX_DEVICES,
-    get_pt2262_cmd,
-    get_pt2262_device,
-    find_possible_pt2262_device,
-    get_rfx_object,
-)
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,
@@ -35,6 +25,14 @@ from . import (
     CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_OFF_DELAY,
+    get_pt2262_deviceid,
+    RECEIVED_EVT_SUBSCRIBERS,
+    apply_received_command,
+    RFX_DEVICES,
+    get_pt2262_cmd,
+    get_pt2262_device,
+    find_possible_pt2262_device,
+    get_rfx_object,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -106,10 +106,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         device_id = slugify(event.device.id_string.lower())
 
-        if device_id in RFX_DEVICES:
-            sensor = RFX_DEVICES[device_id]
-        else:
-            sensor = get_pt2262_device(device_id)
+        sensor = RFX_DEVICES.get(device_id, get_pt2262_device(device_id))
 
         if sensor is None:
             # Add the entity if not exists and automatic_add is True

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -25,13 +25,13 @@ from . import (
     CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_OFF_DELAY,
-    get_pt2262_deviceid,
     RECEIVED_EVT_SUBSCRIBERS,
-    apply_received_command,
     RFX_DEVICES,
+    apply_received_command,
+    find_possible_pt2262_device,
     get_pt2262_cmd,
     get_pt2262_device,
-    find_possible_pt2262_device,
+    get_pt2262_deviceid,
     get_rfx_object,
 )
 

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -12,11 +12,11 @@ from . import (
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
-    RfxtrxDevice,
     RECEIVED_EVT_SUBSCRIBERS,
+    RfxtrxDevice,
     apply_received_command,
-    get_new_device,
     get_devices_from_config,
+    get_new_device,
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -2,13 +2,6 @@
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
-from . import (
-    RfxtrxDevice,
-    RECEIVED_EVT_SUBSCRIBERS,
-    apply_received_command,
-    get_new_device,
-    get_devices_from_config,
-)
 from homeassistant.components.cover import PLATFORM_SCHEMA, CoverDevice
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import config_validation as cv
@@ -19,6 +12,11 @@ from . import (
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
+    RfxtrxDevice,
+    RECEIVED_EVT_SUBSCRIBERS,
+    apply_received_command,
+    get_new_device,
+    get_devices_from_config,
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -2,7 +2,13 @@
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
-from homeassistant.components import rfxtrx
+from . import (
+    RfxtrxDevice,
+    RECEIVED_EVT_SUBSCRIBERS,
+    apply_received_command,
+    get_new_device,
+    get_devices_from_config,
+)
 from homeassistant.components.cover import PLATFORM_SCHEMA, CoverDevice
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import config_validation as cv
@@ -35,7 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx cover."""
-    covers = rfxtrx.get_devices_from_config(config, RfxtrxCover)
+    covers = get_devices_from_config(config, RfxtrxCover)
     add_entities(covers)
 
     def cover_update(event):
@@ -47,18 +53,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ):
             return
 
-        new_device = rfxtrx.get_new_device(event, config, RfxtrxCover)
+        new_device = get_new_device(event, config, RfxtrxCover)
         if new_device:
             add_entities([new_device])
 
-        rfxtrx.apply_received_command(event)
+        apply_received_command(event)
 
     # Subscribe to main RFXtrx events
-    if cover_update not in rfxtrx.RECEIVED_EVT_SUBSCRIBERS:
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS.append(cover_update)
+    if cover_update not in RECEIVED_EVT_SUBSCRIBERS:
+        RECEIVED_EVT_SUBSCRIBERS.append(cover_update)
 
 
-class RfxtrxCover(rfxtrx.RfxtrxDevice, CoverDevice):
+class RfxtrxCover(RfxtrxDevice, CoverDevice):
     """Representation of a RFXtrx cover."""
 
     @property

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -4,7 +4,13 @@ import logging
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
-from homeassistant.components import rfxtrx
+from . import (
+    RfxtrxDevice,
+    get_devices_from_config,
+    get_new_device,
+    RECEIVED_EVT_SUBSCRIBERS,
+    apply_received_command,
+)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
@@ -46,7 +52,7 @@ SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
-    lights = rfxtrx.get_devices_from_config(config, RfxtrxLight)
+    lights = get_devices_from_config(config, RfxtrxLight)
     add_entities(lights)
 
     def light_update(event):
@@ -57,18 +63,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ):
             return
 
-        new_device = rfxtrx.get_new_device(event, config, RfxtrxLight)
+        new_device = get_new_device(event, config, RfxtrxLight)
         if new_device:
             add_entities([new_device])
 
-        rfxtrx.apply_received_command(event)
+        apply_received_command(event)
 
     # Subscribe to main RFXtrx events
-    if light_update not in rfxtrx.RECEIVED_EVT_SUBSCRIBERS:
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS.append(light_update)
+    if light_update not in RECEIVED_EVT_SUBSCRIBERS:
+        RECEIVED_EVT_SUBSCRIBERS.append(light_update)
 
 
-class RfxtrxLight(rfxtrx.RfxtrxDevice, Light):
+class RfxtrxLight(RfxtrxDevice, Light):
     """Representation of a RFXtrx light."""
 
     @property

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -19,11 +19,11 @@ from . import (
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
+    RECEIVED_EVT_SUBSCRIBERS,
     RfxtrxDevice,
+    apply_received_command,
     get_devices_from_config,
     get_new_device,
-    RECEIVED_EVT_SUBSCRIBERS,
-    apply_received_command,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -4,13 +4,6 @@ import logging
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
-from . import (
-    RfxtrxDevice,
-    get_devices_from_config,
-    get_new_device,
-    RECEIVED_EVT_SUBSCRIBERS,
-    apply_received_command,
-)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
@@ -26,6 +19,11 @@ from . import (
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
+    RfxtrxDevice,
+    get_devices_from_config,
+    get_new_device,
+    RECEIVED_EVT_SUBSCRIBERS,
+    apply_received_command,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -18,9 +18,9 @@ from . import (
     CONF_DEVICES,
     CONF_FIRE_EVENT,
     DATA_TYPES,
-    get_rfx_object,
-    RFX_DEVICES,
     RECEIVED_EVT_SUBSCRIBERS,
+    RFX_DEVICES,
+    get_rfx_object,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -4,7 +4,6 @@ import logging
 from RFXtrx import SensorEvent
 import voluptuous as vol
 
-from homeassistant.components import rfxtrx
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, CONF_NAME
 import homeassistant.helpers.config_validation as cv
@@ -19,6 +18,9 @@ from . import (
     CONF_DEVICES,
     CONF_FIRE_EVENT,
     DATA_TYPES,
+    get_rfx_object,
+    RFX_DEVICES,
+    RECEIVED_EVT_SUBSCRIBERS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,9 +48,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
     sensors = []
     for packet_id, entity_info in config[CONF_DEVICES].items():
-        event = rfxtrx.get_rfx_object(packet_id)
+        event = get_rfx_object(packet_id)
         device_id = "sensor_{}".format(slugify(event.device.id_string.lower()))
-        if device_id in rfxtrx.RFX_DEVICES:
+        if device_id in RFX_DEVICES:
             continue
         _LOGGER.info("Add %s rfxtrx.sensor", entity_info[ATTR_NAME])
 
@@ -66,7 +68,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             )
             sensors.append(new_sensor)
             sub_sensors[_data_type] = new_sensor
-        rfxtrx.RFX_DEVICES[device_id] = sub_sensors
+        RFX_DEVICES[device_id] = sub_sensors
     add_entities(sensors)
 
     def sensor_update(event):
@@ -76,8 +78,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         device_id = "sensor_" + slugify(event.device.id_string.lower())
 
-        if device_id in rfxtrx.RFX_DEVICES:
-            sensors = rfxtrx.RFX_DEVICES[device_id]
+        if device_id in RFX_DEVICES:
+            sensors = RFX_DEVICES[device_id]
             for data_type in sensors:
                 # Some multi-sensor devices send individual messages for each
                 # of their sensors. Update only if event contains the
@@ -108,11 +110,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         new_sensor = RfxtrxSensor(event, pkt_id, data_type)
         sub_sensors = {}
         sub_sensors[new_sensor.data_type] = new_sensor
-        rfxtrx.RFX_DEVICES[device_id] = sub_sensors
+        RFX_DEVICES[device_id] = sub_sensors
         add_entities([new_sensor])
 
-    if sensor_update not in rfxtrx.RECEIVED_EVT_SUBSCRIBERS:
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS.append(sensor_update)
+    if sensor_update not in RECEIVED_EVT_SUBSCRIBERS:
+        RECEIVED_EVT_SUBSCRIBERS.append(sensor_update)
 
 
 class RfxtrxSensor(Entity):

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -4,7 +4,13 @@ import logging
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
-from homeassistant.components import rfxtrx
+from . import (
+    get_devices_from_config,
+    get_new_device,
+    RECEIVED_EVT_SUBSCRIBERS,
+    apply_received_command,
+)
+from . import RfxtrxDevice
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import config_validation as cv
@@ -40,7 +46,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the RFXtrx platform."""
     # Add switch from config file
-    switches = rfxtrx.get_devices_from_config(config, RfxtrxSwitch)
+    switches = get_devices_from_config(config, RfxtrxSwitch)
     add_entities_callback(switches)
 
     def switch_update(event):
@@ -52,18 +58,18 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         ):
             return
 
-        new_device = rfxtrx.get_new_device(event, config, RfxtrxSwitch)
+        new_device = get_new_device(event, config, RfxtrxSwitch)
         if new_device:
             add_entities_callback([new_device])
 
-        rfxtrx.apply_received_command(event)
+        apply_received_command(event)
 
     # Subscribe to main RFXtrx events
-    if switch_update not in rfxtrx.RECEIVED_EVT_SUBSCRIBERS:
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS.append(switch_update)
+    if switch_update not in RECEIVED_EVT_SUBSCRIBERS:
+        RECEIVED_EVT_SUBSCRIBERS.append(switch_update)
 
 
-class RfxtrxSwitch(rfxtrx.RfxtrxDevice, SwitchDevice):
+class RfxtrxSwitch(RfxtrxDevice, SwitchDevice):
     """Representation of a RFXtrx switch."""
 
     def turn_on(self, **kwargs):

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -4,7 +4,6 @@ import logging
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
-from . import RfxtrxDevice
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import config_validation as cv
@@ -19,6 +18,7 @@ from . import (
     get_new_device,
     RECEIVED_EVT_SUBSCRIBERS,
     apply_received_command,
+    RfxtrxDevice,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -4,12 +4,6 @@ import logging
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
-from . import (
-    get_devices_from_config,
-    get_new_device,
-    RECEIVED_EVT_SUBSCRIBERS,
-    apply_received_command,
-)
 from . import RfxtrxDevice
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import CONF_NAME
@@ -21,6 +15,10 @@ from . import (
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
+    get_devices_from_config,
+    get_new_device,
+    RECEIVED_EVT_SUBSCRIBERS,
+    apply_received_command,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -14,11 +14,11 @@ from . import (
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
+    RECEIVED_EVT_SUBSCRIBERS,
+    RfxtrxDevice,
+    apply_received_command,
     get_devices_from_config,
     get_new_device,
-    RECEIVED_EVT_SUBSCRIBERS,
-    apply_received_command,
-    RfxtrxDevice,
 )
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Description:
Fix imports so rfxtrx component so it can be run as a custom component

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#28604

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
