### PR TITLE
Sort imports according to PEP8 for components starting with "B"

### DIFF
--- a/homeassistant/components/bbb_gpio/binary_sensor.py
+++ b/homeassistant/components/bbb_gpio/binary_sensor.py
@@ -4,8 +4,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import bbb_gpio
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
-from homeassistant.const import DEVICE_DEFAULT_NAME, CONF_NAME
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
+from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/bbb_gpio/switch.py
+++ b/homeassistant/components/bbb_gpio/switch.py
@@ -3,11 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.components import bbb_gpio
-from homeassistant.const import DEVICE_DEFAULT_NAME, CONF_NAME
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bbox/device_tracker.py
+++ b/homeassistant/components/bbox/device_tracker.py
@@ -5,7 +5,6 @@ import logging
 from typing import List
 
 import pybbox
-
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (

--- a/homeassistant/components/bbox/sensor.py
+++ b/homeassistant/components/bbox/sensor.py
@@ -1,20 +1,19 @@
 """Support for Bbox Bouygues Modem Router."""
-import logging
 from datetime import timedelta
+import logging
 
-import requests
 import pybbox
-
+import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
-    CONF_MONITORED_VARIABLES,
     ATTR_ATTRIBUTION,
+    CONF_MONITORED_VARIABLES,
+    CONF_NAME,
     DEVICE_CLASS_TIMESTAMP,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.dt import utcnow

--- a/homeassistant/components/beewi_smartclim/sensor.py
+++ b/homeassistant/components/beewi_smartclim/sensor.py
@@ -5,15 +5,15 @@ from beewi_smartclim import BeewiSmartClimPoller
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_NAME,
     CONF_MAC,
-    TEMP_CELSIUS,
+    CONF_NAME,
+    DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_BATTERY,
+    TEMP_CELSIUS,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/bh1750/sensor.py
+++ b/homeassistant/components/bh1750/sensor.py
@@ -2,14 +2,13 @@
 from functools import partial
 import logging
 
-import smbus  # pylint: disable=import-error
 from i2csense.bh1750 import BH1750  # pylint: disable=import-error
-
+import smbus  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, DEVICE_CLASS_ILLUMINANCE
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/bizkaibus/sensor.py
+++ b/homeassistant/components/bizkaibus/sensor.py
@@ -2,14 +2,13 @@
 
 import logging
 
-import voluptuous as vol
 from bizkaibus.bizkaibus import BizkaibusData
-import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 
-from homeassistant.const import CONF_NAME
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/blackbird/media_player.py
+++ b/homeassistant/components/blackbird/media_player.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 import homeassistant.helpers.config_validation as cv
+
 from .const import DOMAIN, SERVICE_SETALLZONES
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/blinkt/light.py
+++ b/homeassistant/components/blinkt/light.py
@@ -4,16 +4,16 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    SUPPORT_BRIGHTNESS,
     ATTR_HS_COLOR,
+    PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     Light,
-    PLATFORM_SCHEMA,
 )
 from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -4,9 +4,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import TEMP_FAHRENHEIT, TEMP_CELSIUS, CONF_MONITORED_CONDITIONS
-from homeassistant.helpers.entity import Entity
+from homeassistant.const import CONF_MONITORED_CONDITIONS, TEMP_CELSIUS, TEMP_FAHRENHEIT
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 from . import BLOOMSKY
 

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -49,6 +49,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
+
 from .const import (
     DOMAIN,
     SERVICE_CLEAR_TIMER,

--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -4,18 +4,18 @@ import logging
 
 import pygatt  # pylint: disable=import-error
 
-from homeassistant.helpers.event import track_point_in_utc_time
+from homeassistant.components.device_tracker.const import (
+    CONF_SCAN_INTERVAL,
+    CONF_TRACK_NEW,
+    SCAN_INTERVAL,
+    SOURCE_TYPE_BLUETOOTH_LE,
+)
 from homeassistant.components.device_tracker.legacy import (
     YAML_DEVICES,
     async_load_config,
 )
-from homeassistant.components.device_tracker.const import (
-    CONF_TRACK_NEW,
-    CONF_SCAN_INTERVAL,
-    SCAN_INTERVAL,
-    SOURCE_TYPE_BLUETOOTH_LE,
-)
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers.event import track_point_in_utc_time
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -1,7 +1,7 @@
 """Tracking for bluetooth devices."""
 import asyncio
 import logging
-from typing import List, Set, Tuple, Optional
+from typing import List, Optional, Set, Tuple
 
 # pylint: disable=import-error
 import bluetooth

--- a/homeassistant/components/bme280/sensor.py
+++ b/homeassistant/components/bme280/sensor.py
@@ -3,14 +3,13 @@ from datetime import timedelta
 from functools import partial
 import logging
 
-import smbus  # pylint: disable=import-error
 from i2csense.bme280 import BME280  # pylint: disable=import-error
-
+import smbus  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_FAHRENHEIT
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import TEMP_FAHRENHEIT, CONF_NAME, CONF_MONITORED_CONDITIONS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit

--- a/homeassistant/components/bme680/sensor.py
+++ b/homeassistant/components/bme680/sensor.py
@@ -3,8 +3,8 @@ import logging
 import threading
 from time import sleep, time
 
-from smbus import SMBus  # pylint: disable=import-error
 import bme680  # pylint: disable=import-error
+from smbus import SMBus  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA

--- a/homeassistant/components/bom/sensor.py
+++ b/homeassistant/components/bom/sensor.py
@@ -12,19 +12,19 @@ import zipfile
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS,
-    TEMP_CELSIUS,
-    CONF_NAME,
     ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
+    TEMP_CELSIUS,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
 
 _RESOURCE = "http://www.bom.gov.au/fwo/{}/{}.{}.json"
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/brottsplatskartan/sensor.py
+++ b/homeassistant/components/brottsplatskartan/sensor.py
@@ -5,7 +5,6 @@ import logging
 import uuid
 
 import brottsplatskartan
-
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA

--- a/homeassistant/components/browser/__init__.py
+++ b/homeassistant/components/browser/__init__.py
@@ -1,5 +1,6 @@
 """Support for launching a web browser on the host machine."""
 import webbrowser
+
 import voluptuous as vol
 
 ATTR_URL = "url"

--- a/homeassistant/components/bt_home_hub_5/device_tracker.py
+++ b/homeassistant/components/bt_home_hub_5/device_tracker.py
@@ -2,16 +2,15 @@
 import logging
 
 import bthomehub5_devicelist
-
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
 from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -1,8 +1,8 @@
 """The test for the bayesian sensor platform."""
 import unittest
 
-from homeassistant.setup import setup_component
 from homeassistant.components.bayesian import binary_sensor as bayesian
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/blackbird/test_media_player.py
+++ b/tests/components/blackbird/test_media_player.py
@@ -1,24 +1,25 @@
 """The tests for the Monoprice Blackbird media player platform."""
+from collections import defaultdict
 import unittest
 from unittest import mock
+
+import pytest
 import voluptuous as vol
 
-from collections import defaultdict
-from homeassistant.components.media_player.const import (
-    SUPPORT_TURN_ON,
-    SUPPORT_TURN_OFF,
-    SUPPORT_SELECT_SOURCE,
-)
-from homeassistant.const import STATE_ON, STATE_OFF
-
-import tests.common
+from homeassistant.components.blackbird.const import DOMAIN, SERVICE_SETALLZONES
 from homeassistant.components.blackbird.media_player import (
     DATA_BLACKBIRD,
     PLATFORM_SCHEMA,
     setup_platform,
 )
-from homeassistant.components.blackbird.const import DOMAIN, SERVICE_SETALLZONES
-import pytest
+from homeassistant.components.media_player.const import (
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+)
+from homeassistant.const import STATE_OFF, STATE_ON
+
+import tests.common
 
 
 class AttrDict(dict):

--- a/tests/components/bom/test_sensor.py
+++ b/tests/components/bom/test_sensor.py
@@ -10,6 +10,7 @@ import requests
 from homeassistant.components import sensor
 from homeassistant.components.bom.sensor import BOMCurrentData
 from homeassistant.setup import setup_component
+
 from tests.common import assert_setup_component, get_test_home_assistant, load_fixture
 
 VALID_CONFIG = {


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"b"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/bbb_gpio/binary_sensor.py` 
- `homeassistant/components/bbb_gpio/switch.py` 
- `homeassistant/components/bbox/device_tracker.py` 
- `homeassistant/components/bbox/sensor.py` 
- `homeassistant/components/beewi_smartclim/sensor.py` 
- `homeassistant/components/bh1750/sensor.py` 
- `homeassistant/components/bizkaibus/sensor.py` 
- `homeassistant/components/blackbird/media_player.py` 
- `homeassistant/components/blinkt/light.py` 
- `homeassistant/components/bloomsky/binary_sensor.py` 
- `homeassistant/components/bloomsky/sensor.py` 
- `homeassistant/components/bluesound/media_player.py` 
- `homeassistant/components/bluetooth_le_tracker/device_tracker.py` 
- `homeassistant/components/bluetooth_tracker/device_tracker.py` 
- `homeassistant/components/bme280/sensor.py` 
- `homeassistant/components/bme680/sensor.py` 
- `homeassistant/components/bom/sensor.py` 
- `homeassistant/components/brottsplatskartan/sensor.py` 
- `homeassistant/components/browser/__init__.py` 
- `homeassistant/components/bt_home_hub_5/device_tracker.py` 
- `tests/components/bayesian/test_binary_sensor.py` 
- `tests/components/blackbird/test_media_player.py` 
- `tests/components/bom/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
