### PR TITLE
Sort imports according to PEP8 for aws

### DIFF
--- a/homeassistant/components/aws/__init__.py
+++ b/homeassistant/components/aws/__init__.py
@@ -1,10 +1,9 @@
 """Support for Amazon Web Services (AWS)."""
 import asyncio
-import logging
 from collections import OrderedDict
+import logging
 
 import aiobotocore
-
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/aws/notify.py
+++ b/homeassistant/components/aws/notify.py
@@ -12,8 +12,9 @@ from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT,
     BaseNotificationService,
 )
-from homeassistant.const import CONF_PLATFORM, CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.helpers.json import JSONEncoder
+
 from .const import (
     CONF_CONTEXT,
     CONF_CREDENTIAL_NAME,

--- a/tests/components/aws/test_init.py
+++ b/tests/components/aws/test_init.py
@@ -1,5 +1,5 @@
 """Tests for the aws component config and setup."""
-from asynctest import patch as async_patch, MagicMock, CoroutineMock
+from asynctest import CoroutineMock, MagicMock, patch as async_patch
 
 from homeassistant.components import aws
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION

## Description:

I have sorted the imports for the `aws` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/aws/__init__.py` 
- `homeassistant/components/aws/notify.py` 
- `tests/components/aws/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
