### PR TITLE
Sort imports according to PEP8 for device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -3,21 +3,19 @@ import asyncio
 
 import voluptuous as vol
 
-from homeassistant.loader import bind_hass
 from homeassistant.components import group
+from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import GPSType, ConfigType, HomeAssistantType
-
 from homeassistant.helpers.event import async_track_utc_time_change
-from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME
+from homeassistant.helpers.typing import ConfigType, GPSType, HomeAssistantType
+from homeassistant.loader import bind_hass
 
 from . import legacy, setup
 from .config_entry import (  # noqa: F401 pylint: disable=unused-import
     async_setup_entry,
     async_unload_entry,
 )
-from .legacy import DeviceScanner  # noqa: F401 pylint: disable=unused-import
 from .const import (
     ATTR_ATTRIBUTES,
     ATTR_BATTERY,
@@ -38,11 +36,12 @@ from .const import (
     DEFAULT_TRACK_NEW,
     DOMAIN,
     PLATFORM_TYPE_LEGACY,
-    SOURCE_TYPE_BLUETOOTH_LE,
     SOURCE_TYPE_BLUETOOTH,
+    SOURCE_TYPE_BLUETOOTH_LE,
     SOURCE_TYPE_GPS,
     SOURCE_TYPE_ROUTER,
 )
+from .legacy import DeviceScanner  # noqa: F401 pylint: disable=unused-import
 
 ENTITY_ID_ALL_DEVICES = group.ENTITY_ID_FORMAT.format("all_devices")
 

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -3,12 +3,12 @@ from typing import Optional
 
 from homeassistant.components import zone
 from homeassistant.const import (
-    STATE_NOT_HOME,
-    STATE_HOME,
+    ATTR_BATTERY_LEVEL,
     ATTR_GPS_ACCURACY,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_BATTERY_LEVEL,
+    STATE_HOME,
+    STATE_NOT_HOME,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent

--- a/homeassistant/components/device_tracker/device_condition.py
+++ b/homeassistant/components/device_tracker/device_condition.py
@@ -1,21 +1,23 @@
 """Provides device automations for Device tracker."""
 from typing import Dict, List
+
 import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_CONDITION,
-    CONF_DOMAIN,
-    CONF_TYPE,
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
     CONF_ENTITY_ID,
-    STATE_NOT_HOME,
+    CONF_TYPE,
     STATE_HOME,
+    STATE_NOT_HOME,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
 from . import DOMAIN
 
 CONDITION_TYPES = {"is_home", "is_not_home"}

--- a/homeassistant/components/device_tracker/setup.py
+++ b/homeassistant/components/device_tracker/setup.py
@@ -1,27 +1,26 @@
 """Device tracker helpers."""
 import asyncio
-from typing import Dict, Any, Callable, Optional
 from types import ModuleType
+from typing import Any, Callable, Dict, Optional
 
 import attr
 
-from homeassistant.core import callback
-from homeassistant.setup import async_prepare_setup_platform
-from homeassistant.helpers import config_per_platform
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util import dt as dt_util
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
-
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_per_platform
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.setup import async_prepare_setup_platform
+from homeassistant.util import dt as dt_util
 
 from .const import (
-    DOMAIN,
-    PLATFORM_TYPE_LEGACY,
     CONF_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    PLATFORM_TYPE_LEGACY,
     SCAN_INTERVAL,
     SOURCE_TYPE_ROUTER,
-    LOGGER,
 )
 
 

--- a/tests/components/device_tracker/common.py
+++ b/tests/components/device_tracker/common.py
@@ -4,15 +4,15 @@ All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
 from homeassistant.components.device_tracker import (
-    DOMAIN,
     ATTR_ATTRIBUTES,
     ATTR_BATTERY,
+    ATTR_DEV_ID,
     ATTR_GPS,
     ATTR_GPS_ACCURACY,
+    ATTR_HOST_NAME,
     ATTR_LOCATION_NAME,
     ATTR_MAC,
-    ATTR_DEV_ID,
-    ATTR_HOST_NAME,
+    DOMAIN,
     SERVICE_SEE,
 )
 from homeassistant.core import callback

--- a/tests/components/device_tracker/test_device_condition.py
+++ b/tests/components/device_tracker/test_device_condition.py
@@ -1,19 +1,19 @@
 """The tests for Device tracker device conditions."""
 import pytest
 
+import homeassistant.components.automation as automation
 from homeassistant.components.device_tracker import DOMAIN
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
-from homeassistant.setup import async_setup_component
-import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_get_device_automations,
     async_mock_service,
     mock_device_registry,
     mock_registry,
-    async_get_device_automations,
 )
 
 

--- a/tests/components/device_tracker/test_entities.py
+++ b/tests/components/device_tracker/test_entities.py
@@ -6,11 +6,12 @@ from homeassistant.components.device_tracker.config_entry import (
     ScannerEntity,
 )
 from homeassistant.components.device_tracker.const import (
-    SOURCE_TYPE_ROUTER,
     ATTR_SOURCE_TYPE,
     DOMAIN,
+    SOURCE_TYPE_ROUTER,
 )
-from homeassistant.const import STATE_HOME, STATE_NOT_HOME, ATTR_BATTERY_LEVEL
+from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_HOME, STATE_NOT_HOME
+
 from tests.common import MockConfigEntry
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `device_tracker` component according to PEP8 using isort.

This affects:

- `homeassistant/components/device_tracker/__init__.py` 
- `homeassistant/components/device_tracker/config_entry.py` 
- `homeassistant/components/device_tracker/device_condition.py` 
- `homeassistant/components/device_tracker/setup.py` 
- `tests/components/device_tracker/common.py` 
- `tests/components/device_tracker/test_device_condition.py` 
- `tests/components/device_tracker/test_entities.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
