### PR TITLE
Sort imports according to PEP8 for geonetnz_volcano

### DIFF
--- a/homeassistant/components/geonetnz_volcano/__init__.py
+++ b/homeassistant/components/geonetnz_volcano/__init__.py
@@ -1,27 +1,27 @@
 """The GeoNet NZ Volcano integration."""
 import asyncio
+from datetime import datetime, timedelta
 import logging
-from datetime import timedelta, datetime
 from typing import Optional
 
-import voluptuous as vol
 from aio_geojson_geonetnz_volcano import GeonetnzVolcanoFeedManager
+import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_RADIUS,
     CONF_SCAN_INTERVAL,
-    CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM,
+    CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_MILES,
 )
-from homeassistant.helpers import config_validation as cv, aiohttp_client
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .config_flow import configured_instances
 from .const import (

--- a/homeassistant/components/geonetnz_volcano/sensor.py
+++ b/homeassistant/components/geonetnz_volcano/sensor.py
@@ -3,11 +3,11 @@ import logging
 from typing import Optional
 
 from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
     CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_KILOMETERS,
-    ATTR_ATTRIBUTION,
-    ATTR_LONGITUDE,
-    ATTR_LATITUDE,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/tests/components/geonetnz_volcano/conftest.py
+++ b/tests/components/geonetnz_volcano/conftest.py
@@ -6,9 +6,10 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_RADIUS,
-    CONF_UNIT_SYSTEM,
     CONF_SCAN_INTERVAL,
+    CONF_UNIT_SYSTEM,
 )
+
 from tests.common import MockConfigEntry
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `geonetnz_volcano` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/geonetnz_volcano/__init__.py` 
- `homeassistant/components/geonetnz_volcano/sensor.py` 
- `tests/components/geonetnz_volcano/conftest.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
