### PR TITLE
Sort imports according to PEP8 for almond

### DIFF
--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -5,26 +5,26 @@ import logging
 import time
 from typing import Optional
 
+from aiohttp import ClientError, ClientSession
 import async_timeout
-from aiohttp import ClientSession, ClientError
-from pyalmond import AlmondLocalAuth, AbstractAlmondWebAuth, WebAlmondAPI
+from pyalmond import AbstractAlmondWebAuth, AlmondLocalAuth, WebAlmondAPI
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, CoreState, Context
-from homeassistant.const import CONF_TYPE, CONF_HOST, EVENT_HOMEASSISTANT_START
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant import config_entries
 from homeassistant.auth.const import GROUP_ID_ADMIN
+from homeassistant.components import conversation
+from homeassistant.const import CONF_HOST, CONF_TYPE, EVENT_HOMEASSISTANT_START
+from homeassistant.core import Context, CoreState, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
-    config_validation as cv,
+    aiohttp_client,
     config_entry_oauth2_flow,
+    config_validation as cv,
     event,
     intent,
-    aiohttp_client,
-    storage,
     network,
+    storage,
 )
-from homeassistant import config_entries
-from homeassistant.components import conversation
 
 from . import config_flow
 from .const import DOMAIN, TYPE_LOCAL, TYPE_OAUTH2

--- a/homeassistant/components/almond/config_flow.py
+++ b/homeassistant/components/almond/config_flow.py
@@ -2,14 +2,14 @@
 import asyncio
 import logging
 
-import async_timeout
 from aiohttp import ClientError
-from yarl import URL
-import voluptuous as vol
+import async_timeout
 from pyalmond import AlmondLocalAuth, WebAlmondAPI
+import voluptuous as vol
+from yarl import URL
 
-from homeassistant import data_entry_flow, config_entries, core
-from homeassistant.helpers import config_entry_oauth2_flow, aiohttp_client
+from homeassistant import config_entries, core, data_entry_flow
+from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
 
 from .const import DOMAIN, TYPE_LOCAL, TYPE_OAUTH2
 

--- a/tests/components/almond/test_config_flow.py
+++ b/tests/components/almond/test_config_flow.py
@@ -1,12 +1,10 @@
 """Test the Almond config flow."""
 import asyncio
-
 from unittest.mock import patch
 
-
-from homeassistant import config_entries, setup, data_entry_flow
-from homeassistant.components.almond.const import DOMAIN
+from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.almond import config_flow
+from homeassistant.components.almond.const import DOMAIN
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry, mock_coro

--- a/tests/components/almond/test_init.py
+++ b/tests/components/almond/test_init.py
@@ -1,16 +1,16 @@
 """Tests for Almond set up."""
-from unittest.mock import patch
 from time import time
+from unittest.mock import patch
 
 import pytest
 
 from homeassistant import config_entries, core
+from homeassistant.components.almond import const
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
-from homeassistant.components.almond import const
 from homeassistant.util.dt import utcnow
 
-from tests.common import MockConfigEntry, mock_coro, async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed, mock_coro
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION

## Description:

I have sorted the imports for the `almond` component according to PEP8 using isort.

This affects:

- `homeassistant/components/almond/__init__.py` 
- `homeassistant/components/almond/config_flow.py` 
- `tests/components/almond/test_config_flow.py` 
- `tests/components/almond/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
