### PR TITLE
Sort imports according to PEP8 for iaqualink

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -5,8 +5,6 @@ import logging
 from typing import Any, Dict
 
 import aiohttp.client_exceptions
-import voluptuous as vol
-
 from iaqualink import (
     AqualinkBinarySensor,
     AqualinkClient,
@@ -17,6 +15,7 @@ from iaqualink import (
     AqualinkThermostat,
     AqualinkToggle,
 )
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -29,17 +28,16 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import DOMAIN, UPDATE_INTERVAL
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -2,9 +2,9 @@
 import logging
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice,
     DEVICE_CLASS_COLD,
     DOMAIN,
+    BinarySensorDevice,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -22,7 +22,7 @@ from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import AqualinkEntity, refresh_system
-from .const import DOMAIN as AQUALINK_DOMAIN, CLIMATE_SUPPORTED_MODES
+from .const import CLIMATE_SUPPORTED_MODES, DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -1,9 +1,8 @@
 """Config flow to configure zone component."""
 from typing import Optional
 
-import voluptuous as vol
-
 from iaqualink import AqualinkClient, AqualinkLoginException
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -5,6 +5,7 @@ import iaqualink
 import pytest
 
 from homeassistant.components.iaqualink import config_flow
+
 from tests.common import MockConfigEntry, mock_coro
 
 DATA = {"username": "test@example.com", "password": "pass"}


### PR DESCRIPTION

## Description:

I have sorted the imports for the `iaqualink` component according to PEP8 using isort.

This affects:

- `homeassistant/components/iaqualink/__init__.py` 
- `homeassistant/components/iaqualink/binary_sensor.py` 
- `homeassistant/components/iaqualink/climate.py` 
- `homeassistant/components/iaqualink/config_flow.py` 
- `tests/components/iaqualink/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
