### PR TITLE
Sort imports according to PEP8 for components starting with "O"

### DIFF
--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -1,10 +1,9 @@
 """Support for Obihai Sensors."""
+from datetime import timedelta
 import logging
 
-from datetime import timedelta
-import voluptuous as vol
-
 from pyobihai import PyObihai
+import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
@@ -13,10 +12,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     DEVICE_CLASS_TIMESTAMP,
 )
-
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -2,23 +2,23 @@
 import logging
 import time
 
+from aiohttp.hdrs import CONTENT_TYPE
 import requests
 import voluptuous as vol
-from aiohttp.hdrs import CONTENT_TYPE
 
 from homeassistant.components.discovery import SERVICE_OCTOPRINT
 from homeassistant.const import (
     CONF_API_KEY,
+    CONF_BINARY_SENSORS,
     CONF_HOST,
-    CONTENT_TYPE_JSON,
+    CONF_MONITORED_CONDITIONS,
     CONF_NAME,
     CONF_PATH,
     CONF_PORT,
-    CONF_SSL,
-    TEMP_CELSIUS,
-    CONF_MONITORED_CONDITIONS,
     CONF_SENSORS,
-    CONF_BINARY_SENSORS,
+    CONF_SSL,
+    CONTENT_TYPE_JSON,
+    TEMP_CELSIUS,
 )
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -1,15 +1,15 @@
 """Support for 1-Wire environment sensors."""
+from glob import glob
+import logging
 import os
 import time
-import logging
-from glob import glob
 
 import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import TEMP_CELSIUS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import TEMP_CELSIUS
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -2,12 +2,13 @@
 import logging
 from typing import List
 
-import voluptuous as vol
 import eiscp
 from eiscp import eISCP
+import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
+    DOMAIN,
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_SELECT_SOURCE,
@@ -16,14 +17,13 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
-    DOMAIN,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_HOST,
     CONF_NAME,
     STATE_OFF,
     STATE_ON,
-    ATTR_ENTITY_ID,
 )
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/openalpr_cloud/image_processing.py
+++ b/homeassistant/components/openalpr_cloud/image_processing.py
@@ -1,26 +1,26 @@
 """Component that will help set the OpenALPR cloud for ALPR processing."""
 import asyncio
-import logging
 from base64 import b64encode
+import logging
 
 import aiohttp
 import async_timeout
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.core import split_entity_id
-from homeassistant.const import CONF_API_KEY
 from homeassistant.components.image_processing import (
-    PLATFORM_SCHEMA,
     CONF_CONFIDENCE,
-    CONF_SOURCE,
     CONF_ENTITY_ID,
     CONF_NAME,
+    CONF_SOURCE,
+    PLATFORM_SCHEMA,
 )
 from homeassistant.components.openalpr_local.image_processing import (
     ImageProcessingAlprEntity,
 )
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import split_entity_id
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/openalpr_local/image_processing.py
+++ b/homeassistant/components/openalpr_local/image_processing.py
@@ -6,19 +6,19 @@ import re
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.core import split_entity_id, callback
-from homeassistant.const import CONF_REGION
 from homeassistant.components.image_processing import (
-    PLATFORM_SCHEMA,
-    ImageProcessingEntity,
+    ATTR_CONFIDENCE,
+    ATTR_ENTITY_ID,
     CONF_CONFIDENCE,
-    CONF_SOURCE,
     CONF_ENTITY_ID,
     CONF_NAME,
-    ATTR_ENTITY_ID,
-    ATTR_CONFIDENCE,
+    CONF_SOURCE,
+    PLATFORM_SCHEMA,
+    ImageProcessingEntity,
 )
+from homeassistant.const import CONF_REGION
+from homeassistant.core import callback, split_entity_id
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async_ import run_callback_threadsafe
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/openexchangerates/sensor.py
+++ b/homeassistant/components/openexchangerates/sensor.py
@@ -7,11 +7,11 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_NAME,
-    CONF_BASE,
-    CONF_QUOTE,
     ATTR_ATTRIBUTION,
+    CONF_API_KEY,
+    CONF_BASE,
+    CONF_NAME,
+    CONF_QUOTE,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -5,22 +5,22 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    CoverDevice,
     DEVICE_CLASS_GARAGE,
     PLATFORM_SCHEMA,
-    SUPPORT_OPEN,
     SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    CoverDevice,
 )
 from homeassistant.const import (
-    CONF_NAME,
-    STATE_CLOSED,
-    STATE_OPEN,
     CONF_COVERS,
     CONF_HOST,
+    CONF_NAME,
     CONF_PORT,
     CONF_SSL,
     CONF_VERIFY_SSL,
+    STATE_CLOSED,
     STATE_CLOSING,
+    STATE_OPEN,
     STATE_OPENING,
 )
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -1,26 +1,25 @@
 """Sensor for the Open Sky Network."""
-import logging
 from datetime import timedelta
+import logging
 
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_RADIUS,
     ATTR_ATTRIBUTION,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    CONF_RADIUS,
     LENGTH_KILOMETERS,
     LENGTH_METERS,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import distance as util_distance
-from homeassistant.util import location as util_location
+from homeassistant.util import distance as util_distance, location as util_location
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/oru/sensor.py
+++ b/homeassistant/components/oru/sensor.py
@@ -2,14 +2,12 @@
 from datetime import timedelta
 import logging
 
+from oru import Meter, MeterError
 import voluptuous as vol
 
-from oru import Meter
-from oru import MeterError
-
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import ENERGY_KILO_WATT_HOUR
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/onboarding/test_init.py
+++ b/tests/components/onboarding/test_init.py
@@ -1,12 +1,12 @@
 """Tests for the init."""
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import onboarding
-
-from tests.common import mock_coro, MockUser
+from homeassistant.setup import async_setup_component
 
 from . import mock_storage
+
+from tests.common import MockUser, mock_coro
 
 # Temporarily: if auth not active, always set onboarded=True
 

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -4,14 +4,14 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import onboarding
 from homeassistant.components.onboarding import const, views
+from homeassistant.setup import async_setup_component
+
+from . import mock_storage
 
 from tests.common import CLIENT_ID, register_auth_provider
 from tests.components.met.conftest import mock_weather  # noqa: F401
-
-from . import mock_storage
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/openalpr_cloud/test_image_processing.py
+++ b/tests/components/openalpr_cloud/test_image_processing.py
@@ -1,15 +1,15 @@
 """The tests for the openalpr cloud platform."""
 import asyncio
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
-from homeassistant.core import callback
-from homeassistant.setup import setup_component
 from homeassistant.components import camera, image_processing as ip
 from homeassistant.components.openalpr_cloud.image_processing import OPENALPR_API_URL
+from homeassistant.core import callback
+from homeassistant.setup import setup_component
 
 from tests.common import (
-    get_test_home_assistant,
     assert_setup_component,
+    get_test_home_assistant,
     load_fixture,
     mock_coro,
 )

--- a/tests/components/openalpr_local/test_image_processing.py
+++ b/tests/components/openalpr_local/test_image_processing.py
@@ -1,13 +1,13 @@
 """The tests for the openalpr local platform."""
 import asyncio
-from unittest.mock import patch, PropertyMock, MagicMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
-from homeassistant.core import callback
-from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.setup import setup_component
 import homeassistant.components.image_processing as ip
+from homeassistant.const import ATTR_ENTITY_PICTURE
+from homeassistant.core import callback
+from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component, load_fixture
+from tests.common import assert_setup_component, get_test_home_assistant, load_fixture
 from tests.components.image_processing import common
 
 

--- a/tests/components/openhardwaremonitor/test_sensor.py
+++ b/tests/components/openhardwaremonitor/test_sensor.py
@@ -1,8 +1,11 @@
 """The tests for the Open Hardware Monitor platform."""
 import unittest
+
 import requests_mock
+
 from homeassistant.setup import setup_component
-from tests.common import load_fixture, get_test_home_assistant
+
+from tests.common import get_test_home_assistant, load_fixture
 
 
 class TestOpenHardwareMonitorSetup(unittest.TestCase):

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -1,7 +1,8 @@
 """Define tests for the OpenUV config flow."""
-import pytest
-from pyopenuv.errors import OpenUvError
 from unittest.mock import patch
+
+from pyopenuv.errors import OpenUvError
+import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.openuv import DOMAIN, config_flow


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"o"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/obihai/sensor.py` 
- `homeassistant/components/octoprint/__init__.py` 
- `homeassistant/components/onewire/sensor.py` 
- `homeassistant/components/onkyo/media_player.py` 
- `homeassistant/components/openalpr_cloud/image_processing.py` 
- `homeassistant/components/openalpr_local/image_processing.py` 
- `homeassistant/components/openexchangerates/sensor.py` 
- `homeassistant/components/opengarage/cover.py` 
- `homeassistant/components/opensky/sensor.py` 
- `homeassistant/components/oru/sensor.py` 
- `tests/components/onboarding/test_init.py` 
- `tests/components/onboarding/test_views.py` 
- `tests/components/openalpr_cloud/test_image_processing.py` 
- `tests/components/openalpr_local/test_image_processing.py` 
- `tests/components/openhardwaremonitor/test_sensor.py` 
- `tests/components/openuv/test_config_flow.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
