### PR TITLE
Sort imports according to PEP8 for hue

### DIFF
--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components.hue import bridge, errors
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from tests.common import mock_coro
 

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -1,10 +1,10 @@
 """Test Hue setup process."""
 from unittest.mock import Mock, patch
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import hue
+from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro, MockConfigEntry
+from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_setup_with_no_config(hass):

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -5,8 +5,8 @@ import logging
 from unittest.mock import Mock
 
 import aiohue
-from aiohue.lights import Lights
 from aiohue.groups import Groups
+from aiohue.lights import Lights
 import pytest
 
 from homeassistant import config_entries


### PR DESCRIPTION

## Description:

I have sorted the imports for the `hue` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `tests/components/hue/test_bridge.py` 
- `tests/components/hue/test_init.py` 
- `tests/components/hue/test_light.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
