### PR TITLE
Sort imports according to PEP8 for http

### DIFF
--- a/tests/components/http/__init__.py
+++ b/tests/components/http/__init__.py
@@ -5,7 +5,6 @@ from aiohttp import web
 
 from homeassistant.components.http.const import KEY_REAL_IP
 
-
 # Relic from the past. Kept here so we can run negative tests.
 HTTP_HEADER_HA_AUTH = "X-HA-access"
 

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -3,16 +3,17 @@ from datetime import timedelta
 from ipaddress import ip_network
 from unittest.mock import patch
 
-import pytest
 from aiohttp import BasicAuth, web
 from aiohttp.web_exceptions import HTTPUnauthorized
+import pytest
 
 from homeassistant.auth.providers import trusted_networks
-from homeassistant.components.http.auth import setup_auth, async_sign_path
+from homeassistant.components.http.auth import async_sign_path, setup_auth
 from homeassistant.components.http.const import KEY_AUTHENTICATED
 from homeassistant.components.http.real_ip import setup_real_ip
 from homeassistant.setup import async_setup_component
-from . import mock_real_ip, HTTP_HEADER_HA_AUTH
+
+from . import HTTP_HEADER_HA_AUTH, mock_real_ip
 
 API_PASSWORD = "test-password"
 

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -1,28 +1,27 @@
 """The tests for the Home Assistant HTTP component."""
 # pylint: disable=protected-access
 from ipaddress import ip_address
-from unittest.mock import patch, mock_open, Mock
+from unittest.mock import Mock, mock_open, patch
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPUnauthorized
 from aiohttp.web_middlewares import middleware
 
-from homeassistant.components.http import KEY_AUTHENTICATED
-from homeassistant.components.http.view import request_handler_factory
-from homeassistant.setup import async_setup_component
 import homeassistant.components.http as http
+from homeassistant.components.http import KEY_AUTHENTICATED
 from homeassistant.components.http.ban import (
-    IpBan,
     IP_BANS_FILE,
-    setup_bans,
     KEY_BANNED_IPS,
     KEY_FAILED_LOGIN_ATTEMPTS,
+    IpBan,
+    setup_bans,
 )
+from homeassistant.components.http.view import request_handler_factory
+from homeassistant.setup import async_setup_component
 
 from . import mock_real_ip
 
 from tests.common import mock_coro
-
 
 BANNED_IPS = ["200.201.202.203", "100.64.0.2"]
 

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 from aiohttp import web
 from aiohttp.hdrs import (
-    ACCESS_CONTROL_ALLOW_ORIGIN,
     ACCESS_CONTROL_ALLOW_HEADERS,
+    ACCESS_CONTROL_ALLOW_ORIGIN,
     ACCESS_CONTROL_REQUEST_HEADERS,
     ACCESS_CONTROL_REQUEST_METHOD,
     AUTHORIZATION,
@@ -13,12 +13,11 @@ from aiohttp.hdrs import (
 )
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components.http.cors import setup_cors
 from homeassistant.components.http.view import HomeAssistantView
+from homeassistant.setup import async_setup_component
 
 from . import HTTP_HEADER_HA_AUTH
-
 
 TRUSTED_ORIGIN = "https://home-assistant.io"
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -3,10 +3,9 @@ import logging
 import unittest
 from unittest.mock import patch
 
-from homeassistant.setup import async_setup_component
-
 import homeassistant.components.http as http
-from homeassistant.util.ssl import server_context_modern, server_context_intermediate
+from homeassistant.setup import async_setup_component
+from homeassistant.util.ssl import server_context_intermediate, server_context_modern
 
 
 class TestView(http.HomeAssistantView):

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -1,10 +1,11 @@
 """Test real IP middleware."""
-from aiohttp import web
-from aiohttp.hdrs import X_FORWARDED_FOR
 from ipaddress import ip_network
 
-from homeassistant.components.http.real_ip import setup_real_ip
+from aiohttp import web
+from aiohttp.hdrs import X_FORWARDED_FOR
+
 from homeassistant.components.http.const import KEY_REAL_IP
+from homeassistant.components.http.real_ip import setup_real_ip
 
 
 async def mock_handler(request):

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -2,8 +2,8 @@
 from unittest.mock import Mock
 
 from aiohttp.web_exceptions import (
-    HTTPInternalServerError,
     HTTPBadRequest,
+    HTTPInternalServerError,
     HTTPUnauthorized,
 )
 import pytest


### PR DESCRIPTION

## Description:

I have sorted the imports for the `http` component according to PEP8 using isort.

This affects:

- `tests/components/http/__init__.py` 
- `tests/components/http/test_auth.py` 
- `tests/components/http/test_ban.py` 
- `tests/components/http/test_cors.py` 
- `tests/components/http/test_init.py` 
- `tests/components/http/test_real_ip.py` 
- `tests/components/http/test_view.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
