### PR TITLE
Sort imports according to PEP8 for deconz

### DIFF
--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -2,11 +2,10 @@
 from copy import deepcopy
 
 from homeassistant.components import deconz
+import homeassistant.components.binary_sensor as binary_sensor
 from homeassistant.setup import async_setup_component
 
-import homeassistant.components.binary_sensor as binary_sensor
-
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 SENSORS = {
     "1": {

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -4,11 +4,10 @@ from copy import deepcopy
 from asynctest import patch
 
 from homeassistant.components import deconz
+import homeassistant.components.climate as climate
 from homeassistant.setup import async_setup_component
 
-import homeassistant.components.climate as climate
-
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 SENSORS = {
     "1": {

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -1,13 +1,13 @@
 """Tests for deCONZ config flow."""
+import asyncio
 from unittest.mock import Mock, patch
 
-import asyncio
+import pydeconz
 
 from homeassistant.components.deconz import config_flow
 from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
-from tests.common import MockConfigEntry
 
-import pydeconz
+from tests.common import MockConfigEntry
 
 
 async def test_flow_works(hass, aioclient_mock):

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -4,11 +4,10 @@ from copy import deepcopy
 from asynctest import patch
 
 from homeassistant.components import deconz
+import homeassistant.components.cover as cover
 from homeassistant.setup import async_setup_component
 
-import homeassistant.components.cover as cover
-
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 COVERS = {
     "1": {

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -5,7 +5,7 @@ from asynctest import Mock
 
 from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
 
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 SENSORS = {
     "1": {

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -3,9 +3,9 @@ from copy import deepcopy
 
 from homeassistant.components.deconz import device_trigger
 
-from tests.common import assert_lists_same, async_get_device_automations
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from tests.common import assert_lists_same, async_get_device_automations
 
 SENSORS = {
     "1": {

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -2,16 +2,13 @@
 from copy import deepcopy
 
 from asynctest import Mock, patch
-
+import pydeconz
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import deconz
-from homeassistant.components import ssdp
+from homeassistant.components import deconz, ssdp
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-
-import pydeconz
 
 BRIDGEID = "0123456789"
 

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -2,11 +2,10 @@
 import asyncio
 
 from asynctest import Mock, patch
-
 import pytest
 
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components import deconz
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -4,11 +4,10 @@ from copy import deepcopy
 from asynctest import patch
 
 from homeassistant.components import deconz
+import homeassistant.components.light as light
 from homeassistant.setup import async_setup_component
 
-import homeassistant.components.light as light
-
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 GROUPS = {
     "1": {

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -4,11 +4,10 @@ from copy import deepcopy
 from asynctest import patch
 
 from homeassistant.components import deconz
+import homeassistant.components.scene as scene
 from homeassistant.setup import async_setup_component
 
-import homeassistant.components.scene as scene
-
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 GROUPS = {
     "1": {

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -2,11 +2,10 @@
 from copy import deepcopy
 
 from homeassistant.components import deconz
+import homeassistant.components.sensor as sensor
 from homeassistant.setup import async_setup_component
 
-import homeassistant.components.sensor as sensor
-
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 SENSORS = {
     "1": {

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -2,7 +2,6 @@
 from copy import deepcopy
 
 from asynctest import Mock, patch
-
 import pytest
 import voluptuous as vol
 
@@ -10,8 +9,8 @@ from homeassistant.components import deconz
 
 from .test_gateway import (
     BRIDGEID,
-    ENTRY_CONFIG,
     DECONZ_WEB_REQUEST,
+    ENTRY_CONFIG,
     setup_deconz_integration,
 )
 

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -4,11 +4,10 @@ from copy import deepcopy
 from asynctest import patch
 
 from homeassistant.components import deconz
+import homeassistant.components.switch as switch
 from homeassistant.setup import async_setup_component
 
-import homeassistant.components.switch as switch
-
-from .test_gateway import ENTRY_CONFIG, DECONZ_WEB_REQUEST, setup_deconz_integration
+from .test_gateway import DECONZ_WEB_REQUEST, ENTRY_CONFIG, setup_deconz_integration
 
 SWITCHES = {
     "1": {


### PR DESCRIPTION

## Description:

I have sorted the imports for the `deconz` component according to PEP8 using isort.

This affects:

- `tests/components/deconz/test_binary_sensor.py` 
- `tests/components/deconz/test_climate.py` 
- `tests/components/deconz/test_config_flow.py` 
- `tests/components/deconz/test_cover.py` 
- `tests/components/deconz/test_deconz_event.py` 
- `tests/components/deconz/test_device_trigger.py` 
- `tests/components/deconz/test_gateway.py` 
- `tests/components/deconz/test_init.py` 
- `tests/components/deconz/test_light.py` 
- `tests/components/deconz/test_scene.py` 
- `tests/components/deconz/test_sensor.py` 
- `tests/components/deconz/test_services.py` 
- `tests/components/deconz/test_switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
