### PR TITLE
Sort imports according to PEP8 for verisure

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -1,11 +1,10 @@
 """Support for Verisure devices."""
+from datetime import timedelta
 import logging
 import threading
-from datetime import timedelta
 
 from jsonpath import jsonpath
 import verisure
-
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -15,8 +14,8 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import discovery
-from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -2,8 +2,8 @@
 import logging
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice,
     DEVICE_CLASS_CONNECTIVITY,
+    BinarySensorDevice,
 )
 
 from . import CONF_DOOR_WINDOW, HUB as hub

--- a/tests/components/verisure/test_ethernet_status.py
+++ b/tests/components/verisure/test_ethernet_status.py
@@ -2,9 +2,9 @@
 from contextlib import contextmanager
 from unittest.mock import patch
 
+from homeassistant.components.verisure import DOMAIN as VERISURE_DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.setup import async_setup_component
-from homeassistant.components.verisure import DOMAIN as VERISURE_DOMAIN
 
 CONFIG = {
     "verisure": {

--- a/tests/components/verisure/test_lock.py
+++ b/tests/components/verisure/test_lock.py
@@ -1,16 +1,16 @@
 """Tests for the Verisure platform."""
 
 from contextlib import contextmanager
-from unittest.mock import patch, call
-from homeassistant.const import STATE_UNLOCKED
-from homeassistant.setup import async_setup_component
+from unittest.mock import call, patch
+
 from homeassistant.components.lock import (
     DOMAIN as LOCK_DOMAIN,
     SERVICE_LOCK,
     SERVICE_UNLOCK,
 )
 from homeassistant.components.verisure import DOMAIN as VERISURE_DOMAIN
-
+from homeassistant.const import STATE_UNLOCKED
+from homeassistant.setup import async_setup_component
 
 NO_DEFAULT_LOCK_CODE_CONFIG = {
     "verisure": {


### PR DESCRIPTION

## Description:

I have sorted the imports for the `verisure` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/verisure/__init__.py` 
- `homeassistant/components/verisure/binary_sensor.py` 
- `tests/components/verisure/test_ethernet_status.py` 
- `tests/components/verisure/test_lock.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
