### PR TITLE
Sort imports according to PEP8 for file

### DIFF
--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -4,16 +4,15 @@ import os
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_FILENAME
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
-
 from homeassistant.components.notify import (
     ATTR_TITLE,
     ATTR_TITLE_DEFAULT,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_FILENAME
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 
 CONF_TIMESTAMP = "timestamp"
 

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -1,12 +1,12 @@
 """Support for sensor value(s) stored in local files."""
-import os
 import logging
+import os
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_NAME, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -3,9 +3,9 @@ import os
 import unittest
 from unittest.mock import call, mock_open, patch
 
-from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify
 from homeassistant.components.notify import ATTR_TITLE_DEFAULT
+from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import assert_setup_component, get_test_home_assistant

--- a/tests/components/file/test_sensor.py
+++ b/tests/components/file/test_sensor.py
@@ -6,8 +6,8 @@ from unittest.mock import Mock, patch
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-from homeassistant.setup import setup_component
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant, mock_registry
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `file` component according to PEP8 using isort.

This affects:

- `homeassistant/components/file/notify.py` 
- `homeassistant/components/file/sensor.py` 
- `tests/components/file/test_notify.py` 
- `tests/components/file/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
