### PR TITLE
Sort imports according to PEP8 for huawei_lte

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -3,12 +3,11 @@
 from collections import defaultdict
 from datetime import timedelta
 from functools import partial
-from urllib.parse import urlparse
 import ipaddress
 import logging
 from typing import Any, Callable, Dict, List, Set, Tuple
+from urllib.parse import urlparse
 
-import voluptuous as vol
 import attr
 from getmac import get_mac_address
 from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
@@ -20,13 +19,14 @@ from huawei_lte_api.exceptions import (
 )
 from requests.exceptions import Timeout
 from url_normalize import url_normalize
+import voluptuous as vol
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_RECIPIENT,
@@ -36,8 +36,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, discovery
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    discovery,
+)
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -46,6 +49,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
+
 from .const import (
     ALL_KEYS,
     CONNECTION_TIMEOUT,
@@ -63,7 +67,6 @@ from .const import (
     UPDATE_OPTIONS_SIGNAL,
     UPDATE_SIGNAL,
 )
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huawei_lte/binary_sensor.py
+++ b/homeassistant/components/huawei_lte/binary_sensor.py
@@ -11,9 +11,9 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice,
 )
 from homeassistant.const import CONF_URL
+
 from . import HuaweiLteBaseEntity
 from .const import DOMAIN, KEY_MONITORING_STATUS
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -8,10 +8,10 @@ from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
 from huawei_lte_api.Client import Client
 from huawei_lte_api.Connection import Connection
 from huawei_lte_api.exceptions import (
-    LoginErrorUsernameWrongException,
     LoginErrorPasswordWrongException,
-    LoginErrorUsernamePasswordWrongException,
     LoginErrorUsernamePasswordOverrunException,
+    LoginErrorUsernamePasswordWrongException,
+    LoginErrorUsernameWrongException,
     ResponseErrorException,
 )
 from requests.exceptions import Timeout
@@ -22,11 +22,10 @@ from homeassistant import config_entries
 from homeassistant.components.ssdp import ATTR_HOST, ATTR_NAME, ATTR_PRESENTATIONURL
 from homeassistant.const import CONF_PASSWORD, CONF_RECIPIENT, CONF_URL, CONF_USERNAME
 from homeassistant.core import callback
+
+# see https://github.com/PyCQA/pylint/issues/3202 about the DOMAIN's pylint issue
 from .const import CONNECTION_TIMEOUT, DEFAULT_DEVICE_NAME
-
-# https://github.com/PyCQA/pylint/issues/3202
 from .const import DOMAIN  # pylint: disable=unused-import
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -15,9 +15,9 @@ from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.const import CONF_URL
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
 from . import HuaweiLteBaseEntity
 from .const import DOMAIN, KEY_WLAN_HOST_LIST, UPDATE_SIGNAL
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huawei_lte/notify.py
+++ b/homeassistant/components/huawei_lte/notify.py
@@ -6,12 +6,11 @@ from typing import Any, List
 import attr
 from huawei_lte_api.exceptions import ResponseErrorException
 
-from homeassistant.components.notify import BaseNotificationService, ATTR_TARGET
+from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
 from homeassistant.const import CONF_RECIPIENT, CONF_URL
 
 from . import Router
 from .const import DOMAIN
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -6,11 +6,11 @@ from typing import Optional
 
 import attr
 
-from homeassistant.const import CONF_URL, STATE_UNKNOWN
 from homeassistant.components.sensor import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DOMAIN as SENSOR_DOMAIN,
 )
+from homeassistant.const import CONF_URL, STATE_UNKNOWN
 
 from . import HuaweiLteBaseEntity
 from .const import (
@@ -21,7 +21,6 @@ from .const import (
     UNIT_BYTES,
     UNIT_SECONDS,
 )
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huawei_lte/switch.py
+++ b/homeassistant/components/huawei_lte/switch.py
@@ -11,9 +11,9 @@ from homeassistant.components.switch import (
     SwitchDevice,
 )
 from homeassistant.const import CONF_URL
+
 from . import HuaweiLteBaseEntity
 from .const import DOMAIN, KEY_DIALUP_MOBILE_DATASWITCH
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -2,14 +2,13 @@
 
 from huawei_lte_api.enums.client import ResponseCodeEnum
 from huawei_lte_api.enums.user import LoginErrorEnum, LoginStateEnum, PasswordTypeEnum
-from requests_mock import ANY
-from requests.exceptions import ConnectionError
 import pytest
+from requests.exceptions import ConnectionError
+from requests_mock import ANY
 
 from homeassistant import data_entry_flow
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_URL
-from homeassistant.components.huawei_lte.const import DOMAIN
 from homeassistant.components.huawei_lte.config_flow import ConfigFlowHandler
+from homeassistant.components.huawei_lte.const import DOMAIN
 from homeassistant.components.ssdp import (
     ATTR_HOST,
     ATTR_MANUFACTURER,
@@ -24,9 +23,9 @@ from homeassistant.components.ssdp import (
     ATTR_UDN,
     ATTR_UPNP_DEVICE_TYPE,
 )
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 
 from tests.common import MockConfigEntry
-
 
 FIXTURE_USER_INPUT = {
     CONF_URL: "http://192.168.1.1/",


### PR DESCRIPTION

## Description:

I have sorted the imports for the `huawei_lte` component according to PEP8 using isort.

This affects:

- `homeassistant/components/huawei_lte/__init__.py` 
- `homeassistant/components/huawei_lte/binary_sensor.py` 
- `homeassistant/components/huawei_lte/config_flow.py` 
- `homeassistant/components/huawei_lte/device_tracker.py` 
- `homeassistant/components/huawei_lte/notify.py` 
- `homeassistant/components/huawei_lte/sensor.py` 
- `homeassistant/components/huawei_lte/switch.py` 
- `tests/components/huawei_lte/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
