### PR TITLE
Sort imports according to PEP8 for gpslogger

### DIFF
--- a/homeassistant/components/gpslogger/__init__.py
+++ b/homeassistant/components/gpslogger/__init__.py
@@ -1,30 +1,33 @@
 """Support for GPSLogger."""
 import logging
 
-import voluptuous as vol
 from aiohttp import web
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import ATTR_BATTERY
+from homeassistant.components.device_tracker import (
+    ATTR_BATTERY,
+    DOMAIN as DEVICE_TRACKER,
+)
 from homeassistant.const import (
-    HTTP_UNPROCESSABLE_ENTITY,
-    HTTP_OK,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
     CONF_WEBHOOK_ID,
+    HTTP_OK,
+    HTTP_UNPROCESSABLE_ENTITY,
 )
 from homeassistant.helpers import config_entry_flow
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
+
 from .const import (
-    DOMAIN,
-    ATTR_ALTITUDE,
     ATTR_ACCURACY,
     ATTR_ACTIVITY,
+    ATTR_ALTITUDE,
     ATTR_DEVICE,
     ATTR_DIRECTION,
     ATTR_PROVIDER,
     ATTR_SPEED,
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/gpslogger/config_flow.py
+++ b/homeassistant/components/gpslogger/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for GPSLogger."""
 from homeassistant.helpers import config_entry_flow
-from .const import DOMAIN
 
+from .const import DOMAIN
 
 config_entry_flow.register_webhook_flow(
     DOMAIN,

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -1,15 +1,15 @@
 """Support for the GPSLogger device tracking."""
 import logging
 
-from homeassistant.core import callback
+from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_GPS_ACCURACY,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
 )
-from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.core import callback
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity


### PR DESCRIPTION

## Description:

I have sorted the imports for the `gpslogger` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/gpslogger/__init__.py` 
- `homeassistant/components/gpslogger/config_flow.py` 
- `homeassistant/components/gpslogger/device_tracker.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
