### PR TITLE
Sort imports according to PEP8 for components starting with "F"

### DIFF
--- a/homeassistant/components/facebook/notify.py
+++ b/homeassistant/components/facebook/notify.py
@@ -6,15 +6,14 @@ from aiohttp.hdrs import CONTENT_TYPE
 import requests
 import voluptuous as vol
 
-from homeassistant.const import CONTENT_TYPE_JSON
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONTENT_TYPE_JSON
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/facebox/image_processing.py
+++ b/homeassistant/components/facebox/image_processing.py
@@ -5,26 +5,27 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
-from homeassistant.core import split_entity_id
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.image_processing import (
-    PLATFORM_SCHEMA,
-    ImageProcessingFaceEntity,
     ATTR_CONFIDENCE,
-    CONF_SOURCE,
     CONF_ENTITY_ID,
     CONF_NAME,
+    CONF_SOURCE,
+    PLATFORM_SCHEMA,
+    ImageProcessingFaceEntity,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_NAME,
     CONF_IP_ADDRESS,
-    CONF_PORT,
     CONF_PASSWORD,
+    CONF_PORT,
     CONF_USERNAME,
     HTTP_BAD_REQUEST,
     HTTP_OK,
     HTTP_UNAUTHORIZED,
 )
+from homeassistant.core import split_entity_id
+import homeassistant.helpers.config_validation as cv
 
 from .const import DOMAIN, SERVICE_TEACH_FACE
 

--- a/homeassistant/components/fail2ban/sensor.py
+++ b/homeassistant/components/fail2ban/sensor.py
@@ -5,17 +5,16 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.fail2ban/
 
 """
-import os
-import logging
-
 from datetime import timedelta
-
+import logging
+import os
 import re
+
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_FILE_PATH
+from homeassistant.const import CONF_FILE_PATH, CONF_NAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -2,15 +2,15 @@
 from datetime import datetime, timedelta
 from logging import getLogger
 from os.path import exists
-from threading import Lock
 import pickle
+from threading import Lock
 
-import voluptuous as vol
 import feedparser
+import voluptuous as vol
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START, CONF_SCAN_INTERVAL
-from homeassistant.helpers.event import track_time_interval
+from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import track_time_interval
 
 _LOGGER = getLogger(__name__)
 

--- a/homeassistant/components/ffmpeg_motion/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_motion/binary_sensor.py
@@ -4,17 +4,17 @@ import logging
 import haffmpeg.sensor as ffmpeg_sensor
 import voluptuous as vol
 
-from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.components.ffmpeg import (
-    FFmpegBase,
-    DATA_FFMPEG,
-    CONF_INPUT,
     CONF_EXTRA_ARGUMENTS,
     CONF_INITIAL_STATE,
+    CONF_INPUT,
+    DATA_FFMPEG,
+    FFmpegBase,
 )
 from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ffmpeg_noise/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_noise/binary_sensor.py
@@ -4,17 +4,17 @@ import logging
 import haffmpeg.sensor as ffmpeg_sensor
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA
-from homeassistant.components.ffmpeg_motion.binary_sensor import FFmpegBinarySensor
 from homeassistant.components.ffmpeg import (
-    DATA_FFMPEG,
-    CONF_INPUT,
-    CONF_OUTPUT,
     CONF_EXTRA_ARGUMENTS,
     CONF_INITIAL_STATE,
+    CONF_INPUT,
+    CONF_OUTPUT,
+    DATA_FFMPEG,
 )
+from homeassistant.components.ffmpeg_motion.binary_sensor import FFmpegBinarySensor
 from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -5,9 +5,9 @@ import os
 
 import voluptuous as vol
 
-from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -1,31 +1,31 @@
 """Allows the creation of a sensor that filters state property."""
-import logging
-import statistics
-from collections import deque, Counter
-from numbers import Number
-from functools import partial
+from collections import Counter, deque
 from copy import copy
 from datetime import timedelta
+from functools import partial
+import logging
+from numbers import Number
+import statistics
 from typing import Optional
 
 import voluptuous as vol
 
-from homeassistant.core import callback
+from homeassistant.components import history
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
-    CONF_ENTITY_ID,
-    ATTR_UNIT_OF_MEASUREMENT,
     ATTR_ENTITY_ID,
     ATTR_ICON,
-    STATE_UNKNOWN,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_ENTITY_ID,
+    CONF_NAME,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.decorator import Registry
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
-from homeassistant.components import history
+from homeassistant.util.decorator import Registry
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -1,7 +1,7 @@
 """Support for the Fitbit API."""
-import os
-import logging
 import datetime
+import logging
+import os
 import time
 
 from fitbit import Fitbit
@@ -9,16 +9,14 @@ from fitbit.api import FitbitOauth2Client
 from oauthlib.oauth2.rfc6749.errors import MismatchingStateError, MissingTokenError
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.const import CONF_UNIT_SYSTEM
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_UNIT_SYSTEM
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
-import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
-
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/flic/binary_sensor.py
+++ b/homeassistant/components/flic/binary_sensor.py
@@ -3,24 +3,24 @@ import logging
 import threading
 
 from pyflic import (
-    FlicClient,
     ButtonConnectionChannel,
     ClickType,
     ConnectionStatus,
+    FlicClient,
     ScanWizard,
     ScanWizardResult,
 )
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import (
+    CONF_DISCOVERY,
     CONF_HOST,
     CONF_PORT,
-    CONF_DISCOVERY,
     CONF_TIMEOUT,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/flock/notify.py
+++ b/homeassistant/components/flock/notify.py
@@ -5,11 +5,10 @@ import logging
 import async_timeout
 import voluptuous as vol
 
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = "https://api.flock.com/hooks/sendMessage/"

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -11,9 +11,7 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.light import (
-    is_on,
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
     ATTR_RGB_COLOR,
@@ -22,29 +20,31 @@ from homeassistant.components.light import (
     ATTR_XY_COLOR,
     DOMAIN as LIGHT_DOMAIN,
     VALID_TRANSITION,
+    is_on,
 )
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    CONF_NAME,
-    CONF_PLATFORM,
     CONF_LIGHTS,
     CONF_MODE,
+    CONF_NAME,
+    CONF_PLATFORM,
     SERVICE_TURN_ON,
     STATE_ON,
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.sun import get_astral_event_date
 from homeassistant.util import slugify
 from homeassistant.util.color import (
-    color_temperature_to_rgb,
     color_RGB_to_xy_brightness,
     color_temperature_kelvin_to_mired,
+    color_temperature_to_rgb,
 )
-from homeassistant.util.dt import utcnow as dt_utcnow, as_local
+from homeassistant.util.dt import as_local, utcnow as dt_utcnow
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -1,28 +1,28 @@
 """Support for Flux lights."""
 import logging
-import socket
 import random
+import socket
 
 from flux_led import BulbScanner, WifiLedBulb
 import voluptuous as vol
 
-from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL, ATTR_MODE
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ATTR_EFFECT,
-    ATTR_WHITE_VALUE,
     ATTR_COLOR_TEMP,
+    ATTR_EFFECT,
+    ATTR_HS_COLOR,
+    ATTR_WHITE_VALUE,
     EFFECT_COLORLOOP,
     EFFECT_RANDOM,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_EFFECT,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
-    SUPPORT_COLOR_TEMP,
-    Light,
     PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR,
+    SUPPORT_COLOR_TEMP,
+    SUPPORT_EFFECT,
+    SUPPORT_WHITE_VALUE,
+    Light,
 )
+from homeassistant.const import ATTR_MODE, CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 

--- a/homeassistant/components/folder/sensor.py
+++ b/homeassistant/components/folder/sensor.py
@@ -6,9 +6,9 @@ import os
 
 import voluptuous as vol
 
-from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -5,17 +5,16 @@ This component is part of the device_tracker platform.
 """
 import logging
 
-import voluptuous as vol
 from fortiosapi import FortiOSAPI
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
-from homeassistant.const import CONF_HOST, CONF_TOKEN
-from homeassistant.const import CONF_VERIFY_SSL
+from homeassistant.const import CONF_HOST, CONF_TOKEN, CONF_VERIFY_SSL
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_VERIFY_SSL = False

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -1,26 +1,26 @@
 """This component provides basic support for Foscam IP cameras."""
-import logging
 import asyncio
+import logging
 
 from libpyfoscam import FoscamCamera
-
 import voluptuous as vol
 
-from homeassistant.components.camera import Camera, PLATFORM_SCHEMA, SUPPORT_STREAM
+from homeassistant.components.camera import PLATFORM_SCHEMA, SUPPORT_STREAM, Camera
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_NAME,
-    CONF_USERNAME,
     CONF_PASSWORD,
     CONF_PORT,
-    ATTR_ENTITY_ID,
+    CONF_USERNAME,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_extract_entity_ids
 
-from .const import DOMAIN as FOSCAM_DOMAIN
-from .const import DATA as FOSCAM_DATA
-from .const import ENTITIES as FOSCAM_ENTITIES
-
+from .const import (
+    DATA as FOSCAM_DATA,
+    DOMAIN as FOSCAM_DOMAIN,
+    ENTITIES as FOSCAM_ENTITIES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/foursquare/__init__.py
+++ b/homeassistant/components/foursquare/__init__.py
@@ -4,9 +4,9 @@ import logging
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_ACCESS_TOKEN, HTTP_BAD_REQUEST
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.const import CONF_ACCESS_TOKEN, HTTP_BAD_REQUEST
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/freedns/__init__.py
+++ b/homeassistant/components/freedns/__init__.py
@@ -1,14 +1,14 @@
 """Integrate with FreeDNS Dynamic DNS service at freedns.afraid.org."""
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
 import aiohttp
 import async_timeout
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_SCAN_INTERVAL, CONF_URL
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -7,11 +7,11 @@ from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     HVAC_MODE_HEAT,
-    PRESET_ECO,
-    PRESET_COMFORT,
-    SUPPORT_TARGET_TEMPERATURE,
     HVAC_MODE_OFF,
+    PRESET_COMFORT,
+    PRESET_ECO,
     SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -2,23 +2,22 @@
 import copy
 from datetime import timedelta
 import logging
-import voluptuous as vol
 
 from pyfronius import Fronius
+import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_RESOURCE,
-    CONF_SENSOR_TYPE,
     CONF_DEVICE,
     CONF_MONITORED_CONDITIONS,
+    CONF_RESOURCE,
     CONF_SCAN_INTERVAL,
+    CONF_SENSOR_TYPE,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/facebook/test_notify.py
+++ b/tests/components/facebook/test_notify.py
@@ -1,5 +1,6 @@
 """The test for the Facebook notify module."""
 import unittest
+
 import requests_mock
 
 # import homeassistant.components.facebook as facebook

--- a/tests/components/facebox/test_image_processing.py
+++ b/tests/components/facebox/test_image_processing.py
@@ -5,23 +5,23 @@ import pytest
 import requests
 import requests_mock
 
-from homeassistant.core import callback
+import homeassistant.components.facebox.image_processing as fb
+import homeassistant.components.image_processing as ip
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_NAME,
     CONF_FRIENDLY_NAME,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_IP_ADDRESS,
+    CONF_PASSWORD,
     CONF_PORT,
+    CONF_USERNAME,
     HTTP_BAD_REQUEST,
     HTTP_OK,
     HTTP_UNAUTHORIZED,
     STATE_UNKNOWN,
 )
+from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
-import homeassistant.components.image_processing as ip
-import homeassistant.components.facebox.image_processing as fb
 
 MOCK_IP = "192.168.0.1"
 MOCK_PORT = "8080"

--- a/tests/components/fail2ban/test_sensor.py
+++ b/tests/components/fail2ban/test_sensor.py
@@ -4,15 +4,15 @@ from unittest.mock import Mock, patch
 
 from mock_open import MockOpen
 
-from homeassistant.setup import setup_component
 from homeassistant.components.fail2ban.sensor import (
-    BanSensor,
-    BanLogParser,
-    STATE_CURRENT_BANS,
     STATE_ALL_BANS,
+    STATE_CURRENT_BANS,
+    BanLogParser,
+    BanSensor,
 )
+from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 def fake_log(log_key):

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -1,27 +1,28 @@
 """The tests for the feedreader component."""
-import time
 from datetime import timedelta
-
-import unittest
-from genericpath import exists
 from logging import getLogger
 from os import remove
+import time
+import unittest
 from unittest import mock
 from unittest.mock import patch
 
+from genericpath import exists
+
 from homeassistant.components import feedreader
 from homeassistant.components.feedreader import (
+    CONF_MAX_ENTRIES,
     CONF_URLS,
+    DEFAULT_MAX_ENTRIES,
+    DEFAULT_SCAN_INTERVAL,
+    EVENT_FEEDREADER,
     FeedManager,
     StoredData,
-    EVENT_FEEDREADER,
-    DEFAULT_SCAN_INTERVAL,
-    CONF_MAX_ENTRIES,
-    DEFAULT_MAX_ENTRIES,
 )
-from homeassistant.const import EVENT_HOMEASSISTANT_START, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
 from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant, load_fixture
 
 _LOGGER = getLogger(__name__)

--- a/tests/components/fido/test_sensor.py
+++ b/tests/components/fido/test_sensor.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.fido import sensor as fido
-from tests.common import assert_setup_component
 
+from tests.common import assert_setup_component
 
 CONTRACT = "123456789"
 

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -1,11 +1,11 @@
 """The tests for the filesize sensor."""
-import unittest
 import os
+import unittest
 
 from homeassistant.components.filesize.sensor import CONF_FILE_PATHS
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant
 
+from tests.common import get_test_home_assistant
 
 TEST_DIR = os.path.join(os.path.dirname(__file__))
 TEST_FILE = os.path.join(TEST_DIR, "mock_file_test_filesize.txt")

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -6,17 +6,18 @@ from unittest.mock import patch
 from homeassistant.components.filter.sensor import (
     LowPassFilter,
     OutlierFilter,
+    RangeFilter,
     ThrottleFilter,
     TimeSMAFilter,
-    RangeFilter,
     TimeThrottleFilter,
 )
-import homeassistant.util.dt as dt_util
-from homeassistant.setup import setup_component
 import homeassistant.core as ha
+from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
+
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
+    get_test_home_assistant,
     init_recorder_component,
 )
 

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -2,15 +2,15 @@
 from asynctest.mock import patch
 import pytest
 
-from homeassistant.setup import async_setup_component
-from homeassistant.components import switch, light
+from homeassistant.components import light, switch
 from homeassistant.const import (
     CONF_PLATFORM,
-    STATE_ON,
     SERVICE_TURN_ON,
+    STATE_ON,
     SUN_EVENT_SUNRISE,
 )
 from homeassistant.core import State
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (

--- a/tests/components/folder/test_sensor.py
+++ b/tests/components/folder/test_sensor.py
@@ -1,11 +1,11 @@
 """The tests for the folder sensor."""
-import unittest
 import os
+import unittest
 
 from homeassistant.components.folder.sensor import CONF_FOLDER_PATHS
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant
 
+from tests.common import get_test_home_assistant
 
 CWD = os.path.join(os.path.dirname(__file__))
 TEST_FOLDER = "test_folder"

--- a/tests/components/folder_watcher/test_init.py
+++ b/tests/components/folder_watcher/test_init.py
@@ -1,9 +1,10 @@
 """The tests for the folder_watcher component."""
-from unittest.mock import Mock, patch
 import os
+from unittest.mock import Mock, patch
 
 from homeassistant.components import folder_watcher
 from homeassistant.setup import async_setup_component
+
 from tests.common import MockDependency
 
 

--- a/tests/components/foobot/test_sensor.py
+++ b/tests/components/foobot/test_sensor.py
@@ -1,16 +1,17 @@
 """The tests for the Foobot sensor platform."""
 
-import re
 import asyncio
+import re
 from unittest.mock import MagicMock
+
 import pytest
 
-
-import homeassistant.components.sensor as sensor
 from homeassistant.components.foobot import sensor as foobot
+import homeassistant.components.sensor as sensor
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.setup import async_setup_component
+
 from tests.common import load_fixture
 
 VALID_CONFIG = {

--- a/tests/components/freedns/test_init.py
+++ b/tests/components/freedns/test_init.py
@@ -1,9 +1,10 @@
 """Test the FreeDNS component."""
 import asyncio
+
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import freedns
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -5,19 +5,18 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
-    DOMAIN,
-    CONF_JS_VERSION,
-    CONF_THEMES,
     CONF_EXTRA_HTML_URL,
     CONF_EXTRA_HTML_URL_ES5,
+    CONF_JS_VERSION,
+    CONF_THEMES,
+    DOMAIN,
     EVENT_PANELS_UPDATED,
 )
 from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro, async_capture_events
-
+from tests.common import async_capture_events, mock_coro
 
 CONFIG_THEMES = {DOMAIN: {CONF_THEMES: {"happy": {"primary-color": "red"}}}}
 

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -1,8 +1,8 @@
 """The tests for frontend storage."""
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import storage
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"f"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/facebook/notify.py` 
- `homeassistant/components/facebox/image_processing.py` 
- `homeassistant/components/fail2ban/sensor.py` 
- `homeassistant/components/feedreader/__init__.py` 
- `homeassistant/components/ffmpeg_motion/binary_sensor.py` 
- `homeassistant/components/ffmpeg_noise/binary_sensor.py` 
- `homeassistant/components/filesize/sensor.py` 
- `homeassistant/components/filter/sensor.py` 
- `homeassistant/components/fitbit/sensor.py` 
- `homeassistant/components/flic/binary_sensor.py` 
- `homeassistant/components/flock/notify.py` 
- `homeassistant/components/flux/switch.py` 
- `homeassistant/components/flux_led/light.py` 
- `homeassistant/components/folder/sensor.py` 
- `homeassistant/components/fortios/device_tracker.py` 
- `homeassistant/components/foscam/camera.py` 
- `homeassistant/components/foursquare/__init__.py` 
- `homeassistant/components/freedns/__init__.py` 
- `homeassistant/components/fritzbox/climate.py` 
- `homeassistant/components/fronius/sensor.py` 
- `tests/components/facebook/test_notify.py` 
- `tests/components/facebox/test_image_processing.py` 
- `tests/components/fail2ban/test_sensor.py` 
- `tests/components/feedreader/test_init.py` 
- `tests/components/fido/test_sensor.py` 
- `tests/components/filesize/test_sensor.py` 
- `tests/components/filter/test_sensor.py` 
- `tests/components/flux/test_switch.py` 
- `tests/components/folder/test_sensor.py` 
- `tests/components/folder_watcher/test_init.py` 
- `tests/components/foobot/test_sensor.py` 
- `tests/components/freedns/test_init.py` 
- `tests/components/frontend/test_init.py` 
- `tests/components/frontend/test_storage.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
