### PR TITLE
sort imports according to PEP8 for homeassistant

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -6,23 +6,22 @@ from typing import Awaitable
 
 import voluptuous as vol
 
-import homeassistant.core as ha
 import homeassistant.config as conf_util
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.service import async_extract_entity_ids
-from homeassistant.helpers import intent
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
-    SERVICE_TOGGLE,
-    SERVICE_HOMEASSISTANT_STOP,
-    SERVICE_HOMEASSISTANT_RESTART,
-    RESTART_EXIT_CODE,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    RESTART_EXIT_CODE,
+    SERVICE_HOMEASSISTANT_RESTART,
+    SERVICE_HOMEASSISTANT_STOP,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
 )
-from homeassistant.helpers import config_validation as cv
+import homeassistant.core as ha
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, intent
+from homeassistant.helpers.service import async_extract_entity_ids
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = ha.DOMAIN

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -4,6 +4,8 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant import config as conf_util
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN, STATES, Scene
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_STATE,
@@ -11,21 +13,19 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME,
     CONF_PLATFORM,
+    SERVICE_RELOAD,
     STATE_OFF,
     STATE_ON,
-    SERVICE_RELOAD,
 )
-from homeassistant.core import State, DOMAIN as HA_DOMAIN
-from homeassistant import config as conf_util
+from homeassistant.core import DOMAIN as HA_DOMAIN, State
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.loader import async_get_integration
 from homeassistant.helpers import (
     config_per_platform,
     config_validation as cv,
     entity_platform,
 )
 from homeassistant.helpers.state import async_reproduce_state
-from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN, STATES, Scene
+from homeassistant.loader import async_get_integration
 
 
 def _convert_states(states):

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -2,40 +2,40 @@
 # pylint: disable=protected-access
 import asyncio
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import yaml
 
-import homeassistant.core as ha
 from homeassistant import config
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    STATE_ON,
-    STATE_OFF,
-    SERVICE_HOMEASSISTANT_RESTART,
-    SERVICE_HOMEASSISTANT_STOP,
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
-    SERVICE_TOGGLE,
-    EVENT_CORE_CONFIG_UPDATE,
-)
 import homeassistant.components as comps
-from homeassistant.setup import async_setup_component
 from homeassistant.components.homeassistant import (
     SERVICE_CHECK_CONFIG,
     SERVICE_RELOAD_CORE_CONFIG,
 )
-import homeassistant.helpers.intent as intent
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_CORE_CONFIG_UPDATE,
+    SERVICE_HOMEASSISTANT_RESTART,
+    SERVICE_HOMEASSISTANT_STOP,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+import homeassistant.core as ha
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity
+import homeassistant.helpers.intent as intent
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
+    async_capture_events,
+    async_mock_service,
     get_test_home_assistant,
+    mock_coro,
     mock_service,
     patch_yaml_files,
-    mock_coro,
-    async_mock_service,
-    async_capture_events,
 )
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `homeassistant` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/homeassistant/__init__.py` 
- `homeassistant/components/homeassistant/scene.py` 
- `tests/components/homeassistant/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
