### PR TITLE
Sort imports according to PEP8 for emulated_roku

### DIFF
--- a/tests/components/emulated_roku/test_binding.py
+++ b/tests/components/emulated_roku/test_binding.py
@@ -2,16 +2,16 @@
 from unittest.mock import Mock, patch
 
 from homeassistant.components.emulated_roku.binding import (
-    EmulatedRoku,
-    EVENT_ROKU_COMMAND,
-    ATTR_SOURCE_NAME,
+    ATTR_APP_ID,
     ATTR_COMMAND_TYPE,
     ATTR_KEY,
-    ATTR_APP_ID,
-    ROKU_COMMAND_KEYPRESS,
+    ATTR_SOURCE_NAME,
+    EVENT_ROKU_COMMAND,
     ROKU_COMMAND_KEYDOWN,
+    ROKU_COMMAND_KEYPRESS,
     ROKU_COMMAND_KEYUP,
     ROKU_COMMAND_LAUNCH,
+    EmulatedRoku,
 )
 
 from tests.common import mock_coro_func

--- a/tests/components/emulated_roku/test_config_flow.py
+++ b/tests/components/emulated_roku/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for emulated_roku config flow."""
 from homeassistant.components.emulated_roku import config_flow
+
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/emulated_roku/test_init.py
+++ b/tests/components/emulated_roku/test_init.py
@@ -1,8 +1,8 @@
 """Test emulated_roku component setup process."""
 from unittest.mock import Mock, patch
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import emulated_roku
+from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro_func
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the `emulated_roku` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `tests/components/emulated_roku/test_binding.py` 
- `tests/components/emulated_roku/test_config_flow.py` 
- `tests/components/emulated_roku/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
