### PR TITLE
Sort imports according to PEP8 for versasense

### DIFF
--- a/homeassistant/components/versasense/__init__.py
+++ b/homeassistant/components/versasense/__init__.py
@@ -10,14 +10,14 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
 from .const import (
+    KEY_CONSUMER,
+    KEY_IDENTIFIER,
+    KEY_MEASUREMENT,
+    KEY_PARENT_MAC,
+    KEY_PARENT_NAME,
+    KEY_UNIT,
     PERIPHERAL_CLASS_SENSOR,
     PERIPHERAL_CLASS_SENSOR_ACTUATOR,
-    KEY_IDENTIFIER,
-    KEY_PARENT_NAME,
-    KEY_PARENT_MAC,
-    KEY_UNIT,
-    KEY_MEASUREMENT,
-    KEY_CONSUMER,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/versasense/sensor.py
+++ b/homeassistant/components/versasense/sensor.py
@@ -5,12 +5,12 @@ from homeassistant.helpers.entity import Entity
 
 from . import DOMAIN
 from .const import (
-    KEY_IDENTIFIER,
-    KEY_PARENT_NAME,
-    KEY_PARENT_MAC,
-    KEY_UNIT,
-    KEY_MEASUREMENT,
     KEY_CONSUMER,
+    KEY_IDENTIFIER,
+    KEY_MEASUREMENT,
+    KEY_PARENT_MAC,
+    KEY_PARENT_NAME,
+    KEY_UNIT,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/versasense/switch.py
+++ b/homeassistant/components/versasense/switch.py
@@ -5,14 +5,14 @@ from homeassistant.components.switch import SwitchDevice
 
 from . import DOMAIN
 from .const import (
-    PERIPHERAL_STATE_ON,
-    PERIPHERAL_STATE_OFF,
-    KEY_IDENTIFIER,
-    KEY_PARENT_NAME,
-    KEY_PARENT_MAC,
-    KEY_UNIT,
-    KEY_MEASUREMENT,
     KEY_CONSUMER,
+    KEY_IDENTIFIER,
+    KEY_MEASUREMENT,
+    KEY_PARENT_MAC,
+    KEY_PARENT_NAME,
+    KEY_UNIT,
+    PERIPHERAL_STATE_OFF,
+    PERIPHERAL_STATE_ON,
 )
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION

## Description:

I have sorted the imports for the `versasense` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/versasense/__init__.py` 
- `homeassistant/components/versasense/sensor.py` 
- `homeassistant/components/versasense/switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
