### PR TITLE
Sort imports according to PEP8 for ring

### DIFF
--- a/tests/components/ring/common.py
+++ b/tests/components/ring/common.py
@@ -1,6 +1,6 @@
 """Common methods used across the tests for ring devices."""
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_SCAN_INTERVAL
 from homeassistant.components.ring import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.setup import async_setup_component
 
 

--- a/tests/components/ring/conftest.py
+++ b/tests/components/ring/conftest.py
@@ -1,8 +1,9 @@
 """Configuration for Ring tests."""
-import requests_mock
-import pytest
-from tests.common import load_fixture
 from asynctest import patch
+import pytest
+import requests_mock
+
+from tests.common import load_fixture
 
 
 @pytest.fixture(name="ring_mock")

--- a/tests/components/ring/test_binary_sensor.py
+++ b/tests/components/ring/test_binary_sensor.py
@@ -1,13 +1,14 @@
 """The tests for the Ring binary sensor platform."""
 import os
 import unittest
+
 import requests_mock
 
-from homeassistant.components.ring import binary_sensor as ring
 from homeassistant.components import ring as base_ring
+from homeassistant.components.ring import binary_sensor as ring
 
-from tests.components.ring.test_init import ATTRIBUTION, VALID_CONFIG
 from tests.common import get_test_config_dir, get_test_home_assistant, load_fixture
+from tests.components.ring.test_init import ATTRIBUTION, VALID_CONFIG
 
 
 class TestRingBinarySensorSetup(unittest.TestCase):

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -1,9 +1,11 @@
 """The tests for the Ring component."""
 from copy import deepcopy
+from datetime import timedelta
 import os
 import unittest
+
 import requests_mock
-from datetime import timedelta
+
 from homeassistant import setup
 import homeassistant.components.ring as ring
 

--- a/tests/components/ring/test_light.py
+++ b/tests/components/ring/test_light.py
@@ -1,7 +1,9 @@
 """The tests for the Ring light platform."""
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from tests.common import load_fixture
+
 from .common import setup_platform
+
+from tests.common import load_fixture
 
 
 async def test_entity_registry(hass, requests_mock):

--- a/tests/components/ring/test_sensor.py
+++ b/tests/components/ring/test_sensor.py
@@ -1,13 +1,15 @@
 """The tests for the Ring sensor platform."""
 import os
 import unittest
+
 import requests_mock
 
-import homeassistant.components.ring.sensor as ring
 from homeassistant.components import ring as base_ring
+import homeassistant.components.ring.sensor as ring
 from homeassistant.helpers.icon import icon_for_battery_level
-from tests.components.ring.test_init import ATTRIBUTION, VALID_CONFIG
+
 from tests.common import get_test_config_dir, get_test_home_assistant, load_fixture
+from tests.components.ring.test_init import ATTRIBUTION, VALID_CONFIG
 
 
 class TestRingSensorSetup(unittest.TestCase):

--- a/tests/components/ring/test_switch.py
+++ b/tests/components/ring/test_switch.py
@@ -1,7 +1,9 @@
 """The tests for the Ring switch platform."""
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from tests.common import load_fixture
+
 from .common import setup_platform
+
+from tests.common import load_fixture
 
 
 async def test_entity_registry(hass, requests_mock):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `ring` component according to PEP8 using isort.

This affects:

- `tests/components/ring/common.py` 
- `tests/components/ring/conftest.py` 
- `tests/components/ring/test_binary_sensor.py` 
- `tests/components/ring/test_init.py` 
- `tests/components/ring/test_light.py` 
- `tests/components/ring/test_sensor.py` 
- `tests/components/ring/test_switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
