### PR TITLE
Sort imports according to PEP8 for geofency

### DIFF
--- a/homeassistant/components/geofency/__init__.py
+++ b/homeassistant/components/geofency/__init__.py
@@ -18,8 +18,8 @@ from homeassistant.helpers import config_entry_flow
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import slugify
-from .const import DOMAIN
 
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/geofency/config_flow.py
+++ b/homeassistant/components/geofency/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Geofency."""
 from homeassistant.helpers import config_entry_flow
-from .const import DOMAIN
 
+from .const import DOMAIN
 
 config_entry_flow.register_webhook_flow(
     DOMAIN,

--- a/homeassistant/components/geofency/device_tracker.py
+++ b/homeassistant/components/geofency/device_tracker.py
@@ -1,13 +1,13 @@
 """Support for the Geofency device tracker platform."""
 import logging
 
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
-from homeassistant.core import callback
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers import device_registry
 
 from . import DOMAIN as GF_DOMAIN, TRACKER_UPDATE
 

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the Geofency device tracker platform."""
 # pylint: disable=redefined-outer-name
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `geofency` component according to PEP8 using isort.

This affects:

- `homeassistant/components/geofency/__init__.py` 
- `homeassistant/components/geofency/config_flow.py` 
- `homeassistant/components/geofency/device_tracker.py` 
- `tests/components/geofency/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
