### PR TITLE
sort imports according to PEP8 for group

### DIFF
--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -19,16 +19,16 @@ from homeassistant.const import (
     CONF_ENTITIES,
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
-    SERVICE_TOGGLE,
-    SERVICE_TOGGLE_COVER_TILT,
     SERVICE_OPEN_COVER,
     SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
-    STATE_OPEN,
+    SERVICE_TOGGLE,
+    SERVICE_TOGGLE_COVER_TILT,
     STATE_CLOSED,
+    STATE_OPEN,
 )
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -5,21 +5,21 @@ from collections import OrderedDict
 import unittest
 from unittest.mock import patch
 
-from homeassistant.setup import setup_component, async_setup_component
-from homeassistant.const import (
-    STATE_ON,
-    STATE_OFF,
-    STATE_HOME,
-    STATE_UNKNOWN,
-    ATTR_ICON,
-    ATTR_HIDDEN,
-    ATTR_ASSUMED_STATE,
-    STATE_NOT_HOME,
-    ATTR_FRIENDLY_NAME,
-)
 import homeassistant.components.group as group
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    ATTR_FRIENDLY_NAME,
+    ATTR_HIDDEN,
+    ATTR_ICON,
+    STATE_HOME,
+    STATE_NOT_HOME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+)
+from homeassistant.setup import async_setup_component, setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import assert_setup_component, get_test_home_assistant
 from tests.components.group import common
 
 

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -3,10 +3,10 @@ import asyncio
 import unittest
 from unittest.mock import MagicMock, patch
 
-from homeassistant.setup import setup_component
-import homeassistant.components.notify as notify
-import homeassistant.components.group.notify as group
 import homeassistant.components.demo.notify as demo
+import homeassistant.components.group.notify as group
+import homeassistant.components.notify as notify
+from homeassistant.setup import setup_component
 
 from tests.common import assert_setup_component, get_test_home_assistant
 

--- a/tests/components/group/test_reproduce_state.py
+++ b/tests/components/group/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 from asyncio import Future
 from unittest.mock import patch
+
 from homeassistant.components.group.reproduce_state import async_reproduce_states
 from homeassistant.core import Context, State
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `group` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `tests/components/group/test_cover.py` 
- `tests/components/group/test_init.py` 
- `tests/components/group/test_notify.py` 
- `tests/components/group/test_reproduce_state.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
