### PR TITLE
Sort imports according to PEP8 for sleepiq

### DIFF
--- a/tests/components/sleepiq/test_binary_sensor.py
+++ b/tests/components/sleepiq/test_binary_sensor.py
@@ -4,11 +4,11 @@ from unittest.mock import MagicMock
 
 import requests_mock
 
-from homeassistant.setup import setup_component
 from homeassistant.components.sleepiq import binary_sensor as sleepiq
+from homeassistant.setup import setup_component
 
-from tests.components.sleepiq.test_init import mock_responses
 from tests.common import get_test_home_assistant
+from tests.components.sleepiq.test_init import mock_responses
 
 
 class TestSleepIQBinarySensorSetup(unittest.TestCase):

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -7,7 +7,7 @@ import requests_mock
 from homeassistant import setup
 import homeassistant.components.sleepiq as sleepiq
 
-from tests.common import load_fixture, get_test_home_assistant
+from tests.common import get_test_home_assistant, load_fixture
 
 
 def mock_responses(mock, single=False):

--- a/tests/components/sleepiq/test_sensor.py
+++ b/tests/components/sleepiq/test_sensor.py
@@ -4,11 +4,11 @@ from unittest.mock import MagicMock
 
 import requests_mock
 
-from homeassistant.setup import setup_component
 import homeassistant.components.sleepiq.sensor as sleepiq
+from homeassistant.setup import setup_component
 
-from tests.components.sleepiq.test_init import mock_responses
 from tests.common import get_test_home_assistant
+from tests.components.sleepiq.test_init import mock_responses
 
 
 class TestSleepIQSensorSetup(unittest.TestCase):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `sleepiq` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `tests/components/sleepiq/test_binary_sensor.py` 
- `tests/components/sleepiq/test_init.py` 
- `tests/components/sleepiq/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
