### PR TITLE
Sort imports according to PEP8 for components starting with "I"

### DIFF
--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -1,24 +1,24 @@
 """Email sensor support."""
-import logging
+from collections import deque
 import datetime
 import email
-from collections import deque
-
 import imaplib
+import logging
+
 import voluptuous as vol
 
-from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
+    ATTR_DATE,
     CONF_NAME,
+    CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_VALUE_TEMPLATE,
     CONTENT_TYPE_TEXT_PLAIN,
-    ATTR_DATE,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/input_boolean/reproduce_state.py
+++ b/homeassistant/components/input_boolean/reproduce_state.py
@@ -4,11 +4,11 @@ import logging
 from typing import Iterable, Optional
 
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    STATE_ON,
     STATE_OFF,
-    ATTR_ENTITY_ID,
+    STATE_ON,
 )
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType

--- a/homeassistant/components/input_number/reproduce_state.py
+++ b/homeassistant/components/input_number/reproduce_state.py
@@ -7,7 +7,7 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN, SERVICE_SET_VALUE, ATTR_VALUE
+from . import ATTR_VALUE, DOMAIN, SERVICE_SET_VALUE
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/input_select/reproduce_state.py
+++ b/homeassistant/components/input_select/reproduce_state.py
@@ -9,11 +9,11 @@ from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
+    ATTR_OPTION,
+    ATTR_OPTIONS,
     DOMAIN,
     SERVICE_SELECT_OPTION,
     SERVICE_SET_OPTIONS,
-    ATTR_OPTION,
-    ATTR_OPTIONS,
 )
 
 ATTR_GROUP = [ATTR_OPTION, ATTR_OPTIONS]

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -1,21 +1,20 @@
 """Numeric integration of data coming from a source sensor over time."""
+from decimal import Decimal, DecimalException
 import logging
 
-from decimal import Decimal, DecimalException
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
-    STATE_UNKNOWN,
+    CONF_NAME,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.restore_state import RestoreEntity
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -4,13 +4,13 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant
-from homeassistant.const import EVENT_COMPONENT_LOADED
-from homeassistant.setup import ATTR_COMPONENT
 from homeassistant.components import http
 from homeassistant.components.http.data_validator import RequestDataValidator
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, intent
-from homeassistant.loader import async_get_integration, IntegrationNotFound
+from homeassistant.loader import IntegrationNotFound, async_get_integration
+from homeassistant.setup import ATTR_COMPONENT
 
 from .const import DOMAIN
 

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.helpers import intent, template, script, config_validation as cv
+from homeassistant.helpers import config_validation as cv, intent, script, template
 
 DOMAIN = "intent_script"
 

--- a/homeassistant/components/ios/config_flow.py
+++ b/homeassistant/components/ios/config_flow.py
@@ -1,8 +1,8 @@
 """Config flow for iOS."""
-from homeassistant.helpers import config_entry_flow
 from homeassistant import config_entries
-from .const import DOMAIN
+from homeassistant.helpers import config_entry_flow
 
+from .const import DOMAIN
 
 config_entry_flow.register_discovery_flow(
     DOMAIN, "Home Assistant iOS", lambda *_: True, config_entries.CONN_CLASS_CLOUD_PUSH

--- a/homeassistant/components/itunes/media_player.py
+++ b/homeassistant/components/itunes/media_player.py
@@ -4,7 +4,7 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_PLAYLIST,
@@ -14,11 +14,11 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SEEK,
+    SUPPORT_SHUFFLE_SET,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
-    SUPPORT_SHUFFLE_SET,
 )
 from homeassistant.const import (
     CONF_HOST,

--- a/tests/components/ign_sismologia/test_geo_location.py
+++ b/tests/components/ign_sismologia/test_geo_location.py
@@ -1,33 +1,34 @@
 """The tests for the IGN Sismologia (Earthquakes) Feed platform."""
 import datetime
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.components.ign_sismologia.geo_location import (
     ATTR_EXTERNAL_ID,
-    SCAN_INTERVAL,
-    ATTR_REGION,
-    ATTR_MAGNITUDE,
     ATTR_IMAGE_URL,
+    ATTR_MAGNITUDE,
     ATTR_PUBLICATION_DATE,
+    ATTR_REGION,
     ATTR_TITLE,
+    SCAN_INTERVAL,
 )
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START,
-    CONF_RADIUS,
+    ATTR_ATTRIBUTION,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
-    ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    ATTR_ICON,
+    CONF_RADIUS,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.setup import async_setup_component
-from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
+
+from tests.common import assert_setup_component, async_fire_time_changed
 
 CONFIG = {geo_location.DOMAIN: [{"platform": "ign_sismologia", CONF_RADIUS: 200}]}
 

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -1,17 +1,17 @@
 """The tests for the image_processing component."""
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
-from homeassistant.core import callback
-from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.setup import setup_component
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.components.http as http
 import homeassistant.components.image_processing as ip
+from homeassistant.const import ATTR_ENTITY_PICTURE
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import setup_component
 
 from tests.common import (
+    assert_setup_component,
     get_test_home_assistant,
     get_test_instance_port,
-    assert_setup_component,
 )
 from tests.components.image_processing import common
 

--- a/tests/components/imap_email_content/test_sensor.py
+++ b/tests/components/imap_email_content/test_sensor.py
@@ -1,14 +1,14 @@
 """The tests for the IMAP email content sensor platform."""
 from collections import deque
+import datetime
 import email
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import datetime
 import unittest
 
-from homeassistant.helpers.template import Template
-from homeassistant.helpers.event import track_state_change
 from homeassistant.components.imap_email_content import sensor as imap_email_content
+from homeassistant.helpers.event import track_state_change
+from homeassistant.helpers.template import Template
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -3,9 +3,9 @@ import datetime
 import unittest
 from unittest import mock
 
-from homeassistant.setup import setup_component
 import homeassistant.components.influxdb as influxdb
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON, STATE_STANDBY
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -2,18 +2,18 @@
 # pylint: disable=protected-access
 import asyncio
 
-from homeassistant.loader import bind_hass
 from homeassistant.components.input_select import (
     ATTR_OPTION,
     ATTR_OPTIONS,
     DOMAIN,
-    SERVICE_SET_OPTIONS,
     SERVICE_SELECT_NEXT,
     SERVICE_SELECT_OPTION,
     SERVICE_SELECT_PREVIOUS,
+    SERVICE_SET_OPTIONS,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_ICON
-from homeassistant.core import State, Context
+from homeassistant.core import Context, State
+from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_restore_cache

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -1,9 +1,9 @@
 """Tests for Intent component."""
 import pytest
 
-from homeassistant.setup import async_setup_component
-from homeassistant.helpers import intent
 from homeassistant.components.cover import SERVICE_OPEN_COVER
+from homeassistant.helpers import intent
+from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
 

--- a/tests/components/ios/test_init.py
+++ b/tests/components/ios/test_init.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.setup import async_setup_component
 from homeassistant.components import ios
+from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component, mock_coro
 

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -1,10 +1,10 @@
 """Tests for IPMA config flow."""
 from unittest.mock import Mock, patch
 
-from tests.common import mock_coro
-
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.components.ipma import config_flow
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+
+from tests.common import mock_coro
 
 
 async def test_show_config_form():

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -1,6 +1,6 @@
 """The tests for the IPMA weather component."""
-from unittest.mock import patch
 from collections import namedtuple
+from unittest.mock import patch
 
 from homeassistant.components import weather
 from homeassistant.components.weather import (
@@ -11,9 +11,9 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
     DOMAIN as WEATHER_DOMAIN,
 )
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, mock_coro
-from homeassistant.setup import async_setup_component
 
 TEST_CONFIG = {"name": "HomeTown", "latitude": "40.00", "longitude": "-8.00"}
 

--- a/tests/components/islamic_prayer_times/test_sensor.py
+++ b/tests/components/islamic_prayer_times/test_sensor.py
@@ -1,9 +1,11 @@
 """The tests for the Islamic prayer times sensor platform."""
 from datetime import datetime, timedelta
 from unittest.mock import patch
-from homeassistant.setup import async_setup_component
+
 from homeassistant.components.islamic_prayer_times.sensor import IslamicPrayerTimesData
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
+
 from tests.common import async_fire_time_changed
 
 LATITUDE = 41

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.izone.const import IZONE, DISPATCH_CONTROLLER_DISCOVERED
+from homeassistant.components.izone.const import DISPATCH_CONTROLLER_DISCOVERED, IZONE
 
 from tests.common import mock_coro
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"i"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/imap_email_content/sensor.py` 
- `homeassistant/components/input_boolean/reproduce_state.py` 
- `homeassistant/components/input_number/reproduce_state.py` 
- `homeassistant/components/input_select/reproduce_state.py` 
- `homeassistant/components/integration/sensor.py` 
- `homeassistant/components/intent/__init__.py` 
- `homeassistant/components/intent_script/__init__.py` 
- `homeassistant/components/ios/config_flow.py` 
- `homeassistant/components/itunes/media_player.py` 
- `tests/components/ign_sismologia/test_geo_location.py` 
- `tests/components/image_processing/test_init.py` 
- `tests/components/imap_email_content/test_sensor.py` 
- `tests/components/influxdb/test_init.py` 
- `tests/components/input_select/test_init.py` 
- `tests/components/intent/test_init.py` 
- `tests/components/ios/test_init.py` 
- `tests/components/ipma/test_config_flow.py` 
- `tests/components/ipma/test_weather.py` 
- `tests/components/islamic_prayer_times/test_sensor.py` 
- `tests/components/izone/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
