### PR TITLE
Sort imports according to PEP8 for kodi

### DIFF
--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -1,13 +1,13 @@
 """The kodi component."""
 
 import asyncio
+
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
-from homeassistant.helpers import config_validation as cv
 from homeassistant.components.kodi.const import DOMAIN
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
-
+from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
+from homeassistant.helpers import config_validation as cv
 
 SERVICE_ADD_MEDIA = "add_to_playlist"
 SERVICE_CALL_METHOD = "call_method"

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -7,15 +7,14 @@ import socket
 import urllib
 
 import aiohttp
-import jsonrpc_base
 import jsonrpc_async
+import jsonrpc_base
 import jsonrpc_websocket
-
 import voluptuous as vol
 
 from homeassistant.components.kodi import SERVICE_CALL_METHOD
 from homeassistant.components.kodi.const import DOMAIN
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     MEDIA_TYPE_MOVIE,
@@ -52,12 +51,11 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import script
+from homeassistant.helpers import config_validation as cv, script
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.template import Template
-from homeassistant.util.yaml import dump
 import homeassistant.util.dt as dt_util
+from homeassistant.util.yaml import dump
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/kodi/notify.py
+++ b/homeassistant/components/kodi/notify.py
@@ -3,9 +3,15 @@ import logging
 
 import aiohttp
 import jsonrpc_async
-
 import voluptuous as vol
 
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
 from homeassistant.const import (
     ATTR_ICON,
     CONF_HOST,
@@ -16,14 +22,6 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import (
-    ATTR_DATA,
-    ATTR_TITLE,
-    ATTR_TITLE_DEFAULT,
-    PLATFORM_SCHEMA,
-    BaseNotificationService,
-)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `kodi` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/kodi/__init__.py` 
- `homeassistant/components/kodi/media_player.py` 
- `homeassistant/components/kodi/notify.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
