### PR TITLE
Sort imports according to PEP8 for yeelight

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -1,24 +1,25 @@
 """Support for Xiaomi Yeelight WiFi color bulb."""
 
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 from yeelight import Bulb, BulbException
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.discovery import SERVICE_YEELIGHT
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_DEVICES,
+    CONF_HOST,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
-    CONF_HOST,
-    ATTR_ENTITY_ID,
 )
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.helpers import discovery
-from homeassistant.helpers.discovery import load_platform
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import dispatcher_send, dispatcher_connect
+from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.dispatcher import dispatcher_connect, dispatcher_send
 from homeassistant.helpers.event import track_time_interval
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/yeelight/binary_sensor.py
+++ b/homeassistant/components/yeelight/binary_sensor.py
@@ -4,7 +4,8 @@ import logging
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from . import DATA_YEELIGHT, DATA_UPDATED
+
+from . import DATA_UPDATED, DATA_YEELIGHT
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -4,60 +4,61 @@ import logging
 import voluptuous as vol
 import yeelight
 from yeelight import (
+    BulbException,
+    Flow,
     RGBTransition,
     SleepTransition,
-    Flow,
-    BulbException,
     transitions as yee_transitions,
 )
-from yeelight.enums import PowerMode, LightType, BulbType, SceneClass
+from yeelight.enums import BulbType, LightType, PowerMode, SceneClass
 
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.service import extract_entity_ids
-import homeassistant.helpers.config_validation as cv
-from homeassistant.util.color import (
-    color_temperature_mired_to_kelvin as mired_to_kelvin,
-    color_temperature_kelvin_to_mired as kelvin_to_mired,
-)
-from homeassistant.const import CONF_HOST, ATTR_ENTITY_ID, ATTR_MODE, CONF_NAME
-from homeassistant.core import callback
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ATTR_TRANSITION,
     ATTR_COLOR_TEMP,
-    ATTR_FLASH,
-    FLASH_SHORT,
-    FLASH_LONG,
     ATTR_EFFECT,
+    ATTR_FLASH,
+    ATTR_HS_COLOR,
+    ATTR_KELVIN,
+    ATTR_RGB_COLOR,
+    ATTR_TRANSITION,
+    FLASH_LONG,
+    FLASH_SHORT,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
-    SUPPORT_TRANSITION,
     SUPPORT_COLOR_TEMP,
-    SUPPORT_FLASH,
     SUPPORT_EFFECT,
+    SUPPORT_FLASH,
+    SUPPORT_TRANSITION,
     Light,
-    ATTR_RGB_COLOR,
-    ATTR_KELVIN,
 )
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, CONF_HOST, CONF_NAME
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.service import extract_entity_ids
 import homeassistant.util.color as color_util
+from homeassistant.util.color import (
+    color_temperature_kelvin_to_mired as kelvin_to_mired,
+    color_temperature_mired_to_kelvin as mired_to_kelvin,
+)
+
 from . import (
-    CONF_TRANSITION,
-    DATA_YEELIGHT,
-    CONF_MODE_MUSIC,
-    CONF_SAVE_ON_CHANGE,
-    CONF_CUSTOM_EFFECTS,
-    DATA_UPDATED,
-    YEELIGHT_SERVICE_SCHEMA,
-    DOMAIN,
-    ATTR_TRANSITIONS,
-    YEELIGHT_FLOW_TRANSITION_SCHEMA,
     ACTION_RECOVER,
-    CONF_FLOW_PARAMS,
     ATTR_ACTION,
     ATTR_COUNT,
-    NIGHTLIGHT_SWITCH_TYPE_LIGHT,
+    ATTR_TRANSITIONS,
+    CONF_CUSTOM_EFFECTS,
+    CONF_FLOW_PARAMS,
+    CONF_MODE_MUSIC,
     CONF_NIGHTLIGHT_SWITCH_TYPE,
+    CONF_SAVE_ON_CHANGE,
+    CONF_TRANSITION,
+    DATA_UPDATED,
+    DATA_YEELIGHT,
+    DOMAIN,
+    NIGHTLIGHT_SWITCH_TYPE_LIGHT,
+    YEELIGHT_FLOW_TRANSITION_SCHEMA,
+    YEELIGHT_SERVICE_SCHEMA,
 )
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION

## Description:

I have sorted the imports for the `yeelight` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `homeassistant/components/yeelight/__init__.py` 
- `homeassistant/components/yeelight/binary_sensor.py` 
- `homeassistant/components/yeelight/light.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
