### PR TITLE
Sort imports according to PEP8 for geonetnz_quakes

### DIFF
--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -1,30 +1,29 @@
 """The GeoNet NZ Quakes integration."""
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
-import voluptuous as vol
 from aio_geojson_geonetnz_quakes import GeonetnzQuakesFeedManager
+import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_RADIUS,
     CONF_SCAN_INTERVAL,
-    CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM,
+    CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_MILES,
 )
-from homeassistant.helpers import config_validation as cv, aiohttp_client
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .config_flow import configured_instances
 from .const import (
-    PLATFORMS,
     CONF_MINIMUM_MAGNITUDE,
     CONF_MMI,
     DEFAULT_FILTER_TIME_INTERVAL,
@@ -34,6 +33,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FEED,
+    PLATFORMS,
     SIGNAL_DELETE_ENTITY,
     SIGNAL_NEW_GEOLOCATION,
     SIGNAL_STATUS,

--- a/homeassistant/components/geonetnz_quakes/config_flow.py
+++ b/homeassistant/components/geonetnz_quakes/config_flow.py
@@ -17,13 +17,13 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
+    CONF_MINIMUM_MAGNITUDE,
     CONF_MMI,
+    DEFAULT_MINIMUM_MAGNITUDE,
     DEFAULT_MMI,
     DEFAULT_RADIUS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    DEFAULT_MINIMUM_MAGNITUDE,
-    CONF_MINIMUM_MAGNITUDE,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/geonetnz_quakes/geo_location.py
+++ b/homeassistant/components/geonetnz_quakes/geo_location.py
@@ -5,10 +5,10 @@ from typing import Optional
 from homeassistant.components.geo_location import GeolocationEvent
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
+    ATTR_TIME,
     CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
-    ATTR_TIME,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/tests/components/geonetnz_quakes/test_config_flow.py
+++ b/tests/components/geonetnz_quakes/test_config_flow.py
@@ -1,26 +1,27 @@
 """Define tests for the GeoNet NZ Quakes config flow."""
 from datetime import timedelta
 
+from asynctest import CoroutineMock, patch
 import pytest
-from asynctest import patch, CoroutineMock
 
 from homeassistant import data_entry_flow
 from homeassistant.components.geonetnz_quakes import (
-    async_setup_entry,
-    config_flow,
-    CONF_MMI,
     CONF_MINIMUM_MAGNITUDE,
+    CONF_MMI,
     DOMAIN,
-    async_unload_entry,
     FEED,
+    async_setup_entry,
+    async_unload_entry,
+    config_flow,
 )
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_RADIUS,
-    CONF_UNIT_SYSTEM,
     CONF_SCAN_INTERVAL,
+    CONF_UNIT_SYSTEM,
 )
+
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -1,34 +1,35 @@
 """The tests for the GeoNet NZ Quakes Feed integration."""
 import datetime
 
-from asynctest import patch, CoroutineMock
+from asynctest import CoroutineMock, patch
 
 from homeassistant.components import geonetnz_quakes
 from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.components.geonetnz_quakes import DEFAULT_SCAN_INTERVAL
 from homeassistant.components.geonetnz_quakes.geo_location import (
-    ATTR_EXTERNAL_ID,
-    ATTR_MAGNITUDE,
-    ATTR_LOCALITY,
-    ATTR_MMI,
     ATTR_DEPTH,
+    ATTR_EXTERNAL_ID,
+    ATTR_LOCALITY,
+    ATTR_MAGNITUDE,
+    ATTR_MMI,
     ATTR_QUALITY,
 )
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START,
-    CONF_RADIUS,
+    ATTR_ATTRIBUTION,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_FRIENDLY_NAME,
-    ATTR_UNIT_OF_MEASUREMENT,
-    ATTR_ATTRIBUTION,
     ATTR_TIME,
-    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_RADIUS,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.setup import async_setup_component
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM
-from tests.common import async_fire_time_changed
 import homeassistant.util.dt as dt_util
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+
+from tests.common import async_fire_time_changed
 from tests.components.geonetnz_quakes import _generate_mock_feed_entry
 
 CONFIG = {geonetnz_quakes.DOMAIN: {CONF_RADIUS: 200}}

--- a/tests/components/geonetnz_quakes/test_sensor.py
+++ b/tests/components/geonetnz_quakes/test_sensor.py
@@ -1,27 +1,28 @@
 """The tests for the GeoNet NZ Quakes Feed integration."""
 import datetime
 
-from asynctest import patch, CoroutineMock
+from asynctest import CoroutineMock, patch
 
 from homeassistant.components import geonetnz_quakes
 from homeassistant.components.geonetnz_quakes import DEFAULT_SCAN_INTERVAL
 from homeassistant.components.geonetnz_quakes.sensor import (
-    ATTR_STATUS,
-    ATTR_LAST_UPDATE,
     ATTR_CREATED,
-    ATTR_UPDATED,
-    ATTR_REMOVED,
+    ATTR_LAST_UPDATE,
     ATTR_LAST_UPDATE_SUCCESSFUL,
+    ATTR_REMOVED,
+    ATTR_STATUS,
+    ATTR_UPDATED,
 )
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START,
-    CONF_RADIUS,
-    ATTR_UNIT_OF_MEASUREMENT,
     ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_RADIUS,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.setup import async_setup_component
-from tests.common import async_fire_time_changed
 import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed
 from tests.components.geonetnz_quakes import _generate_mock_feed_entry
 
 CONFIG = {geonetnz_quakes.DOMAIN: {CONF_RADIUS: 200}}


### PR DESCRIPTION

## Description:

I have sorted the imports for the `geonetnz_quakes` component according to PEP8 using isort.

This affects:

- `homeassistant/components/geonetnz_quakes/__init__.py` 
- `homeassistant/components/geonetnz_quakes/config_flow.py` 
- `homeassistant/components/geonetnz_quakes/geo_location.py` 
- `tests/components/geonetnz_quakes/test_config_flow.py` 
- `tests/components/geonetnz_quakes/test_geo_location.py` 
- `tests/components/geonetnz_quakes/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
