### PR TITLE
Sort imports according to PEP8 for pi_hole

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -1,31 +1,31 @@
 """The pi_hole component."""
 import logging
 
-import voluptuous as vol
 from hole import Hole
 from hole.exceptions import HoleError
+import voluptuous as vol
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
+    CONF_API_KEY,
     CONF_HOST,
     CONF_NAME,
-    CONF_API_KEY,
     CONF_SSL,
     CONF_VERIFY_SSL,
 )
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.util import Throttle
 
 from .const import (
-    DOMAIN,
     CONF_LOCATION,
     DEFAULT_HOST,
     DEFAULT_LOCATION,
     DEFAULT_NAME,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
+    DOMAIN,
     MIN_TIME_BETWEEN_UPDATES,
     SERVICE_DISABLE,
     SERVICE_DISABLE_ATTR_DURATION,

--- a/homeassistant/components/pi_hole/sensor.py
+++ b/homeassistant/components/pi_hole/sensor.py
@@ -4,10 +4,10 @@ import logging
 from homeassistant.helpers.entity import Entity
 
 from .const import (
-    DOMAIN as PIHOLE_DOMAIN,
     ATTR_BLOCKED_DOMAINS,
-    SENSOR_LIST,
+    DOMAIN as PIHOLE_DOMAIN,
     SENSOR_DICT,
+    SENSOR_LIST,
 )
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -1,11 +1,13 @@
 """Test pi_hole component."""
 
+from unittest.mock import patch
+
 from asynctest import CoroutineMock
 from hole import Hole
 
 from homeassistant.components import pi_hole
+
 from tests.common import async_setup_component
-from unittest.mock import patch
 
 
 def mock_pihole_data_call(Hole):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `pi_hole` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/pi_hole/__init__.py` 
- `homeassistant/components/pi_hole/sensor.py` 
- `tests/components/pi_hole/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
