### PR TITLE
Sort imports according to PEP8 for vacuum

### DIFF
--- a/homeassistant/components/mqtt/vacuum/__init__.py
+++ b/homeassistant/components/mqtt/vacuum/__init__.py
@@ -8,14 +8,15 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.vacuum import DOMAIN
 from homeassistant.components.mqtt import ATTR_DISCOVERY_HASH
 from homeassistant.components.mqtt.discovery import (
     MQTT_DISCOVERY_NEW,
     clear_discovery_hash,
 )
+from homeassistant.components.vacuum import DOMAIN
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from .schema import CONF_SCHEMA, LEGACY, STATE, MQTT_VACUUM_SCHEMA
+
+from .schema import CONF_SCHEMA, LEGACY, MQTT_VACUUM_SCHEMA, STATE
 from .schema_legacy import PLATFORM_SCHEMA_LEGACY, async_setup_entity_legacy
 from .schema_state import PLATFORM_SCHEMA_STATE, async_setup_entity_state
 

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -1,10 +1,18 @@
 """Support for Legacy MQTT vacuum."""
-import logging
 import json
+import logging
 
 import voluptuous as vol
 
 from homeassistant.components import mqtt
+from homeassistant.components.mqtt import (
+    CONF_UNIQUE_ID,
+    MqttAttributes,
+    MqttAvailability,
+    MqttDiscoveryUpdate,
+    MqttEntityDeviceInfo,
+    subscription,
+)
 from homeassistant.components.vacuum import (
     SUPPORT_BATTERY,
     SUPPORT_CLEAN_SPOT,
@@ -23,15 +31,6 @@ from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_DEVICE, CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.icon import icon_for_battery_level
-
-from homeassistant.components.mqtt import (
-    CONF_UNIQUE_ID,
-    MqttAttributes,
-    MqttAvailability,
-    MqttDiscoveryUpdate,
-    MqttEntityDeviceInfo,
-    subscription,
-)
 
 from .schema import MQTT_VACUUM_SCHEMA, services_to_strings, strings_to_services
 

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -1,27 +1,39 @@
 """Support for a State MQTT vacuum."""
-import logging
 import json
+import logging
 
 import voluptuous as vol
 
 from homeassistant.components import mqtt
+from homeassistant.components.mqtt import (
+    CONF_COMMAND_TOPIC,
+    CONF_QOS,
+    CONF_RETAIN,
+    CONF_STATE_TOPIC,
+    CONF_UNIQUE_ID,
+    MqttAttributes,
+    MqttAvailability,
+    MqttDiscoveryUpdate,
+    MqttEntityDeviceInfo,
+    subscription,
+)
 from homeassistant.components.vacuum import (
+    STATE_CLEANING,
+    STATE_DOCKED,
+    STATE_ERROR,
+    STATE_IDLE,
+    STATE_PAUSED,
+    STATE_RETURNING,
     SUPPORT_BATTERY,
     SUPPORT_CLEAN_SPOT,
     SUPPORT_FAN_SPEED,
-    SUPPORT_START,
     SUPPORT_LOCATE,
     SUPPORT_PAUSE,
     SUPPORT_RETURN_HOME,
     SUPPORT_SEND_COMMAND,
+    SUPPORT_START,
     SUPPORT_STATUS,
     SUPPORT_STOP,
-    STATE_CLEANING,
-    STATE_DOCKED,
-    STATE_PAUSED,
-    STATE_IDLE,
-    STATE_RETURNING,
-    STATE_ERROR,
     StateVacuumDevice,
 )
 from homeassistant.const import (
@@ -32,19 +44,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.mqtt import (
-    CONF_UNIQUE_ID,
-    MqttAttributes,
-    MqttAvailability,
-    MqttDiscoveryUpdate,
-    MqttEntityDeviceInfo,
-    subscription,
-    CONF_COMMAND_TOPIC,
-    CONF_RETAIN,
-    CONF_STATE_TOPIC,
-    CONF_QOS,
-)
 
 from .schema import MQTT_VACUUM_SCHEMA, services_to_strings, strings_to_services
 

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -12,21 +12,20 @@ from homeassistant.const import (  # noqa: F401 # STATE_PAUSED/IDLE are API
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_IDLE,
     STATE_ON,
     STATE_PAUSED,
-    STATE_IDLE,
 )
-from homeassistant.loader import bind_hass
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
-    make_entity_service_schema,
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
+    make_entity_service_schema,
 )
+from homeassistant.helpers.entity import Entity, ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity import ToggleEntity, Entity
 from homeassistant.helpers.icon import icon_for_battery_level
-
+from homeassistant.loader import bind_hass
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/vacuum/device_action.py
+++ b/homeassistant/components/vacuum/device_action.py
@@ -1,18 +1,20 @@
 """Provides device automations for Vacuum."""
-from typing import Optional, List
+from typing import List, Optional
+
 import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_TYPE,
 )
-from homeassistant.core import HomeAssistant, Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
-from . import DOMAIN, SERVICE_START, SERVICE_RETURN_TO_BASE
+
+from . import DOMAIN, SERVICE_RETURN_TO_BASE, SERVICE_START
 
 ACTION_TYPES = {"clean", "dock"}
 

--- a/homeassistant/components/vacuum/device_condition.py
+++ b/homeassistant/components/vacuum/device_condition.py
@@ -1,20 +1,22 @@
 """Provide the device automations for Vacuum."""
 from typing import Dict, List
+
 import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_CONDITION,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_TYPE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
-from . import DOMAIN, STATE_DOCKED, STATE_CLEANING, STATE_RETURNING
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from . import DOMAIN, STATE_CLEANING, STATE_DOCKED, STATE_RETURNING
 
 CONDITION_TYPES = {"is_cleaning", "is_docked"}
 

--- a/homeassistant/components/vacuum/device_trigger.py
+++ b/homeassistant/components/vacuum/device_trigger.py
@@ -1,19 +1,21 @@
 """Provides device automations for Vacuum."""
 from typing import List
+
 import voluptuous as vol
 
+from homeassistant.components.automation import AutomationActionType, state
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
-    CONF_DOMAIN,
-    CONF_TYPE,
-    CONF_PLATFORM,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
 )
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.components.automation import state, AutomationActionType
-from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+
 from . import DOMAIN, STATE_CLEANING, STATE_DOCKED, STATES
 
 TRIGGER_TYPES = {"cleaning", "docked"}

--- a/tests/components/vacuum/common.py
+++ b/tests/components/vacuum/common.py
@@ -10,20 +10,20 @@ from homeassistant.components.vacuum import (
     SERVICE_CLEAN_SPOT,
     SERVICE_LOCATE,
     SERVICE_PAUSE,
+    SERVICE_RETURN_TO_BASE,
     SERVICE_SEND_COMMAND,
     SERVICE_SET_FAN_SPEED,
     SERVICE_START,
     SERVICE_START_PAUSE,
     SERVICE_STOP,
-    SERVICE_RETURN_TO_BASE,
 )
 from homeassistant.const import (
     ATTR_COMMAND,
     ATTR_ENTITY_ID,
+    ENTITY_MATCH_ALL,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    ENTITY_MATCH_ALL,
 )
 from homeassistant.loader import bind_hass
 

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -1,18 +1,18 @@
 """The tests for Vacuum device actions."""
 import pytest
 
-from homeassistant.components.vacuum import DOMAIN
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
+from homeassistant.components.vacuum import DOMAIN
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -1,23 +1,23 @@
 """The tests for Vacuum device conditions."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.components.vacuum import (
     DOMAIN,
     STATE_CLEANING,
     STATE_DOCKED,
     STATE_RETURNING,
 )
-from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -1,18 +1,18 @@
 """The tests for Vacuum device triggers."""
 import pytest
 
-from homeassistant.components.vacuum import DOMAIN, STATE_DOCKED, STATE_CLEANING
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
+from homeassistant.components.vacuum import DOMAIN, STATE_CLEANING, STATE_DOCKED
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `vacuum` component according to PEP8 using isort.

This affects:

- `homeassistant/components/mqtt/vacuum/__init__.py` 
- `homeassistant/components/mqtt/vacuum/schema_legacy.py` 
- `homeassistant/components/mqtt/vacuum/schema_state.py` 
- `homeassistant/components/vacuum/__init__.py` 
- `homeassistant/components/vacuum/device_action.py` 
- `homeassistant/components/vacuum/device_condition.py` 
- `homeassistant/components/vacuum/device_trigger.py` 
- `tests/components/vacuum/common.py` 
- `tests/components/vacuum/test_device_action.py` 
- `tests/components/vacuum/test_device_condition.py` 
- `tests/components/vacuum/test_device_trigger.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
