### PR TITLE
Sort imports according to PEP8 for soma

### DIFF
--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -1,20 +1,18 @@
 """Support for Soma Smartshades."""
 import logging
 
-import voluptuous as vol
 from api.soma_api import SomaApi
 from requests import RequestException
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from homeassistant.const import CONF_HOST, CONF_PORT
-
-from .const import DOMAIN, HOST, PORT, API
-
+from .const import API, DOMAIN, HOST, PORT
 
 DEVICES = "devices"
 

--- a/homeassistant/components/soma/config_flow.py
+++ b/homeassistant/components/soma/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow for Soma."""
 import logging
 
-import voluptuous as vol
 from api.soma_api import SomaApi
 from requests import RequestException
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -2,9 +2,8 @@
 
 import logging
 
-from homeassistant.components.cover import CoverDevice, ATTR_POSITION
-from homeassistant.components.soma import DOMAIN, SomaEntity, DEVICES, API
-
+from homeassistant.components.cover import ATTR_POSITION, CoverDevice
+from homeassistant.components.soma import API, DEVICES, DOMAIN, SomaEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/soma/test_config_flow.py
+++ b/tests/components/soma/test_config_flow.py
@@ -5,9 +5,9 @@ from api.soma_api import SomaApi
 from requests import RequestException
 
 from homeassistant import data_entry_flow
-from homeassistant.components.soma import config_flow, DOMAIN
-from tests.common import MockConfigEntry
+from homeassistant.components.soma import DOMAIN, config_flow
 
+from tests.common import MockConfigEntry
 
 MOCK_HOST = "123.45.67.89"
 MOCK_PORT = 3000


### PR DESCRIPTION

## Description:

I have sorted the imports for the `soma` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/soma/__init__.py` 
- `homeassistant/components/soma/config_flow.py` 
- `homeassistant/components/soma/cover.py` 
- `tests/components/soma/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
