### PR TITLE
Sort imports according to PEP8 for device_automation

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -1,21 +1,20 @@
 """Helpers for device automations."""
 import asyncio
 import logging
-from typing import Any, List, MutableMapping
 from types import ModuleType
+from typing import Any, List, MutableMapping
 
 import voluptuous as vol
 import voluptuous_serialize
 
-from homeassistant.const import CONF_PLATFORM, CONF_DOMAIN, CONF_DEVICE_ID
 from homeassistant.components import websocket_api
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_registry import async_entries_for_device
-from homeassistant.loader import async_get_integration, IntegrationNotFound
+from homeassistant.loader import IntegrationNotFound, async_get_integration
 
 from .exceptions import InvalidDeviceAutomationConfig
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -1,11 +1,11 @@
 """Device automation helpers for toggle entity."""
 from typing import Any, Dict, List
+
 import voluptuous as vol
 
-from homeassistant.core import Context, HomeAssistant, CALLBACK_TYPE
 from homeassistant.components.automation import (
-    state as state_automation,
     AutomationActionType,
+    state as state_automation,
 )
 from homeassistant.components.device_automation.const import (
     CONF_IS_OFF,
@@ -24,11 +24,12 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.helpers.entity_registry import async_entries_for_device
+from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant
 from homeassistant.helpers import condition, config_validation as cv
+from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
-from . import TRIGGER_BASE_SCHEMA
 
+from . import TRIGGER_BASE_SCHEMA
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -1,12 +1,11 @@
 """The test for light device automation."""
 import pytest
 
-from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
 from homeassistant.components.websocket_api.const import TYPE_RESULT
-from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
+from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
-
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,


### PR DESCRIPTION

## Description:

I have sorted the imports for the `device_automation` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/device_automation/__init__.py` 
- `homeassistant/components/device_automation/toggle_entity.py` 
- `tests/components/device_automation/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
