### PR TITLE
Sort imports according to PEP8 for components starting with "N"

### DIFF
--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -1,7 +1,7 @@
 """Support for Ness D8X/D16X devices."""
+from collections import namedtuple
 import datetime
 import logging
-from collections import namedtuple
 
 import voluptuous as vol
 
@@ -9,9 +9,9 @@ from homeassistant.components.binary_sensor import DEVICE_CLASSES
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_STATE,
-    EVENT_HOMEASSISTANT_STOP,
-    CONF_SCAN_INTERVAL,
     CONF_HOST,
+    CONF_SCAN_INTERVAL,
+    EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -4,21 +4,21 @@ import logging
 from pynetgear import Netgear
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
 from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_PORT,
-    CONF_SSL,
     CONF_DEVICES,
     CONF_EXCLUDE,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
 )
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/nfandroidtv/notify.py
+++ b/homeassistant/components/nfandroidtv/notify.py
@@ -7,9 +7,6 @@ import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 import voluptuous as vol
 
-from homeassistant.const import CONF_TIMEOUT, CONF_HOST
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TITLE,
@@ -17,6 +14,8 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -1,8 +1,9 @@
 """Support for the Nissan Leaf Carwings/Nissan Connect API."""
-from datetime import datetime, timedelta
 import asyncio
+from datetime import datetime, timedelta
 import logging
 import sys
+
 from pycarwings2 import CarwingsError, Session
 import voluptuous as vol
 

--- a/homeassistant/components/no_ip/__init__.py
+++ b/homeassistant/components/no_ip/__init__.py
@@ -5,11 +5,11 @@ from datetime import timedelta
 import logging
 
 import aiohttp
-from aiohttp.hdrs import USER_AGENT, AUTHORIZATION
+from aiohttp.hdrs import AUTHORIZATION, USER_AGENT
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import CONF_DOMAIN, CONF_TIMEOUT, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_DOMAIN, CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -1,19 +1,18 @@
 """Provides functionality to notify people."""
 import asyncio
-import logging
 from functools import partial
+import logging
 from typing import Optional
 
 import voluptuous as vol
 
-from homeassistant.setup import async_prepare_setup_platform
-from homeassistant.exceptions import HomeAssistantError
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform, discovery
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.util import slugify
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/nws/weather.py
+++ b/homeassistant/components/nws/weather.py
@@ -9,32 +9,32 @@ from pynws import SimpleNWS
 import voluptuous as vol
 
 from homeassistant.components.weather import (
-    WeatherEntity,
-    PLATFORM_SCHEMA,
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TIME,
-    ATTR_FORECAST_WIND_SPEED,
     ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_SPEED,
+    PLATFORM_SCHEMA,
+    WeatherEntity,
 )
 from homeassistant.const import (
     CONF_API_KEY,
-    CONF_NAME,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_MODE,
+    CONF_NAME,
     LENGTH_KILOMETERS,
     LENGTH_METERS,
     LENGTH_MILES,
     PRESSURE_HPA,
-    PRESSURE_PA,
     PRESSURE_INHG,
+    PRESSURE_PA,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import Throttle
 from homeassistant.util.distance import convert as convert_distance
 from homeassistant.util.pressure import convert as convert_pressure

--- a/tests/components/namecheapdns/test_init.py
+++ b/tests/components/namecheapdns/test_init.py
@@ -4,8 +4,8 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import namecheapdns
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -1,36 +1,37 @@
 """Tests for the ness_alarm component."""
 from enum import Enum
 
+from asynctest import MagicMock, patch
 import pytest
-from asynctest import patch, MagicMock
 
 from homeassistant.components import alarm_control_panel
 from homeassistant.components.ness_alarm import (
-    DOMAIN,
-    CONF_DEVICE_PORT,
-    CONF_ZONE_NAME,
-    CONF_ZONES,
-    CONF_ZONE_ID,
-    SERVICE_AUX,
-    SERVICE_PANIC,
     ATTR_CODE,
     ATTR_OUTPUT_ID,
+    CONF_DEVICE_PORT,
+    CONF_ZONE_ID,
+    CONF_ZONE_NAME,
+    CONF_ZONES,
+    DOMAIN,
+    SERVICE_AUX,
+    SERVICE_PANIC,
 )
 from homeassistant.const import (
-    STATE_ALARM_ARMING,
-    SERVICE_ALARM_DISARM,
     ATTR_ENTITY_ID,
+    CONF_HOST,
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_HOME,
+    SERVICE_ALARM_DISARM,
     SERVICE_ALARM_TRIGGER,
-    STATE_ALARM_DISARMED,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMING,
+    STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
     STATE_UNKNOWN,
-    CONF_HOST,
 )
 from homeassistant.setup import async_setup_component
+
 from tests.common import MockDependency
 
 VALID_CONFIG = {

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -1,14 +1,13 @@
 """The tests for the nexbus sensor component."""
 from copy import deepcopy
-
-import pytest
 from unittest.mock import patch
 
-import homeassistant.components.sensor as sensor
+import pytest
+
 import homeassistant.components.nextbus.sensor as nextbus
+import homeassistant.components.sensor as sensor
 
 from tests.common import assert_setup_component, async_setup_component
-
 
 VALID_AGENCY = "sf-muni"
 VALID_ROUTE = "F"

--- a/tests/components/no_ip/test_init.py
+++ b/tests/components/no_ip/test_init.py
@@ -4,8 +4,8 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import no_ip
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed

--- a/tests/components/notion/test_config_flow.py
+++ b/tests/components/notion/test_config_flow.py
@@ -1,6 +1,7 @@
 """Define tests for the Notion config flow."""
-import aionotion
 from unittest.mock import patch
+
+import aionotion
 import pytest
 
 from homeassistant import data_entry_flow

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 
 from homeassistant.components import sensor
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant, assert_setup_component
+
+from tests.common import assert_setup_component, get_test_home_assistant
 
 VALID_CONFIG = {
     "platform": "nsw_fuel_station",

--- a/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
+++ b/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
@@ -3,22 +3,22 @@ import datetime
 from unittest.mock import ANY
 
 from aio_geojson_nsw_rfs_incidents import NswRuralFireServiceIncidentsFeed
-from asynctest.mock import patch, MagicMock, call
+from asynctest.mock import MagicMock, call, patch
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.components.nsw_rural_fire_service_feed.geo_location import (
-    ATTR_EXTERNAL_ID,
-    SCAN_INTERVAL,
     ATTR_CATEGORY,
+    ATTR_COUNCIL_AREA,
+    ATTR_EXTERNAL_ID,
     ATTR_FIRE,
     ATTR_LOCATION,
-    ATTR_COUNCIL_AREA,
+    ATTR_PUBLICATION_DATE,
+    ATTR_RESPONSIBLE_AGENCY,
+    ATTR_SIZE,
     ATTR_STATUS,
     ATTR_TYPE,
-    ATTR_SIZE,
-    ATTR_RESPONSIBLE_AGENCY,
-    ATTR_PUBLICATION_DATE,
+    SCAN_INTERVAL,
 )
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -34,8 +34,9 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.setup import async_setup_component
-from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
+
+from tests.common import assert_setup_component, async_fire_time_changed
 
 CONFIG = {
     geo_location.DOMAIN: [{"platform": "nsw_rural_fire_service_feed", CONF_RADIUS: 200}]

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -1,6 +1,12 @@
 """Tests for the NWS weather component."""
 from homeassistant.components.nws.weather import ATTR_FORECAST_PRECIP_PROB
 from homeassistant.components.weather import (
+    ATTR_FORECAST,
+    ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_TEMP,
+    ATTR_FORECAST_TIME,
+    ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_SPEED,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
@@ -8,32 +14,23 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED,
 )
-from homeassistant.components.weather import (
-    ATTR_FORECAST,
-    ATTR_FORECAST_CONDITION,
-    ATTR_FORECAST_TEMP,
-    ATTR_FORECAST_TIME,
-    ATTR_FORECAST_WIND_BEARING,
-    ATTR_FORECAST_WIND_SPEED,
-)
-
 from homeassistant.const import (
     LENGTH_KILOMETERS,
     LENGTH_METERS,
     LENGTH_MILES,
+    PRESSURE_HPA,
     PRESSURE_INHG,
     PRESSURE_PA,
-    PRESSURE_HPA,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
-from homeassistant.util.pressure import convert as convert_pressure
-from homeassistant.util.distance import convert as convert_distance
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
-from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.setup import async_setup_component
+from homeassistant.util.distance import convert as convert_distance
+from homeassistant.util.pressure import convert as convert_pressure
+from homeassistant.util.temperature import convert as convert_temperature
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
-from tests.common import load_fixture, assert_setup_component
+from tests.common import assert_setup_component, load_fixture
 
 EXP_OBS_IMP = {
     ATTR_WEATHER_TEMPERATURE: round(

--- a/tests/components/nx584/test_binary_sensor.py
+++ b/tests/components/nx584/test_binary_sensor.py
@@ -1,15 +1,15 @@
 """The tests for the nx584 sensor platform."""
-import requests
 import unittest
 from unittest import mock
 
 from nx584 import client as nx584_client
+import pytest
+import requests
 
 from homeassistant.components.nx584 import binary_sensor as nx584
 from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
-import pytest
 
 
 class StopMe(Exception):


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"n"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/ness_alarm/__init__.py` 
- `homeassistant/components/netgear/device_tracker.py` 
- `homeassistant/components/nfandroidtv/notify.py` 
- `homeassistant/components/nissan_leaf/__init__.py` 
- `homeassistant/components/no_ip/__init__.py` 
- `homeassistant/components/notify/__init__.py` 
- `homeassistant/components/nws/weather.py` 
- `tests/components/namecheapdns/test_init.py` 
- `tests/components/ness_alarm/test_init.py` 
- `tests/components/nextbus/test_sensor.py` 
- `tests/components/no_ip/test_init.py` 
- `tests/components/notion/test_config_flow.py` 
- `tests/components/nsw_fuel_station/test_sensor.py` 
- `tests/components/nsw_rural_fire_service_feed/test_geo_location.py` 
- `tests/components/nws/test_weather.py` 
- `tests/components/nx584/test_binary_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
