### PR TITLE
Sort imports according to PEP8 for eufy

### DIFF
--- a/homeassistant/components/eufy/__init__.py
+++ b/homeassistant/components/eufy/__init__.py
@@ -1,7 +1,7 @@
 """Support for Eufy devices."""
 import logging
-import lakeside
 
+import lakeside
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/eufy/light.py
+++ b/homeassistant/components/eufy/light.py
@@ -1,5 +1,6 @@
 """Support for Eufy lights."""
 import logging
+
 import lakeside
 
 from homeassistant.components.light import (
@@ -7,16 +8,14 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
     SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR_TEMP,
     SUPPORT_COLOR,
+    SUPPORT_COLOR_TEMP,
     Light,
 )
-
 import homeassistant.util.color as color_util
-
 from homeassistant.util.color import (
-    color_temperature_mired_to_kelvin as mired_to_kelvin,
     color_temperature_kelvin_to_mired as kelvin_to_mired,
+    color_temperature_mired_to_kelvin as mired_to_kelvin,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/eufy/switch.py
+++ b/homeassistant/components/eufy/switch.py
@@ -1,5 +1,6 @@
 """Support for Eufy switches."""
 import logging
+
 import lakeside
 
 from homeassistant.components.switch import SwitchDevice


### PR DESCRIPTION

## Description:

I have sorted the imports for the `eufy` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/eufy/__init__.py` 
- `homeassistant/components/eufy/light.py` 
- `homeassistant/components/eufy/switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
