### PR TITLE
Sort imports according to PEP8 for components starting with "V"

### DIFF
--- a/homeassistant/components/vasttrafik/sensor.py
+++ b/homeassistant/components/vasttrafik/sensor.py
@@ -5,9 +5,9 @@ import logging
 import vasttrafik
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.dt import now

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -4,27 +4,27 @@ import logging
 from venstarcolortouch import VenstarColorTouch
 import voluptuous as vol
 
-from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
+    FAN_AUTO,
+    FAN_ON,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_COOL,
-    CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_OFF,
-    SUPPORT_FAN_MODE,
-    FAN_ON,
-    FAN_AUTO,
-    SUPPORT_TARGET_HUMIDITY,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
     PRESET_AWAY,
     PRESET_NONE,
+    SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.const import (

--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -1,25 +1,24 @@
 """Support for Vera devices."""
-import logging
 from collections import defaultdict
+import logging
 
 import pyvera as veraApi
-import voluptuous as vol
 from requests.exceptions import RequestException
+import voluptuous as vol
 
-from homeassistant.util.dt import utc_from_timestamp
-from homeassistant.util import convert, slugify
-from homeassistant.helpers import discovery
-from homeassistant.helpers import config_validation as cv
 from homeassistant.const import (
     ATTR_ARMED,
     ATTR_BATTERY_LEVEL,
     ATTR_LAST_TRIP_TIME,
     ATTR_TRIPPED,
-    EVENT_HOMEASSISTANT_STOP,
-    CONF_LIGHTS,
     CONF_EXCLUDE,
+    CONF_LIGHTS,
+    EVENT_HOMEASSISTANT_STOP,
 )
+from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import convert, slugify
+from homeassistant.util.dt import utc_from_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -1,20 +1,20 @@
 """Sensor that can display the current Home Assistant versions."""
-import logging
 from datetime import timedelta
+import logging
 
 from pyhaversion import (
-    LocalVersion,
     DockerVersion,
-    HassioVersion,
-    PyPiVersion,
     HaIoVersion,
+    HassioVersion,
+    LocalVersion,
+    PyPiVersion,
 )
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_SOURCE
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 

--- a/homeassistant/components/vivotek/camera.py
+++ b/homeassistant/components/vivotek/camera.py
@@ -2,9 +2,10 @@
 
 import logging
 
-import voluptuous as vol
 from libpyvivotek import VivotekCamera
+import voluptuous as vol
 
+from homeassistant.components.camera import PLATFORM_SCHEMA, SUPPORT_STREAM, Camera
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_NAME,
@@ -13,7 +14,6 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.components.camera import PLATFORM_SCHEMA, SUPPORT_STREAM, Camera
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/vlc/media_player.py
+++ b/homeassistant/components/vlc/media_player.py
@@ -1,10 +1,10 @@
 """Provide functionality to interact with vlc devices on the network."""
 import logging
 
-import voluptuous as vol
 import vlc
+import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_PAUSE,
@@ -17,7 +17,6 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import CONF_NAME, STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -1,33 +1,33 @@
 """Provide functionality to interact with the vlc telnet interface."""
 import logging
+
+from python_telnet_vlc import ConnectionError as ConnErr, VLCTelnet
 import voluptuous as vol
 
-from python_telnet_vlc import VLCTelnet, ConnectionError as ConnErr
-
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
+    SUPPORT_CLEAR_PLAYLIST,
+    SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SEEK,
+    SUPPORT_SHUFFLE_SET,
     SUPPORT_STOP,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SEEK,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_CLEAR_PLAYLIST,
-    SUPPORT_SHUFFLE_SET,
 )
 from homeassistant.const import (
+    CONF_HOST,
     CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
     STATE_IDLE,
     STATE_PAUSED,
     STATE_PLAYING,
     STATE_UNAVAILABLE,
-    CONF_HOST,
-    CONF_PORT,
-    CONF_PASSWORD,
 )
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/volkszaehler/sensor.py
+++ b/homeassistant/components/volkszaehler/sensor.py
@@ -9,11 +9,11 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST,
+    CONF_MONITORED_CONDITIONS,
     CONF_NAME,
     CONF_PORT,
-    CONF_MONITORED_CONDITIONS,
-    POWER_WATT,
     ENERGY_WATT_HOUR,
+    POWER_WATT,
 )
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -14,7 +14,7 @@ import socket
 import aiohttp
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_CLEAR_PLAYLIST,
@@ -25,11 +25,11 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SEEK,
     SUPPORT_SELECT_SOURCE,
+    SUPPORT_SHUFFLE_SET,
     SUPPORT_STOP,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
-    SUPPORT_SHUFFLE_SET,
 )
 from homeassistant.const import (
     CONF_HOST,

--- a/tests/components/voicerss/test_tts.py
+++ b/tests/components/voicerss/test_tts.py
@@ -3,16 +3,15 @@ import asyncio
 import os
 import shutil
 
-import homeassistant.components.tts as tts
 from homeassistant.components.media_player.const import (
-    SERVICE_PLAY_MEDIA,
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
+    SERVICE_PLAY_MEDIA,
 )
+import homeassistant.components.tts as tts
 from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component, mock_service
-
+from tests.common import assert_setup_component, get_test_home_assistant, mock_service
 from tests.components.tts.test_init import mutagen_mock  # noqa: F401
 
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"v"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/vasttrafik/sensor.py` 
- `homeassistant/components/venstar/climate.py` 
- `homeassistant/components/vera/__init__.py` 
- `homeassistant/components/version/sensor.py` 
- `homeassistant/components/vivotek/camera.py` 
- `homeassistant/components/vlc/media_player.py` 
- `homeassistant/components/vlc_telnet/media_player.py` 
- `homeassistant/components/volkszaehler/sensor.py` 
- `homeassistant/components/volumio/media_player.py` 
- `tests/components/voicerss/test_tts.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
