### PR TITLE
Sort imports according to PEP8 for dyson

### DIFF
--- a/tests/components/dyson/test_air_quality.py
+++ b/tests/components/dyson/test_air_quality.py
@@ -6,14 +6,14 @@ import asynctest
 from libpurecool.dyson_pure_cool import DysonPureCool
 from libpurecool.dyson_pure_state_v2 import DysonEnvironmentalSensorV2State
 
-import homeassistant.components.dyson.air_quality as dyson
 from homeassistant.components import dyson as dyson_parent
 from homeassistant.components.air_quality import (
-    DOMAIN as AIQ_DOMAIN,
+    ATTR_NO2,
     ATTR_PM_2_5,
     ATTR_PM_10,
-    ATTR_NO2,
+    DOMAIN as AIQ_DOMAIN,
 )
+import homeassistant.components.dyson.air_quality as dyson
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -9,8 +9,9 @@ from libpurecool.dyson_pure_state import DysonPureHotCoolState
 
 from homeassistant.components import dyson as dyson_parent
 from homeassistant.components.dyson import climate as dyson
-from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.setup import async_setup_component
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -4,27 +4,28 @@ import unittest
 from unittest import mock
 
 import asynctest
-from libpurecool.const import FanSpeed, FanMode, NightMode, Oscillation
+from libpurecool.const import FanMode, FanSpeed, NightMode, Oscillation
 from libpurecool.dyson_pure_cool import DysonPureCool
 from libpurecool.dyson_pure_cool_link import DysonPureCoolLink
 from libpurecool.dyson_pure_state import DysonPureCoolState
 from libpurecool.dyson_pure_state_v2 import DysonPureCoolV2State
 
-import homeassistant.components.dyson.fan as dyson
 from homeassistant.components import dyson as dyson_parent
 from homeassistant.components.dyson import DYSON_DEVICES
+import homeassistant.components.dyson.fan as dyson
 from homeassistant.components.fan import (
-    DOMAIN,
-    ATTR_SPEED,
     ATTR_OSCILLATING,
+    ATTR_SPEED,
+    DOMAIN,
+    SERVICE_OSCILLATE,
+    SPEED_HIGH,
     SPEED_LOW,
     SPEED_MEDIUM,
-    SPEED_HIGH,
-    SERVICE_OSCILLATE,
 )
-from homeassistant.const import SERVICE_TURN_ON, SERVICE_TURN_OFF, ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/dyson/test_init.py
+++ b/tests/components/dyson/test_init.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 
 from homeassistant.components import dyson
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/dyson/test_sensor.py
+++ b/tests/components/dyson/test_sensor.py
@@ -8,9 +8,10 @@ from libpurecool.dyson_pure_cool_link import DysonPureCoolLink
 
 from homeassistant.components import dyson as dyson_parent
 from homeassistant.components.dyson import sensor as dyson
-from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT, STATE_OFF
+from homeassistant.const import STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/dyson/test_vacuum.py
+++ b/tests/components/dyson/test_vacuum.py
@@ -7,6 +7,7 @@ from libpurecool.dyson_360_eye import Dyson360Eye
 
 from homeassistant.components.dyson import vacuum as dyson
 from homeassistant.components.dyson.vacuum import Dyson360EyeDevice
+
 from tests.common import get_test_home_assistant
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `dyson` component according to PEP8 using isort.

This affects:

- `tests/components/dyson/test_air_quality.py` 
- `tests/components/dyson/test_climate.py` 
- `tests/components/dyson/test_fan.py` 
- `tests/components/dyson/test_init.py` 
- `tests/components/dyson/test_sensor.py` 
- `tests/components/dyson/test_vacuum.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
