### PR TITLE
sort imports according to PEP8 for withings

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -7,11 +7,11 @@ import voluptuous as vol
 from withings_api import WithingsAuth
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-from homeassistant.helpers import config_validation as cv, config_entry_oauth2_flow
 
 from . import config_flow, const
-from .common import _LOGGER, get_data_manager, NotAuthenticatedError
+from .common import _LOGGER, NotAuthenticatedError, get_data_manager
 
 DOMAIN = const.DOMAIN
 

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -1,4 +1,5 @@
 """Common code for Withings."""
+from asyncio import run_coroutine_threadsafe
 import datetime
 from functools import partial
 import logging
@@ -6,15 +7,14 @@ import re
 import time
 from typing import Any, Dict
 
-from asyncio import run_coroutine_threadsafe
 import requests
 from withings_api import (
     AbstractWithingsApi,
-    SleepGetResponse,
     MeasureGetMeasResponse,
+    SleepGetResponse,
     SleepGetSummaryResponse,
 )
-from withings_api.common import UnauthorizedException, AuthFailedException
+from withings_api.common import AuthFailedException, UnauthorizedException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -2,21 +2,21 @@
 from typing import Callable, List, Union
 
 from withings_api.common import (
-    MeasureType,
     GetSleepSummaryField,
     MeasureGetMeasResponse,
+    MeasureGroupAttribs,
+    MeasureType,
     SleepGetResponse,
     SleepGetSummaryResponse,
-    get_measure_value,
-    MeasureGroupAttribs,
     SleepState,
+    get_measure_value,
 )
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
-from homeassistant.helpers import config_entry_oauth2_flow
 
 from . import const
 from .common import _LOGGER, WithingsDataManager, get_data_manager

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -1,15 +1,14 @@
 """Tests for the Withings component."""
 from asynctest import MagicMock
-
 import pytest
 from withings_api import WithingsApi
-from withings_api.common import UnauthorizedException, TimeoutException
+from withings_api.common import TimeoutException, UnauthorizedException
 
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.components.withings.common import (
     NotAuthenticatedError,
     WithingsDataManager,
 )
+from homeassistant.exceptions import PlatformNotReady
 
 
 @pytest.fixture(name="withings_api")

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -10,26 +10,26 @@ from withings_api.common import SleepModel, SleepState
 
 import homeassistant.components.http as http
 from homeassistant.components.withings import (
+    CONFIG_SCHEMA,
     async_setup,
     async_setup_entry,
     const,
-    CONFIG_SCHEMA,
 )
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from .common import (
-    assert_state_equals,
-    configure_integration,
-    setup_hass,
     WITHINGS_GET_DEVICE_RESPONSE,
     WITHINGS_GET_DEVICE_RESPONSE_EMPTY,
+    WITHINGS_MEASURES_RESPONSE,
+    WITHINGS_MEASURES_RESPONSE_EMPTY,
     WITHINGS_SLEEP_RESPONSE,
     WITHINGS_SLEEP_RESPONSE_EMPTY,
     WITHINGS_SLEEP_SUMMARY_RESPONSE,
     WITHINGS_SLEEP_SUMMARY_RESPONSE_EMPTY,
-    WITHINGS_MEASURES_RESPONSE,
-    WITHINGS_MEASURES_RESPONSE_EMPTY,
+    assert_state_equals,
+    configure_integration,
+    setup_hass,
 )
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `withings` component according to PEP8 using isort.

This affects:

- `homeassistant/components/withings/__init__.py` 
- `homeassistant/components/withings/common.py` 
- `homeassistant/components/withings/sensor.py` 
- `tests/components/withings/test_common.py` 
- `tests/components/withings/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
