### PR TITLE
Sort imports according to PEP8 for specific_devices

### DIFF
--- a/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
@@ -5,10 +5,11 @@ https://github.com/home-assistant/home-assistant/issues/20957
 """
 
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
+
 from tests.components.homekit_controller.common import (
+    Helper,
     setup_accessories_from_file,
     setup_test_accessories,
-    Helper,
 )
 
 

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -8,19 +8,18 @@ from unittest import mock
 
 from homekit import AccessoryDisconnectedError
 
-from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_TEMPERATURE,
 )
-
+from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 
 from tests.components.homekit_controller.common import (
     FakePairing,
+    Helper,
     device_config_changed,
     setup_accessories_from_file,
     setup_test_accessories,
-    Helper,
     time_changed,
 )
 

--- a/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
@@ -1,9 +1,9 @@
 """Tests for handling accessories on a Hue bridge via HomeKit."""
 
 from tests.components.homekit_controller.common import (
+    Helper,
     setup_accessories_from_file,
     setup_test_accessories,
-    Helper,
 )
 
 

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -3,17 +3,18 @@
 from datetime import timedelta
 from unittest import mock
 
+from homekit.exceptions import AccessoryDisconnectedError, EncryptionError
 import pytest
 
-from homekit.exceptions import AccessoryDisconnectedError, EncryptionError
-import homeassistant.util.dt as dt_util
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
+import homeassistant.util.dt as dt_util
+
 from tests.common import async_fire_time_changed
 from tests.components.homekit_controller.common import (
-    setup_accessories_from_file,
-    setup_test_accessories,
     FakePairing,
     Helper,
+    setup_accessories_from_file,
+    setup_test_accessories,
 )
 
 LIGHT_ON = ("lightbulb", "on")

--- a/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
+++ b/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
@@ -5,10 +5,11 @@ https://github.com/home-assistant/home-assistant/issues/20885
 """
 
 from homeassistant.components.climate.const import SUPPORT_TARGET_TEMPERATURE
+
 from tests.components.homekit_controller.common import (
+    Helper,
     setup_accessories_from_file,
     setup_test_accessories,
-    Helper,
 )
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `specific_devices` component according to PEP8 using isort.

This affects:

- `tests/components/homekit_controller/specific_devices/test_aqara_gateway.py` 
- `tests/components/homekit_controller/specific_devices/test_ecobee3.py` 
- `tests/components/homekit_controller/specific_devices/test_hue_bridge.py` 
- `tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py` 
- `tests/components/homekit_controller/specific_devices/test_lennox_e30.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
