### PR TITLE
Sort imports according to PEP8 for linky

### DIFF
--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow to configure the Linky integration."""
 import logging
 
-import voluptuous as vol
 from pylinky.client import LinkyClient
 from pylinky.exceptions import (
     PyLinkyAccessException,
@@ -9,6 +8,7 @@ from pylinky.exceptions import (
     PyLinkyException,
     PyLinkyWrongLoginException,
 )
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -1,10 +1,9 @@
 """Support for Linky."""
+from datetime import timedelta
 import json
 import logging
-from datetime import timedelta
 
-from pylinky.client import DAILY, MONTHLY, YEARLY, LinkyClient
-from pylinky.client import PyLinkyException
+from pylinky.client import DAILY, MONTHLY, YEARLY, LinkyClient, PyLinkyException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/tests/components/linky/test_config_flow.py
+++ b/tests/components/linky/test_config_flow.py
@@ -1,16 +1,17 @@
 """Tests for the Linky config flow."""
-import pytest
 from unittest.mock import patch
+
 from pylinky.exceptions import (
     PyLinkyAccessException,
     PyLinkyEnedisException,
     PyLinkyException,
     PyLinkyWrongLoginException,
 )
+import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.linky import config_flow
-from homeassistant.components.linky.const import DOMAIN, DEFAULT_TIMEOUT
+from homeassistant.components.linky.const import DEFAULT_TIMEOUT, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
 
 from tests.common import MockConfigEntry


### PR DESCRIPTION

## Description:

I have sorted the imports for the `linky` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/linky/config_flow.py` 
- `homeassistant/components/linky/sensor.py` 
- `tests/components/linky/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
