### PR TITLE
Sort imports according to PEP8 for vultr

### DIFF
--- a/tests/components/vultr/test_binary_sensor.py
+++ b/tests/components/vultr/test_binary_sensor.py
@@ -3,25 +3,25 @@ import json
 import unittest
 from unittest.mock import patch
 
-import requests_mock
 import pytest
+import requests_mock
 import voluptuous as vol
 
-from homeassistant.components.vultr import binary_sensor as vultr
 from homeassistant.components import vultr as base_vultr
 from homeassistant.components.vultr import (
     ATTR_ALLOWED_BANDWIDTH,
     ATTR_AUTO_BACKUPS,
-    ATTR_IPV4_ADDRESS,
     ATTR_COST_PER_MONTH,
     ATTR_CREATED_AT,
+    ATTR_IPV4_ADDRESS,
     ATTR_SUBSCRIPTION_ID,
     CONF_SUBSCRIPTION,
+    binary_sensor as vultr,
 )
-from homeassistant.const import CONF_PLATFORM, CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_PLATFORM
 
-from tests.components.vultr.test_init import VALID_CONFIG
 from tests.common import get_test_home_assistant, load_fixture
+from tests.components.vultr.test_init import VALID_CONFIG
 
 
 class TestVultrBinarySensorSetup(unittest.TestCase):

--- a/tests/components/vultr/test_sensor.py
+++ b/tests/components/vultr/test_sensor.py
@@ -7,13 +7,13 @@ import pytest
 import requests_mock
 import voluptuous as vol
 
-import homeassistant.components.vultr.sensor as vultr
 from homeassistant.components import vultr as base_vultr
 from homeassistant.components.vultr import CONF_SUBSCRIPTION
-from homeassistant.const import CONF_NAME, CONF_MONITORED_CONDITIONS, CONF_PLATFORM
+import homeassistant.components.vultr.sensor as vultr
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_PLATFORM
 
-from tests.components.vultr.test_init import VALID_CONFIG
 from tests.common import get_test_home_assistant, load_fixture
+from tests.components.vultr.test_init import VALID_CONFIG
 
 
 class TestVultrSensorSetup(unittest.TestCase):

--- a/tests/components/vultr/test_switch.py
+++ b/tests/components/vultr/test_switch.py
@@ -3,25 +3,25 @@ import json
 import unittest
 from unittest.mock import patch
 
-import requests_mock
 import pytest
+import requests_mock
 import voluptuous as vol
 
-from homeassistant.components.vultr import switch as vultr
 from homeassistant.components import vultr as base_vultr
 from homeassistant.components.vultr import (
     ATTR_ALLOWED_BANDWIDTH,
     ATTR_AUTO_BACKUPS,
-    ATTR_IPV4_ADDRESS,
     ATTR_COST_PER_MONTH,
     ATTR_CREATED_AT,
+    ATTR_IPV4_ADDRESS,
     ATTR_SUBSCRIPTION_ID,
     CONF_SUBSCRIPTION,
+    switch as vultr,
 )
-from homeassistant.const import CONF_PLATFORM, CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_PLATFORM
 
-from tests.components.vultr.test_init import VALID_CONFIG
 from tests.common import get_test_home_assistant, load_fixture
+from tests.components.vultr.test_init import VALID_CONFIG
 
 
 class TestVultrSwitchSetup(unittest.TestCase):


### PR DESCRIPTION

## Description:

I have sorted the imports for the `vultr` component according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.

Black and isort do not play nice by default, however, using the following `.isort.cfg` config:
```yaml
[settings]
multi_line_output=3
include_trailing_comma=True
force_grid_wrap=0
use_parentheses=True
line_length=88
```
it works.

This PR affects:

- `tests/components/vultr/test_binary_sensor.py` 
- `tests/components/vultr/test_sensor.py` 
- `tests/components/vultr/test_switch.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
