### PR TITLE
Sort imports according to PEP8 for components starting with "W"

### DIFF
--- a/homeassistant/components/w800rf32/__init__.py
+++ b/homeassistant/components/w800rf32/__init__.py
@@ -1,15 +1,14 @@
 """Support for w800rf32 devices."""
 import logging
 
-import voluptuous as vol
 import W800rf32 as w800
+import voluptuous as vol
 
 from homeassistant.const import (
     CONF_DEVICE,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
 )
-
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
 

--- a/homeassistant/components/w800rf32/binary_sensor.py
+++ b/homeassistant/components/w800rf32/binary_sensor.py
@@ -1,8 +1,8 @@
 """Support for w800rf32 binary sensors."""
 import logging
 
-import voluptuous as vol
 import W800rf32 as w800
+import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,

--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -1,21 +1,21 @@
 """Support for the World Air Quality Index service."""
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
 import aiohttp
 import voluptuous as vol
 from waqiasync import WaqiClient
 
-from homeassistant.exceptions import PlatformNotReady
-import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
-    ATTR_TIME,
     ATTR_TEMPERATURE,
+    ATTR_TIME,
     CONF_TOKEN,
 )
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -1,32 +1,31 @@
 """Support for water heater devices."""
 from datetime import timedelta
-import logging
 import functools as ft
+import logging
 
 import voluptuous as vol
 
-from homeassistant.helpers.temperature import display_temp as show_temp
-from homeassistant.util.temperature import convert as convert_temperature
-from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity import Entity
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_TEMPERATURE,
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
-    STATE_ON,
-    STATE_OFF,
-    TEMP_CELSIUS,
-    PRECISION_WHOLE,
-    PRECISION_TENTHS,
-    TEMP_FAHRENHEIT,
-)
-
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.temperature import display_temp as show_temp
+from homeassistant.util.temperature import convert as convert_temperature
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/components/waterfurnace/__init__.py
+++ b/homeassistant/components/waterfurnace/__init__.py
@@ -1,16 +1,15 @@
 """Support for Waterfurnaces."""
 from datetime import timedelta
 import logging
-import time
 import threading
+import time
 
 import voluptuous as vol
 from waterfurnace.waterfurnace import WaterFurnace, WFCredentialError, WFException
 
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import discovery
+from homeassistant.helpers import config_validation as cv, discovery
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/watson_tts/tts.py
+++ b/homeassistant/components/watson_tts/tts.py
@@ -1,8 +1,8 @@
 """Support for IBM Watson TTS integration."""
 import logging
 
-from ibm_watson import TextToSpeechV1
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_watson import TextToSpeechV1
 import voluptuous as vol
 
 from homeassistant.components.tts import PLATFORM_SCHEMA, Provider

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.temperature import display_temp as show_temp
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -1,14 +1,14 @@
 """Webhooks for Home Assistant."""
 import logging
 
-from aiohttp.web import Response, Request
+from aiohttp.web import Request, Response
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.loader import bind_hass
 from homeassistant.auth.util import generate_secret
 from homeassistant.components import websocket_api
 from homeassistant.components.http.view import HomeAssistantView
+from homeassistant.core import callback
+from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/weblink/__init__.py
+++ b/homeassistant/components/weblink/__init__.py
@@ -3,10 +3,10 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, CONF_ICON, CONF_URL
+from homeassistant.const import CONF_ICON, CONF_NAME, CONF_URL
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
-import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -6,8 +6,8 @@ import os
 import time
 
 from aiohttp.web import Response
-import pywink
 from pubnubsubhandler import PubNubSubscriptionHandler
+import pywink
 import voluptuous as vol
 
 from homeassistant.components.http import HomeAssistantView

--- a/homeassistant/components/wink/climate.py
+++ b/homeassistant/components/wink/climate.py
@@ -23,12 +23,12 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     PRESET_AWAY,
     PRESET_ECO,
+    PRESET_NONE,
     SUPPORT_AUX_HEAT,
     SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
-    SUPPORT_PRESET_MODE,
-    PRESET_NONE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, TEMP_CELSIUS
 from homeassistant.helpers.temperature import display_temp as show_temp

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -1,12 +1,12 @@
 """Sensor to indicate whether the current day is a workday."""
-import logging
 from datetime import datetime, timedelta
+import logging
 
 import holidays
 import voluptuous as vol
 
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import CONF_NAME, WEEKDAYS
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/worldclock/sensor.py
+++ b/homeassistant/components/worldclock/sensor.py
@@ -5,9 +5,9 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
-import homeassistant.util.dt as dt_util
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/worxlandroid/sensor.py
+++ b/homeassistant/components/worxlandroid/sensor.py
@@ -1,18 +1,16 @@
 """Support for Worx Landroid mower."""
-import logging
 import asyncio
+import logging
 
 import aiohttp
 import async_timeout
-
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-
-from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_PIN, CONF_TIMEOUT
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wsdot/sensor.py
+++ b/homeassistant/components/wsdot/sensor.py
@@ -1,21 +1,21 @@
 """Support for Washington State Department of Transportation (WSDOT) data."""
+from datetime import datetime, timedelta, timezone
 import logging
 import re
-from datetime import datetime, timezone, timedelta
 
 import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_NAME,
     ATTR_ATTRIBUTION,
-    CONF_ID,
     ATTR_NAME,
+    CONF_API_KEY,
+    CONF_ID,
+    CONF_NAME,
 )
-from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wunderground/sensor.py
+++ b/homeassistant/components/wunderground/sensor.py
@@ -9,27 +9,27 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.components import sensor
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS,
+    ATTR_ATTRIBUTION,
     CONF_API_KEY,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    TEMP_FAHRENHEIT,
-    TEMP_CELSIUS,
+    CONF_MONITORED_CONDITIONS,
+    LENGTH_FEET,
     LENGTH_INCHES,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
-    LENGTH_FEET,
-    ATTR_ATTRIBUTION,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
 )
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.util import Throttle
 
 _RESOURCE = "http://api.wunderground.com/api/{}/{}/{}/q/"
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/wunderlist/__init__.py
+++ b/homeassistant/components/wunderlist/__init__.py
@@ -4,8 +4,8 @@ import logging
 import voluptuous as vol
 from wunderpy2 import WunderApi
 
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_NAME, CONF_ACCESS_TOKEN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -2,7 +2,6 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.helpers import config_validation as cv
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
@@ -12,6 +11,7 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM_METRIC,
 )
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 
 from .const import CONF_WINDOW, DEFAULT_RADIUS, DEFAULT_WINDOW, DOMAIN
 

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -2,13 +2,12 @@
 import unittest
 from unittest.mock import patch
 
-from homeassistant.setup import setup_component
-from homeassistant.const import STATE_ON, STATE_OFF
 import homeassistant.components.switch as switch
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant, mock_service
 from tests.components.switch import common
-
 
 TEST_STATE = None
 

--- a/tests/components/water_heater/common.py
+++ b/tests/components/water_heater/common.py
@@ -9,8 +9,8 @@ from homeassistant.components.water_heater import (
     ATTR_OPERATION_MODE,
     DOMAIN,
     SERVICE_SET_AWAY_MODE,
-    SERVICE_SET_TEMPERATURE,
     SERVICE_SET_OPERATION_MODE,
+    SERVICE_SET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, ENTITY_MATCH_ALL
 from homeassistant.loader import bind_hass

--- a/tests/components/weather/test_weather.py
+++ b/tests/components/weather/test_weather.py
@@ -3,6 +3,11 @@ import unittest
 
 from homeassistant.components import weather
 from homeassistant.components.weather import (
+    ATTR_FORECAST,
+    ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_PRECIPITATION,
+    ATTR_FORECAST_TEMP,
+    ATTR_FORECAST_TEMP_LOW,
     ATTR_WEATHER_ATTRIBUTION,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_OZONE,
@@ -10,14 +15,9 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED,
-    ATTR_FORECAST,
-    ATTR_FORECAST_CONDITION,
-    ATTR_FORECAST_PRECIPITATION,
-    ATTR_FORECAST_TEMP,
-    ATTR_FORECAST_TEMP_LOW,
 )
-from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.setup import setup_component
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/weblink/test_init.py
+++ b/tests/components/weblink/test_init.py
@@ -1,8 +1,8 @@
 """The tests for the weblink component."""
 import unittest
 
-from homeassistant.setup import setup_component
 from homeassistant.components import weblink
+from homeassistant.setup import setup_component
 
 from tests.common import get_test_home_assistant
 

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -5,8 +5,7 @@ from unittest.mock import patch
 from homeassistant.components.workday.binary_sensor import day_to_string
 from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, assert_setup_component
-
+from tests.common import assert_setup_component, get_test_home_assistant
 
 FUNCTION_PATH = "homeassistant.components.workday.binary_sensor.get_date"
 

--- a/tests/components/worldclock/test_sensor.py
+++ b/tests/components/worldclock/test_sensor.py
@@ -2,8 +2,9 @@
 import unittest
 
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant
 import homeassistant.util.dt as dt_util
+
+from tests.common import get_test_home_assistant
 
 
 class TestWorldClockSensor(unittest.TestCase):

--- a/tests/components/wsdot/test_sensor.py
+++ b/tests/components/wsdot/test_sensor.py
@@ -4,7 +4,6 @@ import re
 import unittest
 
 import requests_mock
-from tests.common import get_test_home_assistant, load_fixture
 
 import homeassistant.components.wsdot.sensor as wsdot
 from homeassistant.components.wsdot.sensor import (
@@ -18,6 +17,8 @@ from homeassistant.components.wsdot.sensor import (
     SCAN_INTERVAL,
 )
 from homeassistant.setup import setup_component
+
+from tests.common import get_test_home_assistant, load_fixture
 
 
 class TestWSDOT(unittest.TestCase):

--- a/tests/components/wunderground/test_sensor.py
+++ b/tests/components/wunderground/test_sensor.py
@@ -1,14 +1,15 @@
 """The tests for the WUnderground platform."""
 import asyncio
-import aiohttp
 
+import aiohttp
 from pytest import raises
 
 import homeassistant.components.wunderground.sensor as wunderground
-from homeassistant.const import TEMP_CELSIUS, LENGTH_INCHES, STATE_UNKNOWN
+from homeassistant.const import LENGTH_INCHES, STATE_UNKNOWN, TEMP_CELSIUS
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.setup import async_setup_component
-from tests.common import load_fixture, assert_setup_component
+
+from tests.common import assert_setup_component, load_fixture
 
 VALID_CONFIG_PWS = {
     "platform": "wunderground",


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"w"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/w800rf32/__init__.py` 
- `homeassistant/components/w800rf32/binary_sensor.py` 
- `homeassistant/components/waqi/sensor.py` 
- `homeassistant/components/water_heater/__init__.py` 
- `homeassistant/components/waterfurnace/__init__.py` 
- `homeassistant/components/watson_tts/tts.py` 
- `homeassistant/components/weather/__init__.py` 
- `homeassistant/components/webhook/__init__.py` 
- `homeassistant/components/weblink/__init__.py` 
- `homeassistant/components/wink/__init__.py` 
- `homeassistant/components/wink/climate.py` 
- `homeassistant/components/workday/binary_sensor.py` 
- `homeassistant/components/worldclock/sensor.py` 
- `homeassistant/components/worxlandroid/sensor.py` 
- `homeassistant/components/wsdot/sensor.py` 
- `homeassistant/components/wunderground/sensor.py` 
- `homeassistant/components/wunderlist/__init__.py` 
- `homeassistant/components/wwlln/config_flow.py` 
- `tests/components/wake_on_lan/test_switch.py` 
- `tests/components/water_heater/common.py` 
- `tests/components/weather/test_weather.py` 
- `tests/components/weblink/test_init.py` 
- `tests/components/workday/test_binary_sensor.py` 
- `tests/components/worldclock/test_sensor.py` 
- `tests/components/wsdot/test_sensor.py` 
- `tests/components/wunderground/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
