### PR TITLE
sort imports according to PEP8 for netatmo

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -1,6 +1,6 @@
 """Support for the Netatmo devices."""
-import logging
 from datetime import timedelta
+import logging
 from urllib.error import HTTPError
 
 import pyatmo
@@ -8,17 +8,17 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_API_KEY,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_DISCOVERY,
+    CONF_PASSWORD,
     CONF_URL,
+    CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-from .const import DOMAIN, DATA_NETATMO_AUTH
+from .const import DATA_NETATMO_AUTH, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -8,8 +8,8 @@ from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensor
 from homeassistant.const import CONF_TIMEOUT
 from homeassistant.helpers import config_validation as cv
 
-from .const import DATA_NETATMO_AUTH
 from . import CameraData
+from .const import DATA_NETATMO_AUTH
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -6,20 +6,20 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.camera import (
-    PLATFORM_SCHEMA,
-    Camera,
-    SUPPORT_STREAM,
     CAMERA_SERVICE_SCHEMA,
+    PLATFORM_SCHEMA,
+    SUPPORT_STREAM,
+    Camera,
 )
-from homeassistant.const import CONF_VERIFY_SSL, STATE_ON, STATE_OFF
+from homeassistant.const import CONF_VERIFY_SSL, STATE_OFF, STATE_ON
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import (
-    async_dispatcher_send,
     async_dispatcher_connect,
+    async_dispatcher_send,
 )
 
-from .const import DATA_NETATMO_AUTH, DOMAIN
 from . import CameraData
+from .const import DATA_NETATMO_AUTH, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -1,34 +1,34 @@
 """Support for Netatmo Smart thermostats."""
 from datetime import timedelta
 import logging
-from typing import Optional, List
+from typing import List, Optional
 
 import pyatmo
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    DEFAULT_MIN_TEMP,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     PRESET_AWAY,
     PRESET_BOOST,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE,
-    SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_PRESET_MODE,
-    DEFAULT_MIN_TEMP,
+    SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
-    TEMP_CELSIUS,
+    ATTR_BATTERY_LEVEL,
     ATTR_TEMPERATURE,
     CONF_NAME,
     PRECISION_HALVES,
     STATE_OFF,
-    ATTR_BATTERY_LEVEL,
+    TEMP_CELSIUS,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 from .const import DATA_NETATMO_AUTH

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -1,7 +1,7 @@
 """Support for the Netatmo Weather Service."""
+from datetime import timedelta
 import logging
 import threading
-from datetime import timedelta
 from time import time
 
 import pyatmo
@@ -9,19 +9,20 @@ import requests
 import urllib3
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
     CONF_MODE,
-    TEMP_CELSIUS,
+    CONF_NAME,
+    DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_BATTERY,
+    TEMP_CELSIUS,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import call_later
 from homeassistant.util import Throttle
+
 from .const import DATA_NETATMO_AUTH, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION

## Description:

I have sorted the imports for the `netatmo` component according to PEP8 using isort.

This affects:

- `homeassistant/components/netatmo/__init__.py` 
- `homeassistant/components/netatmo/binary_sensor.py` 
- `homeassistant/components/netatmo/camera.py` 
- `homeassistant/components/netatmo/climate.py` 
- `homeassistant/components/netatmo/sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
