### PR TITLE
Sort imports according to PEP8 for template

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -1,10 +1,9 @@
 """The template component."""
 
+from itertools import chain
 import logging
 
-from itertools import chain
 from homeassistant.const import MATCH_ALL
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -3,28 +3,29 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice,
+    DEVICE_CLASSES_SCHEMA,
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
-    DEVICE_CLASSES_SCHEMA,
+    BinarySensorDevice,
 )
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME,
     ATTR_ENTITY_ID,
-    CONF_VALUE_TEMPLATE,
-    CONF_ICON_TEMPLATE,
-    CONF_ENTITY_PICTURE_TEMPLATE,
-    CONF_SENSORS,
+    ATTR_FRIENDLY_NAME,
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_PICTURE_TEMPLATE,
+    CONF_ICON_TEMPLATE,
+    CONF_SENSORS,
+    CONF_VALUE_TEMPLATE,
     EVENT_HOMEASSISTANT_START,
     MATCH_ALL,
 )
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.event import async_track_state_change, async_track_same_state
+from homeassistant.helpers.event import async_track_same_state, async_track_state_change
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -3,40 +3,41 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.cover import (
-    ENTITY_ID_FORMAT,
-    CoverDevice,
-    PLATFORM_SCHEMA,
-    DEVICE_CLASSES_SCHEMA,
-    SUPPORT_OPEN_TILT,
-    SUPPORT_CLOSE_TILT,
-    SUPPORT_STOP_TILT,
-    SUPPORT_SET_TILT_POSITION,
-    SUPPORT_OPEN,
-    SUPPORT_CLOSE,
-    SUPPORT_STOP,
-    SUPPORT_SET_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    DEVICE_CLASSES_SCHEMA,
+    ENTITY_ID_FORMAT,
+    PLATFORM_SCHEMA,
+    SUPPORT_CLOSE,
+    SUPPORT_CLOSE_TILT,
+    SUPPORT_OPEN,
+    SUPPORT_OPEN_TILT,
+    SUPPORT_SET_POSITION,
+    SUPPORT_SET_TILT_POSITION,
+    SUPPORT_STOP,
+    SUPPORT_STOP_TILT,
+    CoverDevice,
 )
 from homeassistant.const import (
-    CONF_FRIENDLY_NAME,
-    CONF_ENTITY_ID,
-    EVENT_HOMEASSISTANT_START,
-    CONF_VALUE_TEMPLATE,
-    CONF_ICON_TEMPLATE,
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_ID,
     CONF_ENTITY_PICTURE_TEMPLATE,
+    CONF_FRIENDLY_NAME,
+    CONF_ICON_TEMPLATE,
     CONF_OPTIMISTIC,
-    STATE_OPEN,
+    CONF_VALUE_TEMPLATE,
+    EVENT_HOMEASSISTANT_START,
     STATE_CLOSED,
+    STATE_OPEN,
 )
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import Script
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -3,35 +3,36 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.fan import (
-    SPEED_LOW,
-    SPEED_MEDIUM,
-    SPEED_HIGH,
-    SUPPORT_SET_SPEED,
-    SUPPORT_OSCILLATE,
-    FanEntity,
-    ATTR_SPEED,
+    ATTR_DIRECTION,
     ATTR_OSCILLATING,
-    ENTITY_ID_FORMAT,
-    SUPPORT_DIRECTION,
+    ATTR_SPEED,
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
-    ATTR_DIRECTION,
+    ENTITY_ID_FORMAT,
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SUPPORT_DIRECTION,
+    SUPPORT_OSCILLATE,
+    SUPPORT_SET_SPEED,
+    FanEntity,
 )
 from homeassistant.const import (
+    CONF_ENTITY_ID,
     CONF_FRIENDLY_NAME,
     CONF_VALUE_TEMPLATE,
-    CONF_ENTITY_ID,
-    STATE_ON,
-    STATE_OFF,
     EVENT_HOMEASSISTANT_START,
+    STATE_OFF,
+    STATE_ON,
     STATE_UNKNOWN,
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.script import Script
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -3,30 +3,31 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ENTITY_ID_FORMAT,
-    Light,
     SUPPORT_BRIGHTNESS,
+    Light,
 )
 from homeassistant.const import (
-    CONF_VALUE_TEMPLATE,
-    CONF_ICON_TEMPLATE,
-    CONF_ENTITY_PICTURE_TEMPLATE,
     CONF_ENTITY_ID,
+    CONF_ENTITY_PICTURE_TEMPLATE,
     CONF_FRIENDLY_NAME,
-    STATE_ON,
-    STATE_OFF,
-    EVENT_HOMEASSISTANT_START,
+    CONF_ICON_TEMPLATE,
     CONF_LIGHTS,
+    CONF_VALUE_TEMPLATE,
+    EVENT_HOMEASSISTANT_START,
+    STATE_OFF,
+    STATE_ON,
 )
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import Script
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -3,22 +3,22 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-
-from homeassistant.core import callback
-from homeassistant.components.lock import LockDevice, PLATFORM_SCHEMA
+from homeassistant.components.lock import PLATFORM_SCHEMA, LockDevice
 from homeassistant.const import (
     CONF_NAME,
     CONF_OPTIMISTIC,
     CONF_VALUE_TEMPLATE,
     EVENT_HOMEASSISTANT_START,
-    STATE_ON,
-    STATE_LOCKED,
     MATCH_ALL,
+    STATE_LOCKED,
+    STATE_ON,
 )
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import Script
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -4,30 +4,30 @@ from typing import Optional
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.sensor import (
+    DEVICE_CLASSES_SCHEMA,
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
-    DEVICE_CLASSES_SCHEMA,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
-    CONF_VALUE_TEMPLATE,
-    CONF_ICON_TEMPLATE,
-    CONF_ENTITY_PICTURE_TEMPLATE,
-    ATTR_ENTITY_ID,
-    CONF_SENSORS,
-    EVENT_HOMEASSISTANT_START,
-    CONF_FRIENDLY_NAME_TEMPLATE,
-    MATCH_ALL,
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_PICTURE_TEMPLATE,
+    CONF_FRIENDLY_NAME_TEMPLATE,
+    CONF_ICON_TEMPLATE,
+    CONF_SENSORS,
+    CONF_VALUE_TEMPLATE,
+    EVENT_HOMEASSISTANT_START,
+    MATCH_ALL,
 )
-
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -3,28 +3,29 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT,
-    SwitchDevice,
     PLATFORM_SCHEMA,
+    SwitchDevice,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
-    CONF_VALUE_TEMPLATE,
-    CONF_ICON_TEMPLATE,
     CONF_ENTITY_PICTURE_TEMPLATE,
+    CONF_ICON_TEMPLATE,
+    CONF_SWITCHES,
+    CONF_VALUE_TEMPLATE,
+    EVENT_HOMEASSISTANT_START,
     STATE_OFF,
     STATE_ON,
-    ATTR_ENTITY_ID,
-    CONF_SWITCHES,
-    EVENT_HOMEASSISTANT_START,
 )
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import Script
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -3,7 +3,6 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.vacuum import (
     ATTR_FAN_SPEED,
     DOMAIN,
@@ -14,35 +13,37 @@ from homeassistant.components.vacuum import (
     SERVICE_SET_FAN_SPEED,
     SERVICE_START,
     SERVICE_STOP,
+    STATE_CLEANING,
+    STATE_DOCKED,
+    STATE_ERROR,
+    STATE_IDLE,
+    STATE_PAUSED,
+    STATE_RETURNING,
     SUPPORT_BATTERY,
     SUPPORT_CLEAN_SPOT,
     SUPPORT_FAN_SPEED,
     SUPPORT_LOCATE,
     SUPPORT_PAUSE,
     SUPPORT_RETURN_HOME,
-    SUPPORT_STOP,
-    SUPPORT_STATE,
     SUPPORT_START,
+    SUPPORT_STATE,
+    SUPPORT_STOP,
     StateVacuumDevice,
-    STATE_CLEANING,
-    STATE_DOCKED,
-    STATE_PAUSED,
-    STATE_IDLE,
-    STATE_RETURNING,
-    STATE_ERROR,
 )
 from homeassistant.const import (
+    CONF_ENTITY_ID,
     CONF_FRIENDLY_NAME,
     CONF_VALUE_TEMPLATE,
-    CONF_ENTITY_ID,
-    MATCH_ALL,
     EVENT_HOMEASSISTANT_START,
+    MATCH_ALL,
     STATE_UNKNOWN,
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.script import Script
+
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -3,24 +3,24 @@ from datetime import timedelta
 import unittest
 from unittest import mock
 
-from homeassistant.const import (
-    MATCH_ALL,
-    EVENT_HOMEASSISTANT_START,
-    STATE_UNAVAILABLE,
-    STATE_ON,
-    STATE_OFF,
-)
 from homeassistant import setup
 from homeassistant.components.template import binary_sensor as template
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START,
+    MATCH_ALL,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template as template_hlpr
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
     async_fire_time_changed,
+    get_test_home_assistant,
 )
 
 

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -1,5 +1,6 @@
 """The tests the cover command line platform."""
 import logging
+
 import pytest
 
 from homeassistant import setup
@@ -8,18 +9,18 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
-    SERVICE_TOGGLE,
-    SERVICE_TOGGLE_COVER_TILT,
     SERVICE_OPEN_COVER,
     SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
+    SERVICE_TOGGLE,
+    SERVICE_TOGGLE_COVER_TILT,
     STATE_CLOSED,
-    STATE_UNAVAILABLE,
-    STATE_OPEN,
-    STATE_ON,
     STATE_OFF,
+    STATE_ON,
+    STATE_OPEN,
+    STATE_UNAVAILABLE,
 )
 
 from tests.common import assert_setup_component, async_mock_service

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -1,23 +1,23 @@
 """The tests for the Template fan platform."""
 import logging
-import pytest
 
+import pytest
 import voluptuous as vol
 
 from homeassistant import setup
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.components.fan import (
-    ATTR_SPEED,
-    ATTR_OSCILLATING,
-    SPEED_LOW,
-    SPEED_MEDIUM,
-    SPEED_HIGH,
     ATTR_DIRECTION,
+    ATTR_OSCILLATING,
+    ATTR_SPEED,
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MEDIUM,
 )
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
-from tests.common import async_mock_service, assert_setup_component
+from tests.common import assert_setup_component, async_mock_service
 from tests.components.fan import common
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1,12 +1,12 @@
 """The tests for the  Template light platform."""
 import logging
 
-from homeassistant.core import callback
 from homeassistant import setup
 from homeassistant.components.light import ATTR_BRIGHTNESS
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import callback
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import assert_setup_component, get_test_home_assistant
 from tests.components.light import common
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -1,13 +1,12 @@
 """The tests for the Template lock platform."""
 import logging
 
-from homeassistant.core import callback
 from homeassistant import setup
 from homeassistant.components import lock
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import callback
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import assert_setup_component, get_test_home_assistant
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1,9 +1,13 @@
 """The test for the Template sensor platform."""
-from homeassistant.const import EVENT_HOMEASSISTANT_START
-from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.setup import async_setup_component, setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component
-from homeassistant.const import STATE_UNAVAILABLE, STATE_ON, STATE_OFF
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 class TestTemplateSensor:

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -1,9 +1,9 @@
 """The tests for the  Template switch platform."""
-from homeassistant.core import callback
 from homeassistant import setup
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import callback
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import assert_setup_component, get_test_home_assistant
 from tests.components.switch import common
 
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -1,9 +1,9 @@
 """The tests for the Template vacuum platform."""
 import logging
+
 import pytest
 
 from homeassistant import setup
-from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN, STATE_UNAVAILABLE
 from homeassistant.components.vacuum import (
     ATTR_BATTERY_LEVEL,
     STATE_CLEANING,
@@ -12,8 +12,9 @@ from homeassistant.components.vacuum import (
     STATE_PAUSED,
     STATE_RETURNING,
 )
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 
-from tests.common import async_mock_service, assert_setup_component
+from tests.common import assert_setup_component, async_mock_service
 from tests.components.vacuum import common
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION

## Description:

I have sorted the imports for the `template` component according to PEP8 using isort.

This affects:

- `homeassistant/components/template/__init__.py` 
- `homeassistant/components/template/binary_sensor.py` 
- `homeassistant/components/template/cover.py` 
- `homeassistant/components/template/fan.py` 
- `homeassistant/components/template/light.py` 
- `homeassistant/components/template/lock.py` 
- `homeassistant/components/template/sensor.py` 
- `homeassistant/components/template/switch.py` 
- `homeassistant/components/template/vacuum.py` 
- `tests/components/template/test_binary_sensor.py` 
- `tests/components/template/test_cover.py` 
- `tests/components/template/test_fan.py` 
- `tests/components/template/test_light.py` 
- `tests/components/template/test_lock.py` 
- `tests/components/template/test_sensor.py` 
- `tests/components/template/test_switch.py` 
- `tests/components/template/test_vacuum.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
