### PR TITLE
Sort imports according to PEP8 for jewish_calendar

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -1,13 +1,12 @@
 """The jewish_calendar component."""
 import logging
 
-import voluptuous as vol
 import hdate
+import voluptuous as vol
 
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
-from homeassistant.helpers.discovery import async_load_platform
 import homeassistant.helpers.config_validation as cv
-
+from homeassistant.helpers.discovery import async_load_platform
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/jewish_calendar/__init__.py
+++ b/tests/components/jewish_calendar/__init__.py
@@ -1,12 +1,11 @@
 """Tests for the jewish_calendar component."""
-from datetime import datetime
 from collections import namedtuple
 from contextlib import contextmanager
+from datetime import datetime
 from unittest.mock import patch
 
 from homeassistant.components import jewish_calendar
 import homeassistant.util.dt as dt_util
-
 
 _LatLng = namedtuple("_LatLng", ["lat", "lng"])
 

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -1,17 +1,16 @@
 """The tests for the Jewish calendar binary sensors."""
-from datetime import timedelta
-from datetime import datetime as dt
+from datetime import datetime as dt, timedelta
 
 import pytest
 
-from homeassistant.const import STATE_ON, STATE_OFF
-import homeassistant.util.dt as dt_util
-from homeassistant.setup import async_setup_component
 from homeassistant.components import jewish_calendar
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
 
 from tests.common import async_fire_time_changed
-from . import alter_time, make_nyc_test_params, make_jerusalem_test_params
-
 
 MELACHA_PARAMS = [
     make_nyc_test_params(dt(2018, 9, 1, 16, 0), STATE_ON),

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -8,9 +8,9 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
-
 from tests.common import async_fire_time_changed
+
+from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
 
 MELACHA_PARAMS = [
     make_nyc_test_params(dt(2018, 9, 1, 16, 0), STATE_ON),

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -1,15 +1,15 @@
 """The tests for the Jewish calendar sensors."""
-from datetime import timedelta
-from datetime import datetime as dt
+from datetime import datetime as dt, timedelta
 
 import pytest
 
-import homeassistant.util.dt as dt_util
-from homeassistant.setup import async_setup_component
 from homeassistant.components import jewish_calendar
-from tests.common import async_fire_time_changed
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
-from . import alter_time, make_nyc_test_params, make_jerusalem_test_params
+from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
+
+from tests.common import async_fire_time_changed
 
 
 async def test_jewish_calendar_min_config(hass):

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -7,9 +7,9 @@ from homeassistant.components import jewish_calendar
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
-
 from tests.common import async_fire_time_changed
+
+from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
 
 
 async def test_jewish_calendar_min_config(hass):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `jewish_calendar` component according to PEP8 using isort.

This affects:

- `homeassistant/components/jewish_calendar/__init__.py` 
- `tests/components/jewish_calendar/__init__.py` 
- `tests/components/jewish_calendar/test_binary_sensor.py` 
- `tests/components/jewish_calendar/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
