### PR TITLE
Sort imports according to PEP8 for vesync

### DIFF
--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -1,20 +1,23 @@
 """Etekcity VeSync integration."""
 import logging
-import voluptuous as vol
+
 from pyvesync import VeSync
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.config_entries import SOURCE_IMPORT
+
 from .common import async_process_devices
 from .config_flow import configured_instances
 from .const import (
     DOMAIN,
-    VS_DISPATCHERS,
-    VS_DISCOVERY,
-    VS_SWITCHES,
     SERVICE_UPDATE_DEVS,
+    VS_DISCOVERY,
+    VS_DISPATCHERS,
     VS_MANAGER,
+    VS_SWITCHES,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -1,6 +1,8 @@
 """Common utilities for VeSync Component."""
 import logging
+
 from homeassistant.helpers.entity import ToggleEntity
+
 from .const import VS_SWITCHES
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/vesync/config_flow.py
+++ b/homeassistant/components/vesync/config_flow.py
@@ -1,11 +1,14 @@
 """Config flow utilities."""
-import logging
 from collections import OrderedDict
-import voluptuous as vol
+import logging
+
 from pyvesync import VeSync
+import voluptuous as vol
+
 from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -1,10 +1,12 @@
 """Support for Etekcity VeSync switches."""
 import logging
-from homeassistant.core import callback
+
 from homeassistant.components.switch import SwitchDevice
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from .const import VS_DISCOVERY, VS_DISPATCHERS, VS_SWITCHES, DOMAIN
+
 from .common import VeSyncDevice
+from .const import DOMAIN, VS_DISCOVERY, VS_DISPATCHERS, VS_SWITCHES
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/vesync/test_config_flow.py
+++ b/tests/components/vesync/test_config_flow.py
@@ -1,8 +1,10 @@
 """Test for vesync config flow."""
 from unittest.mock import patch
+
 from homeassistant import data_entry_flow
-from homeassistant.components.vesync import config_flow, DOMAIN
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.components.vesync import DOMAIN, config_flow
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
 from tests.common import MockConfigEntry
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `vesync` component according to PEP8 using isort.

This affects:

- `homeassistant/components/vesync/__init__.py` 
- `homeassistant/components/vesync/common.py` 
- `homeassistant/components/vesync/config_flow.py` 
- `homeassistant/components/vesync/switch.py` 
- `tests/components/vesync/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
