### PR TITLE
Fix withings wrong sleep state entry

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -7,11 +7,11 @@ import voluptuous as vol
 from withings_api import WithingsAuth
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-from homeassistant.helpers import config_validation as cv, config_entry_oauth2_flow
 
 from . import config_flow, const
-from .common import _LOGGER, get_data_manager, NotAuthenticatedError
+from .common import _LOGGER, NotAuthenticatedError, get_data_manager
 
 DOMAIN = const.DOMAIN
 

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -1,4 +1,5 @@
 """Common code for Withings."""
+from asyncio import run_coroutine_threadsafe
 import datetime
 from functools import partial
 import logging
@@ -6,15 +7,14 @@ import re
 import time
 from typing import Any, Dict
 
-from asyncio import run_coroutine_threadsafe
 import requests
 from withings_api import (
     AbstractWithingsApi,
-    SleepGetResponse,
     MeasureGetMeasResponse,
+    SleepGetResponse,
     SleepGetSummaryResponse,
 )
-from withings_api.common import UnauthorizedException, AuthFailedException
+from withings_api.common import AuthFailedException, UnauthorizedException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -2,22 +2,22 @@
 from typing import Callable, List, Union
 
 from withings_api.common import (
-    MeasureType,
     GetSleepSummaryField,
     MeasureGetMeasResponse,
-    SleepGetResponse,
-    SleepGetSummaryResponse,
-    get_measure_value,
     MeasureGroupAttribs,
+    MeasureType,
+    SleepGetResponse,
+    SleepGetSerie,
+    SleepGetSummaryResponse,
     SleepState,
-    SleepGetSerie
+    get_measure_value,
 )
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
-from homeassistant.helpers import config_entry_oauth2_flow
 
 from . import const
 from .common import _LOGGER, WithingsDataManager, get_data_manager

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -10,6 +10,7 @@ from withings_api.common import (
     get_measure_value,
     MeasureGroupAttribs,
     SleepState,
+    SleepGetSerie
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -382,7 +383,11 @@ class WithingsHealthSensor(Entity):
             self._state = None
             return
 
-        serie = data.series[len(data.series) - 1]
+        def sort_serie(serie: SleepGetSerie) -> str:
+            return serie.startdate
+
+        sorted_series = sorted(data.series, key=sort_serie)
+        serie = sorted_series[len(data.series) - 1]
         state = None
         if serie.state == SleepState.AWAKE:
             state = const.STATE_AWAKE

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -7,7 +7,6 @@ from withings_api.common import (
     MeasureGroupAttribs,
     MeasureType,
     SleepGetResponse,
-    SleepGetSerie,
     SleepGetSummaryResponse,
     SleepState,
     get_measure_value,
@@ -383,11 +382,8 @@ class WithingsHealthSensor(Entity):
             self._state = None
             return
 
-        def sort_serie(serie: SleepGetSerie) -> str:
-            return serie.startdate
-
-        sorted_series = sorted(data.series, key=sort_serie)
-        serie = sorted_series[len(data.series) - 1]
+        sorted_series = sorted(data.series, key=lambda serie: serie.startdate)
+        serie = sorted_series[len(sorted_series) - 1]
         state = None
         if serie.state == SleepState.AWAKE:
             state = const.STATE_AWAKE

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -1,15 +1,14 @@
 """Tests for the Withings component."""
 from asynctest import MagicMock
-
 import pytest
 from withings_api import WithingsApi
-from withings_api.common import UnauthorizedException, TimeoutException
+from withings_api.common import TimeoutException, UnauthorizedException
 
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.components.withings.common import (
     NotAuthenticatedError,
     WithingsDataManager,
 )
+from homeassistant.exceptions import PlatformNotReady
 
 
 @pytest.fixture(name="withings_api")

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -10,26 +10,26 @@ from withings_api.common import SleepModel, SleepState
 
 import homeassistant.components.http as http
 from homeassistant.components.withings import (
+    CONFIG_SCHEMA,
     async_setup,
     async_setup_entry,
     const,
-    CONFIG_SCHEMA,
 )
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from .common import (
-    assert_state_equals,
-    configure_integration,
-    setup_hass,
     WITHINGS_GET_DEVICE_RESPONSE,
     WITHINGS_GET_DEVICE_RESPONSE_EMPTY,
+    WITHINGS_MEASURES_RESPONSE,
+    WITHINGS_MEASURES_RESPONSE_EMPTY,
     WITHINGS_SLEEP_RESPONSE,
     WITHINGS_SLEEP_RESPONSE_EMPTY,
     WITHINGS_SLEEP_SUMMARY_RESPONSE,
     WITHINGS_SLEEP_SUMMARY_RESPONSE_EMPTY,
-    WITHINGS_MEASURES_RESPONSE,
-    WITHINGS_MEASURES_RESPONSE_EMPTY,
+    assert_state_equals,
+    configure_integration,
+    setup_hass,
 )
 
 
@@ -314,7 +314,7 @@ async def test_full_setup(hass: HomeAssistant, aiohttp_client, aioclient_mock) -
                         "startdate": "2019-02-01 01:00:00",
                         "enddate": "2019-02-01 02:00:00",
                         "state": SleepState.AWAKE.real,
-                    }
+                    },
                 ],
             },
         },
@@ -343,7 +343,7 @@ async def test_full_setup(hass: HomeAssistant, aiohttp_client, aioclient_mock) -
                         "startdate": "2019-02-01 00:00:00",
                         "enddate": "2019-02-01 01:00:00",
                         "state": SleepState.REM.real,
-                    }
+                    },
                 ],
             },
         },
@@ -377,7 +377,7 @@ async def test_full_setup(hass: HomeAssistant, aiohttp_client, aioclient_mock) -
                         "startdate": "2019-02-01 01:00:00",
                         "enddate": "2019-02-01 02:00:00",
                         "state": SleepState.AWAKE.real,
-                    }
+                    },
                 ],
             },
         },

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -308,6 +308,11 @@ async def test_full_setup(hass: HomeAssistant, aiohttp_client, aioclient_mock) -
                     {
                         "startdate": "2019-02-01 00:00:00",
                         "enddate": "2019-02-01 01:00:00",
+                        "state": SleepState.REM.real,
+                    },
+                    {
+                        "startdate": "2019-02-01 01:00:00",
+                        "enddate": "2019-02-01 02:00:00",
                         "state": SleepState.AWAKE.real,
                     }
                 ],
@@ -330,9 +335,14 @@ async def test_full_setup(hass: HomeAssistant, aiohttp_client, aioclient_mock) -
                 "model": SleepModel.TRACKER.real,
                 "series": [
                     {
+                        "startdate": "2019-02-01 01:00:00",
+                        "enddate": "2019-02-01 02:00:00",
+                        "state": SleepState.LIGHT.real,
+                    },
+                    {
                         "startdate": "2019-02-01 00:00:00",
                         "enddate": "2019-02-01 01:00:00",
-                        "state": SleepState.LIGHT.real,
+                        "state": SleepState.REM.real,
                     }
                 ],
             },
@@ -356,7 +366,17 @@ async def test_full_setup(hass: HomeAssistant, aiohttp_client, aioclient_mock) -
                     {
                         "startdate": "2019-02-01 00:00:00",
                         "enddate": "2019-02-01 01:00:00",
+                        "state": SleepState.LIGHT.real,
+                    },
+                    {
+                        "startdate": "2019-02-01 02:00:00",
+                        "enddate": "2019-02-01 03:00:00",
                         "state": SleepState.REM.real,
+                    },
+                    {
+                        "startdate": "2019-02-01 01:00:00",
+                        "enddate": "2019-02-01 02:00:00",
+                        "state": SleepState.AWAKE.real,
                     }
                 ],
             },


### PR DESCRIPTION
## Breaking Change:

No breaking changes.

## Description:
Uses latest sleep state as the withings api appears to no always return a predictable order.

**Related issue (if applicable):** fixes #29397 fixes #28370

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** 
N/A


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
