### PR TITLE
Sort imports according to PEP8 for components starting with "H"

### DIFF
--- a/homeassistant/components/haveibeenpwned/sensor.py
+++ b/homeassistant/components/haveibeenpwned/sensor.py
@@ -7,7 +7,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_EMAIL, CONF_API_KEY, ATTR_ATTRIBUTION
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_EMAIL
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_point_in_time

--- a/homeassistant/components/hddtemp/sensor.py
+++ b/homeassistant/components/hddtemp/sensor.py
@@ -1,21 +1,21 @@
 """Support for getting the disk temperature of a host."""
-import logging
 from datetime import timedelta
-from telnetlib import Telnet
+import logging
 import socket
+from telnetlib import Telnet
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
+    CONF_DISKS,
     CONF_HOST,
+    CONF_NAME,
     CONF_PORT,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
-    CONF_DISKS,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/history_graph/__init__.py
+++ b/homeassistant/components/history_graph/__init__.py
@@ -3,8 +3,8 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.const import ATTR_ENTITY_ID, CONF_ENTITIES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_ENTITIES, CONF_NAME, ATTR_ENTITY_ID
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 

--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -5,21 +5,21 @@ import math
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components import history
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
     CONF_ENTITY_ID,
+    CONF_NAME,
     CONF_STATE,
     CONF_TYPE,
     EVENT_HOMEASSISTANT_START,
 )
+from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hitron_coda/device_tracker.py
+++ b/homeassistant/components/hitron_coda/device_tracker.py
@@ -1,17 +1,17 @@
 """Support for the Hitron CODA-4582U, provided by Rogers."""
-import logging
 from collections import namedtuple
+import logging
 
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_TYPE
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_TYPE, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -1,43 +1,43 @@
 """Support for Honeywell (US) Total Connect Comfort climate systems."""
 import datetime
 import logging
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 import requests
-import voluptuous as vol
 import somecomfort
+import voluptuous as vol
 
-from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_FAN,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
     FAN_AUTO,
     FAN_DIFFUSE,
     FAN_ON,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_OFF,
+    PRESET_AWAY,
+    PRESET_NONE,
     SUPPORT_AUX_HEAT,
     SUPPORT_FAN_MODE,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_HUMIDITY,
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
-    CURRENT_HVAC_COOL,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_FAN,
-    HVAC_MODE_OFF,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT_COOL,
-    PRESET_AWAY,
-    PRESET_NONE,
 )
 from homeassistant.const import (
+    ATTR_TEMPERATURE,
     CONF_PASSWORD,
+    CONF_REGION,
     CONF_USERNAME,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
-    ATTR_TEMPERATURE,
-    CONF_REGION,
 )
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/hook/switch.py
+++ b/homeassistant/components/hook/switch.py
@@ -1,13 +1,13 @@
 """Support Hook, available at hooksmarthome.com."""
-import logging
 import asyncio
+import logging
 
-import voluptuous as vol
-import async_timeout
 import aiohttp
+import async_timeout
+import voluptuous as vol
 
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_TOKEN
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -1,23 +1,30 @@
 """HTML5 Push Messaging notification service."""
 from datetime import datetime, timedelta
-
 from functools import partial
-from urllib.parse import urlparse
 import json
 import logging
 import time
+from urllib.parse import urlparse
 import uuid
 
 from aiohttp.hdrs import AUTHORIZATION
 import jwt
-from pywebpush import WebPusher
 from py_vapid import Vapid
+from pywebpush import WebPusher
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 from homeassistant.components import websocket_api
 from homeassistant.components.frontend import add_manifest_json_key
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    ATTR_TARGET,
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
 from homeassistant.const import (
     HTTP_BAD_REQUEST,
     HTTP_INTERNAL_SERVER_ERROR,
@@ -28,15 +35,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import ensure_unique_string
 from homeassistant.util.json import load_json, save_json
-
-from homeassistant.components.notify import (
-    ATTR_DATA,
-    ATTR_TARGET,
-    ATTR_TITLE,
-    ATTR_TITLE_DEFAULT,
-    PLATFORM_SCHEMA,
-    BaseNotificationService,
-)
 
 from .const import DOMAIN, SERVICE_DISMISS
 

--- a/homeassistant/components/huawei_router/device_tracker.py
+++ b/homeassistant/components/huawei_router/device_tracker.py
@@ -1,19 +1,19 @@
 """Support for HUAWEI routers."""
 import base64
+from collections import namedtuple
 import logging
 import re
-from collections import namedtuple
 
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/hddtemp/test_sensor.py
+++ b/tests/components/hddtemp/test_sensor.py
@@ -1,6 +1,5 @@
 """The tests for the hddtemp platform."""
 import socket
-
 import unittest
 from unittest.mock import patch
 

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -4,15 +4,15 @@ from datetime import timedelta
 import unittest
 from unittest.mock import patch, sentinel
 
-from homeassistant.setup import setup_component, async_setup_component
-import homeassistant.core as ha
-import homeassistant.util.dt as dt_util
 from homeassistant.components import history, recorder
+import homeassistant.core as ha
+from homeassistant.setup import async_setup_component, setup_component
+import homeassistant.util.dt as dt_util
 
 from tests.common import (
+    get_test_home_assistant,
     init_recorder_component,
     mock_state_change_event,
-    get_test_home_assistant,
 )
 
 

--- a/tests/components/history_graph/test_init.py
+++ b/tests/components/history_graph/test_init.py
@@ -3,7 +3,8 @@
 import unittest
 
 from homeassistant.setup import setup_component
-from tests.common import init_recorder_component, get_test_home_assistant
+
+from tests.common import get_test_home_assistant, init_recorder_component
 
 
 class TestGraph(unittest.TestCase):

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -3,17 +3,18 @@
 from datetime import datetime, timedelta
 import unittest
 from unittest.mock import patch
+
 import pytest
 import pytz
 
-from homeassistant.const import STATE_UNKNOWN
-from homeassistant.setup import setup_component
 from homeassistant.components.history_stats.sensor import HistoryStatsSensor
+from homeassistant.const import STATE_UNKNOWN
 import homeassistant.core as ha
 from homeassistant.helpers.template import Template
+from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import init_recorder_component, get_test_home_assistant
+from tests.common import get_test_home_assistant, init_recorder_component
 
 
 class TestHistoryStatsSensor(unittest.TestCase):

--- a/tests/components/homematic/test_notify.py
+++ b/tests/components/homematic/test_notify.py
@@ -2,8 +2,9 @@
 
 import unittest
 
-from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify_comp
+from homeassistant.setup import setup_component
+
 from tests.common import assert_setup_component, get_test_home_assistant
 
 

--- a/tests/components/honeywell/test_climate.py
+++ b/tests/components/honeywell/test_climate.py
@@ -2,25 +2,23 @@
 import unittest
 from unittest import mock
 
-import voluptuous as vol
+import pytest
 import requests.exceptions
 import somecomfort
-import pytest
+import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_USERNAME,
-    CONF_PASSWORD,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
-)
 from homeassistant.components.climate.const import (
     ATTR_FAN_MODE,
     ATTR_FAN_MODES,
     ATTR_HVAC_MODES,
 )
-
 import homeassistant.components.honeywell.climate as honeywell
-
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
 
 pytestmark = pytest.mark.skip("Need to be fixed!")
 

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -1,11 +1,12 @@
 """Test HTML5 notify platform."""
 import json
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import MagicMock, mock_open, patch
+
 from aiohttp.hdrs import AUTHORIZATION
 
-from homeassistant.setup import async_setup_component
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.components.html5.notify as html5
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
 
 CONFIG_FILE = "file.conf"
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"h"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/haveibeenpwned/sensor.py` 
- `homeassistant/components/hddtemp/sensor.py` 
- `homeassistant/components/history_graph/__init__.py` 
- `homeassistant/components/history_stats/sensor.py` 
- `homeassistant/components/hitron_coda/device_tracker.py` 
- `homeassistant/components/honeywell/climate.py` 
- `homeassistant/components/hook/switch.py` 
- `homeassistant/components/html5/notify.py` 
- `homeassistant/components/huawei_router/device_tracker.py` 
- `tests/components/hddtemp/test_sensor.py` 
- `tests/components/history/test_init.py` 
- `tests/components/history_graph/test_init.py` 
- `tests/components/history_stats/test_sensor.py` 
- `tests/components/homematic/test_notify.py` 
- `tests/components/honeywell/test_climate.py` 
- `tests/components/html5/test_notify.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
