### PR TITLE
Sort imports according to PEP8 for components starting with "Q"

### DIFF
--- a/tests/components/qld_bushfire/test_geo_location.py
+++ b/tests/components/qld_bushfire/test_geo_location.py
@@ -1,6 +1,6 @@
 """The tests for the Queensland Bushfire Alert Feed platform."""
 import datetime
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -25,8 +25,9 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.setup import async_setup_component
-from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
+
+from tests.common import assert_setup_component, async_fire_time_changed
 
 CONFIG = {geo_location.DOMAIN: [{"platform": "qld_bushfire", CONF_RADIUS: 200}]}
 

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -1,14 +1,14 @@
 """Test qwikswitch sensors."""
 import logging
 
+from aiohttp.client_exceptions import ClientError
 import pytest
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START
-from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
 from homeassistant.bootstrap import async_setup_component
-from tests.test_util.aiohttp import mock_aiohttp_client
-from aiohttp.client_exceptions import ClientError
+from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
+from homeassistant.const import EVENT_HOMEASSISTANT_START
 
+from tests.test_util.aiohttp import mock_aiohttp_client
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION

## Description:

I have sorted the imports for the components that start with the letter `"q"` according to PEP8 using isort.

I think it would be good if in the future we can add `isort` to the `.pre-commit-config.yaml`.
To do that I will first fix all sorting issues per component.


This PR affects:

- `tests/components/qld_bushfire/test_geo_location.py` 
- `tests/components/qwikswitch/test_init.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
