### PR TITLE
Sort imports according to PEP8 for somfy

### DIFF
--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -5,15 +5,15 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/integrations/somfy/
 """
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
-import voluptuous as vol
 from requests import HTTPError
+import voluptuous as vol
 
-from homeassistant.helpers import config_validation as cv, config_entry_oauth2_flow
 from homeassistant.components.somfy import config_flow
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import Throttle

--- a/homeassistant/components/somfy/api.py
+++ b/homeassistant/components/somfy/api.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 
 from pymfy.api import somfy_api
 
-from homeassistant import core, config_entries
+from homeassistant import config_entries, core
 from homeassistant.helpers import config_entry_oauth2_flow
 
 

--- a/homeassistant/components/somfy/config_flow.py
+++ b/homeassistant/components/somfy/config_flow.py
@@ -3,6 +3,7 @@ import logging
 
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_oauth2_flow
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -1,13 +1,14 @@
 """Support for Somfy Covers."""
-from pymfy.api.devices.category import Category
 from pymfy.api.devices.blind import Blind
+from pymfy.api.devices.category import Category
 
 from homeassistant.components.cover import (
-    CoverDevice,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    CoverDevice,
 )
-from . import DOMAIN, SomfyEntity, DEVICES, API
+
+from . import API, DEVICES, DOMAIN, SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/somfy/switch.py
+++ b/homeassistant/components/somfy/switch.py
@@ -3,7 +3,8 @@ from pymfy.api.devices.camera_protect import CameraProtect
 from pymfy.api.devices.category import Category
 
 from homeassistant.components.switch import SwitchDevice
-from . import DOMAIN, SomfyEntity, DEVICES, API
+
+from . import API, DEVICES, DOMAIN, SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/tests/components/somfy/test_config_flow.py
+++ b/tests/components/somfy/test_config_flow.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import data_entry_flow, setup, config_entries
-from homeassistant.components.somfy import config_flow, DOMAIN
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.somfy import DOMAIN, config_flow
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry


### PR DESCRIPTION

## Description:

I have sorted the imports for the `somfy` component according to PEP8 using isort.

This affects:

- `homeassistant/components/somfy/__init__.py` 
- `homeassistant/components/somfy/api.py` 
- `homeassistant/components/somfy/config_flow.py` 
- `homeassistant/components/somfy/cover.py` 
- `homeassistant/components/somfy/switch.py` 
- `tests/components/somfy/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
