### PR TITLE
Sort imports according to PEP8 for starline

### DIFF
--- a/homeassistant/components/starline/__init__.py
+++ b/homeassistant/components/starline/__init__.py
@@ -1,17 +1,18 @@
 """The StarLine component."""
 import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .account import StarlineAccount
 from .const import (
-    DOMAIN,
-    PLATFORMS,
-    SERVICE_UPDATE_STATE,
-    SERVICE_SET_SCAN_INTERVAL,
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    PLATFORMS,
+    SERVICE_SET_SCAN_INTERVAL,
+    SERVICE_UPDATE_STATE,
 )
 
 

--- a/homeassistant/components/starline/account.py
+++ b/homeassistant/components/starline/account.py
@@ -1,6 +1,7 @@
 """StarLine Account."""
-from datetime import timedelta, datetime
-from typing import Callable, Optional, Dict, Any
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, Optional
+
 from starline import StarlineApi, StarlineDevice
 
 from homeassistant.config_entries import ConfigEntry
@@ -8,13 +9,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
+    DATA_EXPIRES,
+    DATA_SLID_TOKEN,
+    DATA_SLNET_TOKEN,
+    DATA_USER_ID,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
-    DEFAULT_SCAN_INTERVAL,
-    DATA_USER_ID,
-    DATA_SLNET_TOKEN,
-    DATA_SLID_TOKEN,
-    DATA_EXPIRES,
 )
 
 

--- a/homeassistant/components/starline/binary_sensor.py
+++ b/homeassistant/components/starline/binary_sensor.py
@@ -1,11 +1,12 @@
 """Reads vehicle status from StarLine API."""
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice,
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_LOCK,
-    DEVICE_CLASS_PROBLEM,
     DEVICE_CLASS_POWER,
+    DEVICE_CLASS_PROBLEM,
+    BinarySensorDevice,
 )
+
 from .account import StarlineAccount, StarlineDevice
 from .const import DOMAIN
 from .entity import StarlineEntity

--- a/homeassistant/components/starline/config_flow.py
+++ b/homeassistant/components/starline/config_flow.py
@@ -1,25 +1,26 @@
 """Config flow to configure StarLine component."""
 from typing import Optional
+
 from starline import StarlineAuth
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from .const import (  # pylint: disable=unused-import
-    DOMAIN,
     CONF_APP_ID,
     CONF_APP_SECRET,
-    CONF_MFA_CODE,
     CONF_CAPTCHA_CODE,
-    LOGGER,
-    ERROR_AUTH_APP,
-    ERROR_AUTH_USER,
-    ERROR_AUTH_MFA,
-    DATA_USER_ID,
-    DATA_SLNET_TOKEN,
-    DATA_SLID_TOKEN,
+    CONF_MFA_CODE,
     DATA_EXPIRES,
+    DATA_SLID_TOKEN,
+    DATA_SLNET_TOKEN,
+    DATA_USER_ID,
+    DOMAIN,
+    ERROR_AUTH_APP,
+    ERROR_AUTH_MFA,
+    ERROR_AUTH_USER,
+    LOGGER,
 )
 
 

--- a/homeassistant/components/starline/device_tracker.py
+++ b/homeassistant/components/starline/device_tracker.py
@@ -2,6 +2,7 @@
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_GPS
 from homeassistant.helpers.restore_state import RestoreEntity
+
 from .account import StarlineAccount, StarlineDevice
 from .const import DOMAIN
 from .entity import StarlineEntity

--- a/homeassistant/components/starline/entity.py
+++ b/homeassistant/components/starline/entity.py
@@ -1,6 +1,8 @@
 """StarLine base entity."""
 from typing import Callable, Optional
+
 from homeassistant.helpers.entity import Entity
+
 from .account import StarlineAccount, StarlineDevice
 
 

--- a/homeassistant/components/starline/lock.py
+++ b/homeassistant/components/starline/lock.py
@@ -1,5 +1,6 @@
 """Support for StarLine lock."""
 from homeassistant.components.lock import LockDevice
+
 from .account import StarlineAccount, StarlineDevice
 from .const import DOMAIN
 from .entity import StarlineEntity

--- a/homeassistant/components/starline/sensor.py
+++ b/homeassistant/components/starline/sensor.py
@@ -2,6 +2,7 @@
 from homeassistant.components.sensor import DEVICE_CLASS_TEMPERATURE
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level, icon_for_signal_level
+
 from .account import StarlineAccount, StarlineDevice
 from .const import DOMAIN
 from .entity import StarlineEntity

--- a/homeassistant/components/starline/switch.py
+++ b/homeassistant/components/starline/switch.py
@@ -1,5 +1,6 @@
 """Support for StarLine switch."""
 from homeassistant.components.switch import SwitchDevice
+
 from .account import StarlineAccount, StarlineDevice
 from .const import DOMAIN
 from .entity import StarlineEntity

--- a/tests/components/starline/test_config_flow.py
+++ b/tests/components/starline/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for StarLine config flow."""
 import requests_mock
+
 from homeassistant.components.starline import config_flow
 
 TEST_APP_ID = "666"


### PR DESCRIPTION

## Description:

I have sorted the imports for the `starline` component according to PEP8 using isort.

This affects:

- `homeassistant/components/starline/__init__.py` 
- `homeassistant/components/starline/account.py` 
- `homeassistant/components/starline/binary_sensor.py` 
- `homeassistant/components/starline/config_flow.py` 
- `homeassistant/components/starline/device_tracker.py` 
- `homeassistant/components/starline/entity.py` 
- `homeassistant/components/starline/lock.py` 
- `homeassistant/components/starline/sensor.py` 
- `homeassistant/components/starline/switch.py` 
- `tests/components/starline/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
