### PR TITLE
Sort imports according to PEP8 for emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -5,22 +5,22 @@ from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import util
+from homeassistant.components.http import real_ip
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.deprecation import get_deprecated
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.deprecation import get_deprecated
 from homeassistant.util.json import load_json, save_json
-from homeassistant.components.http import real_ip
 
 from .hue_api import (
-    HueUsernameView,
-    HueUnauthorizedUser,
-    HueAllLightsStateView,
-    HueOneLightStateView,
-    HueOneLightChangeView,
-    HueGroupView,
     HueAllGroupsStateView,
+    HueAllLightsStateView,
     HueFullStateView,
+    HueGroupView,
+    HueOneLightChangeView,
+    HueOneLightStateView,
+    HueUnauthorizedUser,
+    HueUsernameView,
 )
 from .upnp import DescriptionXmlView, UPNPResponderThread
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -1,6 +1,6 @@
 """Support for a Hue API to control Home Assistant."""
-import logging
 import hashlib
+import logging
 
 from homeassistant import core
 from homeassistant.components import (
@@ -34,8 +34,8 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_REAL_IP
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
     ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
@@ -49,8 +49,8 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     HTTP_BAD_REQUEST,
-    HTTP_UNAUTHORIZED,
     HTTP_NOT_FOUND,
+    HTTP_UNAUTHORIZED,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_TURN_OFF,

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -1,8 +1,8 @@
 """Support UPNP discovery method that mimics Hue hubs."""
-import threading
-import socket
 import logging
 import select
+import socket
+import threading
 
 from aiohttp import web
 

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1,43 +1,42 @@
 """The tests for the emulated Hue component."""
 import asyncio
-import json
+from datetime import timedelta
 from ipaddress import ip_address
+import json
 from unittest.mock import patch
 
 from aiohttp.hdrs import CONTENT_TYPE
 import pytest
-from tests.common import get_test_instance_port
 
 from homeassistant import const, setup
 from homeassistant.components import (
+    climate,
+    cover,
+    emulated_hue,
     fan,
     http,
     light,
-    script,
-    emulated_hue,
     media_player,
-    cover,
-    climate,
+    script,
 )
 from homeassistant.components.emulated_hue import Config
 from homeassistant.components.emulated_hue.hue_api import (
-    HUE_API_STATE_ON,
     HUE_API_STATE_BRI,
     HUE_API_STATE_HUE,
+    HUE_API_STATE_ON,
     HUE_API_STATE_SAT,
     HUE_API_USERNAME,
-    HueUsernameView,
-    HueOneLightStateView,
-    HueAllLightsStateView,
-    HueOneLightChangeView,
     HueAllGroupsStateView,
+    HueAllLightsStateView,
     HueFullStateView,
+    HueOneLightChangeView,
+    HueOneLightStateView,
+    HueUsernameView,
 )
-from homeassistant.const import STATE_ON, STATE_OFF
-
+from homeassistant.const import STATE_OFF, STATE_ON
 import homeassistant.util.dt as dt_util
-from datetime import timedelta
-from tests.common import async_fire_time_changed
+
+from tests.common import async_fire_time_changed, get_test_instance_port
 
 HTTP_SERVER_PORT = get_test_instance_port()
 BRIDGE_SERVER_PORT = get_test_instance_port()

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,5 +1,5 @@
 """Test the Emulated Hue component."""
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 from homeassistant.components.emulated_hue import Config
 

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -1,15 +1,15 @@
 """The tests for the emulated Hue component."""
 import json
-
 import unittest
 from unittest.mock import patch
-import requests
-from aiohttp.hdrs import CONTENT_TYPE
 
-from homeassistant import setup, const
+from aiohttp.hdrs import CONTENT_TYPE
+import requests
+
+from homeassistant import const, setup
 from homeassistant.components import emulated_hue, http
 
-from tests.common import get_test_instance_port, get_test_home_assistant
+from tests.common import get_test_home_assistant, get_test_instance_port
 
 HTTP_SERVER_PORT = get_test_instance_port()
 BRIDGE_SERVER_PORT = get_test_instance_port()


### PR DESCRIPTION

## Description:

I have sorted the imports for the `emulated_hue` component according to PEP8 using isort.

This affects:

- `homeassistant/components/emulated_hue/__init__.py` 
- `homeassistant/components/emulated_hue/hue_api.py` 
- `homeassistant/components/emulated_hue/upnp.py` 
- `tests/components/emulated_hue/test_hue_api.py` 
- `tests/components/emulated_hue/test_init.py` 
- `tests/components/emulated_hue/test_upnp.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
