### PR TITLE
Sort imports according to PEP8 for components starting with "D"

### DIFF
--- a/homeassistant/components/denon/media_player.py
+++ b/homeassistant/components/denon/media_player.py
@@ -4,7 +4,7 @@ import telnetlib
 
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,

--- a/homeassistant/components/deutsche_bahn/sensor.py
+++ b/homeassistant/components/deutsche_bahn/sensor.py
@@ -2,9 +2,8 @@
 from datetime import timedelta
 import logging
 
-import voluptuous as vol
-
 import schiene
+import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -1,11 +1,9 @@
 """Support to turn on lights based on the states."""
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
-import homeassistant.util.dt as dt_util
 from homeassistant.components.light import (
     ATTR_PROFILE,
     ATTR_TRANSITION,
@@ -20,12 +18,14 @@ from homeassistant.const import (
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
 )
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_state_change,
 )
-from homeassistant.helpers.sun import is_up, get_astral_event_next
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.sun import get_astral_event_next, is_up
+import homeassistant.util.dt as dt_util
 
 DOMAIN = "device_sun_light_trigger"
 CONF_DEVICE_GROUP = "device_group"

--- a/homeassistant/components/dht/sensor.py
+++ b/homeassistant/components/dht/sensor.py
@@ -1,13 +1,13 @@
 """Support for Adafruit DHT temperature and humidity sensor."""
-import logging
 from datetime import timedelta
+import logging
 
 import Adafruit_DHT  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_FAHRENHEIT
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import TEMP_FAHRENHEIT, CONF_NAME, CONF_MONITORED_CONDITIONS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit

--- a/homeassistant/components/digital_ocean/__init__.py
+++ b/homeassistant/components/digital_ocean/__init__.py
@@ -1,13 +1,13 @@
 """Support for Digital Ocean."""
-import logging
 from datetime import timedelta
+import logging
 
 import digitalocean
 import voluptuous as vol
 
 from homeassistant.const import CONF_ACCESS_TOKEN
-from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/digitalloggers/switch.py
+++ b/homeassistant/components/digitalloggers/switch.py
@@ -1,17 +1,17 @@
 """Support for Digital Loggers DIN III Relays."""
-import logging
 from datetime import timedelta
+import logging
 
 import dlipower
 import voluptuous as vol
 
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
-    CONF_USERNAME,
     CONF_PASSWORD,
     CONF_TIMEOUT,
+    CONF_USERNAME,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -5,15 +5,14 @@ import os.path
 import discord
 import voluptuous as vol
 
-from homeassistant.const import CONF_TOKEN
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_TOKEN
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -6,19 +6,19 @@ Will emit EVENT_PLATFORM_DISCOVERED whenever a new service has been discovered.
 Knows which components handle certain types, will make sure they are
 loaded before the EVENT_PLATFORM_DISCOVERED is fired.
 """
-import json
 from datetime import timedelta
+import json
 import logging
 
 from netdisco.discovery import NetworkDiscovery
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import callback
 from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import async_discover, async_load_platform
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
 DOMAIN = "discovery"

--- a/homeassistant/components/dlib_face_detect/image_processing.py
+++ b/homeassistant/components/dlib_face_detect/image_processing.py
@@ -4,14 +4,13 @@ import logging
 
 import face_recognition  # pylint: disable=import-error
 
+# pylint: disable=unused-import
 from homeassistant.components.image_processing import (
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_SOURCE,
     ImageProcessingFaceEntity,
 )
-
-# pylint: disable=unused-import
 from homeassistant.components.image_processing import PLATFORM_SCHEMA  # noqa: F401
 from homeassistant.core import split_entity_id
 

--- a/homeassistant/components/dlib_face_detect/image_processing.py
+++ b/homeassistant/components/dlib_face_detect/image_processing.py
@@ -4,15 +4,18 @@ import logging
 
 import face_recognition  # pylint: disable=import-error
 
-# pylint: disable=unused-import
 from homeassistant.components.image_processing import (
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_SOURCE,
     ImageProcessingFaceEntity,
 )
-from homeassistant.components.image_processing import PLATFORM_SCHEMA  # noqa: F401
 from homeassistant.core import split_entity_id
+
+# pylint: disable=unused-import
+from homeassistant.components.image_processing import (  # noqa: F401, isort:skip
+    PLATFORM_SCHEMA,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/dlib_face_identify/image_processing.py
+++ b/homeassistant/components/dlib_face_identify/image_processing.py
@@ -1,20 +1,20 @@
 """Component that will help set the Dlib face detect processing."""
-import logging
 import io
+import logging
 
 # pylint: disable=import-error
 import face_recognition
 import voluptuous as vol
 
-from homeassistant.core import split_entity_id
 from homeassistant.components.image_processing import (
-    ImageProcessingFaceEntity,
-    PLATFORM_SCHEMA,
-    CONF_SOURCE,
+    CONF_CONFIDENCE,
     CONF_ENTITY_ID,
     CONF_NAME,
-    CONF_CONFIDENCE,
+    CONF_SOURCE,
+    PLATFORM_SCHEMA,
+    ImageProcessingFaceEntity,
 )
+from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -3,11 +3,10 @@ import io
 import logging
 import time
 
-import voluptuous as vol
 from PIL import Image, ImageDraw
 from pydoods import PyDOODS
+import voluptuous as vol
 
-from homeassistant.const import CONF_TIMEOUT
 from homeassistant.components.image_processing import (
     CONF_CONFIDENCE,
     CONF_ENTITY_ID,
@@ -17,6 +16,7 @@ from homeassistant.components.image_processing import (
     ImageProcessingEntity,
     draw_box,
 )
+from homeassistant.const import CONF_TIMEOUT
 from homeassistant.core import split_entity_id
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/dovado/__init__.py
+++ b/homeassistant/components/dovado/__init__.py
@@ -1,18 +1,18 @@
 """Support for Dovado router."""
-import logging
 from datetime import timedelta
+import logging
 
 import dovado
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_HOST,
+    CONF_PASSWORD,
     CONF_PORT,
+    CONF_USERNAME,
     DEVICE_DEFAULT_NAME,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/dublin_bus_transport/sensor.py
+++ b/homeassistant/components/dublin_bus_transport/sensor.py
@@ -7,17 +7,17 @@ https://data.gov.ie/dataset/real-time-passenger-information-rtpi-for-dublin-bus-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.dublin_public_transport/
 """
+from datetime import datetime, timedelta
 import logging
-from datetime import timedelta, datetime
 
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = "https://data.dublinked.ie/cgi-bin/rtpi/realtimebusinformation"

--- a/homeassistant/components/duckdns/__init__.py
+++ b/homeassistant/components/duckdns/__init__.py
@@ -1,14 +1,14 @@
 """Integrate with DuckDNS."""
-import logging
 from asyncio import iscoroutinefunction
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_DOMAIN
-from homeassistant.core import callback, CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -12,19 +12,19 @@ Unwetterwarnungen (Stufe 3)
 Warnungen vor markantem Wetter (Stufe 2)
 Wetterwarnungen (Stufe 1)
 """
-import logging
-import json
 from datetime import timedelta
+import json
+import logging
 
 import voluptuous as vol
 
+from homeassistant.components.rest.sensor import RestData
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_MONITORED_CONDITIONS
 from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
-from homeassistant.components.rest.sensor import RestData
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/datadog/test_init.py
+++ b/tests/components/datadog/test_init.py
@@ -1,16 +1,16 @@
 """The tests for the Datadog component."""
-from unittest import mock
 import unittest
+from unittest import mock
 
+import homeassistant.components.datadog as datadog
 from homeassistant.const import (
     EVENT_LOGBOOK_ENTRY,
     EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.setup import setup_component
-import homeassistant.components.datadog as datadog
 import homeassistant.core as ha
+from homeassistant.setup import setup_component
 
 from tests.common import assert_setup_component, get_test_home_assistant
 

--- a/tests/components/default_config/test_init.py
+++ b/tests/components/default_config/test_init.py
@@ -1,9 +1,9 @@
 """Test the default_config init."""
 from unittest.mock import patch
 
-from homeassistant.setup import async_setup_component
-
 import pytest
+
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockDependency, mock_coro
 

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -1,20 +1,21 @@
 """The tests device sun light trigger component."""
 # pylint: disable=protected-access
 from datetime import datetime
+
 from asynctest import patch
 import pytest
 
-from homeassistant.setup import async_setup_component
-from homeassistant.const import CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME
 from homeassistant.components import (
-    device_tracker,
-    light,
     device_sun_light_trigger,
+    device_tracker,
     group,
+    light,
 )
 from homeassistant.components.device_tracker.const import (
     ENTITY_ID_FORMAT as DT_ENTITY_ID_FORMAT,
 )
+from homeassistant.const import CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -1,33 +1,10 @@
 """The tests for the DirecTV Media player platform."""
+from datetime import datetime, timedelta
 from unittest.mock import call, patch
 
-from datetime import datetime, timedelta
-import requests
 import pytest
+import requests
 
-from homeassistant.components.media_player.const import (
-    ATTR_MEDIA_CONTENT_ID,
-    ATTR_MEDIA_CONTENT_TYPE,
-    MEDIA_TYPE_TVSHOW,
-    ATTR_MEDIA_ENQUEUE,
-    ATTR_MEDIA_DURATION,
-    ATTR_MEDIA_TITLE,
-    ATTR_MEDIA_POSITION,
-    ATTR_MEDIA_SERIES_TITLE,
-    ATTR_MEDIA_CHANNEL,
-    ATTR_INPUT_SOURCE,
-    ATTR_MEDIA_POSITION_UPDATED_AT,
-    DOMAIN,
-    SERVICE_PLAY_MEDIA,
-    SUPPORT_PAUSE,
-    SUPPORT_TURN_ON,
-    SUPPORT_TURN_OFF,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_STOP,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_PLAY,
-)
 from homeassistant.components.directv.media_player import (
     ATTR_MEDIA_CURRENTLY_RECORDING,
     ATTR_MEDIA_RATING,
@@ -35,6 +12,29 @@ from homeassistant.components.directv.media_player import (
     ATTR_MEDIA_START_TIME,
     DEFAULT_DEVICE,
     DEFAULT_PORT,
+)
+from homeassistant.components.media_player.const import (
+    ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_CHANNEL,
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_DURATION,
+    ATTR_MEDIA_ENQUEUE,
+    ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_POSITION_UPDATED_AT,
+    ATTR_MEDIA_SERIES_TITLE,
+    ATTR_MEDIA_TITLE,
+    DOMAIN,
+    MEDIA_TYPE_TVSHOW,
+    SERVICE_PLAY_MEDIA,
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_PLAY_MEDIA,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_STOP,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the discovery component."""
 import asyncio
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,7 +9,7 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import discovery
 from homeassistant.util.dt import utcnow
 
-from tests.common import mock_coro, async_fire_time_changed
+from tests.common import async_fire_time_changed, mock_coro
 
 # One might consider to "mock" services, but it's easy enough to just use
 # what is already available.

--- a/tests/components/duckdns/test_init.py
+++ b/tests/components/duckdns/test_init.py
@@ -1,13 +1,14 @@
 """Test the DuckDNS component."""
 from datetime import timedelta
 import logging
+
 import pytest
 
+from homeassistant.components import duckdns
+from homeassistant.components.duckdns import async_track_time_interval_backoff
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
-from homeassistant.components import duckdns
 from homeassistant.util.dt import utcnow
-from homeassistant.components.duckdns import async_track_time_interval_backoff
 
 from tests.common import async_fire_time_changed
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"d"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/denon/media_player.py` 
- `homeassistant/components/deutsche_bahn/sensor.py` 
- `homeassistant/components/device_sun_light_trigger/__init__.py` 
- `homeassistant/components/dht/sensor.py` 
- `homeassistant/components/digital_ocean/__init__.py` 
- `homeassistant/components/digitalloggers/switch.py` 
- `homeassistant/components/discord/notify.py` 
- `homeassistant/components/discovery/__init__.py` 
- `homeassistant/components/dlib_face_detect/image_processing.py` 
- `homeassistant/components/dlib_face_identify/image_processing.py` 
- `homeassistant/components/doods/image_processing.py` 
- `homeassistant/components/dovado/__init__.py` 
- `homeassistant/components/dublin_bus_transport/sensor.py` 
- `homeassistant/components/duckdns/__init__.py` 
- `homeassistant/components/dwd_weather_warnings/sensor.py` 
- `tests/components/datadog/test_init.py` 
- `tests/components/default_config/test_init.py` 
- `tests/components/device_sun_light_trigger/test_init.py` 
- `tests/components/directv/test_media_player.py` 
- `tests/components/discovery/test_init.py` 
- `tests/components/duckdns/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
