### PR TITLE
Sort imports according to PEP8 for pilight

### DIFF
--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -1,25 +1,24 @@
 """Component to create an interface to a Pilight daemon."""
-import logging
+from datetime import timedelta
 import functools
+import logging
 import socket
 import threading
-from datetime import timedelta
-
-import voluptuous as vol
 
 from pilight import pilight
+import voluptuous as vol
 
-from homeassistant.helpers.event import track_point_in_utc_time
-from homeassistant.util import dt as dt_util
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
     CONF_HOST,
     CONF_PORT,
-    CONF_WHITELIST,
     CONF_PROTOCOL,
+    CONF_WHITELIST,
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
 )
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import track_point_in_utc_time
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pilight/binary_sensor.py
+++ b/homeassistant/components/pilight/binary_sensor.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 
 import voluptuous as vol
+
 from homeassistant.components import pilight
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import (
@@ -15,7 +16,6 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import track_point_in_time
 from homeassistant.util import dt as dt_util
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pilight/sensor.py
+++ b/homeassistant/components/pilight/sensor.py
@@ -3,11 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT, CONF_PAYLOAD
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.helpers.entity import Entity
 from homeassistant.components import pilight
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_PAYLOAD, CONF_UNIT_OF_MEASUREMENT
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pilight/switch.py
+++ b/homeassistant/components/pilight/switch.py
@@ -3,17 +3,17 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components import pilight
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import (
-    CONF_NAME,
     CONF_ID,
-    CONF_SWITCHES,
-    CONF_STATE,
+    CONF_NAME,
     CONF_PROTOCOL,
+    CONF_STATE,
+    CONF_SWITCHES,
     STATE_ON,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/pilight/test_init.py
+++ b/tests/components/pilight/test_init.py
@@ -1,18 +1,18 @@
 """The tests for the pilight component."""
+from datetime import timedelta
 import logging
+import socket
 import unittest
 from unittest.mock import patch
-import socket
-from datetime import timedelta
 
 import pytest
 
 from homeassistant import core as ha
-from homeassistant.setup import setup_component
 from homeassistant.components import pilight
+from homeassistant.setup import setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import assert_setup_component, get_test_home_assistant
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/pilight/test_sensor.py
+++ b/tests/components/pilight/test_sensor.py
@@ -1,11 +1,11 @@
 """The tests for the Pilight sensor platform."""
 import logging
 
-from homeassistant.setup import setup_component
-import homeassistant.components.sensor as sensor
 from homeassistant.components import pilight
+import homeassistant.components.sensor as sensor
+from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component, mock_component
+from tests.common import assert_setup_component, get_test_home_assistant, mock_component
 
 HASS = None
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `pilight` component according to PEP8 using isort.

This affects:

- `homeassistant/components/pilight/__init__.py` 
- `homeassistant/components/pilight/binary_sensor.py` 
- `homeassistant/components/pilight/sensor.py` 
- `homeassistant/components/pilight/switch.py` 
- `tests/components/pilight/test_init.py` 
- `tests/components/pilight/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
