### PR TITLE
Sort imports according to PEP8 for components starting with "S"

### DIFF
--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -9,8 +9,8 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST,
-    CONF_PASSWORD,
     CONF_NAME,
+    CONF_PASSWORD,
     CONF_TYPE,
     CONF_USERNAME,
     DEVICE_CLASS_POWER,

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -3,15 +3,15 @@ import asyncio
 from datetime import timedelta
 import socket
 
-from samsungctl import exceptions as samsung_exceptions, Remote as SamsungRemote
+from samsungctl import Remote as SamsungRemote, exceptions as samsung_exceptions
 import voluptuous as vol
 import wakeonlan
 from websocket import WebSocketException
 
 from homeassistant.components.media_player import (
-    MediaPlayerDevice,
-    PLATFORM_SCHEMA,
     DEVICE_CLASS_TV,
+    PLATFORM_SCHEMA,
+    MediaPlayerDevice,
 )
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,

--- a/homeassistant/components/scrape/sensor.py
+++ b/homeassistant/components/scrape/sensor.py
@@ -2,27 +2,27 @@
 import logging
 
 from bs4 import BeautifulSoup
-import voluptuous as vol
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.components.rest.sensor import RestData
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
+    CONF_AUTHENTICATION,
+    CONF_HEADERS,
     CONF_NAME,
+    CONF_PASSWORD,
     CONF_RESOURCE,
     CONF_UNIT_OF_MEASUREMENT,
+    CONF_USERNAME,
     CONF_VALUE_TEMPLATE,
     CONF_VERIFY_SSL,
-    CONF_USERNAME,
-    CONF_HEADERS,
-    CONF_PASSWORD,
-    CONF_AUTHENTICATION,
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
 )
-from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -6,23 +6,22 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-    SERVICE_TOGGLE,
-    SERVICE_RELOAD,
-    STATE_ON,
+    ATTR_NAME,
     CONF_ALIAS,
     EVENT_SCRIPT_STARTED,
-    ATTR_NAME,
+    SERVICE_RELOAD,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
 )
-from homeassistant.loader import bind_hass
-from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.entity_component import EntityComponent
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import make_entity_service_schema
-from homeassistant.helpers.service import async_set_service_schema
-
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.script import Script
+from homeassistant.helpers.service import async_set_service_schema
+from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sendgrid/notify.py
+++ b/homeassistant/components/sendgrid/notify.py
@@ -1,17 +1,8 @@
 """SendGrid notification service."""
 import logging
 
-import voluptuous as vol
-
 from sendgrid import SendGridAPIClient
-
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_RECIPIENT,
-    CONF_SENDER,
-    CONTENT_TYPE_TEXT_PLAIN,
-)
-import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 
 from homeassistant.components.notify import (
     ATTR_TITLE,
@@ -19,6 +10,13 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_RECIPIENT,
+    CONF_SENDER,
+    CONTENT_TYPE_TEXT_PLAIN,
+)
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -5,16 +5,16 @@ import logging
 
 import aiohttp
 import async_timeout
-import voluptuous as vol
 import pysensibo
+import voluptuous as vol
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
     HVAC_MODE_FAN_ONLY,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
     SUPPORT_FAN_MODE,
     SUPPORT_SWING_MODE,

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -5,8 +5,8 @@ import shlex
 
 import voluptuous as vol
 
-from homeassistant.exceptions import TemplateError
 from homeassistant.core import ServiceCall
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 

--- a/homeassistant/components/sigfox/sensor.py
+++ b/homeassistant/components/sigfox/sensor.py
@@ -1,15 +1,15 @@
 """Sensor for SigFox devices."""
-import logging
 import datetime
 import json
+import logging
 from urllib.parse import urljoin
 
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/simulated/sensor.py
+++ b/homeassistant/components/simulated/sensor.py
@@ -1,8 +1,8 @@
 """Adds a simulated sensor."""
+from datetime import datetime
 import logging
 import math
 from random import Random
-from datetime import datetime
 
 import voluptuous as vol
 

--- a/homeassistant/components/sinch/notify.py
+++ b/homeassistant/components/sinch/notify.py
@@ -1,25 +1,25 @@
 """Support for Sinch notifications."""
 import logging
 
-import voluptuous as vol
 from clx.xms.api import MtBatchTextSmsResult
 from clx.xms.client import Client
 from clx.xms.exceptions import (
     ErrorResponseException,
-    UnexpectedResponseException,
-    UnauthorizedException,
     NotFoundException,
+    UnauthorizedException,
+    UnexpectedResponseException,
 )
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.notify import (
-    ATTR_MESSAGE,
     ATTR_DATA,
+    ATTR_MESSAGE,
     ATTR_TARGET,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
 from homeassistant.const import CONF_API_KEY, CONF_SENDER
+import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "sinch"
 

--- a/homeassistant/components/sky_hub/device_tracker.py
+++ b/homeassistant/components/sky_hub/device_tracker.py
@@ -5,13 +5,13 @@ import re
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
 from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 _MAC_REGEX = re.compile(r"(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})")

--- a/homeassistant/components/slide/__init__.py
+++ b/homeassistant/components/slide/__init__.py
@@ -1,24 +1,25 @@
 """Component for the Go Slide API."""
 
-import logging
 from datetime import timedelta
+import logging
 
-import voluptuous as vol
 from goslideapi import GoSlideCloud, goslideapi
+import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_USERNAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
-    STATE_OPEN,
+    CONF_USERNAME,
     STATE_CLOSED,
-    STATE_OPENING,
     STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.helpers.event import async_track_time_interval, async_call_later
-from .const import DOMAIN, SLIDES, API, COMPONENT, DEFAULT_RETRY
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
+
+from .const import API, COMPONENT, DEFAULT_RETRY, DOMAIN, SLIDES
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/slide/cover.py
+++ b/homeassistant/components/slide/cover.py
@@ -2,15 +2,16 @@
 
 import logging
 
-from homeassistant.const import ATTR_ID
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    STATE_CLOSED,
-    STATE_OPENING,
-    STATE_CLOSING,
     DEVICE_CLASS_CURTAIN,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPENING,
     CoverDevice,
 )
+from homeassistant.const import ATTR_ID
+
 from .const import API, DOMAIN, SLIDES
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -10,6 +10,13 @@ import smtplib
 
 import voluptuous as vol
 
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
@@ -20,14 +27,6 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
-
-from homeassistant.components.notify import (
-    ATTR_DATA,
-    ATTR_TITLE,
-    ATTR_TITLE_DEFAULT,
-    PLATFORM_SCHEMA,
-    BaseNotificationService,
-)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/snips/__init__.py
+++ b/homeassistant/components/snips/__init__.py
@@ -1,13 +1,13 @@
 """Support for Snips on-device ASR and NLU."""
+from datetime import timedelta
 import json
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.helpers import intent, config_validation as cv
 from homeassistant.components import mqtt
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv, intent
 
 DOMAIN = "snips"
 CONF_INTENTS = "intents"

--- a/homeassistant/components/snmp/switch.py
+++ b/homeassistant/components/snmp/switch.py
@@ -2,7 +2,6 @@
 import logging
 
 from pyasn1.type.univ import Integer
-
 import pysnmp.hlapi.asyncio as hlapi
 from pysnmp.hlapi.asyncio import (
     CommunityData,

--- a/homeassistant/components/solaredge_local/sensor.py
+++ b/homeassistant/components/solaredge_local/sensor.py
@@ -1,10 +1,10 @@
 """Support for SolarEdge-local Monitoring API."""
-import logging
-from datetime import timedelta
-import statistics
 from copy import deepcopy
+from datetime import timedelta
+import logging
+import statistics
 
-from requests.exceptions import HTTPError, ConnectTimeout
+from requests.exceptions import ConnectTimeout, HTTPError
 from solaredge_local import SolarEdge
 import voluptuous as vol
 
@@ -12,8 +12,8 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_NAME,
-    POWER_WATT,
     ENERGY_WATT_HOUR,
+    POWER_WATT,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -1,6 +1,5 @@
 """Support for Solax inverter via local API."""
 import asyncio
-
 from datetime import timedelta
 import logging
 
@@ -8,11 +7,11 @@ from solax import real_time_api
 from solax.inverter import InverterError
 import voluptuous as vol
 
-from homeassistant.const import TEMP_CELSIUS, CONF_IP_ADDRESS, CONF_PORT
-from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, TEMP_CELSIUS
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -1,19 +1,19 @@
 """Support for Songpal-enabled (Sony) media devices."""
 import asyncio
-import logging
 from collections import OrderedDict
+import logging
 
-import voluptuous as vol
 from songpal import (
+    ConnectChange,
+    ContentChange,
     Device,
+    PowerChange,
     SongpalException,
     VolumeChange,
-    ContentChange,
-    PowerChange,
-    ConnectChange,
 )
+import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
@@ -25,9 +25,9 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_NAME,
+    EVENT_HOMEASSISTANT_STOP,
     STATE_OFF,
     STATE_ON,
-    EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -7,12 +7,12 @@ import requests
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_SSL,
-    CONF_VERIFY_SSL,
     CONF_HOST,
     CONF_NAME,
     CONF_PORT,
+    CONF_SSL,
     CONF_TOKEN,
+    CONF_VERIFY_SSL,
     EVENT_STATE_CHANGED,
 )
 from homeassistant.helpers import state as state_helper

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -38,9 +38,9 @@ from homeassistant.const import (
     STATE_PAUSED,
     STATE_PLAYING,
 )
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util.dt import utcnow
 
 from .const import DOMAIN, SERVICE_CALL_METHOD

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -8,8 +8,8 @@ import aiohttp
 from defusedxml import ElementTree
 from netdisco import ssdp, util
 
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.generated.ssdp import SSDP
+from homeassistant.helpers.event import async_track_time_interval
 
 DOMAIN = "ssdp"
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/suez_water/sensor.py
+++ b/homeassistant/components/suez_water/sensor.py
@@ -2,10 +2,9 @@
 from datetime import timedelta
 import logging
 
-import voluptuous as vol
-
-from pysuez.client import PySuezError
 from pysuez import SuezClient
+from pysuez.client import PySuezError
+import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, VOLUME_LITERS

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -1,12 +1,12 @@
 """Support for functionality to keep track of the sun."""
-import logging
 from datetime import timedelta
+import logging
 
 from homeassistant.const import (
     CONF_ELEVATION,
+    EVENT_CORE_CONFIG_UPDATE,
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
-    EVENT_CORE_CONFIG_UPDATE,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
@@ -16,7 +16,6 @@ from homeassistant.helpers.sun import (
     get_location_astral_event_next,
 )
 from homeassistant.util import dt as dt_util
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/supervisord/sensor.py
+++ b/homeassistant/components/supervisord/sensor.py
@@ -6,8 +6,8 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_URL
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/synology_chat/notify.py
+++ b/homeassistant/components/synology_chat/notify.py
@@ -5,14 +5,13 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.const import CONF_RESOURCE, CONF_VERIFY_SSL
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.components.notify import (
     ATTR_DATA,
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.const import CONF_RESOURCE, CONF_VERIFY_SSL
+import homeassistant.helpers.config_validation as cv
 
 ATTR_FILE_URL = "file_url"
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1,13 +1,12 @@
 """Tests for samsungtv component."""
 import asyncio
-from unittest.mock import call, patch
 from datetime import timedelta
-
 import logging
+from unittest.mock import call, patch
+
 from asynctest import mock
 import pytest
 from samsungctl import exceptions
-from tests.common import async_fire_time_changed
 from websocket import WebSocketException
 
 from homeassistant.components.media_player import DEVICE_CLASS_TV
@@ -17,11 +16,11 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_VOLUME_MUTED,
     DOMAIN,
+    MEDIA_TYPE_CHANNEL,
+    MEDIA_TYPE_URL,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     SUPPORT_TURN_ON,
-    MEDIA_TYPE_CHANNEL,
-    MEDIA_TYPE_URL,
 )
 from homeassistant.components.samsungtv.const import DOMAIN as SAMSUNGTV_DOMAIN
 from homeassistant.components.samsungtv.media_player import (
@@ -56,6 +55,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from tests.common import async_fire_time_changed
 
 ENTITY_ID = f"{DOMAIN}.fake"
 MOCK_CONFIG = {

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1,7 +1,7 @@
 """The tests for the Script component."""
 # pylint: disable=protected-access
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -10,20 +10,19 @@ from homeassistant.components.script import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_NAME,
+    EVENT_SCRIPT_STARTED,
     SERVICE_RELOAD,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    EVENT_SCRIPT_STARTED,
 )
 from homeassistant.core import Context, callback, split_entity_id
+from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.loader import bind_hass
-from homeassistant.setup import setup_component, async_setup_component
-from homeassistant.exceptions import ServiceNotFound
+from homeassistant.setup import async_setup_component, setup_component
 
 from tests.common import get_test_home_assistant
-
 
 ENTITY_ID = "script.test"
 

--- a/tests/components/season/test_sensor.py
+++ b/tests/components/season/test_sensor.py
@@ -1,13 +1,12 @@
 """The tests for the Season sensor platform."""
 # pylint: disable=protected-access
-import unittest
 from datetime import datetime
+import unittest
 
-from homeassistant.setup import setup_component
 import homeassistant.components.season.sensor as season
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
-
 
 HEMISPHERE_NORTHERN = {
     "homeassistant": {"latitude": "48.864716", "longitude": "2.349014"},

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -2,17 +2,18 @@
 import datetime
 from typing import Union
 
-import pytest
 import mock
 from py17track.package import Package
+import pytest
 
 from homeassistant.components.seventeentrack.sensor import (
     CONF_SHOW_ARCHIVED,
     CONF_SHOW_DELIVERED,
 )
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
+
 from tests.common import MockDependency, async_fire_time_changed
 
 VALID_CONFIG_MINIMAL = {

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -2,12 +2,12 @@
 import asyncio
 import os
 import tempfile
-import unittest
 from typing import Tuple
+import unittest
 from unittest.mock import Mock, patch
 
-from homeassistant.setup import setup_component
 from homeassistant.components import shell_command
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/sigfox/test_sensor.py
+++ b/tests/components/sigfox/test_sensor.py
@@ -1,7 +1,8 @@
 """Tests for the sigfox sensor."""
 import re
-import requests_mock
 import unittest
+
+import requests_mock
 
 from homeassistant.components.sigfox.sensor import (
     API_URL,
@@ -9,6 +10,7 @@ from homeassistant.components.sigfox.sensor import (
     CONF_API_PASSWORD,
 )
 from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant
 
 TEST_API_LOGIN = "foo"

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -1,7 +1,7 @@
 """Define tests for the SimpliSafe config flow."""
-import json
 from datetime import timedelta
-from unittest.mock import mock_open, patch, MagicMock, PropertyMock
+import json
+from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.simplisafe import DOMAIN, config_flow

--- a/tests/components/simulated/test_sensor.py
+++ b/tests/components/simulated/test_sensor.py
@@ -1,27 +1,27 @@
 """The tests for the simulated sensor."""
 import unittest
 
-from tests.common import get_test_home_assistant
-
 from homeassistant.components.simulated.sensor import (
     CONF_AMP,
     CONF_FWHM,
     CONF_MEAN,
     CONF_PERIOD,
     CONF_PHASE,
+    CONF_RELATIVE_TO_EPOCH,
     CONF_SEED,
     CONF_UNIT,
-    CONF_RELATIVE_TO_EPOCH,
     DEFAULT_AMP,
     DEFAULT_FWHM,
     DEFAULT_MEAN,
     DEFAULT_NAME,
     DEFAULT_PHASE,
-    DEFAULT_SEED,
     DEFAULT_RELATIVE_TO_EPOCH,
+    DEFAULT_SEED,
 )
 from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.setup import setup_component
+
+from tests.common import get_test_home_assistant
 
 
 class TestSimulatedSensor(unittest.TestCase):

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -6,7 +6,6 @@ from asynctest import Mock, patch
 from pysmartthings import APIResponseError
 
 from homeassistant import data_entry_flow
-from homeassistant.setup import async_setup_component
 from homeassistant.components.smartthings import smartapp
 from homeassistant.components.smartthings.config_flow import SmartThingsFlowHandler
 from homeassistant.components.smartthings.const import (
@@ -16,6 +15,7 @@ from homeassistant.components.smartthings.const import (
     CONF_REFRESH_TOKEN,
     DOMAIN,
 )
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, mock_coro
 

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -6,7 +6,6 @@ from asynctest import Mock, patch
 from pysmartthings import InstalledAppStatus, OAuthToken
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import cloud, smartthings
 from homeassistant.components.smartthings.const import (
     CONF_CLOUDHOOK_URL,
@@ -20,6 +19,7 @@ from homeassistant.components.smartthings.const import (
 )
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/smhi/test_config_flow.py
+++ b/tests/components/smhi/test_config_flow.py
@@ -3,10 +3,10 @@ from unittest.mock import Mock, patch
 
 from smhi.smhi_lib import Smhi as SmhiApi, SmhiForecastException
 
-from tests.common import mock_coro
-
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.components.smhi import config_flow
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+
+from tests.common import mock_coro
 
 
 # pylint: disable=protected-access

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -1,31 +1,30 @@
 """Test for the smhi weather entity."""
 import asyncio
-import logging
 from datetime import datetime
+import logging
 from unittest.mock import Mock, patch
 
+from homeassistant.components.smhi import weather as weather_smhi
+from homeassistant.components.smhi.const import ATTR_SMHI_CLOUDINESS
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_TEMP,
+    ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
-    ATTR_WEATHER_TEMPERATURE,
+    ATTR_WEATHER_ATTRIBUTION,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
-    ATTR_FORECAST_TEMP_LOW,
+    ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_VISIBILITY,
-    ATTR_WEATHER_ATTRIBUTION,
     ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED,
-    ATTR_FORECAST_PRECIPITATION,
     DOMAIN as WEATHER_DOMAIN,
 )
-from homeassistant.components.smhi import weather as weather_smhi
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 
-from tests.common import load_fixture, MockConfigEntry
-
-from homeassistant.components.smhi.const import ATTR_SMHI_CLOUDINESS
+from tests.common import MockConfigEntry, load_fixture
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -1,11 +1,11 @@
 """The tests for the notify smtp platform."""
+import re
 import unittest
 from unittest.mock import patch
 
 from homeassistant.components.smtp.notify import MailNotificationService
 
 from tests.common import get_test_home_assistant
-import re
 
 
 class MockSMTP(MailNotificationService):

--- a/tests/components/snips/test_init.py
+++ b/tests/components/snips/test_init.py
@@ -9,11 +9,12 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.mqtt import MQTT_PUBLISH_SCHEMA
 import homeassistant.components.snips as snips
 from homeassistant.helpers.intent import ServiceIntentHandler, async_register
+
 from tests.common import (
     async_fire_mqtt_message,
     async_mock_intent,
-    async_mock_service,
     async_mock_mqtt_component,
+    async_mock_service,
 )
 
 

--- a/tests/components/solaredge/test_config_flow.py
+++ b/tests/components/solaredge/test_config_flow.py
@@ -1,12 +1,13 @@
 """Tests for the SolarEdge config flow."""
+from unittest.mock import Mock, patch
+
 import pytest
-from requests.exceptions import HTTPError, ConnectTimeout
-from unittest.mock import patch, Mock
+from requests.exceptions import ConnectTimeout, HTTPError
 
 from homeassistant import data_entry_flow
 from homeassistant.components.solaredge import config_flow
 from homeassistant.components.solaredge.const import CONF_SITE_ID, DEFAULT_NAME
-from homeassistant.const import CONF_NAME, CONF_API_KEY
+from homeassistant.const import CONF_API_KEY, CONF_NAME
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -1,7 +1,7 @@
 """The tests for the Sonarr platform."""
-import unittest
-import time
 from datetime import datetime
+import time
+import unittest
 
 import pytest
 

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -2,10 +2,12 @@
 import logging
 import unittest
 from unittest import mock
-from libsoundtouch.device import SoundTouchDevice as STD, Status, Volume, Preset, Config
+
+from libsoundtouch.device import Config, Preset, SoundTouchDevice as STD, Status, Volume
 
 from homeassistant.components.soundtouch import media_player as soundtouch
 from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -3,10 +3,11 @@
 from unittest.mock import patch
 
 import pytest
-from tests.common import mock_coro
 
 from homeassistant.components.spaceapi import DOMAIN, SPACEAPI_VERSION, URL_API_SPACEAPI
 from homeassistant.setup import async_setup_component
+
+from tests.common import mock_coro
 
 CONFIG = {
     DOMAIN: {

--- a/tests/components/spc/test_init.py
+++ b/tests/components/spc/test_init.py
@@ -1,5 +1,5 @@
 """Tests for Vanderbilt SPC component."""
-from unittest.mock import patch, PropertyMock, Mock
+from unittest.mock import Mock, PropertyMock, patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.spc import DATA_API

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -3,12 +3,12 @@ import json
 import unittest
 from unittest import mock
 
-from homeassistant.setup import setup_component
 import homeassistant.components.splunk as splunk
-from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
-from homeassistant.helpers import state as state_helper
-import homeassistant.util.dt as dt_util
+from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
 from homeassistant.core import State
+from homeassistant.helpers import state as state_helper
+from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
 
 from tests.common import get_test_home_assistant, mock_state_change_event
 

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,12 +1,12 @@
 """Test the SSDP integration."""
 import asyncio
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import aiohttp
 import pytest
 
-from homeassistant.generated import ssdp as gn_ssdp
 from homeassistant.components import ssdp
+from homeassistant.generated import ssdp as gn_ssdp
 
 from tests.common import mock_coro
 

--- a/tests/components/startca/test_sensor.py
+++ b/tests/components/startca/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Start.ca sensor platform."""
 import asyncio
+
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.startca.sensor import StartcaData
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1,18 +1,18 @@
 """The test for the statistics sensor platform."""
-import unittest
+from datetime import datetime, timedelta
 import statistics
+import unittest
+from unittest.mock import patch
 
 import pytest
 
-from homeassistant.setup import setup_component
-from homeassistant.components.statistics.sensor import StatisticsSensor
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS, STATE_UNKNOWN
-from homeassistant.util import dt as dt_util
-from tests.common import get_test_home_assistant
-from unittest.mock import patch
-from datetime import datetime, timedelta
-from tests.common import init_recorder_component
 from homeassistant.components import recorder
+from homeassistant.components.statistics.sensor import StatisticsSensor
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS
+from homeassistant.setup import setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import get_test_home_assistant, init_recorder_component
 
 
 class TestStatisticsSensor(unittest.TestCase):

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -1,7 +1,7 @@
 """Test STT component setup."""
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import stt
+from homeassistant.setup import async_setup_component
 
 
 async def test_setup_comp(hass):

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -5,10 +5,10 @@ from unittest.mock import patch
 from pytest import mark
 
 import homeassistant.components.sun as sun
-import homeassistant.core as ha
-import homeassistant.util.dt as dt_util
 from homeassistant.const import EVENT_STATE_CHANGED
+import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
 
 async def test_setting_rising(hass):

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -1,27 +1,25 @@
 """Test cases for the switcher_kis component."""
 
 from datetime import timedelta
-from typing import Any, Generator, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Generator
 
 from pytest import raises
 
-from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.components.switcher_kis import (
     CONF_AUTO_OFF,
-    DOMAIN,
     DATA_DEVICE,
+    DOMAIN,
     SERVICE_SET_AUTO_OFF_NAME,
     SERVICE_SET_AUTO_OFF_SCHEMA,
     SIGNAL_SWITCHER_DEVICE_UPDATE,
 )
-from homeassistant.core import callback, Context
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.core import Context, callback
+from homeassistant.exceptions import Unauthorized, UnknownUser
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.exceptions import Unauthorized, UnknownUser
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
-
-from tests.common import async_mock_service, async_fire_time_changed
 
 from .consts import (
     DUMMY_AUTO_OFF_SET,
@@ -37,6 +35,8 @@ from .consts import (
     MANDATORY_CONFIGURATION,
     SWITCH_ENTITY_ID,
 )
+
+from tests.common import async_fire_time_changed, async_mock_service
 
 if TYPE_CHECKING:
     from tests.common import MockUser

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -2,9 +2,9 @@
 import logging
 from unittest.mock import MagicMock, patch
 
-from homeassistant.core import callback
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import system_log
+from homeassistant.core import callback
 
 _LOGGER = logging.getLogger("test_logger")
 BASIC_CONFIG = {"system_log": {"max_entries": 2}}


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"s"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/saj/sensor.py` 
- `homeassistant/components/samsungtv/media_player.py` 
- `homeassistant/components/scrape/sensor.py` 
- `homeassistant/components/script/__init__.py` 
- `homeassistant/components/sendgrid/notify.py` 
- `homeassistant/components/sensibo/climate.py` 
- `homeassistant/components/shell_command/__init__.py` 
- `homeassistant/components/sigfox/sensor.py` 
- `homeassistant/components/simulated/sensor.py` 
- `homeassistant/components/sinch/notify.py` 
- `homeassistant/components/sky_hub/device_tracker.py` 
- `homeassistant/components/slide/__init__.py` 
- `homeassistant/components/slide/cover.py` 
- `homeassistant/components/smtp/notify.py` 
- `homeassistant/components/snips/__init__.py` 
- `homeassistant/components/snmp/switch.py` 
- `homeassistant/components/solaredge_local/sensor.py` 
- `homeassistant/components/solax/sensor.py` 
- `homeassistant/components/songpal/media_player.py` 
- `homeassistant/components/splunk/__init__.py` 
- `homeassistant/components/squeezebox/media_player.py` 
- `homeassistant/components/ssdp/__init__.py` 
- `homeassistant/components/suez_water/sensor.py` 
- `homeassistant/components/sun/__init__.py` 
- `homeassistant/components/supervisord/sensor.py` 
- `homeassistant/components/synology_chat/notify.py` 
- `tests/components/samsungtv/test_media_player.py` 
- `tests/components/script/test_init.py` 
- `tests/components/season/test_sensor.py` 
- `tests/components/seventeentrack/test_sensor.py` 
- `tests/components/shell_command/test_init.py` 
- `tests/components/sigfox/test_sensor.py` 
- `tests/components/simplisafe/test_config_flow.py` 
- `tests/components/simulated/test_sensor.py` 
- `tests/components/smartthings/test_config_flow.py` 
- `tests/components/smartthings/test_init.py` 
- `tests/components/smhi/test_config_flow.py` 
- `tests/components/smhi/test_weather.py` 
- `tests/components/smtp/test_notify.py` 
- `tests/components/snips/test_init.py` 
- `tests/components/solaredge/test_config_flow.py` 
- `tests/components/sonarr/test_sensor.py` 
- `tests/components/soundtouch/test_media_player.py` 
- `tests/components/spaceapi/test_init.py` 
- `tests/components/spc/test_init.py` 
- `tests/components/splunk/test_init.py` 
- `tests/components/ssdp/test_init.py` 
- `tests/components/startca/test_sensor.py` 
- `tests/components/statistics/test_sensor.py` 
- `tests/components/stt/test_init.py` 
- `tests/components/sun/test_init.py` 
- `tests/components/switcher_kis/test_init.py` 
- `tests/components/system_log/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
