### PR TITLE
Sort imports according to PEP8 for minio

### DIFF
--- a/homeassistant/components/minio/__init__.py
+++ b/homeassistant/components/minio/__init__.py
@@ -1,8 +1,8 @@
 """Minio component."""
 import logging
 import os
-import threading
 from queue import Queue
+import threading
 from typing import List
 
 import voluptuous as vol
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
 
-from .minio_helper import create_minio_client, MinioEventThread
+from .minio_helper import MinioEventThread, create_minio_client
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/minio/minio_helper.py
+++ b/homeassistant/components/minio/minio_helper.py
@@ -1,11 +1,11 @@
 """Minio helper methods."""
-import time
 from collections.abc import Iterable
 import json
 import logging
+from queue import Queue
 import re
 import threading
-from queue import Queue
+import time
 from typing import Iterator, List
 from urllib.parse import unquote
 

--- a/tests/components/minio/test_minio.py
+++ b/tests/components/minio/test_minio.py
@@ -3,19 +3,19 @@ import asyncio
 import json
 from unittest.mock import MagicMock
 
+from asynctest import call, patch
 import pytest
-from asynctest import patch, call
 
 from homeassistant.components.minio import (
-    QueueListener,
-    DOMAIN,
-    CONF_HOST,
-    CONF_PORT,
     CONF_ACCESS_KEY,
-    CONF_SECRET_KEY,
-    CONF_SECURE,
+    CONF_HOST,
     CONF_LISTEN,
     CONF_LISTEN_BUCKET,
+    CONF_PORT,
+    CONF_SECRET_KEY,
+    CONF_SECURE,
+    DOMAIN,
+    QueueListener,
 )
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION

## Description:

I have sorted the imports for the `minio` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/minio/__init__.py` 
- `homeassistant/components/minio/minio_helper.py` 
- `tests/components/minio/test_minio.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
