### PR TITLE
Sort imports according to PEP8 for plex

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -27,10 +27,10 @@ from homeassistant.helpers.dispatcher import (
 )
 
 from .const import (
-    CONF_USE_EPISODE_ART,
-    CONF_SHOW_ALL_CONTROLS,
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
+    CONF_SHOW_ALL_CONTROLS,
+    CONF_USE_EPISODE_ART,
     DEFAULT_PORT,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -8,12 +8,12 @@ from plexauth import PlexAuth
 import requests.exceptions
 import voluptuous as vol
 
-from homeassistant.components.http.view import HomeAssistantView
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant import config_entries
+from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.const import CONF_URL, CONF_TOKEN, CONF_SSL, CONF_VERIFY_SSL
+from homeassistant.const import CONF_SSL, CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.json import load_json
 
 from .const import (  # pylint: disable=unused-import
@@ -22,16 +22,16 @@ from .const import (  # pylint: disable=unused-import
     CONF_CLIENT_IDENTIFIER,
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
-    CONF_USE_EPISODE_ART,
     CONF_SHOW_ALL_CONTROLS,
+    CONF_USE_EPISODE_ART,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     PLEX_CONFIG_FILE,
     PLEX_SERVER_CONFIG,
     X_PLEX_DEVICE_NAME,
-    X_PLEX_VERSION,
-    X_PLEX_PRODUCT,
     X_PLEX_PLATFORM,
+    X_PLEX_PRODUCT,
+    X_PLEX_VERSION,
 )
 from .errors import NoServersFound, ServerNotSpecified
 from .server import PlexServer

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -1,6 +1,6 @@
 """Mock classes used in tests."""
-from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.components.plex.const import CONF_SERVER, CONF_SERVER_IDENTIFIER
+from homeassistant.const import CONF_HOST, CONF_PORT
 
 MOCK_SERVERS = [
     {

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -9,9 +9,9 @@ from homeassistant.components.plex import config_flow
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONF_TOKEN, CONF_URL
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
-
 from .mock_classes import MOCK_SERVERS, MockPlexAccount, MockPlexServer
+
+from tests.common import MockConfigEntry
 
 MOCK_TOKEN = "secret_token"
 MOCK_FILE_CONTENTS = {


### PR DESCRIPTION

## Description:

I have sorted the imports for the `plex` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/plex/__init__.py` 
- `homeassistant/components/plex/config_flow.py` 
- `tests/components/plex/mock_classes.py` 
- `tests/components/plex/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
