### PR TITLE
Sort imports according to PEP8 for darksky

### DIFF
--- a/homeassistant/components/darksky/sensor.py
+++ b/homeassistant/components/darksky/sensor.py
@@ -1,12 +1,11 @@
 """Support for Dark Sky weather service."""
-import logging
 from datetime import timedelta
+import logging
 
 import forecastio
-import voluptuous as vol
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -15,9 +14,10 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MONITORED_CONDITIONS,
     CONF_NAME,
-    UNIT_UV_INDEX,
     CONF_SCAN_INTERVAL,
+    UNIT_UV_INDEX,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -1,18 +1,17 @@
 """The tests for the Dark Sky platform."""
+from datetime import timedelta
 import re
 import unittest
 from unittest.mock import MagicMock, patch
-from datetime import timedelta
-
-from requests.exceptions import HTTPError
-import requests_mock
 
 import forecastio
+from requests.exceptions import HTTPError
+import requests_mock
 
 from homeassistant.components.darksky import sensor as darksky
 from homeassistant.setup import setup_component
 
-from tests.common import load_fixture, get_test_home_assistant, MockDependency
+from tests.common import MockDependency, get_test_home_assistant, load_fixture
 
 VALID_CONFIG_MINIMAL = {
     "sensor": {

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -4,15 +4,14 @@ import unittest
 from unittest.mock import patch
 
 import forecastio
+from requests.exceptions import ConnectionError
 import requests_mock
 
-from requests.exceptions import ConnectionError
-
 from homeassistant.components import weather
-from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.setup import setup_component
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from tests.common import load_fixture, get_test_home_assistant
+from tests.common import get_test_home_assistant, load_fixture
 
 
 class TestDarkSky(unittest.TestCase):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `darksky` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/darksky/sensor.py` 
- `tests/components/darksky/test_sensor.py` 
- `tests/components/darksky/test_weather.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
