### PR TITLE
Sort imports according to PEP8 for met

### DIFF
--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -1,5 +1,6 @@
 """The met component."""
 from homeassistant.core import Config, HomeAssistant
+
 from .config_flow import MetFlowHandler  # noqa: F401
 from .const import DOMAIN  # noqa: F401
 

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, C
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN, HOME_LOCATION_NAME, CONF_TRACK_HOME
+from .const import CONF_TRACK_HOME, DOMAIN, HOME_LOCATION_NAME
 
 
 @callback

--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -5,16 +5,16 @@ from random import randrange
 import metno
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.weather import PLATFORM_SCHEMA, WeatherEntity
 from homeassistant.const import (
     CONF_ELEVATION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_NAME,
-    TEMP_CELSIUS,
     EVENT_CORE_CONFIG_UPDATE,
+    TEMP_CELSIUS,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -1,10 +1,10 @@
 """Tests for Met.no config flow."""
 from unittest.mock import Mock, patch
 
-from tests.common import MockConfigEntry, mock_coro
-
-from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.components.met import config_flow
+from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
+
+from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_show_config_form():


### PR DESCRIPTION

## Description:

I have sorted the imports for the `met` component according to PEP8 using isort.

This affects:

- `homeassistant/components/met/__init__.py` 
- `homeassistant/components/met/config_flow.py` 
- `homeassistant/components/met/weather.py` 
- `tests/components/met/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
