### PR TITLE
sort imports according to PEP8 for lock

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -5,26 +5,25 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.loader import bind_hass
-from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.config_validation import (  # noqa: F401
-    make_entity_service_schema,
-    PLATFORM_SCHEMA,
-    PLATFORM_SCHEMA_BASE,
-)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components import group
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_CODE_FORMAT,
+    SERVICE_LOCK,
+    SERVICE_OPEN,
+    SERVICE_UNLOCK,
     STATE_LOCKED,
     STATE_UNLOCKED,
-    SERVICE_LOCK,
-    SERVICE_UNLOCK,
-    SERVICE_OPEN,
 )
-from homeassistant.components import group
-
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import (  # noqa: F401
+    PLATFORM_SCHEMA,
+    PLATFORM_SCHEMA_BASE,
+    make_entity_service_schema,
+)
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.loader import bind_hass
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/lock/device_action.py
+++ b/homeassistant/components/lock/device_action.py
@@ -1,21 +1,23 @@
 """Provides device automations for Lock."""
-from typing import Optional, List
+from typing import List, Optional
+
 import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_TYPE,
     SERVICE_LOCK,
     SERVICE_OPEN,
     SERVICE_UNLOCK,
 )
-from homeassistant.core import HomeAssistant, Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
+
 from . import DOMAIN, SUPPORT_OPEN
 
 ACTION_TYPES = {"lock", "unlock", "open"}

--- a/homeassistant/components/lock/device_condition.py
+++ b/homeassistant/components/lock/device_condition.py
@@ -1,21 +1,23 @@
 """Provides device automations for Lock."""
 from typing import List
+
 import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_CONDITION,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_TYPE,
     STATE_LOCKED,
     STATE_UNLOCKED,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
 from . import DOMAIN
 
 CONDITION_TYPES = {"is_locked", "is_unlocked"}

--- a/homeassistant/components/lock/device_trigger.py
+++ b/homeassistant/components/lock/device_trigger.py
@@ -1,21 +1,23 @@
 """Provides device automations for Lock."""
 from typing import List
+
 import voluptuous as vol
 
+from homeassistant.components.automation import AutomationActionType, state
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
-    CONF_DOMAIN,
-    CONF_TYPE,
-    CONF_PLATFORM,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
     STATE_LOCKED,
     STATE_UNLOCKED,
 )
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.components.automation import state, AutomationActionType
-from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+
 from . import DOMAIN
 
 TRIGGER_TYPES = {"locked", "unlocked"}

--- a/homeassistant/components/lock/reproduce_state.py
+++ b/homeassistant/components/lock/reproduce_state.py
@@ -5,10 +5,10 @@ from typing import Iterable, Optional
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    STATE_LOCKED,
-    STATE_UNLOCKED,
     SERVICE_LOCK,
     SERVICE_UNLOCK,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
 )
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType

--- a/tests/components/lock/common.py
+++ b/tests/components/lock/common.py
@@ -7,10 +7,10 @@ from homeassistant.components.lock import DOMAIN
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
-    SERVICE_LOCK,
-    SERVICE_UNLOCK,
-    SERVICE_OPEN,
     ENTITY_MATCH_ALL,
+    SERVICE_LOCK,
+    SERVICE_OPEN,
+    SERVICE_UNLOCK,
 )
 from homeassistant.loader import bind_hass
 

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -1,19 +1,19 @@
 """The tests for Lock device actions."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.components.lock import DOMAIN
 from homeassistant.const import CONF_PLATFORM
-from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/lock/test_device_condition.py
+++ b/tests/components/lock/test_device_condition.py
@@ -1,19 +1,19 @@
 """The tests for Lock device conditions."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.components.lock import DOMAIN
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
-from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -1,19 +1,19 @@
 """The tests for Lock device triggers."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.components.lock import DOMAIN
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
-from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `lock` component according to PEP8 using isort.

This affects:

- `homeassistant/components/lock/__init__.py` 
- `homeassistant/components/lock/device_action.py` 
- `homeassistant/components/lock/device_condition.py` 
- `homeassistant/components/lock/device_trigger.py` 
- `homeassistant/components/lock/reproduce_state.py` 
- `tests/components/lock/common.py` 
- `tests/components/lock/test_device_action.py` 
- `tests/components/lock/test_device_condition.py` 
- `tests/components/lock/test_device_trigger.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
