### PR TITLE
Add input_text reload service.

### DIFF
--- a/homeassistant/components/input_text/services.yaml
+++ b/homeassistant/components/input_text/services.yaml
@@ -4,3 +4,5 @@ set_value:
     entity_id: {description: Entity id of the input text to set the new value., example: input_text.text1}
     value: {description: The target value the entity should be set to., example: This
         is an example text}
+reload:
+  description: Reload the input_text configuration.

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -1,10 +1,14 @@
 """The tests for the Input text component."""
 # pylint: disable=protected-access
 import asyncio
+from unittest.mock import patch
+
+import pytest
 
 from homeassistant.components.input_text import ATTR_VALUE, DOMAIN, SERVICE_SET_VALUE
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_RELOAD
 from homeassistant.core import Context, CoreState, State
+from homeassistant.exceptions import Unauthorized
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
@@ -195,3 +199,64 @@ async def test_config_none(hass):
     state = hass.states.get("input_text.b1")
     assert state
     assert str(state.state) == "unknown"
+
+
+async def test_reload(hass, hass_admin_user, hass_read_only_user):
+    """Test reload service."""
+    count_start = len(hass.states.async_entity_ids())
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {"test_1": {"initial": "test 1"}, "test_2": {"initial": "test 2"}}},
+    )
+
+    assert count_start + 2 == len(hass.states.async_entity_ids())
+
+    state_1 = hass.states.get("input_text.test_1")
+    state_2 = hass.states.get("input_text.test_2")
+    state_3 = hass.states.get("input_text.test_3")
+
+    assert state_1 is not None
+    assert state_2 is not None
+    assert state_3 is None
+    assert "test 1" == state_1.state
+    assert "test 2" == state_2.state
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value={
+            DOMAIN: {
+                "test_2": {"initial": "test reloaded"},
+                "test_3": {"initial": "test 3"},
+            }
+        },
+    ):
+        with patch("homeassistant.config.find_config_file", return_value=""):
+            with pytest.raises(Unauthorized):
+                await hass.services.async_call(
+                    DOMAIN,
+                    SERVICE_RELOAD,
+                    blocking=True,
+                    context=Context(user_id=hass_read_only_user.id),
+                )
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_RELOAD,
+                blocking=True,
+                context=Context(user_id=hass_admin_user.id),
+            )
+            await hass.async_block_till_done()
+
+    assert count_start + 2 == len(hass.states.async_entity_ids())
+
+    state_1 = hass.states.get("input_text.test_1")
+    state_2 = hass.states.get("input_text.test_2")
+    state_3 = hass.states.get("input_text.test_3")
+
+    assert state_1 is None
+    assert state_2 is not None
+    assert state_3 is not None
+    assert "test reloaded" == state_2.state
+    assert "test 3" == state_3.state


### PR DESCRIPTION
## Description:
Add `input_text.reload` admin service. Allows adding new `input_text` entities without restarting the entire HA instance.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
