### PR TITLE
Sort imports according to PEP8 for components starting with "Z"

### DIFF
--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -1,8 +1,6 @@
 """Support to check for available updates."""
 import asyncio
 from datetime import timedelta
-
-# pylint: disable=import-error
 from distutils.version import StrictVersion
 import json
 import logging
@@ -10,7 +8,7 @@ import uuid
 
 import aiohttp
 import async_timeout
-from distro import linux_distribution
+from distro import linux_distribution  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.const import __version__ as current_version

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -12,18 +12,18 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.weather import (
+    ATTR_WEATHER_ATTRIBUTION,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
-    ATTR_WEATHER_WIND_SPEED,
-    ATTR_WEATHER_ATTRIBUTION,
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_WIND_BEARING,
+    ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import (
-    CONF_NAME,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
     __version__,
 )
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/zengge/light.py
+++ b/homeassistant/components/zengge/light.py
@@ -1,20 +1,20 @@
 """Support for Zengge lights."""
 import logging
 
-from zengge import zengge
 import voluptuous as vol
+from zengge import zengge
 
-from homeassistant.const import CONF_DEVICES, CONF_NAME
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
     ATTR_WHITE_VALUE,
+    PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     SUPPORT_WHITE_VALUE,
     Light,
-    PLATFORM_SCHEMA,
 )
+from homeassistant.const import CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -1,26 +1,25 @@
 """Support for exposing Home Assistant via Zeroconf."""
 
+import ipaddress
 import logging
 import socket
 
-import ipaddress
 import voluptuous as vol
-
 from zeroconf import (
+    NonUniqueNameException,
     ServiceBrowser,
     ServiceInfo,
     ServiceStateChange,
     Zeroconf,
-    NonUniqueNameException,
 )
 
 from homeassistant import util
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_STOP,
     EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
     __version__,
 )
-from homeassistant.generated.zeroconf import ZEROCONF, HOMEKIT
+from homeassistant.generated.zeroconf import HOMEKIT, ZEROCONF
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zestimate/sensor.py
+++ b/homeassistant/components/zestimate/sensor.py
@@ -3,11 +3,11 @@ from datetime import timedelta
 import logging
 
 import requests
-import xmltodict
 import voluptuous as vol
+import xmltodict
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_API_KEY, CONF_NAME, ATTR_ATTRIBUTION
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -8,8 +8,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 
 # Loading the config flow file will register the flow
-from . import config_flow  # noqa: F401 pylint: disable=unused-import
 from . import api
+from . import config_flow  # noqa: F401 pylint: disable=unused-import
 from .core import ZHAGateway
 from .core.const import (
     COMPONENTS,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -8,6 +8,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 
 from . import api
+from . import config_flow  # noqa: F401 pylint: disable=unused-import
 from .core import ZHAGateway
 from .core.const import (
     COMPONENTS,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -1,4 +1,8 @@
-"""Support for Zigbee Home Automation devices."""
+"""Support for Zigbee Home Automation devices.
+
+isort:skip_file
+"""
+
 import logging
 
 import voluptuous as vol
@@ -7,8 +11,8 @@ from homeassistant import config_entries, const as ha_const
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 
-from . import api
 from . import config_flow  # noqa: F401 pylint: disable=unused-import
+from . import api
 from .core import ZHAGateway
 from .core.const import (
     COMPONENTS,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -7,9 +7,7 @@ from homeassistant import config_entries, const as ha_const
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 
-# Loading the config flow file will register the flow
 from . import api
-from . import config_flow  # noqa: F401 pylint: disable=unused-import
 from .core import ZHAGateway
 from .core.const import (
     COMPONENTS,
@@ -100,7 +98,7 @@ async def async_setup_entry(hass, config_entry):
     if config.get(CONF_ENABLE_QUIRKS, True):
         # needs to be done here so that the ZHA module is finished loading
         # before zhaquirks is imported
-        import zhaquirks  # noqa: F401 pylint: disable=unused-import, import-outside-toplevel
+        import zhaquirks  # noqa: F401 pylint: disable=unused-import, import-outside-toplevel, import-error
 
     zha_gateway = ZHAGateway(hass, config, config_entry)
     await zha_gateway.async_initialize()

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -395,14 +395,16 @@ class EventRelayChannel(ZigbeeChannel):
 
 
 # pylint: disable=wrong-import-position, import-outside-toplevel
-from . import closures  # noqa: F401
-from . import general  # noqa: F401
-from . import homeautomation  # noqa: F401
-from . import hvac  # noqa: F401
-from . import lighting  # noqa: F401
-from . import lightlink  # noqa: F401
-from . import manufacturerspecific  # noqa: F401
-from . import measurement  # noqa: F401
-from . import protocol  # noqa: F401
-from . import security  # noqa: F401
-from . import smartenergy  # noqa: F401
+from . import (  # noqa: F401 isort:skip
+    closures,
+    general,
+    homeautomation,
+    hvac,
+    lighting,
+    lightlink,
+    manufacturerspecific,
+    measurement,
+    protocol,
+    security,
+    smartenergy,
+)

--- a/homeassistant/components/zigbee/__init__.py
+++ b/homeassistant/components/zigbee/__init__.py
@@ -1,24 +1,24 @@
 """Support for Zigbee devices."""
-import logging
 from binascii import hexlify, unhexlify
+import logging
 
-import xbee_helper.const as xb_const
-from xbee_helper import ZigBee
-from xbee_helper.device import convert_adc
-from xbee_helper.exceptions import ZigBeeException, ZigBeeTxFailure
 from serial import Serial, SerialException
 import voluptuous as vol
+from xbee_helper import ZigBee
+import xbee_helper.const as xb_const
+from xbee_helper.device import convert_adc
+from xbee_helper.exceptions import ZigBeeException, ZigBeeTxFailure
 
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_STOP,
+    CONF_ADDRESS,
     CONF_DEVICE,
     CONF_NAME,
     CONF_PIN,
-    CONF_ADDRESS,
+    EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zigbee/switch.py
+++ b/homeassistant/components/zigbee/switch.py
@@ -5,7 +5,6 @@ from homeassistant.components.switch import SwitchDevice
 
 from . import PLATFORM_SCHEMA, ZigBeeDigitalOut, ZigBeeDigitalOutConfig
 
-
 CONF_ON_STATE = "on_state"
 
 DEFAULT_ON_STATE = "high"

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -4,9 +4,9 @@ from unittest.mock import patch
 import pytest
 from zeroconf import ServiceInfo, ServiceStateChange
 
+from homeassistant.components import zeroconf
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.setup import async_setup_component
-from homeassistant.components import zeroconf
 
 
 @pytest.fixture


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"z"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `homeassistant/components/zamg/sensor.py` 
- `homeassistant/components/zengge/light.py` 
- `homeassistant/components/zeroconf/__init__.py` 
- `homeassistant/components/zestimate/sensor.py` 
- `homeassistant/components/zha/__init__.py` 
- `homeassistant/components/zigbee/__init__.py` 
- `homeassistant/components/zigbee/switch.py` 
- `tests/components/zeroconf/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
