### PR TITLE
Add input_select reload service.

### DIFF
--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -3,10 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_ICON, CONF_NAME
+from homeassistant.const import CONF_ICON, CONF_NAME, SERVICE_RELOAD
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
+import homeassistant.helpers.service
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,23 +62,31 @@ CONFIG_SCHEMA = vol.Schema(
     required=True,
     extra=vol.ALLOW_EXTRA,
 )
+RELOAD_SERVICE_SCHEMA = vol.Schema({})
 
 
 async def async_setup(hass, config):
     """Set up an input select."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    entities = []
+    entities = await _async_process_config(config)
 
-    for object_id, cfg in config[DOMAIN].items():
-        name = cfg.get(CONF_NAME)
-        options = cfg.get(CONF_OPTIONS)
-        initial = cfg.get(CONF_INITIAL)
-        icon = cfg.get(CONF_ICON)
-        entities.append(InputSelect(object_id, name, initial, options, icon))
+    async def reload_service_handler(service_call):
+        """Remove all entities and load new ones from config."""
+        conf = await component.async_prepare_reload()
+        if conf is None:
+            return
+        new_entities = await _async_process_config(conf)
+        if new_entities:
+            await component.async_add_entities(new_entities)
 
-    if not entities:
-        return False
+    homeassistant.helpers.service.async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_RELOAD,
+        reload_service_handler,
+        schema=RELOAD_SERVICE_SCHEMA,
+    )
 
     component.async_register_entity_service(
         SERVICE_SELECT_OPTION,
@@ -103,8 +112,23 @@ async def async_setup(hass, config):
         "async_set_options",
     )
 
-    await component.async_add_entities(entities)
+    if entities:
+        await component.async_add_entities(entities)
     return True
+
+
+async def _async_process_config(config):
+    """Process config and create list of entities."""
+    entities = []
+
+    for object_id, cfg in config[DOMAIN].items():
+        name = cfg.get(CONF_NAME)
+        options = cfg.get(CONF_OPTIONS)
+        initial = cfg.get(CONF_INITIAL)
+        icon = cfg.get(CONF_ICON)
+        entities.append(InputSelect(object_id, name, initial, options, icon))
+
+    return entities
 
 
 class InputSelect(RestoreEntity):

--- a/homeassistant/components/input_select/services.yaml
+++ b/homeassistant/components/input_select/services.yaml
@@ -20,3 +20,5 @@ set_options:
         for., example: input_select.my_select}
     options: {description: Options for the input select entity., example: '["Item
         A", "Item B", "Item C"]'}
+reload:
+  description: Reload the input_select configuration.

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -1,6 +1,9 @@
 """The tests for the Input select component."""
 # pylint: disable=protected-access
 import asyncio
+from unittest.mock import patch
+
+import pytest
 
 from homeassistant.components.input_select import (
     ATTR_OPTION,
@@ -11,8 +14,14 @@ from homeassistant.components.input_select import (
     SERVICE_SELECT_PREVIOUS,
     SERVICE_SET_OPTIONS,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_ICON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    SERVICE_RELOAD,
+)
 from homeassistant.core import Context, State
+from homeassistant.exceptions import Unauthorized
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
@@ -322,3 +331,81 @@ async def test_input_select_context(hass, hass_admin_user):
     assert state2 is not None
     assert state.state != state2.state
     assert state2.context.user_id == hass_admin_user.id
+
+
+async def test_reload(hass, hass_admin_user, hass_read_only_user):
+    """Test reload service."""
+    count_start = len(hass.states.async_entity_ids())
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test_1": {
+                    "options": ["first option", "middle option", "last option"],
+                    "initial": "middle option",
+                },
+                "test_2": {
+                    "options": ["an option", "not an option"],
+                    "initial": "an option",
+                },
+            }
+        },
+    )
+
+    assert count_start + 2 == len(hass.states.async_entity_ids())
+
+    state_1 = hass.states.get("input_select.test_1")
+    state_2 = hass.states.get("input_select.test_2")
+    state_3 = hass.states.get("input_select.test_3")
+
+    assert state_1 is not None
+    assert state_2 is not None
+    assert state_3 is None
+    assert "middle option" == state_1.state
+    assert "an option" == state_2.state
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value={
+            DOMAIN: {
+                "test_2": {
+                    "options": ["an option", "reloaded option"],
+                    "initial": "reloaded option",
+                },
+                "test_3": {
+                    "options": ["new option", "newer option"],
+                    "initial": "newer option",
+                },
+            }
+        },
+    ):
+        with patch("homeassistant.config.find_config_file", return_value=""):
+            with pytest.raises(Unauthorized):
+                await hass.services.async_call(
+                    DOMAIN,
+                    SERVICE_RELOAD,
+                    blocking=True,
+                    context=Context(user_id=hass_read_only_user.id),
+                )
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_RELOAD,
+                blocking=True,
+                context=Context(user_id=hass_admin_user.id),
+            )
+            await hass.async_block_till_done()
+
+    assert count_start + 2 == len(hass.states.async_entity_ids())
+
+    state_1 = hass.states.get("input_select.test_1")
+    state_2 = hass.states.get("input_select.test_2")
+    state_3 = hass.states.get("input_select.test_3")
+
+    assert state_1 is None
+    assert state_2 is not None
+    assert state_3 is not None
+    assert "reloaded option" == state_2.state
+    assert "newer option" == state_3.state


### PR DESCRIPTION
## Description:
Add `input_select.reload` admin services. Allows adding new `input_select` entities without restarting the entire HA instance.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
