### PR TITLE
Sort imports according to PEP8 for utility_meter

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -1,33 +1,34 @@
 """Support for tracking consumption over given periods of time."""
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_NAME
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+
 from .const import (
-    DOMAIN,
-    SIGNAL_RESET_METER,
-    METER_TYPES,
-    CONF_METER_TYPE,
-    CONF_METER_OFFSET,
-    CONF_METER_NET_CONSUMPTION,
-    CONF_SOURCE_SENSOR,
-    CONF_TARIFF_ENTITY,
-    CONF_TARIFF,
-    CONF_TARIFFS,
-    CONF_METER,
-    DATA_UTILITY,
-    SERVICE_RESET,
-    SERVICE_SELECT_TARIFF,
-    SERVICE_SELECT_NEXT_TARIFF,
     ATTR_TARIFF,
+    CONF_METER,
+    CONF_METER_NET_CONSUMPTION,
+    CONF_METER_OFFSET,
+    CONF_METER_TYPE,
+    CONF_SOURCE_SENSOR,
+    CONF_TARIFF,
+    CONF_TARIFF_ENTITY,
+    CONF_TARIFFS,
+    DATA_UTILITY,
+    DOMAIN,
+    METER_TYPES,
+    SERVICE_RESET,
+    SERVICE_SELECT_NEXT_TARIFF,
+    SERVICE_SELECT_TARIFF,
+    SIGNAL_RESET_METER,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -1,39 +1,40 @@
 """Utility meter from sensors providing raw data."""
-import logging
 from datetime import date, timedelta
 from decimal import Decimal, DecimalException
+import logging
 
-import homeassistant.util.dt as dt_util
 from homeassistant.const import (
-    CONF_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
     EVENT_HOMEASSISTANT_START,
-    STATE_UNKNOWN,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import (
     async_track_state_change,
     async_track_time_change,
 )
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
+import homeassistant.util.dt as dt_util
+
 from .const import (
-    DATA_UTILITY,
-    SIGNAL_RESET_METER,
-    HOURLY,
-    DAILY,
-    WEEKLY,
-    MONTHLY,
-    QUARTERLY,
-    YEARLY,
-    CONF_SOURCE_SENSOR,
-    CONF_METER_TYPE,
-    CONF_METER_OFFSET,
+    CONF_METER,
     CONF_METER_NET_CONSUMPTION,
+    CONF_METER_OFFSET,
+    CONF_METER_TYPE,
+    CONF_SOURCE_SENSOR,
     CONF_TARIFF,
     CONF_TARIFF_ENTITY,
-    CONF_METER,
+    DAILY,
+    DATA_UTILITY,
+    HOURLY,
+    MONTHLY,
+    QUARTERLY,
+    SIGNAL_RESET_METER,
+    WEEKLY,
+    YEARLY,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -1,20 +1,19 @@
 """The tests for the utility_meter component."""
-import logging
-
 from datetime import timedelta
+import logging
 from unittest.mock import patch
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START, ATTR_ENTITY_ID
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.utility_meter.const import (
-    SERVICE_RESET,
-    SERVICE_SELECT_TARIFF,
-    SERVICE_SELECT_NEXT_TARIFF,
     ATTR_TARIFF,
+    DOMAIN,
+    SERVICE_RESET,
+    SERVICE_SELECT_NEXT_TARIFF,
+    SERVICE_SELECT_TARIFF,
 )
+from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.components.utility_meter.const import DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1,20 +1,20 @@
 """The tests for the utility_meter sensor platform."""
-import logging
-
-from datetime import timedelta
-from unittest.mock import patch
 from contextlib import contextmanager
+from datetime import timedelta
+import logging
+from unittest.mock import patch
 
-from tests.common import async_fire_time_changed
-from homeassistant.const import EVENT_HOMEASSISTANT_START, ATTR_ENTITY_ID
-from homeassistant.setup import async_setup_component
-import homeassistant.util.dt as dt_util
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.utility_meter.const import (
+    ATTR_TARIFF,
     DOMAIN,
     SERVICE_SELECT_TARIFF,
-    ATTR_TARIFF,
 )
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `utility_meter` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/utility_meter/__init__.py` 
- `homeassistant/components/utility_meter/sensor.py` 
- `tests/components/utility_meter/test_init.py` 
- `tests/components/utility_meter/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
