### PR TITLE
Add frontier_silicon name option

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_NAME,
     STATE_OFF,
     STATE_PAUSED,
     STATE_PLAYING,
@@ -54,12 +55,14 @@ SUPPORT_FRONTIER_SILICON = (
 DEFAULT_PORT = 80
 DEFAULT_PASSWORD = "1234"
 DEVICE_URL = "http://{0}:{1}/device"
+DEFAULT_NAME = "Frontier Silicon"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
 
@@ -68,17 +71,23 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Frontier Silicon platform."""
     if discovery_info is not None:
         async_add_entities(
-            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD)], True
+            [
+                AFSAPIDevice(
+                    discovery_info["ssdp_description"], DEFAULT_PASSWORD, DEFAULT_NAME
+                )
+            ],
+            True,
         )
         return True
 
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     password = config.get(CONF_PASSWORD)
+    name = config.get(CONF_NAME)
 
     try:
         async_add_entities(
-            [AFSAPIDevice(DEVICE_URL.format(host, port), password)], True
+            [AFSAPIDevice(DEVICE_URL.format(host, port), password, name)], True
         )
         _LOGGER.debug("FSAPI device %s:%s -> %s", host, port, password)
         return True
@@ -93,13 +102,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class AFSAPIDevice(MediaPlayerDevice):
     """Representation of a Frontier Silicon device on the network."""
 
-    def __init__(self, device_url, password):
+    def __init__(self, device_url, password, name):
         """Initialize the Frontier Silicon API device."""
         self._device_url = device_url
         self._password = password
         self._state = None
 
-        self._name = None
+        self._name = name
         self._title = None
         self._artist = None
         self._album_name = None


### PR DESCRIPTION
## Description:

I am faceing quite often the issue that my frontier-silicon devices get the names unnamed_device_X Therefore I put a name in the config which can be picked up during initalisation

## Example entry for `configuration.yaml` (if applicable):
```yaml
name: kitchen
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
