### PR TITLE
Sort imports according to PEP8 for components starting with "X"

### DIFF
--- a/homeassistant/components/x10/light.py
+++ b/homeassistant/components/x10/light.py
@@ -1,16 +1,16 @@
 """Support for X10 lights."""
 import logging
-from subprocess import check_output, CalledProcessError, STDOUT
+from subprocess import STDOUT, CalledProcessError, check_output
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, CONF_ID, CONF_DEVICES
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
     Light,
-    PLATFORM_SCHEMA,
 )
+from homeassistant.const import CONF_DEVICES, CONF_ID, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/xbox_live/sensor.py
+++ b/homeassistant/components/xbox_live/sensor.py
@@ -1,6 +1,6 @@
 """Sensor for Xbox Live account status."""
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 from xboxapi import xbox_api

--- a/homeassistant/components/xeoma/camera.py
+++ b/homeassistant/components/xeoma/camera.py
@@ -1,8 +1,8 @@
 """Support for Xeoma Cameras."""
 import logging
 
-import voluptuous as vol
 from pyxeoma.xeoma import Xeoma, XeomaError
+import voluptuous as vol
 
 from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME

--- a/homeassistant/components/xfinity/device_tracker.py
+++ b/homeassistant/components/xfinity/device_tracker.py
@@ -5,13 +5,13 @@ from requests.exceptions import RequestException
 import voluptuous as vol
 from xfinity_gateway import XfinityGateway
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN,
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
 from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/xiaomi_tv/media_player.py
+++ b/homeassistant/components/xiaomi_tv/media_player.py
@@ -1,10 +1,10 @@
 """Add support for the Xiaomi TVs."""
 import logging
 
-import voluptuous as vol
 import pymitv
+import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,

--- a/homeassistant/components/xmpp/notify.py
+++ b/homeassistant/components/xmpp/notify.py
@@ -9,14 +9,20 @@ import string
 import requests
 import slixmpp
 from slixmpp.exceptions import IqError, IqTimeout, XMPPError
-from slixmpp.xmlstream.xmlstream import NotConnectedError
 from slixmpp.plugins.xep_0363.http_upload import (
     FileTooBig,
     FileUploadError,
     UploadServiceNotFound,
 )
+from slixmpp.xmlstream.xmlstream import NotConnectedError
 import voluptuous as vol
 
+from homeassistant.components.notify import (
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_RECIPIENT,
@@ -26,13 +32,6 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.template as template_helper
-
-from homeassistant.components.notify import (
-    ATTR_TITLE,
-    ATTR_TITLE_DEFAULT,
-    PLATFORM_SCHEMA,
-    BaseNotificationService,
-)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/xs1/climate.py
+++ b/homeassistant/components/xs1/climate.py
@@ -5,8 +5,8 @@ from xs1_api_client.api_constants import ActuatorType
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE,
     HVAC_MODE_HEAT,
+    SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_TEMPERATURE
 

--- a/tests/components/xiaomi/test_device_tracker.py
+++ b/tests/components/xiaomi/test_device_tracker.py
@@ -1,13 +1,13 @@
 """The tests for the Xiaomi router device tracker platform."""
 import logging
-from asynctest import mock, patch
 
+from asynctest import mock, patch
 import requests
 
 from homeassistant.components.device_tracker import DOMAIN
 import homeassistant.components.xiaomi.device_tracker as xiaomi
 from homeassistant.components.xiaomi.device_tracker import get_scanner
-from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PLATFORM
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"x"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/x10/light.py` 
- `homeassistant/components/xbox_live/sensor.py` 
- `homeassistant/components/xeoma/camera.py` 
- `homeassistant/components/xfinity/device_tracker.py` 
- `homeassistant/components/xiaomi_tv/media_player.py` 
- `homeassistant/components/xmpp/notify.py` 
- `homeassistant/components/xs1/climate.py` 
- `tests/components/xiaomi/test_device_tracker.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
