### PR TITLE
Safely generate entity id for lastfm sensors

### DIFF
--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -19,6 +19,8 @@ ATTR_PLAY_COUNT = "play_count"
 ATTR_TOP_PLAYED = "top_played"
 ATTRIBUTION = "Data provided by Last.fm"
 
+STATE_NOT_SCROBBLING = "Not Scrobbling"
+
 CONF_USERS = "users"
 
 ENTITY_ID_FORMAT = "sensor.lastfm_{}"
@@ -33,7 +35,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(hass: HomeAssistantType, config: ConfigType, add_entities, discovery_info=None):
+def setup_platform(
+    hass: HomeAssistantType, config: ConfigType, add_entities, discovery_info=None
+):
     """Set up the Last.fm sensor platform."""
     api_key = config[CONF_API_KEY]
     users = config.get(CONF_USERS)
@@ -60,12 +64,12 @@ class LastfmSensor(Entity):
         self._user = lastfm_api.get_user(user)
         self._name = user
         self._lastfm = lastfm_api
-        self._state = "Not Scrobbling"
+        self._state = STATE_NOT_SCROBBLING
         self._playcount = None
         self._lastplayed = None
         self._topplayed = None
         self._cover = None
-        
+
         self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, user, hass=hass)
 
     @property
@@ -90,7 +94,7 @@ class LastfmSensor(Entity):
         self._topplayed = "{} - {}".format(topartist.group(1), toptitle.group(1))
         now = self._user.get_now_playing()
         if now is None:
-            self._state = "Not Scrobbling"
+            self._state = STATE_NOT_SCROBBLING
             return
         self._state = f"{now.artist} - {now.title}"
 

--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, generate_entity_id
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass: HomeAssistantType, config: ConfigType, add_entities, discovery_info=None):
     """Set up the Last.fm sensor platform."""
     api_key = config[CONF_API_KEY]
     users = config.get(CONF_USERS)
@@ -54,7 +55,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class LastfmSensor(Entity):
     """A class for the Last.fm account."""
 
-    def __init__(self, hass, user, lastfm_api):
+    def __init__(self, hass: HomeAssistantType, user, lastfm_api):
         """Initialize the sensor."""
         self._user = lastfm_api.get_user(user)
         self._name = user

--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -88,10 +88,10 @@ class LastfmSensor(Entity):
         toptitle = re.search("', '(.+?)',", str(top))
         topartist = re.search("'(.+?)',", str(top))
         self._topplayed = "{} - {}".format(topartist.group(1), toptitle.group(1))
-        if self._user.get_now_playing() is None:
+        now = self._user.get_now_playing()
+        if now is None:
             self._state = "Not Scrobbling"
             return
-        now = self._user.get_now_playing()
         self._state = f"{now.artist} - {now.title}"
 
     @property

--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -19,6 +19,8 @@ ATTR_PLAY_COUNT = "play_count"
 ATTR_TOP_PLAYED = "top_played"
 ATTRIBUTION = "Data provided by Last.fm"
 
+STATE_NOT_SCROBBLING = "Not Scrobbling"
+
 CONF_USERS = "users"
 
 ENTITY_ID_FORMAT = "sensor.lastfm_{}"
@@ -60,7 +62,7 @@ class LastfmSensor(Entity):
         self._user = lastfm_api.get_user(user)
         self._name = user
         self._lastfm = lastfm_api
-        self._state = "Not Scrobbling"
+        self._state = STATE_NOT_SCROBBLING
         self._playcount = None
         self._lastplayed = None
         self._topplayed = None
@@ -90,7 +92,7 @@ class LastfmSensor(Entity):
         self._topplayed = "{} - {}".format(topartist.group(1), toptitle.group(1))
         now = self._user.get_now_playing()
         if now is None:
-            self._state = "Not Scrobbling"
+            self._state = STATE_NOT_SCROBBLING
             return
         self._state = f"{now.artist} - {now.title}"
 


### PR DESCRIPTION
## Description:
* Generate entity id using home assistants `generate_entity_id` method, rather than string format.
* Efficiency fix in update method; removed the need for duplicate request to last.fm api.
* Housekeeping; adds type hints.
* Refactor: extract the state `not scrobbling` string.

**Related issue (if applicable):** fixes #16437

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html