### PR TITLE
Sort imports according to PEP8 for unifi

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -3,9 +3,8 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
-
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from .config_flow import get_controller_id_from_config_entry
 from .const import (

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -2,7 +2,6 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import callback
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -10,6 +9,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.core import callback
 
 from .const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
@@ -21,10 +21,10 @@ from .const import (
     CONF_TRACK_WIRED_CLIENTS,
     CONTROLLER_ID,
     DEFAULT_ALLOW_BANDWIDTH_SENSORS,
+    DEFAULT_DETECTION_TIME,
     DEFAULT_TRACK_CLIENTS,
     DEFAULT_TRACK_DEVICES,
     DEFAULT_TRACK_WIRED_CLIENTS,
-    DEFAULT_DETECTION_TIME,
     DOMAIN,
     LOGGER,
 )

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -1,16 +1,14 @@
 """UniFi Controller abstraction."""
-from datetime import timedelta
-
 import asyncio
+from datetime import timedelta
 import ssl
-import async_timeout
 
 from aiohttp import CookieJar
-
 import aiounifi
+import async_timeout
 
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_HOST
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -22,19 +20,19 @@ from .const import (
     CONF_DONT_TRACK_CLIENTS,
     CONF_DONT_TRACK_DEVICES,
     CONF_DONT_TRACK_WIRED_CLIENTS,
+    CONF_SITE_ID,
+    CONF_SSID_FILTER,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
     CONF_TRACK_WIRED_CLIENTS,
-    CONF_SITE_ID,
-    CONF_SSID_FILTER,
     CONTROLLER_ID,
     DEFAULT_ALLOW_BANDWIDTH_SENSORS,
     DEFAULT_BLOCK_CLIENTS,
+    DEFAULT_DETECTION_TIME,
+    DEFAULT_SSID_FILTER,
     DEFAULT_TRACK_CLIENTS,
     DEFAULT_TRACK_DEVICES,
     DEFAULT_TRACK_WIRED_CLIENTS,
-    DEFAULT_DETECTION_TIME,
-    DEFAULT_SSID_FILTER,
     DOMAIN,
     LOGGER,
     UNIFI_CONFIG,

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -1,16 +1,15 @@
 """Track devices using UniFi controllers."""
 import logging
 
-from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
+from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_registry import DISABLED_CONFIG_ENTRY
-
 import homeassistant.util.dt as dt_util
 
 from .const import ATTR_MANUFACTURER

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -1,8 +1,8 @@
 """Support for devices connected to UniFi POE."""
 import logging
 
-from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -1,10 +1,10 @@
 """Test UniFi config flow."""
+import aiounifi
 from asynctest import patch
 
 from homeassistant.components import unifi
 from homeassistant.components.unifi import config_flow
 from homeassistant.components.unifi.const import CONF_CONTROLLER, CONF_SITE_ID
-
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -14,8 +14,6 @@ from homeassistant.const import (
 )
 
 from tests.common import MockConfigEntry
-
-import aiounifi
 
 
 async def test_flow_works(hass, aioclient_mock):

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -2,12 +2,11 @@
 from collections import deque
 from datetime import timedelta
 
+import aiounifi
 from asynctest import Mock, patch
-
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components import unifi
 from homeassistant.components.unifi.const import (
     CONF_CONTROLLER,
@@ -22,7 +21,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-import aiounifi
+from homeassistant.exceptions import ConfigEntryNotReady
 
 CONTROLLER_HOST = {
     "hostname": "controller_host",

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from homeassistant import config_entries
 from homeassistant.components import unifi
+import homeassistant.components.device_tracker as device_tracker
 from homeassistant.components.unifi.const import (
     CONF_SSID_FILTER,
     CONF_TRACK_DEVICES,
@@ -12,8 +13,6 @@ from homeassistant.components.unifi.const import (
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
-
-import homeassistant.components.device_tracker as device_tracker
 import homeassistant.util.dt as dt_util
 
 from .test_controller import ENTRY_CONFIG, SITES, setup_unifi_integration

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -2,11 +2,9 @@
 from unittest.mock import Mock, patch
 
 from homeassistant.components import unifi
-
 from homeassistant.setup import async_setup_component
 
-
-from tests.common import mock_coro, MockConfigEntry
+from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_setup_with_no_config(hass):

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -2,9 +2,8 @@
 from copy import deepcopy
 
 from homeassistant.components import unifi
-from homeassistant.setup import async_setup_component
-
 import homeassistant.components.sensor as sensor
+from homeassistant.setup import async_setup_component
 
 from .test_controller import ENTRY_CONFIG, SITES, setup_unifi_integration
 

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -3,10 +3,9 @@ from copy import deepcopy
 
 from homeassistant import config_entries
 from homeassistant.components import unifi
+import homeassistant.components.switch as switch
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
-
-import homeassistant.components.switch as switch
 
 from .test_controller import (
     CONTROLLER_HOST,


### PR DESCRIPTION

## Description:

I have sorted the imports for the `unifi` component according to PEP8 using isort.

This affects:

- `homeassistant/components/unifi/__init__.py` 
- `homeassistant/components/unifi/config_flow.py` 
- `homeassistant/components/unifi/controller.py` 
- `homeassistant/components/unifi/device_tracker.py` 
- `homeassistant/components/unifi/switch.py` 
- `tests/components/unifi/test_config_flow.py` 
- `tests/components/unifi/test_controller.py` 
- `tests/components/unifi/test_device_tracker.py` 
- `tests/components/unifi/test_init.py` 
- `tests/components/unifi/test_sensor.py` 
- `tests/components/unifi/test_switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
