### PR TITLE
Sort imports according to PEP8 for components starting with "G"

### DIFF
--- a/homeassistant/components/garadget/cover.py
+++ b/homeassistant/components/garadget/cover.py
@@ -4,19 +4,19 @@ import logging
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.cover import CoverDevice, PLATFORM_SCHEMA
-from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.components.cover import PLATFORM_SCHEMA, CoverDevice
 from homeassistant.const import (
-    CONF_DEVICE,
-    CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_ACCESS_TOKEN,
+    CONF_COVERS,
+    CONF_DEVICE,
     CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
     STATE_CLOSED,
     STATE_OPEN,
-    CONF_COVERS,
 )
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import track_utc_time_change
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/geizhals/sensor.py
+++ b/homeassistant/components/geizhals/sensor.py
@@ -1,15 +1,15 @@
 """Parse prices of a device from geizhals."""
-import logging
 from datetime import timedelta
+import logging
 
 from geizhals import Device, Geizhals
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
-from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -8,24 +8,24 @@ import requests
 from requests.auth import HTTPDigestAuth
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_USERNAME,
-    CONF_PASSWORD,
-    CONF_AUTHENTICATION,
-    HTTP_BASIC_AUTHENTICATION,
-    HTTP_DIGEST_AUTHENTICATION,
-    CONF_VERIFY_SSL,
-)
-from homeassistant.exceptions import TemplateError
 from homeassistant.components.camera import (
-    PLATFORM_SCHEMA,
     DEFAULT_CONTENT_TYPE,
+    PLATFORM_SCHEMA,
     SUPPORT_STREAM,
     Camera,
 )
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.const import (
+    CONF_AUTHENTICATION,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    HTTP_BASIC_AUTHENTICATION,
+    HTTP_DIGEST_AUTHENTICATION,
+)
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -15,9 +15,9 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     PRESET_AWAY,
+    PRESET_NONE,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
-    PRESET_NONE,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -1,5 +1,5 @@
 """Support for Genius Hub switch/outlet devices."""
-from homeassistant.components.switch import SwitchDevice, DEVICE_CLASS_OUTLET
+from homeassistant.components.switch import DEVICE_CLASS_OUTLET, SwitchDevice
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import DOMAIN, GeniusZone

--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/geo_rss_events/sensor.py
+++ b/homeassistant/components/geo_rss_events/sensor.py
@@ -8,23 +8,23 @@ and grouped by category.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.geo_rss_events/
 """
-import logging
 from datetime import timedelta
+import logging
 
-import voluptuous as vol
 from georss_client import UPDATE_OK, UPDATE_OK_NO_DATA
 from georss_client.generic_feed import GenericFeed
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_UNIT_OF_MEASUREMENT,
-    CONF_NAME,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    CONF_NAME,
     CONF_RADIUS,
+    CONF_UNIT_OF_MEASUREMENT,
     CONF_URL,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -1,6 +1,7 @@
 """Support for GitHub."""
 from datetime import timedelta
 import logging
+
 import github
 import voluptuous as vol
 

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -1,23 +1,22 @@
 """Support for Google - Calendar Event Devices."""
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 import logging
 import os
-import yaml
 
+from googleapiclient import discovery as google_discovery
 import httplib2
 from oauth2client.client import (
-    OAuth2WebServerFlow,
-    OAuth2DeviceCodeError,
     FlowExchangeError,
+    OAuth2DeviceCodeError,
+    OAuth2WebServerFlow,
 )
 from oauth2client.file import Storage
-from googleapiclient import discovery as google_discovery
-
 import voluptuous as vol
 from voluptuous.error import Error as VoluptuousError
+import yaml
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.event import track_time_change
 from homeassistant.util import convert, dt

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -1,11 +1,11 @@
 """Support for the Google Cloud TTS service."""
+import asyncio
 import logging
 import os
 
-import asyncio
 import async_timeout
-import voluptuous as vol
 from google.cloud import texttospeech
+import voluptuous as vol
 
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/google_domains/__init__.py
+++ b/homeassistant/components/google_domains/__init__.py
@@ -7,8 +7,8 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_DOMAIN, CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/google_wifi/sensor.py
+++ b/homeassistant/components/google_wifi/sensor.py
@@ -1,21 +1,20 @@
 """Support for retrieving status info from Google Wifi/OnHub routers."""
-import logging
 from datetime import timedelta
+import logging
 
-import voluptuous as vol
 import requests
+import voluptuous as vol
 
-from homeassistant.util import dt
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
     CONF_HOST,
     CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
     STATE_UNKNOWN,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle, dt
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -7,7 +7,6 @@ import time
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -17,6 +16,7 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
 )
 from homeassistant.helpers import state
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -1,17 +1,17 @@
 """Read status of growatt inverters."""
-import re
+import datetime
 import json
 import logging
-import datetime
+import re
 
 import growattServer
 import voluptuous as vol
 
-from homeassistant.util import Throttle
-from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -1,6 +1,5 @@
 """The tests for generic camera component."""
 import asyncio
-
 from unittest import mock
 
 from homeassistant.setup import async_setup_component

--- a/tests/components/geo_json_events/test_geo_location.py
+++ b/tests/components/geo_json_events/test_geo_location.py
@@ -1,29 +1,30 @@
 """The tests for the geojson platform."""
-from asynctest.mock import patch, MagicMock, call
+from asynctest.mock import MagicMock, call, patch
 
 from homeassistant.components import geo_location
-from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.components.geo_json_events.geo_location import (
-    SCAN_INTERVAL,
     ATTR_EXTERNAL_ID,
+    SCAN_INTERVAL,
     SIGNAL_DELETE_ENTITY,
     SIGNAL_UPDATE_ENTITY,
 )
+from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.const import (
-    CONF_URL,
-    EVENT_HOMEASSISTANT_START,
-    CONF_RADIUS,
+    ATTR_FRIENDLY_NAME,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    CONF_RADIUS,
+    CONF_URL,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
-from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
+
+from tests.common import assert_setup_component, async_fire_time_changed
 
 URL = "http://geo.json.local/geo_json_events.json"
 CONFIG = {

--- a/tests/components/geo_rss_events/test_sensor.py
+++ b/tests/components/geo_rss_events/test_sensor.py
@@ -4,20 +4,21 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from homeassistant.components import sensor
+import homeassistant.components.geo_rss_events.sensor as geo_rss_events
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT,
     ATTR_FRIENDLY_NAME,
-    EVENT_HOMEASSISTANT_START,
     ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
+
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
     fire_time_changed,
+    get_test_home_assistant,
 )
-import homeassistant.components.geo_rss_events.sensor as geo_rss_events
-import homeassistant.util.dt as dt_util
 
 URL = "http://geo.rss.local/geo_rss_events.xml"
 VALID_CONFIG_WITH_CATEGORIES = {

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -25,7 +25,6 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import async_mock_service
 
-
 GOOGLE_CONFIG = {CONF_CLIENT_ID: "client_id", CONF_CLIENT_SECRET: "client_secret"}
 TEST_ENTITY = "calendar.we_are_we_are_a_test_calendar"
 TEST_ENTITY_NAME = "We are, we are, a... Test Calendar"

--- a/tests/components/google_domains/test_init.py
+++ b/tests/components/google_domains/test_init.py
@@ -4,8 +4,8 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import google_domains
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -4,16 +4,15 @@ import os
 import shutil
 from unittest.mock import patch
 
-import homeassistant.components.tts as tts
 from homeassistant.components.media_player.const import (
-    SERVICE_PLAY_MEDIA,
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
+    SERVICE_PLAY_MEDIA,
 )
+import homeassistant.components.tts as tts
 from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component, mock_service
-
+from tests.common import assert_setup_component, get_test_home_assistant, mock_service
 from tests.components.tts.test_init import mutagen_mock  # noqa: F401
 
 

--- a/tests/components/google_wifi/test_sensor.py
+++ b/tests/components/google_wifi/test_sensor.py
@@ -1,17 +1,17 @@
 """The tests for the Google Wifi platform."""
-import unittest
-from unittest.mock import patch, Mock
 from datetime import datetime, timedelta
+import unittest
+from unittest.mock import Mock, patch
 
 import requests_mock
 
 from homeassistant import core as ha
-from homeassistant.setup import setup_component
 import homeassistant.components.google_wifi.sensor as google_wifi
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.setup import setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import get_test_home_assistant, assert_setup_component
+from tests.common import assert_setup_component, get_test_home_assistant
 
 NAME = "foo"
 

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -4,16 +4,17 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
-from homeassistant.setup import setup_component
-import homeassistant.core as ha
 import homeassistant.components.graphite as graphite
 from homeassistant.const import (
-    EVENT_STATE_CHANGED,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
-    STATE_ON,
+    EVENT_STATE_CHANGED,
     STATE_OFF,
+    STATE_ON,
 )
+import homeassistant.core as ha
+from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"g"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/garadget/cover.py` 
- `homeassistant/components/geizhals/sensor.py` 
- `homeassistant/components/generic/camera.py` 
- `homeassistant/components/generic_thermostat/climate.py` 
- `homeassistant/components/geniushub/switch.py` 
- `homeassistant/components/geo_location/__init__.py` 
- `homeassistant/components/geo_rss_events/sensor.py` 
- `homeassistant/components/github/sensor.py` 
- `homeassistant/components/google/__init__.py` 
- `homeassistant/components/google_cloud/tts.py` 
- `homeassistant/components/google_domains/__init__.py` 
- `homeassistant/components/google_wifi/sensor.py` 
- `homeassistant/components/graphite/__init__.py` 
- `homeassistant/components/growatt_server/sensor.py` 
- `tests/components/generic/test_camera.py` 
- `tests/components/geo_json_events/test_geo_location.py` 
- `tests/components/geo_rss_events/test_sensor.py` 
- `tests/components/google/test_calendar.py` 
- `tests/components/google_domains/test_init.py` 
- `tests/components/google_translate/test_tts.py` 
- `tests/components/google_wifi/test_sensor.py` 
- `tests/components/graphite/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
