### PR TITLE
Sort imports according to PEP8 for input_text

### DIFF
--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -3,14 +3,14 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT,
     ATTR_MODE,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_ICON,
-    CONF_NAME,
     CONF_MODE,
+    CONF_NAME,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 

--- a/homeassistant/components/input_text/reproduce_state.py
+++ b/homeassistant/components/input_text/reproduce_state.py
@@ -7,7 +7,7 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN, SERVICE_SET_VALUE, ATTR_VALUE
+from . import ATTR_VALUE, DOMAIN, SERVICE_SET_VALUE
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -4,7 +4,7 @@ import asyncio
 
 from homeassistant.components.input_text import ATTR_VALUE, DOMAIN, SERVICE_SET_VALUE
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import CoreState, State, Context
+from homeassistant.core import Context, CoreState, State
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `input_text` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/input_text/__init__.py` 
- `homeassistant/components/input_text/reproduce_state.py` 
- `tests/components/input_text/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
