### PR TITLE
Sort imports according to PEP8 for counter

### DIFF
--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -3,8 +3,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_ICON, CONF_NAME, CONF_MAXIMUM, CONF_MINIMUM
-
+from homeassistant.const import CONF_ICON, CONF_MAXIMUM, CONF_MINIMUM, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity

--- a/homeassistant/components/counter/reproduce_state.py
+++ b/homeassistant/components/counter/reproduce_state.py
@@ -12,9 +12,9 @@ from . import (
     ATTR_MAXIMUM,
     ATTR_MINIMUM,
     ATTR_STEP,
-    VALUE,
     DOMAIN,
     SERVICE_CONFIGURE,
+    VALUE,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/counter/common.py
+++ b/tests/components/counter/common.py
@@ -3,13 +3,13 @@
 All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
-from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.components.counter import (
     DOMAIN,
     SERVICE_DECREMENT,
     SERVICE_INCREMENT,
     SERVICE_RESET,
 )
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.components.counter import (
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON
 from homeassistant.core import Context, CoreState, State
 from homeassistant.setup import async_setup_component
+
 from tests.common import mock_restore_cache
 from tests.components.counter.common import (
     async_decrement,


### PR DESCRIPTION

## Description:

I have sorted the imports for the `counter` component according to PEP8 using isort.

This affects:

- `homeassistant/components/counter/__init__.py` 
- `homeassistant/components/counter/reproduce_state.py` 
- `tests/components/counter/common.py` 
- `tests/components/counter/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
