### PR TITLE
Sort imports according to PEP8 for rest

### DIFF
--- a/homeassistant/components/rest/notify.py
+++ b/homeassistant/components/rest/notify.py
@@ -4,6 +4,14 @@ import logging
 import requests
 import voluptuous as vol
 
+from homeassistant.components.notify import (
+    ATTR_MESSAGE,
+    ATTR_TARGET,
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
 from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_HEADERS,
@@ -17,15 +25,6 @@ from homeassistant.const import (
     HTTP_DIGEST_AUTHENTICATION,
 )
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import (
-    ATTR_TARGET,
-    ATTR_TITLE,
-    ATTR_TITLE_DEFAULT,
-    ATTR_MESSAGE,
-    PLATFORM_SCHEMA,
-    BaseNotificationService,
-)
 
 CONF_DATA = "data"
 CONF_DATA_TEMPLATE = "data_template"

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -1,34 +1,34 @@
 """Support for RESTful API sensors."""
-import logging
 import json
+import logging
 
-import voluptuous as vol
 import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA
+from homeassistant.components.sensor import DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_AUTHENTICATION,
+    CONF_DEVICE_CLASS,
     CONF_FORCE_UPDATE,
     CONF_HEADERS,
-    CONF_NAME,
     CONF_METHOD,
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_PAYLOAD,
     CONF_RESOURCE,
     CONF_RESOURCE_TEMPLATE,
+    CONF_TIMEOUT,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_USERNAME,
-    CONF_TIMEOUT,
     CONF_VALUE_TEMPLATE,
     CONF_VERIFY_SSL,
-    CONF_DEVICE_CLASS,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
 )
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -6,15 +6,15 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import (
     CONF_HEADERS,
+    CONF_METHOD,
     CONF_NAME,
+    CONF_PASSWORD,
     CONF_RESOURCE,
     CONF_TIMEOUT,
-    CONF_METHOD,
     CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_VERIFY_SSL,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -1,21 +1,21 @@
 """The tests for the REST binary sensor platform."""
 import unittest
-from pytest import raises
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
+import pytest
+from pytest import raises
 import requests
 from requests.exceptions import Timeout
 import requests_mock
 
-from homeassistant.exceptions import PlatformNotReady
-from homeassistant.setup import setup_component
 import homeassistant.components.binary_sensor as binary_sensor
 import homeassistant.components.rest.binary_sensor as rest
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import template
+from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component
-import pytest
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 class TestRestBinarySensorSetup(unittest.TestCase):

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -1,20 +1,20 @@
 """The tests for the REST sensor platform."""
 import unittest
-from pytest import raises
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
+import pytest
+from pytest import raises
 import requests
-from requests.exceptions import Timeout, RequestException
+from requests.exceptions import RequestException, Timeout
 import requests_mock
 
-from homeassistant.exceptions import PlatformNotReady
-from homeassistant.setup import setup_component
-import homeassistant.components.sensor as sensor
 import homeassistant.components.rest.sensor as rest
+import homeassistant.components.sensor as sensor
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.config_validation import template
+from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component
-import pytest
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 class TestRestSensorSetup(unittest.TestCase):

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -4,9 +4,10 @@ import asyncio
 import aiohttp
 
 import homeassistant.components.rest.switch as rest
-from homeassistant.setup import setup_component
 from homeassistant.helpers.template import Template
-from tests.common import get_test_home_assistant, assert_setup_component
+from homeassistant.setup import setup_component
+
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 class TestRestSwitchSetup:


### PR DESCRIPTION

## Description:

I have sorted the imports for the `rest` component according to PEP8 using isort.

This affects:

- `homeassistant/components/rest/notify.py` 
- `homeassistant/components/rest/sensor.py` 
- `homeassistant/components/rest/switch.py` 
- `tests/components/rest/test_binary_sensor.py` 
- `tests/components/rest/test_sensor.py` 
- `tests/components/rest/test_switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
