### PR TITLE
Sort imports according to PEP8 for components starting with "K"

### DIFF
--- a/homeassistant/components/kankun/switch.py
+++ b/homeassistant/components/kankun/switch.py
@@ -4,15 +4,15 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
-    CONF_PORT,
-    CONF_PATH,
-    CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_PATH,
+    CONF_PORT,
     CONF_SWITCHES,
+    CONF_USERNAME,
 )
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/keba/binary_sensor.py
+++ b/homeassistant/components/keba/binary_sensor.py
@@ -1,12 +1,12 @@
 """Support for KEBA charging station binary sensors."""
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_PLUG,
     DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_PLUG,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_SAFETY,
+    BinarySensorDevice,
 )
 
 from . import DOMAIN

--- a/homeassistant/components/keba/sensor.py
+++ b/homeassistant/components/keba/sensor.py
@@ -1,9 +1,8 @@
 """Support for KEBA charging station sensors."""
 import logging
 
-from homeassistant.const import ENERGY_KILO_WATT_HOUR
+from homeassistant.const import DEVICE_CLASS_POWER, ENERGY_KILO_WATT_HOUR
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import DEVICE_CLASS_POWER
 
 from . import DOMAIN
 

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -1,13 +1,14 @@
 """Receive signals from a keyboard and use it as a remote control."""
 # pylint: disable=import-error
-import logging
 import asyncio
+import logging
 
-from evdev import InputDevice, categorize, ecodes, list_devices
 import aionotify
+from evdev import InputDevice, categorize, ecodes, list_devices
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
+
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/kira/test_init.py
+++ b/tests/components/kira/test_init.py
@@ -3,9 +3,8 @@
 import os
 import shutil
 import tempfile
-
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import homeassistant.components.kira as kira
 from homeassistant.setup import setup_component


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"k"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/kankun/switch.py` 
- `homeassistant/components/keba/binary_sensor.py` 
- `homeassistant/components/keba/sensor.py` 
- `homeassistant/components/keyboard_remote/__init__.py` 
- `tests/components/kira/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
