### PR TITLE
Sort imports according to PEP8 for opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -1,16 +1,16 @@
 """Support for OpenTherm Gateway devices."""
 import asyncio
+from datetime import date, datetime
 import logging
-from datetime import datetime, date
 
 import pyotgw
 import pyotgw.vars as gw_vars
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.components.binary_sensor import DOMAIN as COMP_BINARY_SENSOR
 from homeassistant.components.climate import DOMAIN as COMP_CLIMATE
 from homeassistant.components.sensor import DOMAIN as COMP_SENSOR
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_DATE,
     ATTR_ID,
@@ -25,14 +25,13 @@ from homeassistant.const import (
     PRECISION_TENTHS,
     PRECISION_WHOLE,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-import homeassistant.helpers.config_validation as cv
-
 from .const import (
+    ATTR_DHW_OVRD,
     ATTR_GW_ID,
     ATTR_LEVEL,
-    ATTR_DHW_OVRD,
     CONF_CLIMATE,
     CONF_FLOOR_TEMP,
     CONF_PRECISION,
@@ -42,14 +41,13 @@ from .const import (
     SERVICE_RESET_GATEWAY,
     SERVICE_SET_CLOCK,
     SERVICE_SET_CONTROL_SETPOINT,
-    SERVICE_SET_HOT_WATER_OVRD,
     SERVICE_SET_GPIO_MODE,
+    SERVICE_SET_HOT_WATER_OVRD,
     SERVICE_SET_LED_MODE,
     SERVICE_SET_MAX_MOD,
     SERVICE_SET_OAT,
     SERVICE_SET_SB_TEMP,
 )
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity import async_generate_entity_id
 from . import DOMAIN
 from .const import BINARY_SENSOR_INFO, DATA_GATEWAYS, DATA_OPENTHERM_GW
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -3,17 +3,17 @@ import logging
 
 from pyotgw import vars as gw_vars
 
-from homeassistant.components.climate import ClimateDevice, ENTITY_ID_FORMAT
+from homeassistant.components.climate import ENTITY_ID_FORMAT, ClimateDevice
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
-    SUPPORT_TARGET_TEMPERATURE,
     PRESET_AWAY,
     PRESET_NONE,
     SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
@@ -29,7 +29,6 @@ from homeassistant.helpers.entity import async_generate_entity_id
 
 from . import DOMAIN
 from .const import CONF_FLOOR_TEMP, CONF_PRECISION, DATA_GATEWAYS, DATA_OPENTHERM_GW
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -1,8 +1,8 @@
 """OpenTherm Gateway config flow."""
 import asyncio
-from serial import SerialException
 
 import pyotgw
+from serial import SerialException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -15,7 +15,6 @@ from homeassistant.const import (
     PRECISION_WHOLE,
 )
 from homeassistant.core import callback
-
 import homeassistant.helpers.config_validation as cv
 
 from . import DOMAIN

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from . import DOMAIN
 from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, SENSOR_INFO
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -1,18 +1,19 @@
 """Test the Opentherm Gateway config flow."""
 import asyncio
-from serial import SerialException
 from unittest.mock import patch
 
+from pyotgw import OTGW_ABOUT
+from serial import SerialException
+
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_NAME, PRECISION_HALVES
 from homeassistant.components.opentherm_gw.const import (
-    DOMAIN,
     CONF_FLOOR_TEMP,
     CONF_PRECISION,
+    DOMAIN,
 )
+from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_NAME, PRECISION_HALVES
 
-from pyotgw import OTGW_ABOUT
-from tests.common import mock_coro, MockConfigEntry
+from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_form_user(hass):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `opentherm_gw` component according to PEP8 using isort.

This affects:

- `homeassistant/components/opentherm_gw/__init__.py` 
- `homeassistant/components/opentherm_gw/binary_sensor.py` 
- `homeassistant/components/opentherm_gw/climate.py` 
- `homeassistant/components/opentherm_gw/config_flow.py` 
- `homeassistant/components/opentherm_gw/sensor.py` 
- `tests/components/opentherm_gw/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
