### PR TITLE
Sort imports according to PEP8 for components starting with "U"

### DIFF
--- a/homeassistant/components/ue_smart_radio/media_player.py
+++ b/homeassistant/components/ue_smart_radio/media_player.py
@@ -5,7 +5,7 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_NEXT_TRACK,

--- a/homeassistant/components/uk_transport/sensor.py
+++ b/homeassistant/components/uk_transport/sensor.py
@@ -3,19 +3,19 @@
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.uk_transport/
 """
+from datetime import datetime, timedelta
 import logging
 import re
-from datetime import datetime, timedelta
 
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_MODE
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -4,7 +4,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     ATTR_APP_ID,
     ATTR_APP_NAME,

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -1,8 +1,7 @@
 """Support to check for available updates."""
+# pylint: disable=import-error
 import asyncio
 from datetime import timedelta
-
-# pylint: disable=import-error
 from distutils.version import StrictVersion
 import json
 import logging
@@ -14,11 +13,10 @@ from distro import linux_distribution
 import voluptuous as vol
 
 from homeassistant.const import __version__ as current_version
-from homeassistant.helpers import event
+from homeassistant.helpers import discovery, event
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers import discovery
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -1,5 +1,4 @@
 """Support to check for available updates."""
-# pylint: disable=import-error
 import asyncio
 from datetime import timedelta
 from distutils.version import StrictVersion
@@ -9,7 +8,7 @@ import uuid
 
 import aiohttp
 import async_timeout
-from distro import linux_distribution
+from distro import linux_distribution  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.const import __version__ as current_version

--- a/homeassistant/components/updater/binary_sensor.py
+++ b/homeassistant/components/updater/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Home Assistant Updater binary sensors."""
 
-from homeassistant.core import callback
 from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import ATTR_NEWEST_VERSION, ATTR_RELEASE_NOTES, DISPATCHER_REMOTE_UPDATE, Updater

--- a/homeassistant/components/uscis/sensor.py
+++ b/homeassistant/components/uscis/sensor.py
@@ -1,16 +1,15 @@
 """Support for USCIS Case Status."""
-import logging
 from datetime import timedelta
+import logging
 
 import uscisstatus
 import voluptuous as vol
 
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_FRIENDLY_NAME
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.helpers import config_validation as cv
-from homeassistant.const import CONF_FRIENDLY_NAME
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/uk_transport/test_sensor.py
+++ b/tests/components/uk_transport/test_sensor.py
@@ -1,23 +1,24 @@
 """The tests for the uk_transport platform."""
 import re
-
-import requests_mock
 import unittest
 
+import requests_mock
+
 from homeassistant.components.uk_transport.sensor import (
-    UkTransportSensor,
     ATTR_ATCOCODE,
-    ATTR_LOCALITY,
-    ATTR_STOP_NAME,
-    ATTR_NEXT_BUSES,
-    ATTR_STATION_CODE,
     ATTR_CALLING_AT,
+    ATTR_LOCALITY,
+    ATTR_NEXT_BUSES,
     ATTR_NEXT_TRAINS,
-    CONF_API_APP_KEY,
+    ATTR_STATION_CODE,
+    ATTR_STOP_NAME,
     CONF_API_APP_ID,
+    CONF_API_APP_KEY,
+    UkTransportSensor,
 )
 from homeassistant.setup import setup_component
-from tests.common import load_fixture, get_test_home_assistant
+
+from tests.common import get_test_home_assistant, load_fixture
 
 BUS_ATCOCODE = "340000368SHE"
 BUS_DIRECTION = "Wantage"

--- a/tests/components/unifi_direct/test_device_tracker.py
+++ b/tests/components/unifi_direct/test_device_tracker.py
@@ -1,29 +1,29 @@
 """The tests for the Unifi direct device tracker platform."""
-import os
 from datetime import timedelta
-from asynctest import mock, patch
+import os
 
+from asynctest import mock, patch
 import pytest
 import voluptuous as vol
 
-from homeassistant.setup import async_setup_component
-from homeassistant.components.device_tracker.legacy import YAML_DEVICES
 from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME,
-    CONF_TRACK_NEW,
     CONF_AWAY_HIDE,
+    CONF_CONSIDER_HOME,
     CONF_NEW_DEVICE_DEFAULTS,
+    CONF_TRACK_NEW,
 )
+from homeassistant.components.device_tracker.legacy import YAML_DEVICES
 from homeassistant.components.unifi_direct.device_tracker import (
-    DOMAIN,
     CONF_PORT,
+    DOMAIN,
     PLATFORM_SCHEMA,
     _response_to_json,
     get_scanner,
 )
-from homeassistant.const import CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME, CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
+from homeassistant.setup import async_setup_component
 
-from tests.common import assert_setup_component, mock_component, load_fixture
+from tests.common import assert_setup_component, load_fixture, mock_component
 
 scanner_path = (
     "homeassistant.components.unifi_direct.device_tracker." + "UnifiDeviceScanner"

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -5,14 +5,14 @@ import unittest
 
 from voluptuous.error import MultipleInvalid
 
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_PLAYING, STATE_PAUSED
-import homeassistant.components.switch as switch
 import homeassistant.components.input_number as input_number
 import homeassistant.components.input_select as input_select
 import homeassistant.components.media_player as media_player
+import homeassistant.components.switch as switch
 import homeassistant.components.universal.media_player as universal
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_PAUSED, STATE_PLAYING
 
-from tests.common import mock_service, get_test_home_assistant
+from tests.common import get_test_home_assistant, mock_service
 
 
 def validate_config(config):

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -1,16 +1,14 @@
 """Test UPnP/IGD setup process."""
 
 from ipaddress import ip_address
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-from homeassistant.setup import async_setup_component
 from homeassistant.components import upnp
 from homeassistant.components.upnp.device import Device
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
-from tests.common import MockDependency
-from tests.common import mock_coro
+from tests.common import MockConfigEntry, MockDependency, mock_coro
 
 
 class MockDevice(Device):

--- a/tests/components/uptime/test_sensor.py
+++ b/tests/components/uptime/test_sensor.py
@@ -1,11 +1,12 @@
 """The tests for the uptime sensor platform."""
 import asyncio
+from datetime import timedelta
 import unittest
 from unittest.mock import patch
-from datetime import timedelta
 
-from homeassistant.setup import setup_component
 from homeassistant.components.uptime.sensor import UptimeSensor
+from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -1,36 +1,37 @@
 """The tests for the USGS Earthquake Hazards Program Feed platform."""
 import datetime
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.components.usgs_earthquakes_feed.geo_location import (
     ATTR_ALERT,
     ATTR_EXTERNAL_ID,
-    SCAN_INTERVAL,
-    ATTR_PLACE,
     ATTR_MAGNITUDE,
+    ATTR_PLACE,
     ATTR_STATUS,
-    ATTR_TYPE,
     ATTR_TIME,
+    ATTR_TYPE,
     ATTR_UPDATED,
     CONF_FEED_TYPE,
+    SCAN_INTERVAL,
 )
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START,
-    CONF_RADIUS,
+    ATTR_ATTRIBUTION,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
-    ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    ATTR_ICON,
+    CONF_RADIUS,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.setup import async_setup_component
-from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
+
+from tests.common import assert_setup_component, async_fire_time_changed
 
 CONFIG = {
     geo_location.DOMAIN: [

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -3,15 +3,15 @@ import socket
 import unittest
 from unittest import mock
 
+import pytest
 import requests
-from uvcclient import camera
-from uvcclient import nvr
+from uvcclient import camera, nvr
 
+from homeassistant.components.uvc import camera as uvc
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.setup import setup_component
-from homeassistant.components.uvc import camera as uvc
+
 from tests.common import get_test_home_assistant
-import pytest
 
 
 class TestUVCSetup(unittest.TestCase):


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"u"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/ue_smart_radio/media_player.py` 
- `homeassistant/components/uk_transport/sensor.py` 
- `homeassistant/components/universal/media_player.py` 
- `homeassistant/components/updater/__init__.py` 
- `homeassistant/components/updater/binary_sensor.py` 
- `homeassistant/components/uscis/sensor.py` 
- `tests/components/uk_transport/test_sensor.py` 
- `tests/components/unifi_direct/test_device_tracker.py` 
- `tests/components/universal/test_media_player.py` 
- `tests/components/upnp/test_init.py` 
- `tests/components/uptime/test_sensor.py` 
- `tests/components/usgs_earthquakes_feed/test_geo_location.py` 
- `tests/components/uvc/test_camera.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
