### PR TITLE
Sort imports according to PEP8 for homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -5,15 +5,14 @@ import homekit
 from homekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import Entity
 
 # We need an import from .config_flow, without it .config_flow is never loaded.
 from .config_flow import HomekitControllerFlowHandler  # noqa: F401
-from .connection import get_accessory_information, HKDevice
-from .const import CONTROLLER, ENTITY_MAP, KNOWN_DEVICES
-from .const import DOMAIN
+from .connection import HKDevice, get_accessory_information
+from .const import CONTROLLER, DOMAIN, ENTITY_MAP, KNOWN_DEVICES
 from .storage import EntityMapStorage
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -4,20 +4,20 @@ import logging
 from homekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.climate import (
-    ClimateDevice,
-    DEFAULT_MIN_HUMIDITY,
     DEFAULT_MAX_HUMIDITY,
+    DEFAULT_MIN_HUMIDITY,
+    ClimateDevice,
 )
 from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT_COOL,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
-    CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_COOL,
-    SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure homekit_controller."""
-import os
 import json
 import logging
+import os
 
 import homekit
 import voluptuous as vol
@@ -9,9 +9,8 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 
+from .connection import get_accessory_name, get_bridge_information
 from .const import DOMAIN, KNOWN_DEVICES
-from .connection import get_bridge_information, get_accessory_name
-
 
 HOMEKIT_IGNORE = ["Home Assistant Bridge"]
 HOMEKIT_DIR = ".homekit"

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -8,13 +8,12 @@ from homekit.exceptions import (
     AccessoryNotFoundError,
     EncryptionError,
 )
-from homekit.model.services import ServicesTypes
 from homekit.model.characteristics import CharacteristicsTypes
+from homekit.model.services import ServicesTypes
 
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, ENTITY_MAP
-
+from .const import DOMAIN, ENTITY_MAP, HOMEKIT_ACCESSORY_DISPATCH
 
 DEFAULT_SCAN_INTERVAL = datetime.timedelta(seconds=60)
 RETRY_INTERVAL = 60  # seconds

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -11,8 +11,8 @@ from homeassistant.components.cover import (
     SUPPORT_OPEN,
     SUPPORT_OPEN_TILT,
     SUPPORT_SET_POSITION,
-    SUPPORT_STOP,
     SUPPORT_SET_TILT_POSITION,
+    SUPPORT_STOP,
     CoverDevice,
 )
 from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -1,7 +1,7 @@
 """Helpers for HomeKit data stored in HA storage."""
 
-from homeassistant.helpers.storage import Store
 from homeassistant.core import callback
+from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
 

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -1,28 +1,29 @@
 """Code to support homekit_controller tests."""
+from datetime import timedelta
 import json
 import os
-from datetime import timedelta
 from unittest import mock
 
-from homekit.model.services import AbstractService, ServicesTypes
+from homekit.exceptions import AccessoryNotFoundError
+from homekit.model import Accessory, get_id
 from homekit.model.characteristics import (
     AbstractCharacteristic,
     CharacteristicPermissions,
     CharacteristicsTypes,
 )
-from homekit.model import Accessory, get_id
-from homekit.exceptions import AccessoryNotFoundError
+from homekit.model.services import AbstractService, ServicesTypes
 
 from homeassistant import config_entries
+from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import (
     CONTROLLER,
     DOMAIN,
     HOMEKIT_ACCESSORY_DISPATCH,
 )
-from homeassistant.components.homekit_controller import config_flow
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from tests.common import async_fire_time_changed, load_fixture, MockConfigEntry
+
+from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
 class FakePairing:

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -1,16 +1,16 @@
 """Basic checks for HomeKitclimate."""
 from homeassistant.components.climate.const import (
     DOMAIN,
-    SERVICE_SET_HVAC_MODE,
-    SERVICE_SET_TEMPERATURE,
-    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
     SERVICE_SET_HUMIDITY,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_TEMPERATURE,
 )
-from tests.components.homekit_controller.common import FakeService, setup_test_component
 
+from tests.components.homekit_controller.common import FakeService, setup_test_component
 
 HEATING_COOLING_TARGET = ("thermostat", "heating-cooling.target")
 HEATING_COOLING_CURRENT = ("thermostat", "heating-cooling.current")

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -7,13 +7,13 @@ import pytest
 
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
+
 from tests.common import MockConfigEntry
 from tests.components.homekit_controller.common import (
     Accessory,
     FakeService,
     setup_platform,
 )
-
 
 PAIRING_START_FORM_ERRORS = [
     (homekit.BusyError, "busy_error"),

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -3,7 +3,6 @@ from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 
 from tests.components.homekit_controller.common import FakeService, setup_test_component
 
-
 LIGHT_ON = ("lightbulb", "on")
 LIGHT_BRIGHTNESS = ("lightbulb", "brightness")
 LIGHT_HUE = ("lightbulb", "hue")

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -1,14 +1,14 @@
 """Basic checks for entity map storage."""
-from tests.common import flush_store
-from tests.components.homekit_controller.common import (
-    FakeService,
-    setup_test_component,
-    setup_platform,
-)
-
 from homeassistant import config_entries
 from homeassistant.components.homekit_controller import async_remove_entry
 from homeassistant.components.homekit_controller.const import ENTITY_MAP
+
+from tests.common import flush_store
+from tests.components.homekit_controller.common import (
+    FakeService,
+    setup_platform,
+    setup_test_component,
+)
 
 
 async def test_load_from_storage(hass, hass_storage):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `homekit_controller` component according to PEP8 using isort.

This affects:

- `homeassistant/components/homekit_controller/__init__.py` 
- `homeassistant/components/homekit_controller/climate.py` 
- `homeassistant/components/homekit_controller/config_flow.py` 
- `homeassistant/components/homekit_controller/connection.py` 
- `homeassistant/components/homekit_controller/cover.py` 
- `homeassistant/components/homekit_controller/storage.py` 
- `tests/components/homekit_controller/common.py` 
- `tests/components/homekit_controller/test_climate.py` 
- `tests/components/homekit_controller/test_config_flow.py` 
- `tests/components/homekit_controller/test_light.py` 
- `tests/components/homekit_controller/test_storage.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
