### PR TITLE
Sort imports according to PEP8 for 'homeassistant' folder

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -5,10 +5,10 @@ import platform
 import subprocess
 import sys
 import threading
-from typing import List, Dict, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from homeassistant import monkey_patch
-from homeassistant.const import __version__, REQUIRED_PYTHON_VER, RESTART_EXIT_CODE
+from homeassistant.const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
 
 if TYPE_CHECKING:
     from homeassistant import core

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -1,21 +1,21 @@
 """Provide an authentication layer for Home Assistant."""
 import asyncio
-import logging
 from collections import OrderedDict
 from datetime import timedelta
+import logging
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 import jwt
 
 from homeassistant import data_entry_flow
 from homeassistant.auth.const import ACCESS_TOKEN_EXPIRATION
-from homeassistant.core import callback, HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
 from . import auth_store, models
 from .const import GROUP_ID_ADMIN
-from .mfa_modules import auth_mfa_module_from_config, MultiFactorAuthModule
-from .providers import auth_provider_from_config, AuthProvider, LoginFlow
+from .mfa_modules import MultiFactorAuthModule, auth_mfa_module_from_config
+from .providers import AuthProvider, LoginFlow, auth_provider_from_config
 
 EVENT_USER_ADDED = "user_added"
 EVENT_USER_REMOVED = "user_removed"

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
 from . import models
-from .const import GROUP_ID_ADMIN, GROUP_ID_USER, GROUP_ID_READ_ONLY
+from .const import GROUP_ID_ADMIN, GROUP_ID_READ_ONLY, GROUP_ID_USER
 from .permissions import PermissionLookup, system_policies
 from .permissions.types import PolicyType
 

--- a/homeassistant/auth/mfa_modules/__init__.py
+++ b/homeassistant/auth/mfa_modules/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
-from homeassistant import requirements, data_entry_flow
+from homeassistant import data_entry_flow, requirements
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError

--- a/homeassistant/auth/mfa_modules/insecure_example.py
+++ b/homeassistant/auth/mfa_modules/insecure_example.py
@@ -7,9 +7,9 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant
 
 from . import (
-    MultiFactorAuthModule,
-    MULTI_FACTOR_AUTH_MODULES,
     MULTI_FACTOR_AUTH_MODULE_SCHEMA,
+    MULTI_FACTOR_AUTH_MODULES,
+    MultiFactorAuthModule,
     SetupFlow,
 )
 

--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -3,9 +3,9 @@
 Sending HOTP through notify service
 """
 import asyncio
-import logging
 from collections import OrderedDict
-from typing import Any, Dict, Optional, List
+import logging
+from typing import Any, Dict, List, Optional
 
 import attr
 import voluptuous as vol
@@ -16,9 +16,9 @@ from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers import config_validation as cv
 
 from . import (
-    MultiFactorAuthModule,
-    MULTI_FACTOR_AUTH_MODULES,
     MULTI_FACTOR_AUTH_MODULE_SCHEMA,
+    MULTI_FACTOR_AUTH_MODULES,
+    MultiFactorAuthModule,
     SetupFlow,
 )
 

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -1,7 +1,7 @@
 """Time-based One Time Password auth module."""
 import asyncio
-import logging
 from io import BytesIO
+import logging
 from typing import Any, Dict, Optional, Tuple
 
 import voluptuous as vol
@@ -10,9 +10,9 @@ from homeassistant.auth.models import User
 from homeassistant.core import HomeAssistant
 
 from . import (
-    MultiFactorAuthModule,
-    MULTI_FACTOR_AUTH_MODULES,
     MULTI_FACTOR_AUTH_MODULE_SCHEMA,
+    MULTI_FACTOR_AUTH_MODULES,
+    MultiFactorAuthModule,
     SetupFlow,
 )
 

--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -5,12 +5,11 @@ from typing import Any, Callable, Optional
 import voluptuous as vol
 
 from .const import CAT_ENTITIES
-from .models import PermissionLookup
-from .types import PolicyType
 from .entities import ENTITY_POLICY_SCHEMA, compile_entities
 from .merge import merge_policies  # noqa: F401
+from .models import PermissionLookup
+from .types import PolicyType
 from .util import test_all
-
 
 POLICY_SCHEMA = vol.Schema({vol.Optional(CAT_ENTITIES): ENTITY_POLICY_SCHEMA})
 

--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -4,11 +4,10 @@ from typing import Callable, Optional
 
 import voluptuous as vol
 
-from .const import SUBCAT_ALL, POLICY_READ, POLICY_CONTROL, POLICY_EDIT
+from .const import POLICY_CONTROL, POLICY_EDIT, POLICY_READ, SUBCAT_ALL
 from .models import PermissionLookup
 from .types import CategoryType, SubCategoryDict, ValueType
-
-from .util import SubCatLookupType, lookup_all, compile_policy
+from .util import SubCatLookupType, compile_policy, lookup_all
 
 SINGLE_ENTITY_SCHEMA = vol.Any(
     True,

--- a/homeassistant/auth/permissions/merge.py
+++ b/homeassistant/auth/permissions/merge.py
@@ -1,7 +1,7 @@
 """Merging of policies."""
-from typing import cast, Dict, List, Set
+from typing import Dict, List, Set, cast
 
-from .types import PolicyType, CategoryType
+from .types import CategoryType, PolicyType
 
 
 def merge_policies(policies: List[PolicyType]) -> PolicyType:

--- a/homeassistant/auth/permissions/system_policies.py
+++ b/homeassistant/auth/permissions/system_policies.py
@@ -1,5 +1,5 @@
 """System policies."""
-from .const import CAT_ENTITIES, SUBCAT_ALL, POLICY_READ
+from .const import CAT_ENTITIES, POLICY_READ, SUBCAT_ALL
 
 ADMIN_POLICY = {CAT_ENTITIES: True}
 

--- a/homeassistant/auth/permissions/util.py
+++ b/homeassistant/auth/permissions/util.py
@@ -1,6 +1,5 @@
 """Helpers to deal with permissions."""
 from functools import wraps
-
 from typing import Callable, Dict, List, Optional, cast
 
 from .const import SUBCAT_ALL

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -8,8 +8,8 @@ import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 from homeassistant import data_entry_flow, requirements
-from homeassistant.core import callback, HomeAssistant
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TYPE
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt as dt_util
 from homeassistant.util.decorator import Registry

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -1,19 +1,17 @@
 """Auth provider that validates credentials via an external command."""
 
-from typing import Any, Dict, Optional, cast
-
 import asyncio.subprocess
 import collections
 import logging
 import os
+from typing import Any, Dict, Optional, cast
 
 import voluptuous as vol
 
 from homeassistant.exceptions import HomeAssistantError
 
-from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
+from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
-
 
 CONF_COMMAND = "command"
 CONF_ARGS = "args"

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -3,20 +3,17 @@ import asyncio
 import base64
 from collections import OrderedDict
 import logging
-
 from typing import Any, Dict, List, Optional, Set, cast
 
 import bcrypt
 import voluptuous as vol
 
 from homeassistant.const import CONF_ID
-from homeassistant.core import callback, HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
-from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
-
+from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
-
 
 STORAGE_VERSION = 1
 STORAGE_KEY = "auth_provider.homeassistant"

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -5,12 +5,11 @@ from typing import Any, Dict, Optional, cast
 
 import voluptuous as vol
 
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 
-from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
+from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
-
 
 USER_SCHEMA = vol.Schema(
     {

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -12,9 +12,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
-from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
+from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from .. import AuthManager
-from ..models import Credentials, UserMeta, User
+from ..models import Credentials, User, UserMeta
 
 AUTH_PROVIDER_TYPE = "legacy_api_password"
 CONF_API_PASSWORD = "api_password"

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -3,15 +3,16 @@
 It shows list of users if access from trusted network.
 Abort login flow if not access from trusted network.
 """
-from ipaddress import ip_network, IPv4Address, IPv6Address, IPv4Network, IPv6Network
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
 from typing import Any, Dict, List, Optional, Union, cast
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
-from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
+import homeassistant.helpers.config_validation as cv
+
+from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
 
 IPAddress = Union[IPv4Address, IPv6Address]

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -1,22 +1,22 @@
 """Provide methods to bootstrap a Home Assistant instance."""
 import asyncio
+from collections import OrderedDict
 import logging
 import logging.handlers
 import os
 import sys
 from time import time
-from collections import OrderedDict
-from typing import Any, Optional, Dict, Set
+from typing import Any, Dict, Optional, Set
 
 import voluptuous as vol
 
-from homeassistant import core, config as conf_util, config_entries, loader
+from homeassistant import config as conf_util, config_entries, core, loader
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.util.logging import AsyncHandler
 from homeassistant.util.package import async_get_user_site, is_virtual_env
 from homeassistant.util.yaml import clear_secret_cache
-from homeassistant.exceptions import HomeAssistantError
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1,59 +1,59 @@
 """Module to help with parsing and generating configuration files."""
-from collections import OrderedDict
-
 # pylint: disable=no-name-in-module
+from collections import OrderedDict
 from distutils.version import LooseVersion  # pylint: disable=import-error
 import logging
 import os
 import re
 import shutil
-from typing import Any, Tuple, Optional, Dict, Union, Callable, Sequence, Set
 from types import ModuleType
+from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, Union
+
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 from homeassistant import auth
 from homeassistant.auth import (
-    providers as auth_providers,
     mfa_modules as auth_mfa_modules,
+    providers as auth_providers,
 )
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     ATTR_FRIENDLY_NAME,
     ATTR_HIDDEN,
-    ATTR_ASSUMED_STATE,
+    CONF_AUTH_MFA_MODULES,
+    CONF_AUTH_PROVIDERS,
+    CONF_CUSTOMIZE,
+    CONF_CUSTOMIZE_DOMAIN,
+    CONF_CUSTOMIZE_GLOB,
+    CONF_ELEVATION,
+    CONF_ID,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_NAME,
     CONF_PACKAGES,
-    CONF_UNIT_SYSTEM,
-    CONF_TIME_ZONE,
-    CONF_ELEVATION,
-    CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_TEMPERATURE_UNIT,
+    CONF_TIME_ZONE,
+    CONF_TYPE,
+    CONF_UNIT_SYSTEM,
+    CONF_UNIT_SYSTEM_IMPERIAL,
+    CONF_WHITELIST_EXTERNAL_DIRS,
     TEMP_CELSIUS,
     __version__,
-    CONF_CUSTOMIZE,
-    CONF_CUSTOMIZE_DOMAIN,
-    CONF_CUSTOMIZE_GLOB,
-    CONF_WHITELIST_EXTERNAL_DIRS,
-    CONF_AUTH_PROVIDERS,
-    CONF_AUTH_MFA_MODULES,
-    CONF_TYPE,
-    CONF_ID,
 )
 from homeassistant.core import DOMAIN as CONF_CORE, SOURCE_YAML, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_per_platform, extract_domain_configs
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_values import EntityValues
 from homeassistant.loader import Integration, IntegrationNotFound
 from homeassistant.requirements import (
-    async_get_integration_with_requirements,
     RequirementsNotFound,
+    async_get_integration_with_requirements,
 )
-from homeassistant.util.yaml import load_yaml, SECRET_YAML
 from homeassistant.util.package import is_docker_env
-import homeassistant.helpers.config_validation as cv
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
-from homeassistant.helpers.entity_values import EntityValues
-from homeassistant.helpers import config_per_platform, extract_domain_configs
+from homeassistant.util.yaml import SECRET_YAML, load_yaml
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1,21 +1,20 @@
 """Manage config entries in Home Assistant."""
 import asyncio
-import logging
 import functools
-import uuid
+import logging
 from typing import Any, Callable, Dict, List, Optional, Set, cast
+import uuid
 import weakref
 
 import attr
 
 from homeassistant import data_entry_flow, loader
-from homeassistant.core import callback, HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ConfigEntryNotReady
-from homeassistant.setup import async_setup_component, async_process_deps_reqs
-from homeassistant.util.decorator import Registry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.event import Event
-
+from homeassistant.setup import async_process_deps_reqs, async_setup_component
+from homeassistant.util.decorator import Registry
 
 _LOGGER = logging.getLogger(__name__)
 _UNDEF: dict = {}

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -14,65 +14,59 @@ import os
 import pathlib
 import threading
 from time import monotonic
-import uuid
-
 from types import MappingProxyType
 from typing import (
-    Optional,
-    Any,
-    Callable,
-    List,
-    TypeVar,
-    Dict,
-    Coroutine,
-    Set,
     TYPE_CHECKING,
+    Any,
     Awaitable,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
     Mapping,
+    Optional,
+    Set,
+    TypeVar,
 )
+import uuid
 
 from async_timeout import timeout
 import attr
 import voluptuous as vol
 
+from homeassistant import loader, util
 from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_FRIENDLY_NAME,
     ATTR_NOW,
+    ATTR_SECONDS,
     ATTR_SERVICE,
     ATTR_SERVICE_DATA,
-    ATTR_SECONDS,
     CONF_UNIT_SYSTEM_IMPERIAL,
     EVENT_CALL_SERVICE,
     EVENT_CORE_CONFIG_UPDATE,
+    EVENT_HOMEASSISTANT_CLOSE,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
-    EVENT_HOMEASSISTANT_CLOSE,
-    EVENT_SERVICE_REMOVED,
     EVENT_SERVICE_REGISTERED,
+    EVENT_SERVICE_REMOVED,
     EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED,
     EVENT_TIMER_OUT_OF_SYNC,
     MATCH_ALL,
     __version__,
 )
-from homeassistant import loader
 from homeassistant.exceptions import (
     HomeAssistantError,
     InvalidEntityFormatError,
     InvalidStateError,
-    Unauthorized,
     ServiceNotFound,
+    Unauthorized,
 )
-from homeassistant.util.async_ import run_callback_threadsafe, fire_coroutine_threadsafe
-from homeassistant import util
-import homeassistant.util.dt as dt_util
 from homeassistant.util import location, slugify
-from homeassistant.util.unit_system import (
-    UnitSystem,
-    IMPERIAL_SYSTEM,
-    METRIC_SYSTEM,
-)
+from homeassistant.util.async_ import fire_coroutine_threadsafe, run_callback_threadsafe
+import homeassistant.util.dt as dt_util
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -1,9 +1,11 @@
 """Classes to help gather user submissions."""
 import logging
-from typing import Dict, Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 import uuid
+
 import voluptuous as vol
-from .core import callback, HomeAssistant
+
+from .core import HomeAssistant, callback
 from .exceptions import HomeAssistantError
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -1,5 +1,6 @@
 """The exceptions used by Home Assistant."""
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
+
 import jinja2
 
 if TYPE_CHECKING:

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -1,6 +1,6 @@
 """Helper methods for components within Home Assistant."""
 import re
-from typing import Any, Iterable, Tuple, Sequence, Dict
+from typing import Any, Dict, Iterable, Sequence, Tuple
 
 from homeassistant.const import CONF_PLATFORM
 

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -1,18 +1,17 @@
 """Helper for aiohttp webclient stuff."""
 import asyncio
-import sys
 from ssl import SSLContext
-from typing import Any, Awaitable, Optional, cast
-from typing import Union
+import sys
+from typing import Any, Awaitable, Optional, Union, cast
 
 import aiohttp
-from aiohttp.hdrs import USER_AGENT, CONTENT_TYPE
 from aiohttp import web
-from aiohttp.web_exceptions import HTTPGatewayTimeout, HTTPBadGateway
+from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
+from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
 import async_timeout
 
-from homeassistant.core import callback, Event
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
+from homeassistant.core import Event, callback
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.loader import bind_hass
 from homeassistant.util import ssl as ssl_util

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -1,10 +1,9 @@
 """Provide a way to connect devices to one physical location."""
-import logging
-import uuid
 from asyncio import Event
 from collections import OrderedDict
-from typing import MutableMapping
-from typing import Iterable, Optional, cast
+import logging
+from typing import Iterable, MutableMapping, Optional, cast
+import uuid
 
 import attr
 

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -6,26 +6,24 @@ import attr
 import voluptuous as vol
 
 from homeassistant import loader
-from homeassistant.core import HomeAssistant
 from homeassistant.config import (
     CONF_CORE,
-    CORE_CONFIG_SCHEMA,
     CONF_PACKAGES,
-    merge_packages_config,
+    CORE_CONFIG_SCHEMA,
     _format_config_error,
+    config_per_platform,
+    extract_domain_configs,
     find_config_file,
     load_yaml_config_file,
-    extract_domain_configs,
-    config_per_platform,
+    merge_packages_config,
 )
-from homeassistant.requirements import (
-    async_get_integration_with_requirements,
-    RequirementsNotFound,
-)
-
-import homeassistant.util.yaml.loader as yaml_loader
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-
+from homeassistant.requirements import (
+    RequirementsNotFound,
+    async_get_integration_with_requirements,
+)
+import homeassistant.util.yaml.loader as yaml_loader
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-warn-return-any
 

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -6,9 +6,6 @@ import logging
 import sys
 from typing import Callable, Container, Optional, Union, cast
 
-from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
-from homeassistant.core import HomeAssistant, State
 from homeassistant.components import zone as zone_cmp
 from homeassistant.components.device_automation import (
     async_get_device_automation_platform,
@@ -34,11 +31,14 @@ from homeassistant.const import (
     SUN_EVENT_SUNSET,
     WEEKDAYS,
 )
-from homeassistant.exceptions import TemplateError, HomeAssistantError
+from homeassistant.core import HomeAssistant, State
+from homeassistant.exceptions import HomeAssistantError, TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.sun import get_astral_event_date
-import homeassistant.util.dt as dt_util
+from homeassistant.helpers.template import Template
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.util.async_ import run_callback_threadsafe
+import homeassistant.util.dt as dt_util
 
 FROM_CONFIG_FORMAT = "{}_from_config"
 ASYNC_FROM_CONFIG_FORMAT = "async_{}_from_config"

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -1,6 +1,8 @@
 """Helpers for data entry flows for config entries."""
-from typing import Callable, Awaitable, Union
+from typing import Awaitable, Callable, Union
+
 from homeassistant import config_entries
+
 from .typing import HomeAssistantType
 
 # mypy: allow-untyped-defs, no-check-untyped-defs

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -5,25 +5,24 @@ This module exists of the following parts:
  - OAuth2 implementation that works with local provided client ID/secret
 
 """
+from abc import ABC, ABCMeta, abstractmethod
 import asyncio
-from abc import ABCMeta, ABC, abstractmethod
 import logging
-from typing import Optional, Any, Dict, cast, Awaitable, Callable
 import time
+from typing import Any, Awaitable, Callable, Dict, Optional, cast
 
+from aiohttp import client, web
 import async_timeout
-from aiohttp import web, client
 import jwt
 import voluptuous as vol
 from yarl import URL
 
-from homeassistant.auth.util import generate_secret
-from homeassistant.core import HomeAssistant, callback
 from homeassistant import config_entries
+from homeassistant.auth.util import generate_secret
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant, callback
 
 from .aiohttp_client import async_get_clientsession
-
 
 DATA_JWT_SECRET = "oauth2_jwt_secret"
 DATA_VIEW_REGISTERED = "oauth2_view_reg"

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,17 +1,17 @@
 """Helpers for config validation using voluptuous."""
-import inspect
-import logging
-import os
-import re
 from datetime import (
-    timedelta,
+    date as date_sys,
     datetime as datetime_sys,
     time as time_sys,
-    date as date_sys,
+    timedelta,
 )
-from socket import _GLOBAL_DEFAULT_TIMEOUT
+import inspect
+import logging
 from numbers import Number
-from typing import Any, Union, TypeVar, Callable, List, Dict, Optional
+import os
+import re
+from socket import _GLOBAL_DEFAULT_TIMEOUT
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -19,8 +19,9 @@ from pkg_resources import parse_version
 import voluptuous as vol
 import voluptuous_serialize
 
-import homeassistant.util.dt as dt_util
 from homeassistant.const import (
+    ATTR_AREA_ID,
+    ATTR_ENTITY_ID,
     CONF_ABOVE,
     CONF_ALIAS,
     CONF_BELOW,
@@ -33,10 +34,10 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     CONF_STATE,
+    CONF_TIMEOUT,
     CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM_METRIC,
     CONF_VALUE_TEMPLATE,
-    CONF_TIMEOUT,
     ENTITY_MATCH_ALL,
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
@@ -44,14 +45,12 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
     WEEKDAYS,
     __version__,
-    ATTR_AREA_ID,
-    ATTR_ENTITY_ID,
 )
-from homeassistant.core import valid_entity_id, split_entity_id
+from homeassistant.core import split_entity_id, valid_entity_id
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
-
+import homeassistant.util.dt as dt_util
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs, no-warn-return-any

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -2,10 +2,9 @@
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow, config_entries
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1,9 +1,9 @@
 """Provide a way to connect entities belonging to one device."""
-import logging
-import uuid
 from asyncio import Event
 from collections import OrderedDict
+import logging
 from typing import List, Optional, cast
+import uuid
 
 import attr
 
@@ -11,7 +11,6 @@ from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
 from .typing import HomeAssistantType
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs, no-warn-return-any

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -5,13 +5,11 @@ There are two different types of discoveries that can be fired/listened for.
  - listen_platform/discover_platform is for platforms. These are used by
    components to allow discovery of their platforms.
 """
-from homeassistant import setup, core
-from homeassistant.loader import bind_hass
+from homeassistant import core, setup
 from homeassistant.const import ATTR_DISCOVERED, ATTR_SERVICE, EVENT_PLATFORM_DISCOVERED
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.loader import DEPENDENCY_BLACKLIST
+from homeassistant.loader import DEPENDENCY_BLACKLIST, bind_hass
 from homeassistant.util.async_ import run_callback_threadsafe
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -6,8 +6,8 @@ from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.logging import catch_log_exception
-from .typing import HomeAssistantType
 
+from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 DATA_DISPATCHER = "dispatcher"

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -2,16 +2,20 @@
 from abc import ABC
 import asyncio
 from datetime import datetime, timedelta
-import logging
 import functools as ft
+import logging
 from timeit import default_timer as timer
 from typing import Any, Dict, Iterable, List, Optional, Union
 
+from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_HIDDEN,
     ATTR_ICON,
+    ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT,
     DEVICE_DEFAULT_NAME,
     STATE_OFF,
@@ -20,22 +24,16 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
-    ATTR_ENTITY_PICTURE,
-    ATTR_SUPPORTED_FEATURES,
-    ATTR_DEVICE_CLASS,
 )
+from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
+from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.entity_registry import (
     EVENT_ENTITY_REGISTRY_UPDATED,
     RegistryEntry,
 )
-from homeassistant.core import HomeAssistant, callback, CALLBACK_TYPE, Context
-from homeassistant.config import DATA_CUSTOMIZE
-from homeassistant.exceptions import NoEntitySpecifiedError
-from homeassistant.util import ensure_unique_string, slugify
+from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
 from homeassistant.util.async_ import run_callback_threadsafe
-from homeassistant.util import dt as dt_util
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs, no-warn-return-any
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -5,11 +5,10 @@ from itertools import chain
 import logging
 
 from homeassistant import config as conf_util
-from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    CONF_SCAN_INTERVAL,
     CONF_ENTITY_NAMESPACE,
+    CONF_SCAN_INTERVAL,
     ENTITY_MATCH_ALL,
 )
 from homeassistant.core import callback
@@ -17,10 +16,11 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform, discovery
 from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.service import async_extract_entity_ids
-from homeassistant.loader import bind_hass, async_get_integration
+from homeassistant.loader import async_get_integration, bind_hass
+from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.util import slugify
-from .entity_platform import EntityPlatform
 
+from .entity_platform import EntityPlatform
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -4,13 +4,12 @@ from contextvars import ContextVar
 from typing import Optional
 
 from homeassistant.const import DEVICE_DEFAULT_NAME
-from homeassistant.core import callback, valid_entity_id, split_entity_id
+from homeassistant.core import callback, split_entity_id, valid_entity_id
 from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.util.async_ import run_callback_threadsafe
 
 from .entity_registry import DISABLED_INTEGRATION
-from .event import async_track_time_interval, async_call_later
-
+from .event import async_call_later, async_track_time_interval
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -23,7 +23,6 @@ from homeassistant.util.yaml import load_yaml
 
 from .typing import HomeAssistantType
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 PATH_REGISTRY = "entity_registry.yaml"

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -5,22 +5,21 @@ from typing import Any, Callable, Dict, Iterable, Optional, Union, cast
 
 import attr
 
-from homeassistant.loader import bind_hass
-from homeassistant.helpers.sun import get_astral_event_next
-from homeassistant.helpers.template import Template
-from homeassistant.core import HomeAssistant, callback, CALLBACK_TYPE, Event, State
 from homeassistant.const import (
     ATTR_NOW,
+    EVENT_CORE_CONFIG_UPDATE,
     EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED,
     MATCH_ALL,
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
-    EVENT_CORE_CONFIG_UPDATE,
 )
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, State, callback
+from homeassistant.helpers.sun import get_astral_event_next
+from homeassistant.helpers.template import Template
+from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
 from homeassistant.util.async_ import run_callback_threadsafe
-
 
 # PyLint does not like the use of threaded_listener_factory
 # pylint: disable=invalid-name

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -5,13 +5,12 @@ from typing import Any, Callable, Dict, Iterable, Optional
 
 import voluptuous as vol
 
-from homeassistant.const import ATTR_SUPPORTED_FEATURES
-from homeassistant.core import callback, State, T, Context
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES
+from homeassistant.core import Context, State, T, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.loader import bind_hass
-from homeassistant.const import ATTR_ENTITY_ID
 
 _LOGGER = logging.getLogger(__name__)
 _SlotsType = Dict[str, Any]

--- a/homeassistant/helpers/logging.py
+++ b/homeassistant/helpers/logging.py
@@ -2,7 +2,6 @@
 import inspect
 import logging
 
-
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -1,6 +1,6 @@
 """Network helpers."""
-from typing import Optional, cast
 from ipaddress import ip_address
+from typing import Optional, cast
 
 import yarl
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -1,24 +1,23 @@
 """Support for restoring entity states on startup."""
 import asyncio
+from datetime import datetime, timedelta
 import logging
-from datetime import timedelta, datetime
-from typing import Any, Dict, List, Set, Optional
+from typing import Any, Dict, List, Optional, Set
 
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import (
-    HomeAssistant,
-    callback,
-    State,
     CoreState,
+    HomeAssistant,
+    State,
+    callback,
     valid_entity_id,
 )
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
-import homeassistant.util.dt as dt_util
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.storage import Store
-
+import homeassistant.util.dt as dt_util
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 # mypy: no-warn-return-any

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,16 +1,16 @@
 """Helpers to execute scripts."""
 import asyncio
-import logging
 from contextlib import suppress
 from datetime import datetime
 from itertools import islice
-from typing import Optional, Sequence, Callable, Dict, List, Set, Tuple, Any
+import logging
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import voluptuous as vol
 
+from homeassistant import exceptions
 import homeassistant.components.device_automation as device_automation
 import homeassistant.components.scene as scene
-from homeassistant.core import HomeAssistant, Context, callback, CALLBACK_TYPE
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_CONDITION,
@@ -19,21 +19,20 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     SERVICE_TURN_ON,
 )
-from homeassistant import exceptions
+from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.helpers import (
-    service,
     condition,
-    template as template,
     config_validation as cv,
+    service,
+    template as template,
 )
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_template,
 )
 from homeassistant.helpers.typing import ConfigType
-import homeassistant.util.dt as date_util
 from homeassistant.util.async_ import run_callback_threadsafe
-
+import homeassistant.util.dt as date_util
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -7,7 +7,7 @@ from typing import Callable
 import voluptuous as vol
 
 from homeassistant.auth.permissions.const import CAT_ENTITIES, POLICY_CONTROL
-from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, ATTR_AREA_ID
+from homeassistant.const import ATTR_AREA_ID, ATTR_ENTITY_ID, ENTITY_MATCH_ALL
 import homeassistant.core as ha
 from homeassistant.exceptions import (
     HomeAssistantError,
@@ -16,12 +16,11 @@ from homeassistant.exceptions import (
     UnknownUser,
 )
 from homeassistant.helpers import template, typing
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.loader import async_get_integration, bind_hass
 from homeassistant.util.yaml import load_yaml
 from homeassistant.util.yaml.loader import JSON_TYPE
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import HomeAssistantType
-
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/signal.py
+++ b/homeassistant/helpers/signal.py
@@ -4,8 +4,8 @@ import signal
 import sys
 from types import FrameType
 
-from homeassistant.core import callback, HomeAssistant
 from homeassistant.const import RESTART_EXIT_CODE
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -1,13 +1,11 @@
 """Helpers that help with state related things."""
 import asyncio
+from collections import defaultdict
 import datetime as dt
 import logging
-from collections import defaultdict
 from types import ModuleType, TracebackType
 from typing import Dict, Iterable, List, Optional, Type, Union
 
-from homeassistant.loader import bind_hass, async_get_integration, IntegrationNotFound
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
 from homeassistant.const import (
     STATE_CLOSED,
@@ -21,6 +19,9 @@ from homeassistant.const import (
     STATE_UNLOCKED,
 )
 from homeassistant.core import Context, State
+from homeassistant.loader import IntegrationNotFound, async_get_integration, bind_hass
+import homeassistant.util.dt as dt_util
+
 from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -3,14 +3,13 @@ import asyncio
 from json import JSONEncoder
 import logging
 import os
-from typing import Dict, List, Optional, Callable, Union, Any, Type
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant, callback, CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.loader import bind_hass
 from homeassistant.util import json as json_util
-from homeassistant.helpers.event import async_call_later
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-warn-return-any
 # mypy: no-check-untyped-defs

--- a/homeassistant/helpers/sun.py
+++ b/homeassistant/helpers/sun.py
@@ -1,11 +1,12 @@
 """Helpers for sun events."""
 import datetime
-from typing import Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
 from homeassistant.core import callback
-from homeassistant.util import dt as dt_util
 from homeassistant.loader import bind_hass
+from homeassistant.util import dt as dt_util
+
 from .typing import HomeAssistantType
 
 if TYPE_CHECKING:

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -6,6 +6,7 @@ from typing import Dict
 from homeassistant.const import __version__ as current_version
 from homeassistant.loader import bind_hass
 from homeassistant.util.package import is_virtual_env
+
 from .typing import HomeAssistantType
 
 

--- a/homeassistant/helpers/temperature.py
+++ b/homeassistant/helpers/temperature.py
@@ -2,9 +2,9 @@
 from numbers import Number
 from typing import Optional
 
+from homeassistant.const import PRECISION_HALVES, PRECISION_TENTHS
 from homeassistant.core import HomeAssistant
 from homeassistant.util.temperature import convert as convert_temperature
-from homeassistant.const import PRECISION_HALVES, PRECISION_TENTHS
 
 
 def display_temp(

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1,12 +1,12 @@
 """Template helper methods for rendering strings with Home Assistant data."""
 import base64
+from datetime import datetime
+from functools import wraps
 import json
 import logging
 import math
 import random
 import re
-from datetime import datetime
-from functools import wraps
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import jinja2
@@ -29,7 +29,6 @@ from homeassistant.helpers.typing import HomeAssistantType, TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util import convert, dt as dt_util, location as loc_util
 from homeassistant.util.async_ import run_callback_threadsafe
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs, no-warn-return-any

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -3,11 +3,12 @@ import logging
 from typing import Any, Dict, Iterable, Optional
 
 from homeassistant.loader import (
+    async_get_config_flows,
     async_get_integration,
     bind_hass,
-    async_get_config_flows,
 )
 from homeassistant.util.json import load_json
+
 from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,5 +1,5 @@
 """Typing Helpers for Home Assistant."""
-from typing import Dict, Any, Tuple, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import homeassistant.core
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -13,14 +13,14 @@ import pathlib
 import sys
 from types import ModuleType
 from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
     Optional,
     Set,
-    TYPE_CHECKING,
-    Callable,
-    Any,
     TypeVar,
-    List,
-    Dict,
     Union,
     cast,
 )

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -1,14 +1,14 @@
 """Module to handle installing requirements."""
 import asyncio
-from pathlib import Path
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-from homeassistant.exceptions import HomeAssistantError
-import homeassistant.util.package as pkg_util
 from homeassistant.core import HomeAssistant
-from homeassistant.loader import async_get_integration, Integration
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.loader import Integration, async_get_integration
+import homeassistant.util.package as pkg_util
 
 DATA_PIP_LOCK = "pip_lock"
 DATA_PKG_CACHE = "pkg_cache"

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -10,8 +10,7 @@ from typing import List, Optional, Sequence, Text
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
 from homeassistant.requirements import pip_kwargs
-from homeassistant.util.package import install_package, is_virtual_env, is_installed
-
+from homeassistant.util.package import install_package, is_installed, is_virtual_env
 
 # mypy: allow-untyped-defs, no-warn-return-any
 

--- a/homeassistant/scripts/auth.py
+++ b/homeassistant/scripts/auth.py
@@ -6,9 +6,8 @@ import os
 
 from homeassistant.auth import auth_manager_from_config
 from homeassistant.auth.providers import homeassistant as hass_auth
-from homeassistant.core import HomeAssistant
 from homeassistant.config import get_default_config_dir
-
+from homeassistant.core import HomeAssistant
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -11,7 +11,6 @@ from homeassistant import core
 from homeassistant.const import ATTR_NOW, EVENT_STATE_CHANGED, EVENT_TIME_CHANGED
 from homeassistant.util import dt as dt_util
 
-
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 # mypy: no-warn-return-any
 

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -1,19 +1,18 @@
 """Script to check the configuration file."""
 
 import argparse
-import logging
-import os
 from collections import OrderedDict
 from glob import glob
-from typing import Dict, List, Sequence, Any, Tuple, Callable
+import logging
+import os
+from typing import Any, Callable, Dict, List, Sequence, Tuple
 from unittest.mock import patch
 
 from homeassistant import bootstrap, core
 from homeassistant.config import get_default_config_dir
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.check_config import async_check_ha_config_file
 import homeassistant.util.yaml.loader as yaml_loader
-from homeassistant.exceptions import HomeAssistantError
-
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -4,7 +4,6 @@ import getpass
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-
 # mypy: allow-untyped-defs
 
 REQUIREMENTS = ["credstash==1.15.0"]

--- a/homeassistant/scripts/ensure_config.py
+++ b/homeassistant/scripts/ensure_config.py
@@ -2,9 +2,8 @@
 import argparse
 import os
 
-from homeassistant.core import HomeAssistant
 import homeassistant.config as config_util
-
+from homeassistant.core import HomeAssistant
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 

--- a/homeassistant/scripts/macos/__init__.py
+++ b/homeassistant/scripts/macos/__init__.py
@@ -2,7 +2,6 @@
 import os
 import time
 
-
 # mypy: allow-untyped-calls, allow-untyped-defs
 
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -2,15 +2,13 @@
 import asyncio
 import logging.handlers
 from timeit import default_timer as timer
-
 from types import ModuleType
-from typing import Awaitable, Callable, Optional, Dict, List
+from typing import Awaitable, Callable, Dict, List, Optional
 
-from homeassistant import requirements, core, loader, config as conf_util
+from homeassistant import config as conf_util, core, loader, requirements
 from homeassistant.config import async_notify_setup_error
 from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
 from homeassistant.exceptions import HomeAssistantError
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -1,23 +1,23 @@
 """Helper methods for various modules."""
 import asyncio
 from datetime import datetime, timedelta
-import threading
-import re
 import enum
-import socket
-import random
-import string
 from functools import wraps
+import random
+import re
+import socket
+import string
+import threading
 from types import MappingProxyType
 from typing import (
     Any,
+    Callable,
+    Coroutine,
+    Iterable,
+    KeysView,
     Optional,
     TypeVar,
-    Callable,
-    KeysView,
     Union,
-    Iterable,
-    Coroutine,
 )
 
 import slugify as unicode_slug

--- a/homeassistant/util/aiohttp.py
+++ b/homeassistant/util/aiohttp.py
@@ -1,7 +1,7 @@
 """Utilities to help with aiohttp."""
 import json
-from urllib.parse import parse_qsl
 from typing import Any, Dict, Optional
+from urllib.parse import parse_qsl
 
 from multidict import CIMultiDict, MultiDict
 

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -1,13 +1,11 @@
 """Asyncio backports for Python 3.6 compatibility."""
-import concurrent.futures
-import threading
-import logging
-from asyncio import coroutines
-from asyncio.events import AbstractEventLoop
-
 import asyncio
-from asyncio import ensure_future
-from typing import Any, Coroutine, Callable, TypeVar, Awaitable
+from asyncio import coroutines, ensure_future
+from asyncio.events import AbstractEventLoop
+import concurrent.futures
+import logging
+import threading
+from typing import Any, Awaitable, Callable, Coroutine, TypeVar
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -1,8 +1,8 @@
 """Color util methods."""
-import math
 import colorsys
+import math
+from typing import List, Optional, Tuple
 
-from typing import Tuple, List, Optional
 import attr
 
 # Official CSS3 colors from w3.org:

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -4,12 +4,12 @@ import logging
 from numbers import Number
 
 from homeassistant.const import (
-    LENGTH_KILOMETERS,
-    LENGTH_MILES,
-    LENGTH_FEET,
-    LENGTH_METERS,
-    UNIT_NOT_RECOGNIZED_TEMPLATE,
     LENGTH,
+    LENGTH_FEET,
+    LENGTH_KILOMETERS,
+    LENGTH_METERS,
+    LENGTH_MILES,
+    UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -1,7 +1,7 @@
 """Helper methods to handle the time in Home Assistant."""
 import datetime as dt
 import re
-from typing import Any, Union, Optional, Tuple, List, cast, Dict
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import pytz
 import pytz.exceptions as pytzexceptions

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -1,10 +1,9 @@
 """JSON utility functions."""
-import logging
-from typing import Union, List, Dict, Optional, Type
-
 import json
+import logging
 import os
 import tempfile
+from typing import Dict, List, Optional, Type, Union
 
 from homeassistant.exceptions import HomeAssistantError
 

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -6,7 +6,7 @@ detect_location_info and elevation are mocked by default during tests.
 import asyncio
 import collections
 import math
-from typing import Any, Optional, Tuple, Dict
+from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
 

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -2,15 +2,14 @@
 import asyncio
 import logging
 import os
+from pathlib import Path
 from subprocess import PIPE, Popen
 import sys
 from typing import Optional
 from urllib.parse import urlparse
-from pathlib import Path
 
+from importlib_metadata import PackageNotFoundError, version
 import pkg_resources
-from importlib_metadata import version, PackageNotFoundError
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -4,13 +4,13 @@ import logging
 from numbers import Number
 
 from homeassistant.const import (
-    PRESSURE_PA,
+    PRESSURE,
     PRESSURE_HPA,
-    PRESSURE_MBAR,
     PRESSURE_INHG,
+    PRESSURE_MBAR,
+    PRESSURE_PA,
     PRESSURE_PSI,
     UNIT_NOT_RECOGNIZED_TEMPLATE,
-    PRESSURE,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/util/ruamel_yaml.py
+++ b/homeassistant/util/ruamel_yaml.py
@@ -1,18 +1,18 @@
 """ruamel.yaml utility functions."""
+from collections import OrderedDict
 import logging
 import os
 from os import O_CREAT, O_TRUNC, O_WRONLY, stat_result
-from collections import OrderedDict
-from typing import Union, List, Dict, Optional
+from typing import Dict, List, Optional, Union
 
 import ruamel.yaml
 from ruamel.yaml import YAML
+from ruamel.yaml.compat import StringIO
 from ruamel.yaml.constructor import SafeConstructor
 from ruamel.yaml.error import YAMLError
-from ruamel.yaml.compat import StringIO
 
-from homeassistant.util.yaml import secret_yaml
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util.yaml import secret_yaml
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/temperature.py
+++ b/homeassistant/util/temperature.py
@@ -2,8 +2,8 @@
 from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
-    UNIT_NOT_RECOGNIZED_TEMPLATE,
     TEMPERATURE,
+    UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
 
 

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -1,35 +1,37 @@
 """Unit system helper class and methods."""
 
 import logging
-from typing import Optional
 from numbers import Number
+from typing import Optional
 
 from homeassistant.const import (
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
-    LENGTH_MILES,
+    CONF_UNIT_SYSTEM_IMPERIAL,
+    CONF_UNIT_SYSTEM_METRIC,
+    LENGTH,
     LENGTH_KILOMETERS,
-    PRESSURE_PA,
-    PRESSURE_PSI,
-    VOLUME_LITERS,
-    VOLUME_GALLONS,
+    LENGTH_MILES,
+    MASS,
     MASS_GRAMS,
     MASS_KILOGRAMS,
     MASS_OUNCES,
     MASS_POUNDS,
-    CONF_UNIT_SYSTEM_METRIC,
-    CONF_UNIT_SYSTEM_IMPERIAL,
-    LENGTH,
-    MASS,
     PRESSURE,
-    VOLUME,
+    PRESSURE_PA,
+    PRESSURE_PSI,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
     TEMPERATURE,
     UNIT_NOT_RECOGNIZED_TEMPLATE,
+    VOLUME,
+    VOLUME_GALLONS,
+    VOLUME_LITERS,
 )
-from homeassistant.util import temperature as temperature_util
-from homeassistant.util import distance as distance_util
-from homeassistant.util import pressure as pressure_util
-from homeassistant.util import volume as volume_util
+from homeassistant.util import (
+    distance as distance_util,
+    pressure as pressure_util,
+    temperature as temperature_util,
+    volume as volume_util,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -2,13 +2,14 @@
 
 import logging
 from numbers import Number
+
 from homeassistant.const import (
+    UNIT_NOT_RECOGNIZED_TEMPLATE,
+    VOLUME,
+    VOLUME_FLUID_OUNCE,
+    VOLUME_GALLONS,
     VOLUME_LITERS,
     VOLUME_MILLILITERS,
-    VOLUME_GALLONS,
-    VOLUME_FLUID_OUNCE,
-    VOLUME,
-    UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/util/yaml/__init__.py
+++ b/homeassistant/util/yaml/__init__.py
@@ -1,8 +1,7 @@
 """YAML utility functions."""
-from .const import SECRET_YAML, _SECRET_NAMESPACE
+from .const import _SECRET_NAMESPACE, SECRET_YAML
 from .dumper import dump, save_yaml
 from .loader import clear_secret_cache, load_yaml, secret_yaml
-
 
 __all__ = [
     "SECRET_YAML",

--- a/homeassistant/util/yaml/dumper.py
+++ b/homeassistant/util/yaml/dumper.py
@@ -1,9 +1,9 @@
 """Custom dumper and representers."""
 from collections import OrderedDict
+
 import yaml
 
 from .objects import NodeListClass
-
 
 # mypy: allow-untyped-calls, no-warn-return-any
 

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -1,12 +1,17 @@
 """Custom loader."""
+from collections import OrderedDict
+import fnmatch
 import logging
 import os
 import sys
-import fnmatch
-from collections import OrderedDict
-from typing import Union, List, Dict, Iterator, overload, TypeVar
+from typing import Dict, Iterator, List, TypeVar, Union, overload
 
 import yaml
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import _SECRET_NAMESPACE, SECRET_YAML
+from .objects import NodeListClass, NodeStrClass
 
 try:
     import keyring
@@ -17,11 +22,6 @@ try:
     import credstash
 except ImportError:
     credstash = None
-
-from homeassistant.exceptions import HomeAssistantError
-
-from .const import _SECRET_NAMESPACE, SECRET_YAML
-from .objects import NodeListClass, NodeStrClass
 
 
 # mypy: allow-untyped-calls, no-warn-return-any


### PR DESCRIPTION

## Description:

The imports imports of `"homeassistant"` according to PEP8 using isort.

See https://github.com/home-assistant/home-assistant/pull/29739

This PR affects:

- `homeassistant/__main__.py` 
- `homeassistant/bootstrap.py` 
- `homeassistant/config.py` 
- `homeassistant/config_entries.py` 
- `homeassistant/core.py` 
- `homeassistant/data_entry_flow.py` 
- `homeassistant/exceptions.py` 
- `homeassistant/loader.py` 
- `homeassistant/requirements.py` 
- `homeassistant/setup.py` 
- `homeassistant/auth/__init__.py` 
- `homeassistant/auth/auth_store.py` 
- `homeassistant/auth/mfa_modules/__init__.py` 
- `homeassistant/auth/mfa_modules/insecure_example.py` 
- `homeassistant/auth/mfa_modules/notify.py` 
- `homeassistant/auth/mfa_modules/totp.py` 
- `homeassistant/auth/permissions/__init__.py` 
- `homeassistant/auth/permissions/entities.py` 
- `homeassistant/auth/permissions/merge.py` 
- `homeassistant/auth/permissions/system_policies.py` 
- `homeassistant/auth/permissions/util.py` 
- `homeassistant/auth/providers/__init__.py` 
- `homeassistant/auth/providers/command_line.py` 
- `homeassistant/auth/providers/homeassistant.py` 
- `homeassistant/auth/providers/insecure_example.py` 
- `homeassistant/auth/providers/legacy_api_password.py` 
- `homeassistant/auth/providers/trusted_networks.py` 
- `homeassistant/helpers/__init__.py` 
- `homeassistant/helpers/aiohttp_client.py` 
- `homeassistant/helpers/area_registry.py` 
- `homeassistant/helpers/check_config.py` 
- `homeassistant/helpers/condition.py` 
- `homeassistant/helpers/config_entry_flow.py` 
- `homeassistant/helpers/config_entry_oauth2_flow.py` 
- `homeassistant/helpers/config_validation.py` 
- `homeassistant/helpers/data_entry_flow.py` 
- `homeassistant/helpers/device_registry.py` 
- `homeassistant/helpers/discovery.py` 
- `homeassistant/helpers/dispatcher.py` 
- `homeassistant/helpers/entity.py` 
- `homeassistant/helpers/entity_component.py` 
- `homeassistant/helpers/entity_platform.py` 
- `homeassistant/helpers/entity_registry.py` 
- `homeassistant/helpers/event.py` 
- `homeassistant/helpers/intent.py` 
- `homeassistant/helpers/logging.py` 
- `homeassistant/helpers/network.py` 
- `homeassistant/helpers/restore_state.py` 
- `homeassistant/helpers/script.py` 
- `homeassistant/helpers/service.py` 
- `homeassistant/helpers/signal.py` 
- `homeassistant/helpers/state.py` 
- `homeassistant/helpers/storage.py` 
- `homeassistant/helpers/sun.py` 
- `homeassistant/helpers/system_info.py` 
- `homeassistant/helpers/temperature.py` 
- `homeassistant/helpers/template.py` 
- `homeassistant/helpers/translation.py` 
- `homeassistant/helpers/typing.py` 
- `homeassistant/scripts/__init__.py` 
- `homeassistant/scripts/auth.py` 
- `homeassistant/scripts/check_config.py` 
- `homeassistant/scripts/credstash.py` 
- `homeassistant/scripts/ensure_config.py` 
- `homeassistant/scripts/benchmark/__init__.py` 
- `homeassistant/scripts/macos/__init__.py` 
- `homeassistant/util/__init__.py` 
- `homeassistant/util/aiohttp.py` 
- `homeassistant/util/async_.py` 
- `homeassistant/util/color.py` 
- `homeassistant/util/distance.py` 
- `homeassistant/util/dt.py` 
- `homeassistant/util/json.py` 
- `homeassistant/util/location.py` 
- `homeassistant/util/package.py` 
- `homeassistant/util/pressure.py` 
- `homeassistant/util/ruamel_yaml.py` 
- `homeassistant/util/temperature.py` 
- `homeassistant/util/unit_system.py` 
- `homeassistant/util/volume.py` 
- `homeassistant/util/yaml/__init__.py` 
- `homeassistant/util/yaml/dumper.py` 
- `homeassistant/util/yaml/loader.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
