### PR TITLE
sort imports according to PEP8 for zone

### DIFF
--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -4,28 +4,27 @@ from typing import Set, cast
 
 import voluptuous as vol
 
-from homeassistant.core import callback, State
-from homeassistant.loader import bind_hass
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_NAME,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_ICON,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_ICON,
+    CONF_NAME,
     CONF_RADIUS,
     EVENT_CORE_CONFIG_UPDATE,
 )
+from homeassistant.core import State, callback
 from homeassistant.helpers import config_per_platform
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.loader import bind_hass
 from homeassistant.util import slugify
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.util.location import distance
 
-
 from .config_flow import configured_zones
-from .const import CONF_PASSIVE, DOMAIN, HOME_ZONE, ATTR_PASSIVE, ATTR_RADIUS
+from .const import ATTR_PASSIVE, ATTR_RADIUS, CONF_PASSIVE, DOMAIN, HOME_ZONE
 from .zone import Zone
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/components/zone/config_flow.py
+++ b/homeassistant/components/zone/config_flow.py
@@ -4,21 +4,20 @@ from typing import Set
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
 from homeassistant.const import (
-    CONF_NAME,
+    CONF_ICON,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_ICON,
+    CONF_NAME,
     CONF_RADIUS,
 )
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import slugify
 
 from .const import CONF_PASSIVE, DOMAIN, HOME_ZONE
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/tests/components/zone/test_config_flow.py
+++ b/tests/components/zone/test_config_flow.py
@@ -3,10 +3,10 @@
 from homeassistant.components.zone import config_flow
 from homeassistant.components.zone.const import CONF_PASSIVE, DOMAIN, HOME_ZONE
 from homeassistant.const import (
-    CONF_NAME,
+    CONF_ICON,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_ICON,
+    CONF_NAME,
     CONF_RADIUS,
 )
 

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -6,8 +6,7 @@ from unittest.mock import Mock
 from homeassistant import setup
 from homeassistant.components import zone
 
-from tests.common import get_test_home_assistant
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_test_home_assistant
 
 
 async def test_setup_entry_successful(hass):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `zone` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/zone/__init__.py` 
- `homeassistant/components/zone/config_flow.py` 
- `tests/components/zone/test_config_flow.py` 
- `tests/components/zone/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
