### PR TITLE
Add isort to CI and pre-commit

### DIFF
--- a/.pre-commit-config-all.yaml
+++ b/.pre-commit-config-all.yaml
@@ -35,6 +35,10 @@ repos:
           - --format=custom
           - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script|tests)/.+\.py$
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    -   id: isort
 # Using a local "system" mypy instead of the mypy hook, because its
 # results depend on what is installed. And the mypy hook runs in a
 # virtualenv of its own, meaning we'd need to install and maintain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,7 @@ repos:
           - --format=custom
           - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script|tests)/.+\.py$
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    -   id: isort

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -54,6 +54,10 @@ stages:
         . venv/bin/activate
         pre-commit run bandit --all-files
       displayName: 'Run bandit'
+    - script: |
+        . venv/bin/activate
+        pre-commit run isort --all-files
+      displayName: 'Run isort'
   - job: 'Validate'
     pool:
       vmImage: 'ubuntu-latest'

--- a/pylintrc
+++ b/pylintrc
@@ -25,6 +25,7 @@ good-names=id,i,j,k,ex,Run,_,fp
 # unnecessary-pass - readability for functions which only contain pass
 # import-outside-toplevel - TODO
 # too-many-ancestors - it's too strict.
+# wrong-import-order - isort ensures this
 disable=
   format,
   abstract-class-little-used,
@@ -50,6 +51,7 @@ disable=
   too-many-boolean-expressions,
   unnecessary-pass,
   unused-argument
+  wrong-import-order
 enable=
   use-symbolic-message-instead
 

--- a/pylintrc
+++ b/pylintrc
@@ -25,7 +25,7 @@ good-names=id,i,j,k,ex,Run,_,fp
 # unnecessary-pass - readability for functions which only contain pass
 # import-outside-toplevel - TODO
 # too-many-ancestors - it's too strict.
-# wrong-import-order - isort ensures this
+# wrong-import-order - isort guards this
 disable=
   format,
   abstract-class-little-used,
@@ -50,7 +50,7 @@ disable=
   too-many-statements,
   too-many-boolean-expressions,
   unnecessary-pass,
-  unused-argument
+  unused-argument,
   wrong-import-order
 enable=
   use-symbolic-message-instead

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -4,4 +4,5 @@ bandit==1.6.2
 black==19.10b0
 flake8-docstrings==1.5.0
 flake8==3.7.9
+isort==v4.3.21
 pydocstyle==5.0.1


### PR DESCRIPTION
## Description:

:tada: All PRs have been merged! 

This adds `isort` to the CI and `pre-commit`. I think it is smart to reduce the number of style changes even further, in that way `git blame` will become even more useful.

`isort` will enforce a consistent import order, and using the settings I added in the `pre-commit` config, it plays well with `black` ([source](https://black.readthedocs.io/en/stable/the_black_code_style.html)).

I have opened PRs for each component that involves changes to >= 3. I've done this because I think it would be too big of a change too sudden otherwise (as it involves >1000 files which is hard to review).

All changes to components that involve <=2 files, I have partitioned into PRs with the starting letter.

Then per main folder, I have another PR (as discussed with @frenck).

I have opened these PRs:
- yweather (https://github.com/home-assistant/home-assistant/pull/29608)
- components (https://github.com/home-assistant/home-assistant/pull/29609)
- abode (https://github.com/home-assistant/home-assistant/pull/29610)
- acer_projector (https://github.com/home-assistant/home-assistant/pull/29611)
- actiontec (https://github.com/home-assistant/home-assistant/pull/29612)
- ads (https://github.com/home-assistant/home-assistant/pull/29613)
- air_quality (https://github.com/home-assistant/home-assistant/pull/29614)
- airly (https://github.com/home-assistant/home-assistant/pull/29615)
- alarm_control_panel (https://github.com/home-assistant/home-assistant/pull/29616)
- alexa (https://github.com/home-assistant/home-assistant/pull/29618)
- auth (https://github.com/home-assistant/home-assistant/pull/29619)
- automation (https://github.com/home-assistant/home-assistant/pull/29620)
- axis (https://github.com/home-assistant/home-assistant/pull/29621)
- binary_sensor (https://github.com/home-assistant/home-assistant/pull/29622)
- buienradar (https://github.com/home-assistant/home-assistant/pull/29623)
- cast (https://github.com/home-assistant/home-assistant/pull/29624)
- climate (https://github.com/home-assistant/home-assistant/pull/29625)
- cloud (https://github.com/home-assistant/home-assistant/pull/29626)
- command_line (https://github.com/home-assistant/home-assistant/pull/29627)
- config (https://github.com/home-assistant/home-assistant/pull/29628)
- cover (https://github.com/home-assistant/home-assistant/pull/29629)
- demo (https://github.com/home-assistant/home-assistant/pull/29630)
- ecobee (https://github.com/home-assistant/home-assistant/pull/29631)
- fan (https://github.com/home-assistant/home-assistant/pull/29632)
- google_assistant (https://github.com/home-assistant/home-assistant/pull/29633)
- hassio (https://github.com/home-assistant/home-assistant/pull/29634)
- homekit (https://github.com/home-assistant/home-assistant/pull/29645)
- homekit_controller (https://github.com/home-assistant/home-assistant/pull/29646)
- light (https://github.com/home-assistant/home-assistant/pull/29648)
- mqtt (https://github.com/home-assistant/home-assistant/pull/29649)
- vacuum (https://github.com/home-assistant/home-assistant/pull/29650)
- recorder (https://github.com/home-assistant/home-assistant/pull/29652)
- starline (https://github.com/home-assistant/home-assistant/pull/29653)
- switch (https://github.com/home-assistant/home-assistant/pull/29654)
- template (https://github.com/home-assistant/home-assistant/pull/29655)
- unifi (https://github.com/home-assistant/home-assistant/pull/29656)
- websocket_api (https://github.com/home-assistant/home-assistant/pull/29657)
- zwave (https://github.com/home-assistant/home-assistant/pull/29658)
- deconz (https://github.com/home-assistant/home-assistant/pull/29659)
- lock (https://github.com/home-assistant/home-assistant/pull/29663)
- huawei_lte (https://github.com/home-assistant/home-assistant/pull/29664)
- media_player (https://github.com/home-assistant/home-assistant/pull/29665)
- device_tracker (https://github.com/home-assistant/home-assistant/pull/29666)
- emulated_hue (https://github.com/home-assistant/home-assistant/pull/29667)
- geonetnz_quakes (https://github.com/home-assistant/home-assistant/pull/29668)
- hive (https://github.com/home-assistant/home-assistant/pull/29669)
- nest (https://github.com/home-assistant/home-assistant/pull/29670)
- opentherm_gw (https://github.com/home-assistant/home-assistant/pull/29671)
- owntracks (https://github.com/home-assistant/home-assistant/pull/29672)
- pilight (https://github.com/home-assistant/home-assistant/pull/29673)
- rest (https://github.com/home-assistant/home-assistant/pull/29674)
- somfy (https://github.com/home-assistant/home-assistant/pull/29675)
- velbus (https://github.com/home-assistant/home-assistant/pull/29676)
- xiaomi_miio (https://github.com/home-assistant/home-assistant/pull/29677)
- dyson (https://github.com/home-assistant/home-assistant/pull/29678)
- http (https://github.com/home-assistant/home-assistant/pull/29679)
- ring (https://github.com/home-assistant/home-assistant/pull/29680)
- iaqualink (https://github.com/home-assistant/home-assistant/pull/29681)
- netatmo (https://github.com/home-assistant/home-assistant/pull/29682)
- sensor (https://github.com/home-assistant/home-assistant/pull/29683)
- vesync (https://github.com/home-assistant/home-assistant/pull/29684)
- wemo (https://github.com/home-assistant/home-assistant/pull/29685)
- withings (https://github.com/home-assistant/home-assistant/pull/29686)
- specific_devices (https://github.com/home-assistant/home-assistant/pull/29687)
- almond (https://github.com/home-assistant/home-assistant/pull/29688)
- ambiclimate (https://github.com/home-assistant/home-assistant/pull/29689)
- broadlink (https://github.com/home-assistant/home-assistant/pull/29690)
- camera (https://github.com/home-assistant/home-assistant/pull/29691)
- counter (https://github.com/home-assistant/home-assistant/pull/29692)
- ffmpeg (https://github.com/home-assistant/home-assistant/pull/29693)
- file (https://github.com/home-assistant/home-assistant/pull/29694)
- geofency (https://github.com/home-assistant/home-assistant/pull/29695)
- ifttt (https://github.com/home-assistant/home-assistant/pull/29696)
- jewish_calendar (https://github.com/home-assistant/home-assistant/pull/29697)
- locative (https://github.com/home-assistant/home-assistant/pull/29698)
- met (https://github.com/home-assistant/home-assistant/pull/29699)
- arduino (https://github.com/home-assistant/home-assistant/pull/29702)
- arest (https://github.com/home-assistant/home-assistant/pull/29703)
- aws (https://github.com/home-assistant/home-assistant/pull/29704)
- cert_expiry (https://github.com/home-assistant/home-assistant/pull/29705)
- darksky (https://github.com/home-assistant/home-assistant/pull/29706)
- plex (https://github.com/home-assistant/home-assistant/pull/29708)
- soma (https://github.com/home-assistant/home-assistant/pull/29709)
- utility_meter (https://github.com/home-assistant/home-assistant/pull/29710)
- verisure (https://github.com/home-assistant/home-assistant/pull/29711)
- zone (https://github.com/home-assistant/home-assistant/pull/29712)
- group (https://github.com/home-assistant/home-assistant/pull/29713)
- device_automation (https://github.com/home-assistant/home-assistant/pull/29707)
- dialogflow (https://github.com/home-assistant/home-assistant/pull/29714)
- eufy (https://github.com/home-assistant/home-assistant/pull/29715)
- geonetnz_volcano (https://github.com/home-assistant/home-assistant/pull/29716)
- gpslogger (https://github.com/home-assistant/home-assistant/pull/29717)
- homeassistant (https://github.com/home-assistant/home-assistant/pull/29718)
- input_text (https://github.com/home-assistant/home-assistant/pull/29719)
- iqvia (https://github.com/home-assistant/home-assistant/pull/29720)
- kodi (https://github.com/home-assistant/home-assistant/pull/29721)
- linky (https://github.com/home-assistant/home-assistant/pull/29722)
- minio (https://github.com/home-assistant/home-assistant/pull/29723)
- neato (https://github.com/home-assistant/home-assistant/pull/29724)
- netgear_lte (https://github.com/home-assistant/home-assistant/pull/29725)
- pi_hole (https://github.com/home-assistant/home-assistant/pull/29726)
- plaato (https://github.com/home-assistant/home-assistant/pull/29747)
- pushbullet (https://github.com/home-assistant/home-assistant/pull/29748)
- remote (https://github.com/home-assistant/home-assistant/pull/29749)
- scene (https://github.com/home-assistant/home-assistant/pull/29750)
- shopping_list (https://github.com/home-assistant/home-assistant/pull/29751)
- solarlog (https://github.com/home-assistant/home-assistant/pull/29752)
- versasense (https://github.com/home-assistant/home-assistant/pull/29753)
- vicare (https://github.com/home-assistant/home-assistant/pull/29754)
- yeelight (https://github.com/home-assistant/home-assistant/pull/29755)
- emulated_roku (https://github.com/home-assistant/home-assistant/pull/29756)
- hue (https://github.com/home-assistant/home-assistant/pull/29757)
- mobile_app (https://github.com/home-assistant/home-assistant/pull/29758)
- sleepiq (https://github.com/home-assistant/home-assistant/pull/29759)
- vultr (https://github.com/home-assistant/home-assistant/pull/29760)


These are for PRs of components starting with:

- A (https://github.com/home-assistant/home-assistant/pull/29761)
- B (https://github.com/home-assistant/home-assistant/pull/29762)
- C (https://github.com/home-assistant/home-assistant/pull/29763)
- D (https://github.com/home-assistant/home-assistant/pull/29764)
- E (https://github.com/home-assistant/home-assistant/pull/29765)
- F (https://github.com/home-assistant/home-assistant/pull/29766)
- G (https://github.com/home-assistant/home-assistant/pull/29767)
- H (https://github.com/home-assistant/home-assistant/pull/29768)
- I (https://github.com/home-assistant/home-assistant/pull/29769)
- K (https://github.com/home-assistant/home-assistant/pull/29770)
- L (https://github.com/home-assistant/home-assistant/pull/29771)
- M (https://github.com/home-assistant/home-assistant/pull/29772)
- N (https://github.com/home-assistant/home-assistant/pull/29773)
- O (https://github.com/home-assistant/home-assistant/pull/29774)
- P (https://github.com/home-assistant/home-assistant/pull/29775)
- R (https://github.com/home-assistant/home-assistant/pull/29776)
- S (https://github.com/home-assistant/home-assistant/pull/29777)
- T (https://github.com/home-assistant/home-assistant/pull/29778)
- U (https://github.com/home-assistant/home-assistant/pull/29779)
- V (https://github.com/home-assistant/home-assistant/pull/29780)
- W (https://github.com/home-assistant/home-assistant/pull/29781)
- X (https://github.com/home-assistant/home-assistant/pull/29782)
- Y (https://github.com/home-assistant/home-assistant/pull/29783)
- Z (https://github.com/home-assistant/home-assistant/pull/29784)
- Q (https://github.com/home-assistant/home-assistant/pull/29785)
​

And the non-components:

- `homeassistant` (https://github.com/home-assistant/home-assistant/pull/29789)
- `script` (https://github.com/home-assistant/home-assistant/pull/29790)
- `tests` (https://github.com/home-assistant/home-assistant/pull/29791)
- `setup.py` (https://github.com/home-assistant/home-assistant/pull/29792)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
