### PR TITLE
Sort imports according to PEP8 for components starting with "L"

### DIFF
--- a/homeassistant/components/lannouncer/notify.py
+++ b/homeassistant/components/lannouncer/notify.py
@@ -5,14 +5,13 @@ from urllib.parse import urlencode
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_HOST, CONF_PORT
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_HOST, CONF_PORT
+import homeassistant.helpers.config_validation as cv
 
 ATTR_METHOD = "method"
 ATTR_METHOD_DEFAULT = "speak"

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -4,7 +4,6 @@ import logging
 import pypck
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.climate import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP
 from homeassistant.const import (
     CONF_ADDRESS,
@@ -22,6 +21,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
 

--- a/homeassistant/components/lcn/services.py
+++ b/homeassistant/components/lcn/services.py
@@ -2,13 +2,13 @@
 import pypck
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_BRIGHTNESS,
     CONF_STATE,
     CONF_UNIT_OF_MEASUREMENT,
 )
+import homeassistant.helpers.config_validation as cv
 
 from .const import (
     CONF_CONNECTIONS,

--- a/homeassistant/components/lifx_cloud/scene.py
+++ b/homeassistant/components/lifx_cloud/scene.py
@@ -8,7 +8,7 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.scene import Scene
-from homeassistant.const import CONF_TOKEN, CONF_TIMEOUT, CONF_PLATFORM
+from homeassistant.const import CONF_PLATFORM, CONF_TIMEOUT, CONF_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/linksys_smart/device_tracker.py
+++ b/homeassistant/components/linksys_smart/device_tracker.py
@@ -4,13 +4,13 @@ import logging
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
 from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
 
 DEFAULT_TIMEOUT = 10
 

--- a/homeassistant/components/liveboxplaytv/media_player.py
+++ b/homeassistant/components/liveboxplaytv/media_player.py
@@ -7,7 +7,7 @@ import pyteleloisirs
 import requests
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,

--- a/homeassistant/components/llamalab_automate/notify.py
+++ b/homeassistant/components/llamalab_automate/notify.py
@@ -4,10 +4,9 @@ import logging
 import requests
 import voluptuous as vol
 
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import CONF_API_KEY, CONF_DEVICE
 from homeassistant.helpers import config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = "https://llamalab.com/automate/cloud/message"

--- a/homeassistant/components/local_file/camera.py
+++ b/homeassistant/components/local_file/camera.py
@@ -5,12 +5,12 @@ import os
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, ATTR_ENTITY_ID
 from homeassistant.components.camera import (
-    Camera,
     CAMERA_SERVICE_SCHEMA,
     PLATFORM_SCHEMA,
+    Camera,
 )
+from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME
 from homeassistant.helpers import config_validation as cv
 
 from .const import (

--- a/homeassistant/components/lockitron/lock.py
+++ b/homeassistant/components/lockitron/lock.py
@@ -4,9 +4,9 @@ import logging
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.lock import LockDevice, PLATFORM_SCHEMA
+from homeassistant.components.lock import PLATFORM_SCHEMA, LockDevice
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_ID
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/logentries/__init__.py
+++ b/homeassistant/components/logentries/__init__.py
@@ -1,13 +1,13 @@
 """Support for sending data to Logentries webhook endpoint."""
 import json
 import logging
-import requests
 
+import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_TOKEN, EVENT_STATE_CHANGED
 from homeassistant.helpers import state as state_helper
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/logger/__init__.py
+++ b/homeassistant/components/logger/__init__.py
@@ -1,6 +1,6 @@
 """Support for settting the level of logging for components."""
-import logging
 from collections import OrderedDict
+import logging
 
 import voluptuous as vol
 

--- a/tests/components/litejet/test_init.py
+++ b/tests/components/litejet/test_init.py
@@ -3,6 +3,7 @@ import logging
 import unittest
 
 from homeassistant.components import litejet
+
 from tests.common import get_test_home_assistant
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1,30 +1,13 @@
 """The tests for the logbook component."""
 # pylint: disable=protected-access,invalid-name
+from datetime import datetime, timedelta
 import logging
-from datetime import timedelta, datetime
 import unittest
 
 import pytest
 import voluptuous as vol
 
-from homeassistant.components import sun
-import homeassistant.core as ha
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_SERVICE,
-    ATTR_NAME,
-    EVENT_STATE_CHANGED,
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
-    EVENT_AUTOMATION_TRIGGERED,
-    EVENT_SCRIPT_STARTED,
-    ATTR_HIDDEN,
-    STATE_NOT_HOME,
-    STATE_ON,
-    STATE_OFF,
-)
-import homeassistant.util.dt as dt_util
-from homeassistant.components import logbook, recorder
+from homeassistant.components import logbook, recorder, sun
 from homeassistant.components.alexa.smart_home import EVENT_ALEXA_SMART_HOME
 from homeassistant.components.homekit.const import (
     ATTR_DISPLAY_NAME,
@@ -32,10 +15,25 @@ from homeassistant.components.homekit.const import (
     DOMAIN as DOMAIN_HOMEKIT,
     EVENT_HOMEKIT_CHANGED,
 )
-from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_HIDDEN,
+    ATTR_NAME,
+    ATTR_SERVICE,
+    EVENT_AUTOMATION_TRIGGERED,
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
+    EVENT_SCRIPT_STARTED,
+    EVENT_STATE_CHANGED,
+    STATE_NOT_HOME,
+    STATE_OFF,
+    STATE_ON,
+)
+import homeassistant.core as ha
+from homeassistant.setup import async_setup_component, setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import init_recorder_component, get_test_home_assistant
-
+from tests.common import get_test_home_assistant, init_recorder_component
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -3,9 +3,9 @@
 import unittest
 from unittest import mock
 
-from homeassistant.setup import setup_component
 import homeassistant.components.logentries as logentries
-from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
+from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -3,8 +3,8 @@ from collections import namedtuple
 import logging
 import unittest
 
-from homeassistant.setup import setup_component
 from homeassistant.components import logger
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -8,8 +8,8 @@ from homeassistant import data_entry_flow
 from homeassistant.components.logi_circle import config_flow
 from homeassistant.components.logi_circle.config_flow import (
     DOMAIN,
-    LogiCircleAuthCallbackView,
     AuthorizationFailed,
+    LogiCircleAuthCallbackView,
 )
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/london_air/test_sensor.py
+++ b/tests/components/london_air/test_sensor.py
@@ -1,10 +1,12 @@
 """The tests for the tube_state platform."""
 import unittest
+
 import requests_mock
 
 from homeassistant.components.london_air.sensor import CONF_LOCATIONS, URL
 from homeassistant.setup import setup_component
-from tests.common import load_fixture, get_test_home_assistant
+
+from tests.common import get_test_home_assistant, load_fixture
 
 VALID_CONFIG = {"platform": "london_air", CONF_LOCATIONS: ["Merton"]}
 

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -1,10 +1,10 @@
 """Test the Lovelace initialization."""
 from unittest.mock import patch
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import frontend, lovelace
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_system_health_info, async_capture_events
+from tests.common import async_capture_events, get_system_health_info
 
 
 async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"l"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/lannouncer/notify.py` 
- `homeassistant/components/lcn/__init__.py` 
- `homeassistant/components/lcn/services.py` 
- `homeassistant/components/lifx_cloud/scene.py` 
- `homeassistant/components/linksys_smart/device_tracker.py` 
- `homeassistant/components/liveboxplaytv/media_player.py` 
- `homeassistant/components/llamalab_automate/notify.py` 
- `homeassistant/components/local_file/camera.py` 
- `homeassistant/components/lockitron/lock.py` 
- `homeassistant/components/logentries/__init__.py` 
- `homeassistant/components/logger/__init__.py` 
- `tests/components/litejet/test_init.py` 
- `tests/components/logbook/test_init.py` 
- `tests/components/logentries/test_init.py` 
- `tests/components/logger/test_init.py` 
- `tests/components/logi_circle/test_config_flow.py` 
- `tests/components/london_air/test_sensor.py` 
- `tests/components/lovelace/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
