### PR TITLE
Sort imports according to PEP8 for components starting with "Y"

### DIFF
--- a/homeassistant/components/yale_smart_alarm/alarm_control_panel.py
+++ b/homeassistant/components/yale_smart_alarm/alarm_control_panel.py
@@ -3,11 +3,11 @@ import logging
 
 import voluptuous as vol
 from yalesmartalarmclient.client import (
-    YaleSmartAlarmClient,
-    AuthenticationError,
-    YALE_STATE_DISARM,
-    YALE_STATE_ARM_PARTIAL,
     YALE_STATE_ARM_FULL,
+    YALE_STATE_ARM_PARTIAL,
+    YALE_STATE_DISARM,
+    AuthenticationError,
+    YaleSmartAlarmClient,
 )
 
 from homeassistant.components.alarm_control_panel import (

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -5,7 +5,7 @@ import requests
 import rxv
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_NEXT_TRACK,
@@ -13,15 +13,14 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SELECT_SOUND_MODE,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
-    SUPPORT_SELECT_SOUND_MODE,
 )
-
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -1,11 +1,11 @@
 """Support for Yamaha MusicCast Receivers."""
 import logging
-
 import socket
+
 import pymusiccast
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_NEXT_TRACK,

--- a/homeassistant/components/yandex_transport/sensor.py
+++ b/homeassistant/components/yandex_transport/sensor.py
@@ -1,16 +1,16 @@
 """Service for obtaining information about closer bus from Transport Yandex Service."""
 
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 from ya_ma import YandexMapsRequester
 
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION, DEVICE_CLASS_TIMESTAMP
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, DEVICE_CLASS_TIMESTAMP
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/yeelightsunflower/light.py
+++ b/homeassistant/components/yeelightsunflower/light.py
@@ -1,19 +1,19 @@
 """Support for Yeelight Sunflower color bulbs (not Yeelight Blue or WiFi)."""
 import logging
 
-import yeelightsunflower
 import voluptuous as vol
+import yeelightsunflower
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.light import (
-    Light,
-    ATTR_HS_COLOR,
-    SUPPORT_COLOR,
     ATTR_BRIGHTNESS,
-    SUPPORT_BRIGHTNESS,
+    ATTR_HS_COLOR,
     PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR,
+    Light,
 )
 from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/yessssms/notify.py
+++ b/homeassistant/components/yessssms/notify.py
@@ -1,15 +1,12 @@
 """Support for the YesssSMS platform."""
 import logging
 
+from YesssSMS import YesssSMS
 import voluptuous as vol
 
-from YesssSMS import YesssSMS
-
+from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
 from homeassistant.const import CONF_PASSWORD, CONF_RECIPIENT, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
-
 
 from .const import CONF_PROVIDER
 

--- a/homeassistant/components/yr/sensor.py
+++ b/homeassistant/components/yr/sensor.py
@@ -1,23 +1,21 @@
 """Support for Yr.no weather service."""
 import asyncio
 import logging
-
 from random import randrange
 from xml.parsers.expat import ExpatError
 
 import aiohttp
 import async_timeout
-import xmltodict
 import voluptuous as vol
+import xmltodict
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    CONF_ELEVATION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_ELEVATION,
     CONF_MONITORED_CONDITIONS,
-    ATTR_ATTRIBUTION,
     CONF_NAME,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_PRESSURE,
@@ -26,8 +24,9 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_utc_time_change, async_call_later
+from homeassistant.helpers.event import async_call_later, async_track_utc_time_change
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -1,10 +1,11 @@
 """The tests for the Yamaha Media player platform."""
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-from homeassistant.setup import setup_component
 import homeassistant.components.media_player as mp
 from homeassistant.components.yamaha import media_player as yamaha
+from homeassistant.setup import setup_component
+
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/yandex_transport/test_yandex_transport_sensor.py
+++ b/tests/components/yandex_transport/test_yandex_transport_sensor.py
@@ -1,15 +1,17 @@
 """Tests for the yandex transport platform."""
 
 import json
+
 import pytest
 
 import homeassistant.components.sensor as sensor
-import homeassistant.util.dt as dt_util
 from homeassistant.const import CONF_NAME
+import homeassistant.util.dt as dt_util
+
 from tests.common import (
+    MockDependency,
     assert_setup_component,
     async_setup_component,
-    MockDependency,
     load_fixture,
 )
 

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -3,14 +3,14 @@ import asyncio
 import os
 import shutil
 
+from homeassistant.components.media_player.const import (
+    DOMAIN as DOMAIN_MP,
+    SERVICE_PLAY_MEDIA,
+)
 import homeassistant.components.tts as tts
 from homeassistant.setup import setup_component
-from homeassistant.components.media_player.const import (
-    SERVICE_PLAY_MEDIA,
-    DOMAIN as DOMAIN_MP,
-)
-from tests.common import get_test_home_assistant, assert_setup_component, mock_service
 
+from tests.common import assert_setup_component, get_test_home_assistant, mock_service
 from tests.components.tts.test_init import mutagen_mock  # noqa: F401
 
 

--- a/tests/components/yessssms/test_notify.py
+++ b/tests/components/yessssms/test_notify.py
@@ -1,16 +1,15 @@
 """The tests for the notify yessssms platform."""
+import logging
 import unittest
 from unittest.mock import patch
 
-import logging
 import pytest
 import requests_mock
 
-from homeassistant.setup import async_setup_component
-import homeassistant.components.yessssms.notify as yessssms
 from homeassistant.components.yessssms.const import CONF_PROVIDER
-
+import homeassistant.components.yessssms.notify as yessssms
 from homeassistant.const import CONF_PASSWORD, CONF_RECIPIENT, CONF_USERNAME
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(name="config")

--- a/tests/components/yr/test_sensor.py
+++ b/tests/components/yr/test_sensor.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 import homeassistant.util.dt as dt_util
-from tests.common import assert_setup_component, load_fixture
 
+from tests.common import assert_setup_component, load_fixture
 
 NOW = datetime(2016, 6, 9, 1, tzinfo=dt_util.UTC)
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"y"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/yale_smart_alarm/alarm_control_panel.py` 
- `homeassistant/components/yamaha/media_player.py` 
- `homeassistant/components/yamaha_musiccast/media_player.py` 
- `homeassistant/components/yandex_transport/sensor.py` 
- `homeassistant/components/yeelightsunflower/light.py` 
- `homeassistant/components/yessssms/notify.py` 
- `homeassistant/components/yr/sensor.py` 
- `tests/components/yamaha/test_media_player.py` 
- `tests/components/yandex_transport/test_yandex_transport_sensor.py` 
- `tests/components/yandextts/test_tts.py` 
- `tests/components/yessssms/test_notify.py` 
- `tests/components/yr/test_sensor.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
