### PR TITLE
Sort imports according to PEP8 for switch

### DIFF
--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -4,21 +4,20 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.loader import bind_hass
-from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components import group
+from homeassistant.const import (
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-from homeassistant.const import (
-    STATE_ON,
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
-    SERVICE_TOGGLE,
-)
-from homeassistant.components import group
-
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.loader import bind_hass
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/switch/device_action.py
+++ b/homeassistant/components/switch/device_action.py
@@ -1,13 +1,14 @@
 """Provides device actions for switches."""
 from typing import List
+
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, Context
 from homeassistant.components.device_automation import toggle_entity
 from homeassistant.const import CONF_DOMAIN
-from homeassistant.helpers.typing import TemplateVarsType, ConfigType
-from . import DOMAIN
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
+from . import DOMAIN
 
 ACTION_SCHEMA = toggle_entity.ACTION_SCHEMA.extend({vol.Required(CONF_DOMAIN): DOMAIN})
 

--- a/homeassistant/components/switch/device_condition.py
+++ b/homeassistant/components/switch/device_condition.py
@@ -1,14 +1,15 @@
 """Provides device conditions for switches."""
 from typing import Dict, List
+
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant
 from homeassistant.components.device_automation import toggle_entity
 from homeassistant.const import CONF_DOMAIN
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.condition import ConditionCheckerType
-from . import DOMAIN
+from homeassistant.helpers.typing import ConfigType
 
+from . import DOMAIN
 
 CONDITION_SCHEMA = toggle_entity.CONDITION_SCHEMA.extend(
     {vol.Required(CONF_DOMAIN): DOMAIN}

--- a/homeassistant/components/switch/device_trigger.py
+++ b/homeassistant/components/switch/device_trigger.py
@@ -1,14 +1,15 @@
 """Provides device triggers for switches."""
 from typing import List
+
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE
 from homeassistant.components.automation import AutomationActionType
 from homeassistant.components.device_automation import toggle_entity
 from homeassistant.const import CONF_DOMAIN
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
-from . import DOMAIN
 
+from . import DOMAIN
 
 TRIGGER_SCHEMA = toggle_entity.TRIGGER_SCHEMA.extend(
     {vol.Required(CONF_DOMAIN): DOMAIN}

--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -1,10 +1,11 @@
 """Light support for switch entities."""
 import logging
-from typing import cast, Callable, Dict, Optional, Sequence
+from typing import Callable, Dict, Optional, Sequence, cast
 
 import voluptuous as vol
 
 from homeassistant.components import switch
+from homeassistant.components.light import PLATFORM_SCHEMA, Light
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
@@ -17,9 +18,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-
-from homeassistant.components.light import PLATFORM_SCHEMA, Light
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/switch/reproduce_state.py
+++ b/homeassistant/components/switch/reproduce_state.py
@@ -5,10 +5,10 @@ from typing import Iterable, Optional
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    STATE_ON,
-    STATE_OFF,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType

--- a/tests/components/switch/common.py
+++ b/tests/components/switch/common.py
@@ -6,9 +6,9 @@ components. Instead call the service directly.
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ENTITY_MATCH_ALL,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    ENTITY_MATCH_ALL,
 )
 from homeassistant.loader import bind_hass
 

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -1,14 +1,14 @@
 """The test for switch device automation."""
 import pytest
 
-from homeassistant.components.switch import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import (
     _async_get_device_automations as async_get_device_automations,
 )
+from homeassistant.components.switch import DOMAIN
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -1,22 +1,23 @@
 """The test for switch device automation."""
 from datetime import timedelta
-import pytest
 from unittest.mock import patch
 
-from homeassistant.components.switch import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
-from homeassistant.setup import async_setup_component
+import pytest
+
 import homeassistant.components.automation as automation
+from homeassistant.components.switch import DOMAIN
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
-    async_get_device_automation_capabilities,
 )
 
 

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -1,22 +1,23 @@
 """The test for switch device automation."""
 from datetime import timedelta
+
 import pytest
 
-from homeassistant.components.switch import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
+from homeassistant.components.switch import DOMAIN
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
-    async_get_device_automation_capabilities,
 )
 
 

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -2,10 +2,10 @@
 # pylint: disable=protected-access
 import unittest
 
-from homeassistant.setup import setup_component, async_setup_component
 from homeassistant import core
 from homeassistant.components import switch
-from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
+from homeassistant.setup import async_setup_component, setup_component
 
 from tests.common import get_test_home_assistant, mock_entity_platform
 from tests.components.switch import common

--- a/tests/components/switch/test_light.py
+++ b/tests/components/switch/test_light.py
@@ -1,6 +1,7 @@
 """The tests for the Light Switch platform."""
 
 from homeassistant.setup import async_setup_component
+
 from tests.components.light import common
 from tests.components.switch import common as switch_common
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `switch` component according to PEP8 using isort.

This affects:

- `homeassistant/components/switch/__init__.py` 
- `homeassistant/components/switch/device_action.py` 
- `homeassistant/components/switch/device_condition.py` 
- `homeassistant/components/switch/device_trigger.py` 
- `homeassistant/components/switch/light.py` 
- `homeassistant/components/switch/reproduce_state.py` 
- `tests/components/switch/common.py` 
- `tests/components/switch/test_device_action.py` 
- `tests/components/switch/test_device_condition.py` 
- `tests/components/switch/test_device_trigger.py` 
- `tests/components/switch/test_init.py` 
- `tests/components/switch/test_light.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
