### PR TITLE
Sort imports according to PEP8 for hive

### DIFF
--- a/homeassistant/components/hive/binary_sensor.py
+++ b/homeassistant/components/hive/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for the Hive binary sensors."""
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
-from . import DOMAIN, DATA_HIVE, HiveEntity
+from . import DATA_HIVE, DOMAIN, HiveEntity
 
 DEVICETYPE_DEVICE_CLASS = {"motionsensor": "motion", "contactsensor": "opening"}
 

--- a/homeassistant/components/hive/climate.py
+++ b/homeassistant/components/hive/climate.py
@@ -1,6 +1,9 @@
 """Support for the Hive climate devices."""
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
@@ -8,14 +11,10 @@ from homeassistant.components.climate.const import (
     PRESET_NONE,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
-    CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_OFF,
-    CURRENT_HVAC_HEAT,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 
-
-from . import DOMAIN, DATA_HIVE, HiveEntity, refresh_system
+from . import DATA_HIVE, DOMAIN, HiveEntity, refresh_system
 
 HIVE_TO_HASS_STATE = {
     "SCHEDULE": HVAC_MODE_AUTO,

--- a/homeassistant/components/hive/light.py
+++ b/homeassistant/components/hive/light.py
@@ -10,7 +10,7 @@ from homeassistant.components.light import (
 )
 import homeassistant.util.color as color_util
 
-from . import DOMAIN, DATA_HIVE, HiveEntity, refresh_system
+from . import DATA_HIVE, DOMAIN, HiveEntity, refresh_system
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/hive/sensor.py
+++ b/homeassistant/components/hive/sensor.py
@@ -2,7 +2,7 @@
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 
-from . import DOMAIN, DATA_HIVE, HiveEntity
+from . import DATA_HIVE, DOMAIN, HiveEntity
 
 FRIENDLY_NAMES = {
     "Hub_OnlineStatus": "Hive Hub Status",

--- a/homeassistant/components/hive/switch.py
+++ b/homeassistant/components/hive/switch.py
@@ -1,7 +1,7 @@
 """Support for the Hive switches."""
 from homeassistant.components.switch import SwitchDevice
 
-from . import DOMAIN, DATA_HIVE, HiveEntity, refresh_system
+from . import DATA_HIVE, DOMAIN, HiveEntity, refresh_system
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/hive/water_heater.py
+++ b/homeassistant/components/hive/water_heater.py
@@ -7,7 +7,8 @@ from homeassistant.components.water_heater import (
     WaterHeaterDevice,
 )
 from homeassistant.const import TEMP_CELSIUS
-from . import DOMAIN, DATA_HIVE, HiveEntity, refresh_system
+
+from . import DATA_HIVE, DOMAIN, HiveEntity, refresh_system
 
 SUPPORT_FLAGS_HEATER = SUPPORT_OPERATION_MODE
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `hive` component according to PEP8 using isort.

This affects:

- `homeassistant/components/hive/binary_sensor.py` 
- `homeassistant/components/hive/climate.py` 
- `homeassistant/components/hive/light.py` 
- `homeassistant/components/hive/sensor.py` 
- `homeassistant/components/hive/switch.py` 
- `homeassistant/components/hive/water_heater.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
