### PR TITLE
Sort imports according to PEP8 for components starting with "A"

### DIFF
--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -4,8 +4,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import (
-    AlarmControlPanel,
     FORMAT_NUMBER,
+    AlarmControlPanel,
 )
 from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -1,30 +1,30 @@
 """Support for repeating alerts when conditions are met."""
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
+    ATTR_DATA,
     ATTR_MESSAGE,
     ATTR_TITLE,
-    ATTR_DATA,
     DOMAIN as DOMAIN_NOTIFY,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
-    STATE_IDLE,
     CONF_NAME,
     CONF_STATE,
-    STATE_ON,
-    STATE_OFF,
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
     SERVICE_TOGGLE,
-    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
 )
-from homeassistant.helpers import service, event
+from homeassistant.helpers import event, service
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.util.dt import now
 

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -2,9 +2,9 @@
 from datetime import timedelta
 import logging
 
-import voluptuous as vol
-from alpha_vantage.timeseries import TimeSeries
 from alpha_vantage.foreignexchange import ForeignExchange
+from alpha_vantage.timeseries import TimeSeries
+import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_CURRENCY, CONF_NAME

--- a/homeassistant/components/amazon_polly/tts.py
+++ b/homeassistant/components/amazon_polly/tts.py
@@ -1,7 +1,7 @@
 """Support for the Amazon Polly text to speech service."""
 import logging
-import boto3
 
+import boto3
 import voluptuous as vol
 
 from homeassistant.components.tts import PLATFORM_SCHEMA, Provider

--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -1,6 +1,6 @@
 """Support for Amcrest IP cameras."""
-import logging
 from datetime import timedelta
+import logging
 import threading
 
 import aiohttp
@@ -36,7 +36,7 @@ from homeassistant.helpers.service import async_extract_entity_ids
 
 from .binary_sensor import BINARY_SENSOR_MOTION_DETECTED, BINARY_SENSORS
 from .camera import CAMERA_SERVICES, STREAM_SOURCE_LIST
-from .const import CAMERAS, DOMAIN, DATA_AMCREST, DEVICES, SERVICE_UPDATE
+from .const import CAMERAS, DATA_AMCREST, DEVICES, DOMAIN, SERVICE_UPDATE
 from .helpers import service_signal
 from .sensor import SENSOR_MOTION_DETECTOR, SENSORS
 from .switch import SWITCHES

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -5,11 +5,11 @@ import logging
 from amcrest import AmcrestError
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice,
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_MOTION,
+    BinarySensorDevice,
 )
-from homeassistant.const import CONF_NAME, CONF_BINARY_SENSORS
+from homeassistant.const import CONF_BINARY_SENSORS, CONF_NAME
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -2,7 +2,6 @@
 import functools
 import logging
 import os
-import voluptuous as vol
 
 from adb_shell.auth.keygen import keygen
 from adb_shell.exceptions import (
@@ -11,10 +10,11 @@ from adb_shell.exceptions import (
     InvalidResponseError,
     TcpTimeoutException,
 )
-from androidtv import setup, ha_state_detection_rules_validator
+from androidtv import ha_state_detection_rules_validator, setup
 from androidtv.constants import APPS, KEYS
+import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,

--- a/homeassistant/components/anthemav/media_player.py
+++ b/homeassistant/components/anthemav/media_player.py
@@ -2,10 +2,9 @@
 import logging
 
 import anthemav
-
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,

--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -1,10 +1,10 @@
 """Support for tracking the online status of a UPS."""
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components import apcupsd
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components import apcupsd
 
 DEFAULT_NAME = "UPS Online Status"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -8,6 +8,7 @@ from aiohttp.web_exceptions import HTTPBadRequest
 import async_timeout
 import voluptuous as vol
 
+from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.bootstrap import DATA_LOGGING
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import (
@@ -31,12 +32,11 @@ from homeassistant.const import (
     __version__,
 )
 import homeassistant.core as ha
-from homeassistant.auth.permissions.const import POLICY_READ
-from homeassistant.exceptions import TemplateError, Unauthorized, ServiceNotFound
+from homeassistant.exceptions import ServiceNotFound, TemplateError, Unauthorized
 from homeassistant.helpers import template
+from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.helpers.state import AsyncTrackStates
-from homeassistant.helpers.json import JSONEncoder
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -6,6 +6,7 @@ from apns2.errors import Unregistered
 from apns2.payload import Payload
 import voluptuous as vol
 
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
@@ -17,7 +18,6 @@ from homeassistant.const import ATTR_NAME, CONF_NAME, CONF_PLATFORM
 from homeassistant.helpers import template as template_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 
 from .const import DOMAIN
 

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -7,11 +7,11 @@ from pyatv import AppleTVDevice, connect_to_apple_tv, scan_for_apple_tvs
 from pyatv.exceptions import DeviceAuthenticationError
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.discovery import SERVICE_APPLE_TV
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -1,11 +1,8 @@
 """Apprise platform for notify component."""
 import logging
 
-import voluptuous as vol
-
 import apprise
-
-import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 
 from homeassistant.components.notify import (
     ATTR_TARGET,
@@ -14,6 +11,7 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/aprs/device_tracker.py
+++ b/homeassistant/components/aprs/device_tracker.py
@@ -3,11 +3,9 @@
 import logging
 import threading
 
-import geopy.distance
 import aprslib
-from aprslib import ConnectionError as AprsConnectionError
-from aprslib import LoginError
-
+from aprslib import ConnectionError as AprsConnectionError, LoginError
+import geopy.distance
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA

--- a/homeassistant/components/aquostv/media_player.py
+++ b/homeassistant/components/aquostv/media_player.py
@@ -2,10 +2,9 @@
 import logging
 
 import sharp_aquos_rc
-
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,

--- a/homeassistant/components/arcam_fmj/__init__.py
+++ b/homeassistant/components/arcam_fmj/__init__.py
@@ -1,31 +1,32 @@
 """Arcam component."""
-import logging
 import asyncio
+import logging
 
-import voluptuous as vol
-import async_timeout
-from arcam.fmj.client import Client
 from arcam.fmj import ConnectionFailed
+from arcam.fmj.client import Client
+import async_timeout
+import voluptuous as vol
 
 from homeassistant import config_entries
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_STOP,
     CONF_HOST,
     CONF_NAME,
     CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_ZONE,
+    EVENT_HOMEASSISTANT_STOP,
     SERVICE_TURN_ON,
 )
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+
 from .const import (
-    DOMAIN,
-    DOMAIN_DATA_ENTRIES,
-    DOMAIN_DATA_CONFIG,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    DOMAIN_DATA_CONFIG,
+    DOMAIN_DATA_ENTRIES,
     SIGNAL_CLIENT_DATA,
     SIGNAL_CLIENT_STARTED,
     SIGNAL_CLIENT_STOPPED,

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -6,14 +6,13 @@ from arcam.fmj import DecodeMode2CH, DecodeModeMCH, IncomingAudioFormat, SourceC
 from arcam.fmj.state import State
 
 from homeassistant import config_entries
-from homeassistant.core import callback
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_SELECT_SOUND_MODE,
     SUPPORT_SELECT_SOURCE,
-    SUPPORT_TURN_ON,
     SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
@@ -25,15 +24,16 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.helpers.typing import HomeAssistantType, ConfigType
+from homeassistant.core import callback
 from homeassistant.helpers.service import async_call_from_config
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import (
+    DOMAIN,
+    DOMAIN_DATA_ENTRIES,
     SIGNAL_CLIENT_DATA,
     SIGNAL_CLIENT_STARTED,
     SIGNAL_CLIENT_STOPPED,
-    DOMAIN_DATA_ENTRIES,
-    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -3,8 +3,8 @@ import json
 import logging
 
 from homeassistant.components import mqtt
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import callback
-from homeassistant.const import TEMP_FAHRENHEIT, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 

--- a/homeassistant/components/asterisk_cdr/mailbox.py
+++ b/homeassistant/components/asterisk_cdr/mailbox.py
@@ -1,12 +1,14 @@
 """Support for the Asterisk CDR interface."""
-import logging
-import hashlib
 import datetime
+import hashlib
+import logging
 
-from homeassistant.core import callback
-from homeassistant.components.asterisk_mbox import SIGNAL_CDR_UPDATE
-from homeassistant.components.asterisk_mbox import DOMAIN as ASTERISK_DOMAIN
+from homeassistant.components.asterisk_mbox import (
+    DOMAIN as ASTERISK_DOMAIN,
+    SIGNAL_CDR_UPDATE,
+)
 from homeassistant.components.mailbox import Mailbox
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/atome/sensor.py
+++ b/homeassistant/components/atome/sensor.py
@@ -1,23 +1,22 @@
 """Linky Atome."""
-import logging
 from datetime import timedelta
+import logging
 
+from pyatome.client import AtomeClient, PyAtomeError
 import voluptuous as vol
-from pyatome.client import AtomeClient
-from pyatome.client import PyAtomeError
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
-    CONF_NAME,
     DEVICE_CLASS_POWER,
-    POWER_WATT,
     ENERGY_KILO_WATT_HOUR,
+    POWER_WATT,
 )
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/aurora/binary_sensor.py
+++ b/homeassistant/components/aurora/binary_sensor.py
@@ -7,7 +7,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
-from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -2,8 +2,8 @@
 
 import logging
 
+from aurorapy.client import AuroraError, AuroraSerialClient
 import voluptuous as vol
-from aurorapy.client import AuroraSerialClient, AuroraError
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (

--- a/homeassistant/components/automatic/device_tracker.py
+++ b/homeassistant/components/automatic/device_tracker.py
@@ -5,9 +5,8 @@ import json
 import logging
 import os
 
-from aiohttp import web
 import aioautomatic
-
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (

--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -1,5 +1,6 @@
 """Support for the Elgato Avea lights."""
 import logging
+
 import avea
 
 from homeassistant.components.light import (
@@ -11,7 +12,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.util.color as color_util
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/azure_event_hub/__init__.py
+++ b/homeassistant/components/azure_event_hub/__init__.py
@@ -3,8 +3,8 @@ import json
 import logging
 from typing import Any, Dict
 
-import voluptuous as vol
 from azure.eventhub import EventData, EventHubClientAsync
+import voluptuous as vol
 
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -1,26 +1,26 @@
 """The tests for the Alert component."""
-import unittest
-
 # pylint: disable=protected-access
 from copy import deepcopy
+import unittest
 
 import homeassistant.components.alert as alert
-import homeassistant.components.notify as notify
 from homeassistant.components.alert import DOMAIN
+import homeassistant.components.notify as notify
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
-    STATE_IDLE,
     CONF_NAME,
     CONF_STATE,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    STATE_ON,
+    STATE_IDLE,
     STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import callback
 from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant
 
 NAME = "alert_test"

--- a/tests/components/ambient_station/test_config_flow.py
+++ b/tests/components/ambient_station/test_config_flow.py
@@ -1,15 +1,15 @@
 """Define tests for the Ambient PWS config flow."""
 import json
+from unittest.mock import patch
 
 import aioambient
 import pytest
-from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.ambient_station import CONF_APP_KEY, DOMAIN, config_flow
 from homeassistant.const import CONF_API_KEY
 
-from tests.common import load_fixture, MockConfigEntry, mock_coro
+from tests.common import MockConfigEntry, load_fixture, mock_coro
 
 
 @pytest.fixture

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -1,7 +1,6 @@
 """The tests for the androidtv platform."""
 import logging
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components.androidtv.media_player import (
     ANDROIDTV_DOMAIN,
     CONF_ADB_SERVER_IP,
@@ -24,9 +23,9 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.setup import async_setup_component
 
 from . import patchers
-
 
 # Android TV device with Python ADB implementation
 CONFIG_ANDROIDTV_PYTHON_ADB = {

--- a/tests/components/apns/test_notify.py
+++ b/tests/components/apns/test_notify.py
@@ -1,15 +1,15 @@
 """The tests for the APNS component."""
 import io
 import unittest
-from unittest.mock import Mock, patch, mock_open
+from unittest.mock import Mock, mock_open, patch
 
 from apns2.errors import Unregistered
 import yaml
 
-import homeassistant.components.notify as notify
-from homeassistant.setup import setup_component
 import homeassistant.components.apns.notify as apns
+import homeassistant.components.notify as notify
 from homeassistant.core import State
+from homeassistant.setup import setup_component
 
 from tests.common import assert_setup_component, get_test_home_assistant
 

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -1,6 +1,5 @@
 """The tests for the apprise notification platform."""
-from unittest.mock import patch
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/arlo/test_sensor.py
+++ b/tests/components/arlo/test_sensor.py
@@ -1,14 +1,15 @@
 """The tests for the Netgear Arlo sensors."""
 from collections import namedtuple
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+from homeassistant.components.arlo import DATA_ARLO, sensor as arlo
 from homeassistant.const import (
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_HUMIDITY,
     ATTR_ATTRIBUTION,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
 )
-from homeassistant.components.arlo import sensor as arlo
-from homeassistant.components.arlo import DATA_ARLO
 
 
 def _get_named_tuple(input_dict):

--- a/tests/components/asuswrt/test_device_tracker.py
+++ b/tests/components/asuswrt/test_device_tracker.py
@@ -1,15 +1,15 @@
 """The tests for the ASUSWRT device tracker platform."""
 from unittest.mock import patch
-from homeassistant.setup import async_setup_component
 
 from homeassistant.components.asuswrt import (
-    CONF_PROTOCOL,
     CONF_MODE,
-    DOMAIN,
     CONF_PORT,
+    CONF_PROTOCOL,
     DATA_ASUSWRT,
+    DOMAIN,
 )
-from homeassistant.const import CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME, CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
+from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro_func
 

--- a/tests/components/aurora/test_binary_sensor.py
+++ b/tests/components/aurora/test_binary_sensor.py
@@ -5,7 +5,8 @@ import unittest
 import requests_mock
 
 from homeassistant.components.aurora import binary_sensor as aurora
-from tests.common import load_fixture, get_test_home_assistant
+
+from tests.common import get_test_home_assistant, load_fixture
 
 
 class TestAuroraSensorSetUp(unittest.TestCase):

--- a/tests/components/automatic/test_device_tracker.py
+++ b/tests/components/automatic/test_device_tracker.py
@@ -2,11 +2,12 @@
 import asyncio
 from datetime import datetime
 import logging
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import aioautomatic
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components.automatic.device_tracker import async_setup_scanner
+from homeassistant.setup import async_setup_component
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -6,7 +6,6 @@ import json
 import logging
 from unittest.mock import patch
 
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.awair.sensor import (
     ATTR_LAST_API_UPDATE,
     ATTR_TIMESTAMP,
@@ -15,6 +14,7 @@ from homeassistant.components.awair.sensor import (
     DEVICE_CLASS_SCORE,
     DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
 )
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"a"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/alarmdecoder/alarm_control_panel.py` 
- `homeassistant/components/alert/__init__.py` 
- `homeassistant/components/alpha_vantage/sensor.py` 
- `homeassistant/components/amazon_polly/tts.py` 
- `homeassistant/components/amcrest/__init__.py` 
- `homeassistant/components/amcrest/binary_sensor.py` 
- `homeassistant/components/androidtv/media_player.py` 
- `homeassistant/components/anthemav/media_player.py` 
- `homeassistant/components/apcupsd/binary_sensor.py` 
- `homeassistant/components/api/__init__.py` 
- `homeassistant/components/apns/notify.py` 
- `homeassistant/components/apple_tv/__init__.py` 
- `homeassistant/components/apprise/notify.py` 
- `homeassistant/components/aprs/device_tracker.py` 
- `homeassistant/components/aquostv/media_player.py` 
- `homeassistant/components/arcam_fmj/__init__.py` 
- `homeassistant/components/arcam_fmj/media_player.py` 
- `homeassistant/components/arwn/sensor.py` 
- `homeassistant/components/asterisk_cdr/mailbox.py` 
- `homeassistant/components/atome/sensor.py` 
- `homeassistant/components/aurora/binary_sensor.py` 
- `homeassistant/components/aurora_abb_powerone/sensor.py` 
- `homeassistant/components/automatic/device_tracker.py` 
- `homeassistant/components/avea/light.py` 
- `homeassistant/components/azure_event_hub/__init__.py` 
- `tests/components/alert/test_init.py` 
- `tests/components/ambient_station/test_config_flow.py` 
- `tests/components/androidtv/test_media_player.py` 
- `tests/components/apns/test_notify.py` 
- `tests/components/apprise/test_notify.py` 
- `tests/components/arlo/test_sensor.py` 
- `tests/components/asuswrt/test_device_tracker.py` 
- `tests/components/aurora/test_binary_sensor.py` 
- `tests/components/automatic/test_device_tracker.py` 
- `tests/components/awair/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
