### PR TITLE
Sort imports according to PEP8 for neato

### DIFF
--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -1,11 +1,11 @@
 """Support for Neato botvac connected vacuum cleaners."""
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
-import voluptuous as vol
 from pybotvac import Account, Neato, Vorwerk
 from pybotvac.exceptions import NeatoException, NeatoLoginException, NeatoRobotException
+import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME

--- a/tests/components/neato/test_config_flow.py
+++ b/tests/components/neato/test_config_flow.py
@@ -1,8 +1,8 @@
 """Tests for the Neato config flow."""
-import pytest
 from unittest.mock import patch
 
 from pybotvac.exceptions import NeatoLoginException, NeatoRobotException
+import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.neato import config_flow

--- a/tests/components/neato/test_init.py
+++ b/tests/components/neato/test_init.py
@@ -1,8 +1,8 @@
 """Tests for the Neato init file."""
-import pytest
 from unittest.mock import patch
 
 from pybotvac.exceptions import NeatoLoginException
+import pytest
 
 from homeassistant.components.neato.const import CONF_VENDOR, NEATO_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME


### PR DESCRIPTION

## Description:

I have sorted the imports for the `neato` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/neato/__init__.py` 
- `tests/components/neato/test_config_flow.py` 
- `tests/components/neato/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
