### PR TITLE
Sort imports according to PEP8 for components starting with "M"

### DIFF
--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.setup import async_prepare_setup_platform
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/mcp23017/binary_sensor.py
+++ b/homeassistant/components/mcp23017/binary_sensor.py
@@ -1,13 +1,13 @@
 """Support for binary sensor using I2C MCP23017 chip."""
 import logging
 
-import voluptuous as vol
+import adafruit_mcp230xx  # pylint: disable=import-error
 import board  # pylint: disable=import-error
 import busio  # pylint: disable=import-error
-import adafruit_mcp230xx  # pylint: disable=import-error
 import digitalio  # pylint: disable=import-error
+import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/mcp23017/switch.py
+++ b/homeassistant/components/mcp23017/switch.py
@@ -1,16 +1,16 @@
 """Support for switch sensor using I2C MCP23017 chip."""
 import logging
 
-import voluptuous as vol
+import adafruit_mcp230xx  # pylint: disable=import-error
 import board  # pylint: disable=import-error
 import busio  # pylint: disable=import-error
-import adafruit_mcp230xx  # pylint: disable=import-error
 import digitalio  # pylint: disable=import-error
+import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.const import DEVICE_DEFAULT_NAME
-from homeassistant.helpers.entity import ToggleEntity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/melissa/climate.py
+++ b/homeassistant/components/melissa/climate.py
@@ -3,6 +3,10 @@ import logging
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
@@ -11,10 +15,6 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
-    FAN_AUTO,
-    FAN_HIGH,
-    FAN_MEDIUM,
-    FAN_LOW,
 )
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
 

--- a/homeassistant/components/meraki/device_tracker.py
+++ b/homeassistant/components/meraki/device_tracker.py
@@ -5,15 +5,16 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.meraki/
 
 """
-import logging
 import json
+import logging
 
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
+
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SOURCE_TYPE_ROUTER
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import HTTP_BAD_REQUEST, HTTP_UNPROCESSABLE_ENTITY
 from homeassistant.core import callback
-from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SOURCE_TYPE_ROUTER
+import homeassistant.helpers.config_validation as cv
 
 CONF_VALIDATOR = "validator"
 CONF_SECRET = "secret"

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -8,7 +8,7 @@ from aiohttp.hdrs import CONTENT_TYPE
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import CONF_API_KEY, CONF_TIMEOUT, ATTR_NAME
+from homeassistant.const import ATTR_NAME, CONF_API_KEY, CONF_TIMEOUT
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/mikrotik/__init__.py
+++ b/homeassistant/components/mikrotik/__init__.py
@@ -2,34 +2,35 @@
 import logging
 import ssl
 
-import voluptuous as vol
 import librouteros
 from librouteros.login import login_plain, login_token
+import voluptuous as vol
 
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
 from homeassistant.const import (
     CONF_HOST,
+    CONF_METHOD,
     CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_PORT,
     CONF_SSL,
-    CONF_METHOD,
+    CONF_USERNAME,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import load_platform
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
+
 from .const import (
-    NAME,
+    CONF_ARP_PING,
+    CONF_ENCODING,
+    CONF_LOGIN_METHOD,
+    CONF_TRACK_DEVICES,
+    DEFAULT_ENCODING,
     DOMAIN,
     HOSTS,
+    IDENTITY,
+    MIKROTIK_SERVICES,
     MTK_LOGIN_PLAIN,
     MTK_LOGIN_TOKEN,
-    DEFAULT_ENCODING,
-    IDENTITY,
-    CONF_TRACK_DEVICES,
-    CONF_ENCODING,
-    CONF_ARP_PING,
-    CONF_LOGIN_METHOD,
-    MIKROTIK_SERVICES,
+    NAME,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -5,18 +5,19 @@ from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER,
     DeviceScanner,
 )
-from homeassistant.util import slugify
 from homeassistant.const import CONF_METHOD
+from homeassistant.util import slugify
+
 from .const import (
-    HOSTS,
-    MIKROTIK,
-    CONF_ARP_PING,
-    MIKROTIK_SERVICES,
-    CAPSMAN,
-    WIRELESS,
-    DHCP,
     ARP,
     ATTR_DEVICE_TRACKER,
+    CAPSMAN,
+    CONF_ARP_PING,
+    DHCP,
+    HOSTS,
+    MIKROTIK,
+    MIKROTIK_SERVICES,
+    WIRELESS,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -6,11 +6,11 @@ import voluptuous as vol
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
+    FAN_ON,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
-    FAN_ON,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,

--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -3,16 +3,16 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
-    STATE_UNKNOWN,
-    STATE_UNAVAILABLE,
-    CONF_TYPE,
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
+    CONF_TYPE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
 

--- a/homeassistant/components/mjpeg/camera.py
+++ b/homeassistant/components/mjpeg/camera.py
@@ -1,7 +1,7 @@
 """Support for IP Cameras."""
 import asyncio
-import logging
 from contextlib import closing
+import logging
 
 import aiohttp
 import async_timeout
@@ -9,21 +9,21 @@ import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 import voluptuous as vol
 
+from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
 from homeassistant.const import (
-    CONF_NAME,
-    CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_AUTHENTICATION,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
-    CONF_VERIFY_SSL,
-)
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
-from homeassistant.helpers.aiohttp_client import (
-    async_get_clientsession,
-    async_aiohttp_proxy_web,
 )
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import (
+    async_aiohttp_proxy_web,
+    async_get_clientsession,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mold_indicator/sensor.py
+++ b/homeassistant/components/mold_indicator/sensor.py
@@ -6,19 +6,18 @@ import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.core import callback
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
     EVENT_HOMEASSISTANT_START,
     STATE_UNKNOWN,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
-    CONF_NAME,
 )
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
-
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mpchc/media_player.py
+++ b/homeassistant/components/mpchc/media_player.py
@@ -5,7 +5,7 @@ import re
 import requests
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,

--- a/homeassistant/components/mqtt_eventstream/__init__.py
+++ b/homeassistant/components/mqtt_eventstream/__init__.py
@@ -4,7 +4,6 @@ import json
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.components.mqtt import valid_publish_topic, valid_subscribe_topic
 from homeassistant.const import (
     ATTR_SERVICE_DATA,
@@ -13,7 +12,7 @@ from homeassistant.const import (
     EVENT_TIME_CHANGED,
     MATCH_ALL,
 )
-from homeassistant.core import EventOrigin, State
+from homeassistant.core import EventOrigin, State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.json import JSONEncoder
 

--- a/homeassistant/components/mqtt_json/device_tracker.py
+++ b/homeassistant/components/mqtt_json/device_tracker.py
@@ -5,17 +5,17 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import mqtt
-from homeassistant.core import callback
-from homeassistant.components.mqtt import CONF_QOS
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components.mqtt import CONF_QOS
 from homeassistant.const import (
-    CONF_DEVICES,
+    ATTR_BATTERY_LEVEL,
     ATTR_GPS_ACCURACY,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_BATTERY_LEVEL,
+    CONF_DEVICES,
 )
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mqtt_room/sensor.py
+++ b/homeassistant/components/mqtt_room/sensor.py
@@ -1,16 +1,16 @@
 """Support for MQTT room presence detection."""
-import logging
-import json
 from datetime import timedelta
+import json
+import logging
 
 import voluptuous as vol
 
 from homeassistant.components import mqtt
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.mqtt import CONF_STATE_TOPIC
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_TIMEOUT, STATE_NOT_HOME, ATTR_ID
+from homeassistant.const import ATTR_ID, CONF_NAME, CONF_TIMEOUT, STATE_NOT_HOME
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt, slugify
 

--- a/homeassistant/components/mqtt_statestream/__init__.py
+++ b/homeassistant/components/mqtt_statestream/__init__.py
@@ -3,6 +3,7 @@ import json
 
 import voluptuous as vol
 
+from homeassistant.components.mqtt import valid_publish_topic
 from homeassistant.const import (
     CONF_DOMAINS,
     CONF_ENTITIES,
@@ -11,11 +12,10 @@ from homeassistant.const import (
     MATCH_ALL,
 )
 from homeassistant.core import callback
-from homeassistant.components.mqtt import valid_publish_topic
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import generate_filter
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.json import JSONEncoder
-import homeassistant.helpers.config_validation as cv
 
 CONF_BASE_TOPIC = "base_topic"
 CONF_PUBLISH_ATTRIBUTES = "publish_attributes"

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -6,10 +6,10 @@ from pymyq.errors import MyQError
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    CoverDevice,
     PLATFORM_SCHEMA,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
+    CoverDevice,
 )
 from homeassistant.const import (
     CONF_PASSWORD,

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -1,22 +1,24 @@
 """The tests for the manual Alarm Control Panel component."""
 from datetime import timedelta
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components import alarm_control_panel
 from homeassistant.components.demo import alarm_control_panel as demo
-from homeassistant.setup import async_setup_component
 from homeassistant.const import (
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_ARMED_CUSTOM_BYPASS,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.components import alarm_control_panel
+from homeassistant.core import CoreState, State
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
+
 from tests.common import async_fire_time_changed, mock_component, mock_restore_cache
 from tests.components.alarm_control_panel import common
-from homeassistant.core import State, CoreState
 
 CODE = "HELLO_CODE"
 

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -1,26 +1,26 @@
 """The tests for the manual_mqtt Alarm Control Panel component."""
 from datetime import timedelta
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
-from homeassistant.setup import setup_component
+from homeassistant.components import alarm_control_panel
 from homeassistant.const import (
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.components import alarm_control_panel
+from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
+    assert_setup_component,
+    fire_mqtt_message,
     fire_time_changed,
     get_test_home_assistant,
     mock_mqtt_component,
-    fire_mqtt_message,
-    assert_setup_component,
 )
 from tests.components.alarm_control_panel import common
 

--- a/tests/components/marytts/test_tts.py
+++ b/tests/components/marytts/test_tts.py
@@ -3,15 +3,14 @@ import asyncio
 import os
 import shutil
 
+from homeassistant.components.media_player.const import (
+    DOMAIN as DOMAIN_MP,
+    SERVICE_PLAY_MEDIA,
+)
 import homeassistant.components.tts as tts
 from homeassistant.setup import setup_component
-from homeassistant.components.media_player.const import (
-    SERVICE_PLAY_MEDIA,
-    DOMAIN as DOMAIN_MP,
-)
 
-from tests.common import get_test_home_assistant, assert_setup_component, mock_service
-
+from tests.common import assert_setup_component, get_test_home_assistant, mock_service
 from tests.components.tts.test_init import mutagen_mock  # noqa: F401
 
 

--- a/tests/components/meraki/test_device_tracker.py
+++ b/tests/components/meraki/test_device_tracker.py
@@ -4,11 +4,14 @@ import json
 
 import pytest
 
-from homeassistant.components.meraki.device_tracker import CONF_VALIDATOR, CONF_SECRET
-from homeassistant.setup import async_setup_component
 import homeassistant.components.device_tracker as device_tracker
+from homeassistant.components.meraki.device_tracker import (
+    CONF_SECRET,
+    CONF_VALIDATOR,
+    URL,
+)
 from homeassistant.const import CONF_PLATFORM
-from homeassistant.components.meraki.device_tracker import URL
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture

--- a/tests/components/mfi/test_sensor.py
+++ b/tests/components/mfi/test_sensor.py
@@ -2,13 +2,13 @@
 import unittest
 import unittest.mock as mock
 
-import requests
 from mficlient.client import FailedToLogin
+import requests
 
-from homeassistant.setup import setup_component
-import homeassistant.components.sensor as sensor
 import homeassistant.components.mfi.sensor as mfi
+import homeassistant.components.sensor as sensor
 from homeassistant.const import TEMP_CELSIUS
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/mfi/test_switch.py
+++ b/tests/components/mfi/test_switch.py
@@ -2,9 +2,9 @@
 import unittest
 import unittest.mock as mock
 
-from homeassistant.setup import setup_component
-import homeassistant.components.switch as switch
 import homeassistant.components.mfi.switch as mfi
+import homeassistant.components.switch as switch
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/mhz19/test_sensor.py
+++ b/tests/components/mhz19/test_sensor.py
@@ -1,12 +1,13 @@
 """Tests for MH-Z19 sensor."""
 import unittest
-from unittest.mock import patch, DEFAULT, Mock
+from unittest.mock import DEFAULT, Mock, patch
 
-from homeassistant.setup import setup_component
-from homeassistant.components.sensor import DOMAIN
 import homeassistant.components.mhz19.sensor as mhz19
+from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import TEMP_FAHRENHEIT
-from tests.common import get_test_home_assistant, assert_setup_component
+from homeassistant.setup import setup_component
+
+from tests.common import assert_setup_component, get_test_home_assistant
 
 
 class TestMHZ19Sensor(unittest.TestCase):

--- a/tests/components/microsoft_face/test_init.py
+++ b/tests/components/microsoft_face/test_init.py
@@ -19,10 +19,10 @@ from homeassistant.const import ATTR_NAME
 from homeassistant.setup import setup_component
 
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
-    mock_coro,
+    get_test_home_assistant,
     load_fixture,
+    mock_coro,
 )
 
 

--- a/tests/components/microsoft_face_detect/test_image_processing.py
+++ b/tests/components/microsoft_face_detect/test_image_processing.py
@@ -1,15 +1,15 @@
 """The tests for the microsoft face detect platform."""
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
-from homeassistant.core import callback
-from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.setup import setup_component
 import homeassistant.components.image_processing as ip
 import homeassistant.components.microsoft_face as mf
+from homeassistant.const import ATTR_ENTITY_PICTURE
+from homeassistant.core import callback
+from homeassistant.setup import setup_component
 
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
+    get_test_home_assistant,
     load_fixture,
     mock_coro,
 )

--- a/tests/components/microsoft_face_identify/test_image_processing.py
+++ b/tests/components/microsoft_face_identify/test_image_processing.py
@@ -1,15 +1,15 @@
 """The tests for the microsoft face identify platform."""
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
-from homeassistant.core import callback
-from homeassistant.const import ATTR_ENTITY_PICTURE, STATE_UNKNOWN
-from homeassistant.setup import setup_component
 import homeassistant.components.image_processing as ip
 import homeassistant.components.microsoft_face as mf
+from homeassistant.const import ATTR_ENTITY_PICTURE, STATE_UNKNOWN
+from homeassistant.core import callback
+from homeassistant.setup import setup_component
 
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
+    get_test_home_assistant,
     load_fixture,
     mock_coro,
 )

--- a/tests/components/min_max/test_sensor.py
+++ b/tests/components/min_max/test_sensor.py
@@ -1,14 +1,15 @@
 """The test for the min/max sensor platform."""
 import unittest
 
-from homeassistant.setup import setup_component
 from homeassistant.const import (
-    STATE_UNKNOWN,
-    STATE_UNAVAILABLE,
     ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
+from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/mochad/test_switch.py
+++ b/tests/components/mochad/test_switch.py
@@ -4,9 +4,9 @@ import unittest.mock as mock
 
 import pytest
 
-from homeassistant.setup import setup_component
 from homeassistant.components import switch
 from homeassistant.components.mochad import switch as mochad
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -1,14 +1,9 @@
 """The tests for the Modbus sensor component."""
-import pytest
 from datetime import timedelta
 from unittest import mock
 
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_OFFSET,
-    CONF_PLATFORM,
-    CONF_SCAN_INTERVAL,
-)
+import pytest
+
 from homeassistant.components.modbus import DEFAULT_HUB, DOMAIN as MODBUS_DOMAIN
 from homeassistant.components.modbus.sensor import (
     CONF_COUNT,
@@ -26,9 +21,16 @@ from homeassistant.components.modbus.sensor import (
     REGISTER_TYPE_INPUT,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_OFFSET,
+    CONF_PLATFORM,
+    CONF_SCAN_INTERVAL,
+)
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from tests.common import MockModule, mock_integration, async_fire_time_changed
+
+from tests.common import MockModule, async_fire_time_changed, mock_integration
 
 
 @pytest.fixture()

--- a/tests/components/mold_indicator/test_sensor.py
+++ b/tests/components/mold_indicator/test_sensor.py
@@ -1,13 +1,13 @@
 """The tests for the MoldIndicator sensor."""
 import unittest
 
-from homeassistant.setup import setup_component
-import homeassistant.components.sensor as sensor
 from homeassistant.components.mold_indicator.sensor import (
-    ATTR_DEWPOINT,
     ATTR_CRITICAL_TEMP,
+    ATTR_DEWPOINT,
 )
+import homeassistant.components.sensor as sensor
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -1,31 +1,32 @@
 """The tests for Monoprice Media player platform."""
+from collections import defaultdict
 import unittest
 from unittest import mock
+
+import pytest
 import voluptuous as vol
 
-from collections import defaultdict
 from homeassistant.components.media_player.const import (
-    SUPPORT_TURN_ON,
+    SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
-    SUPPORT_SELECT_SOURCE,
-)
-from homeassistant.const import STATE_ON, STATE_OFF
-
-import tests.common
-from homeassistant.components.monoprice.media_player import (
-    DATA_MONOPRICE,
-    PLATFORM_SCHEMA,
-    setup_platform,
 )
 from homeassistant.components.monoprice.const import (
     DOMAIN,
     SERVICE_RESTORE,
     SERVICE_SNAPSHOT,
 )
-import pytest
+from homeassistant.components.monoprice.media_player import (
+    DATA_MONOPRICE,
+    PLATFORM_SCHEMA,
+    setup_platform,
+)
+from homeassistant.const import STATE_OFF, STATE_ON
+
+import tests.common
 
 
 class AttrDict(dict):

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -1,10 +1,10 @@
 """The test for the moon sensor platform."""
-import unittest
 from datetime import datetime
+import unittest
 from unittest.mock import patch
 
-import homeassistant.util.dt as dt_util
 from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/mqtt_eventstream/test_init.py
+++ b/tests/components/mqtt_eventstream/test_init.py
@@ -2,19 +2,19 @@
 import json
 from unittest.mock import ANY, patch
 
-from homeassistant.setup import setup_component
 import homeassistant.components.mqtt_eventstream as eventstream
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import State, callback
 from homeassistant.helpers.json import JSONEncoder
+from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
+    fire_mqtt_message,
+    fire_time_changed,
     get_test_home_assistant,
     mock_mqtt_component,
-    fire_mqtt_message,
     mock_state_change_event,
-    fire_time_changed,
 )
 
 

--- a/tests/components/mqtt_json/test_device_tracker.py
+++ b/tests/components/mqtt_json/test_device_tracker.py
@@ -2,18 +2,19 @@
 import json
 import logging
 import os
+
 from asynctest import patch
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components.device_tracker.legacy import (
-    YAML_DEVICES,
-    ENTITY_ID_FORMAT,
     DOMAIN as DT_DOMAIN,
+    ENTITY_ID_FORMAT,
+    YAML_DEVICES,
 )
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.setup import async_setup_component
 
-from tests.common import async_mock_mqtt_component, async_fire_mqtt_message
+from tests.common import async_fire_mqtt_message, async_mock_mqtt_component
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/mqtt_room/test_sensor.py
+++ b/tests/components/mqtt_room/test_sensor.py
@@ -1,12 +1,12 @@
 """The tests for the MQTT room presence sensor."""
-import json
 import datetime
+import json
 from unittest.mock import patch
 
-from homeassistant.setup import async_setup_component
+from homeassistant.components.mqtt import CONF_QOS, CONF_STATE_TOPIC, DEFAULT_QOS
 import homeassistant.components.sensor as sensor
-from homeassistant.components.mqtt import CONF_STATE_TOPIC, CONF_QOS, DEFAULT_QOS
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.common import async_fire_mqtt_message, async_mock_mqtt_component

--- a/tests/components/mqtt_statestream/test_init.py
+++ b/tests/components/mqtt_statestream/test_init.py
@@ -1,9 +1,9 @@
 """The tests for the MQTT statestream component."""
 from unittest.mock import ANY, call, patch
 
-from homeassistant.setup import setup_component
 import homeassistant.components.mqtt_statestream as statestream
 from homeassistant.core import State
+from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant,

--- a/tests/components/mythicbeastsdns/test_init.py
+++ b/tests/components/mythicbeastsdns/test_init.py
@@ -1,9 +1,10 @@
 """Test the Mythic Beasts DNS component."""
 import logging
+
 import asynctest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import mythicbeastsdns
+from homeassistant.setup import async_setup_component
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"m"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/mailbox/__init__.py` 
- `homeassistant/components/mcp23017/binary_sensor.py` 
- `homeassistant/components/mcp23017/switch.py` 
- `homeassistant/components/melissa/climate.py` 
- `homeassistant/components/meraki/device_tracker.py` 
- `homeassistant/components/microsoft_face/__init__.py` 
- `homeassistant/components/mikrotik/__init__.py` 
- `homeassistant/components/mikrotik/device_tracker.py` 
- `homeassistant/components/mill/climate.py` 
- `homeassistant/components/min_max/sensor.py` 
- `homeassistant/components/mjpeg/camera.py` 
- `homeassistant/components/mold_indicator/sensor.py` 
- `homeassistant/components/mpchc/media_player.py` 
- `homeassistant/components/mqtt_eventstream/__init__.py` 
- `homeassistant/components/mqtt_json/device_tracker.py` 
- `homeassistant/components/mqtt_room/sensor.py` 
- `homeassistant/components/mqtt_statestream/__init__.py` 
- `homeassistant/components/myq/cover.py` 
- `tests/components/manual/test_alarm_control_panel.py` 
- `tests/components/manual_mqtt/test_alarm_control_panel.py` 
- `tests/components/marytts/test_tts.py` 
- `tests/components/meraki/test_device_tracker.py` 
- `tests/components/mfi/test_sensor.py` 
- `tests/components/mfi/test_switch.py` 
- `tests/components/mhz19/test_sensor.py` 
- `tests/components/microsoft_face/test_init.py` 
- `tests/components/microsoft_face_detect/test_image_processing.py` 
- `tests/components/microsoft_face_identify/test_image_processing.py` 
- `tests/components/min_max/test_sensor.py` 
- `tests/components/mochad/test_switch.py` 
- `tests/components/modbus/test_modbus_sensor.py` 
- `tests/components/mold_indicator/test_sensor.py` 
- `tests/components/monoprice/test_media_player.py` 
- `tests/components/moon/test_sensor.py` 
- `tests/components/mqtt_eventstream/test_init.py` 
- `tests/components/mqtt_json/test_device_tracker.py` 
- `tests/components/mqtt_room/test_sensor.py` 
- `tests/components/mqtt_statestream/test_init.py` 
- `tests/components/mythicbeastsdns/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
