### PR TITLE
Sort imports according to PEP8 for components starting with "C"

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util import dt
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/clickatell/notify.py
+++ b/homeassistant/components/clickatell/notify.py
@@ -4,10 +4,9 @@ import logging
 import requests
 import voluptuous as vol
 
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import CONF_API_KEY, CONF_RECIPIENT
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/clicksend/notify.py
+++ b/homeassistant/components/clicksend/notify.py
@@ -6,6 +6,7 @@ from aiohttp.hdrs import CONTENT_TYPE
 import requests
 import voluptuous as vol
 
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_RECIPIENT,
@@ -14,8 +15,6 @@ from homeassistant.const import (
     CONTENT_TYPE_JSON,
 )
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/clicksend_tts/notify.py
+++ b/homeassistant/components/clicksend_tts/notify.py
@@ -6,6 +6,7 @@ from aiohttp.hdrs import CONTENT_TYPE
 import requests
 import voluptuous as vol
 
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_RECIPIENT,
@@ -13,8 +14,6 @@ from homeassistant.const import (
     CONTENT_TYPE_JSON,
 )
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/configurator/__init__.py
+++ b/homeassistant/components/configurator/__init__.py
@@ -9,14 +9,14 @@ the user has submitted configuration information.
 import functools as ft
 import logging
 
-from homeassistant.core import callback as async_callback
 from homeassistant.const import (
-    EVENT_TIME_CHANGED,
-    ATTR_FRIENDLY_NAME,
     ATTR_ENTITY_PICTURE,
+    ATTR_FRIENDLY_NAME,
+    EVENT_TIME_CHANGED,
 )
-from homeassistant.loader import bind_hass
+from homeassistant.core import callback as async_callback
 from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.loader import bind_hass
 from homeassistant.util.async_ import run_callback_threadsafe
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import config_validation as cv, intent
 from homeassistant.loader import bind_hass
 
 from .agent import AbstractConversationAgent
-from .default_agent import async_register, DefaultAgent
+from .default_agent import DefaultAgent, async_register
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -3,7 +3,7 @@
 from pycoolmasternet import CoolMasterNet
 import voluptuous as vol
 
-from homeassistant import core, config_entries
+from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST, CONF_PORT
 
 # pylint: disable=unused-import

--- a/homeassistant/components/cups/sensor.py
+++ b/homeassistant/components/cups/sensor.py
@@ -1,14 +1,14 @@
 """Details about printers which are connected to CUPS."""
+from datetime import timedelta
 import importlib
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/currencylayer/sensor.py
+++ b/homeassistant/components/currencylayer/sensor.py
@@ -5,15 +5,15 @@ import logging
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_NAME,
-    CONF_BASE,
-    CONF_QUOTE,
     ATTR_ATTRIBUTION,
+    CONF_API_KEY,
+    CONF_BASE,
+    CONF_NAME,
+    CONF_QUOTE,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/canary/test_init.py
+++ b/tests/components/canary/test_init.py
@@ -1,9 +1,10 @@
 """The tests for the Canary component."""
 import unittest
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
-import homeassistant.components.canary as canary
 from homeassistant import setup
+import homeassistant.components.canary as canary
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -3,16 +3,16 @@ import copy
 import unittest
 from unittest.mock import Mock
 
-from homeassistant.components.canary import DATA_CANARY
-from homeassistant.components.canary import sensor as canary
+from homeassistant.components.canary import DATA_CANARY, sensor as canary
 from homeassistant.components.canary.sensor import (
-    CanarySensor,
-    SENSOR_TYPES,
     ATTR_AIR_QUALITY,
-    STATE_AIR_QUALITY_NORMAL,
+    SENSOR_TYPES,
     STATE_AIR_QUALITY_ABNORMAL,
+    STATE_AIR_QUALITY_NORMAL,
     STATE_AIR_QUALITY_VERY_ABNORMAL,
+    CanarySensor,
 )
+
 from tests.common import get_test_home_assistant
 from tests.components.canary.test_init import mock_device, mock_location
 

--- a/tests/components/coinmarketcap/test_sensor.py
+++ b/tests/components/coinmarketcap/test_sensor.py
@@ -1,12 +1,12 @@
 """Tests for the CoinMarketCap sensor platform."""
 import json
-
 import unittest
 from unittest.mock import patch
 
 import homeassistant.components.sensor as sensor
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant, load_fixture, assert_setup_component
+
+from tests.common import assert_setup_component, get_test_home_assistant, load_fixture
 
 VALID_CONFIG = {
     "platform": "coinmarketcap",

--- a/tests/components/configurator/test_init.py
+++ b/tests/components/configurator/test_init.py
@@ -3,7 +3,7 @@
 import unittest
 
 import homeassistant.components.configurator as configurator
-from homeassistant.const import EVENT_TIME_CHANGED, ATTR_FRIENDLY_NAME
+from homeassistant.const import ATTR_FRIENDLY_NAME, EVENT_TIME_CHANGED
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1,10 +1,10 @@
 """The tests for the Conversation component."""
 import pytest
 
-from homeassistant.core import DOMAIN as HASS_DOMAIN, Context
-from homeassistant.setup import async_setup_component
 from homeassistant.components import conversation
+from homeassistant.core import DOMAIN as HASS_DOMAIN, Context
 from homeassistant.helpers import intent
+from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_intent, async_mock_service
 

--- a/tests/components/coolmaster/test_config_flow.py
+++ b/tests/components/coolmaster/test_config_flow.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries, setup
-from homeassistant.components.coolmaster.const import DOMAIN, AVAILABLE_MODES
+from homeassistant.components.coolmaster.const import AVAILABLE_MODES, DOMAIN
 
 from tests.common import mock_coro
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"c"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/calendar/__init__.py` 
- `homeassistant/components/clickatell/notify.py` 
- `homeassistant/components/clicksend/notify.py` 
- `homeassistant/components/clicksend_tts/notify.py` 
- `homeassistant/components/configurator/__init__.py` 
- `homeassistant/components/conversation/__init__.py` 
- `homeassistant/components/coolmaster/config_flow.py` 
- `homeassistant/components/cups/sensor.py` 
- `homeassistant/components/currencylayer/sensor.py` 
- `homeassistant/components/zha/core/channels/__init__.py` 
- `tests/components/canary/test_init.py` 
- `tests/components/canary/test_sensor.py` 
- `tests/components/coinmarketcap/test_sensor.py` 
- `tests/components/configurator/test_init.py` 
- `tests/components/conversation/test_init.py` 
- `tests/components/coolmaster/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
