### PR TITLE
Sort imports according to PEP8 for components starting with "P"

### DIFF
--- a/homeassistant/components/pcal9535a/binary_sensor.py
+++ b/homeassistant/components/pcal9535a/binary_sensor.py
@@ -1,10 +1,10 @@
 """Support for binary sensor using I2C PCAL9535A chip."""
 import logging
 
-import voluptuous as vol
 from pcal9535a import PCAL9535A
+import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/pcal9535a/switch.py
+++ b/homeassistant/components/pcal9535a/switch.py
@@ -1,8 +1,8 @@
 """Support for switch sensor using I2C PCAL9535A chip."""
 import logging
 
-import voluptuous as vol
 from pcal9535a import PCAL9535A
+import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.loader import bind_hass
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
 
-
 # mypy: allow-untyped-calls, allow-untyped-defs
 
 ATTR_CREATED_AT = "created_at"

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -7,27 +7,27 @@ import uuid
 
 import voluptuous as vol
 
+from homeassistant.auth import EVENT_USER_REMOVED
 from homeassistant.components import websocket_api
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     ATTR_SOURCE_TYPE,
+    DOMAIN as DEVICE_TRACKER_DOMAIN,
     SOURCE_TYPE_GPS,
 )
 from homeassistant.const import (
+    ATTR_GPS_ACCURACY,
     ATTR_ID,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_GPS_ACCURACY,
     CONF_ID,
     CONF_NAME,
     EVENT_HOMEASSISTANT_START,
-    STATE_UNKNOWN,
-    STATE_UNAVAILABLE,
     STATE_HOME,
     STATE_NOT_HOME,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
-from homeassistant.core import callback, Event, State
-from homeassistant.auth import EVENT_USER_REMOVED
+from homeassistant.core import Event, State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_state_change

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -1,15 +1,15 @@
 """Tracks the latency of a host by sending ICMP echo requests (ping)."""
-import logging
-import subprocess
-import re
-import sys
 from datetime import timedelta
+import logging
+import re
+import subprocess
+import sys
 
 import voluptuous as vol
 
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
+from homeassistant.const import CONF_HOST, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -1,20 +1,19 @@
 """Tracks devices by sending a ICMP echo request (ping)."""
+from datetime import timedelta
 import logging
 import subprocess
 import sys
-from datetime import timedelta
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
+from homeassistant import const, util
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.components.device_tracker.const import (
     CONF_SCAN_INTERVAL,
     SCAN_INTERVAL,
     SOURCE_TYPE_ROUTER,
 )
-from homeassistant import util
-from homeassistant import const
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -4,7 +4,7 @@ import telnetlib
 
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_PAUSE,
     SUPPORT_PLAY,

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -2,18 +2,17 @@
 
 import logging
 
-import voluptuous as vol
 import haanna
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
-    CURRENT_HVAC_HEAT,
     CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
+    HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_AUTO,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -27,6 +26,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 

--- a/homeassistant/components/prowl/notify.py
+++ b/homeassistant/components/prowl/notify.py
@@ -5,10 +5,6 @@ import logging
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import CONF_API_KEY
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TITLE,
@@ -16,6 +12,9 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_API_KEY
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = "https://api.prowlapp.com/publicapi/"

--- a/homeassistant/components/proximity/__init__.py
+++ b/homeassistant/components/proximity/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.event import track_state_change
 from homeassistant.util.distance import convert
 from homeassistant.util.location import distance
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/pulseaudio_loopback/switch.py
+++ b/homeassistant/components/pulseaudio_loopback/switch.py
@@ -1,14 +1,14 @@
 """Switch logic for loading/unloading pulseaudio loopback modules."""
+from datetime import timedelta
 import logging
 import re
 import socket
-from datetime import timedelta
 
 import voluptuous as vol
 
 from homeassistant import util
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/push/camera.py
+++ b/homeassistant/components/push/camera.py
@@ -1,22 +1,22 @@
 """Camera platform that receives images through HTTP POST."""
-import logging
 import asyncio
-
 from collections import deque
 from datetime import timedelta
-import voluptuous as vol
+import logging
+
 import aiohttp
 import async_timeout
+import voluptuous as vol
 
 from homeassistant.components.camera import (
-    Camera,
     PLATFORM_SCHEMA,
     STATE_IDLE,
     STATE_RECORDING,
+    Camera,
 )
 from homeassistant.components.camera.const import DOMAIN
-from homeassistant.core import callback
 from homeassistant.const import CONF_NAME, CONF_TIMEOUT, CONF_WEBHOOK_ID
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_point_in_utc_time
 import homeassistant.util.dt as dt_util

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -1,12 +1,9 @@
 """Pushover platform for notify component."""
 import logging
 
+from pushover import Client, InitError, RequestError
 import requests
 import voluptuous as vol
-from pushover import InitError, Client, RequestError
-
-from homeassistant.const import CONF_API_KEY
-import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -16,6 +13,8 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_API_KEY
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pushsafer/notify.py
+++ b/homeassistant/components/pushsafer/notify.py
@@ -7,8 +7,6 @@ import requests
 from requests.auth import HTTPBasicAuth
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
@@ -17,6 +15,7 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = "https://www.pushsafer.com/api"

--- a/homeassistant/components/pvoutput/sensor.py
+++ b/homeassistant/components/pvoutput/sensor.py
@@ -1,22 +1,22 @@
 """Support for getting collected information from PVOutput."""
-import logging
 from collections import namedtuple
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import Entity
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.components.rest.sensor import RestData
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_API_KEY,
-    CONF_NAME,
     ATTR_DATE,
+    ATTR_TEMPERATURE,
     ATTR_TIME,
     ATTR_VOLTAGE,
+    CONF_API_KEY,
+    CONF_NAME,
 )
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 _ENDPOINT = "http://pvoutput.org/service/r2/getstatus.jsp"

--- a/homeassistant/components/pyload/sensor.py
+++ b/homeassistant/components/pyload/sensor.py
@@ -8,14 +8,14 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_SSL,
     CONF_HOST,
+    CONF_MONITORED_VARIABLES,
     CONF_NAME,
-    CONF_PORT,
     CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
     CONF_USERNAME,
     CONTENT_TYPE_JSON,
-    CONF_MONITORED_VARIABLES,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -1,7 +1,7 @@
 """The tests for the persistent notification component."""
-from homeassistant.components.websocket_api.const import TYPE_RESULT
-from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.persistent_notification as pn
+from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.setup import async_setup_component, setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -1,22 +1,22 @@
 """Unit tests for platform/plant.py."""
 import asyncio
-import unittest
-import pytest
 from datetime import datetime, timedelta
+import unittest
 
-from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-    STATE_PROBLEM,
-    STATE_OK,
-)
+import pytest
+
 from homeassistant.components import recorder
 import homeassistant.components.plant as plant
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_OK,
+    STATE_PROBLEM,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant, init_recorder_component
-
 
 GOOD_DATA = {
     "moisture": 50,

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -1,14 +1,14 @@
 """The tests for the Prometheus exporter."""
 import asyncio
-import pytest
 
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, DEVICE_CLASS_POWER
+import pytest
 
 from homeassistant import setup
 from homeassistant.components import climate, sensor
 from homeassistant.components.demo.sensor import DemoSensor
-from homeassistant.setup import async_setup_component
 import homeassistant.components.prometheus as prometheus
+from homeassistant.const import DEVICE_CLASS_POWER, ENERGY_KILO_WATT_HOUR
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -3,8 +3,8 @@ import unittest
 
 from homeassistant.components import proximity
 from homeassistant.components.proximity import DOMAIN
-
 from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -26,8 +26,9 @@ from homeassistant.const import (
     CONF_TOKEN,
 )
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import location
 from homeassistant.setup import async_setup_component
+from homeassistant.util import location
+
 from tests.common import MockConfigEntry, mock_coro, mock_registry
 
 MOCK_HOST = "192.168.0.1"

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -29,13 +29,13 @@ from homeassistant.const import (
     CONF_REGION,
     CONF_TOKEN,
     STATE_IDLE,
-    STATE_STANDBY,
     STATE_PLAYING,
+    STATE_STANDBY,
     STATE_UNKNOWN,
 )
 from homeassistant.setup import async_setup_component
-from tests.common import MockConfigEntry, mock_device_registry, mock_registry, mock_coro
 
+from tests.common import MockConfigEntry, mock_coro, mock_device_registry, mock_registry
 
 MOCK_CREDS = "123412341234abcd12341234abcd12341234abcd12341234abcd12341234abcd"
 MOCK_NAME = "ha_ps4_name"

--- a/tests/components/ptvsd/test_ptvsd.py
+++ b/tests/components/ptvsd/test_ptvsd.py
@@ -1,12 +1,13 @@
 """Tests for PTVSD Debugger."""
 
 from unittest.mock import patch
+
 from asynctest import CoroutineMock
 from pytest import mark
 
+from homeassistant.bootstrap import _async_set_up_integrations
 import homeassistant.components.ptvsd as ptvsd_component
 from homeassistant.setup import async_setup_component
-from homeassistant.bootstrap import _async_set_up_integrations
 
 
 @mark.skip("causes code cover to fail")

--- a/tests/components/push/test_camera.py
+++ b/tests/components/push/test_camera.py
@@ -1,7 +1,6 @@
 """The tests for generic camera component."""
-import io
-
 from datetime import timedelta
+import io
 
 from homeassistant import core as ha
 from homeassistant.setup import async_setup_component

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -1,11 +1,11 @@
 """Test the python_script component."""
 import asyncio
 import logging
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
+from homeassistant.components.python_script import DOMAIN, FOLDER, execute
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.setup import async_setup_component
-from homeassistant.components.python_script import DOMAIN, execute, FOLDER
 
 from tests.common import patch_yaml_files
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"p"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/pcal9535a/binary_sensor.py` 
- `homeassistant/components/pcal9535a/switch.py` 
- `homeassistant/components/persistent_notification/__init__.py` 
- `homeassistant/components/person/__init__.py` 
- `homeassistant/components/ping/binary_sensor.py` 
- `homeassistant/components/ping/device_tracker.py` 
- `homeassistant/components/pioneer/media_player.py` 
- `homeassistant/components/plugwise/climate.py` 
- `homeassistant/components/prowl/notify.py` 
- `homeassistant/components/proximity/__init__.py` 
- `homeassistant/components/pulseaudio_loopback/switch.py` 
- `homeassistant/components/push/camera.py` 
- `homeassistant/components/pushover/notify.py` 
- `homeassistant/components/pushsafer/notify.py` 
- `homeassistant/components/pvoutput/sensor.py` 
- `homeassistant/components/pyload/sensor.py` 
- `tests/components/persistent_notification/test_init.py` 
- `tests/components/plant/test_init.py` 
- `tests/components/prometheus/test_init.py` 
- `tests/components/proximity/test_init.py` 
- `tests/components/ps4/test_init.py` 
- `tests/components/ps4/test_media_player.py` 
- `tests/components/ptvsd/test_ptvsd.py` 
- `tests/components/push/test_camera.py` 
- `tests/components/python_script/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
