### PR TITLE
Sort imports according to PEP8 for 'tests'

### DIFF
--- a/tests/auth/mfa_modules/test_insecure_example.py
+++ b/tests/auth/mfa_modules/test_insecure_example.py
@@ -2,6 +2,7 @@
 from homeassistant import auth, data_entry_flow
 from homeassistant.auth.mfa_modules import auth_mfa_module_from_config
 from homeassistant.auth.models import Credentials
+
 from tests.common import MockUser
 
 

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -3,9 +3,10 @@ import asyncio
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
-from homeassistant.auth import models as auth_models, auth_manager_from_config
+from homeassistant.auth import auth_manager_from_config, models as auth_models
 from homeassistant.auth.mfa_modules import auth_mfa_module_from_config
 from homeassistant.components.notify import NOTIFY_SERVICE_SCHEMA
+
 from tests.common import MockUser, async_mock_service
 
 MOCK_CODE = "123456"

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -3,8 +3,9 @@ import asyncio
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
-from homeassistant.auth import models as auth_models, auth_manager_from_config
+from homeassistant.auth import auth_manager_from_config, models as auth_models
 from homeassistant.auth.mfa_modules import auth_mfa_module_from_config
+
 from tests.common import MockUser
 
 MOCK_CODE = "123456"

--- a/tests/auth/permissions/test_entities.py
+++ b/tests/auth/permissions/test_entities.py
@@ -3,14 +3,14 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.auth.permissions.entities import (
-    compile_entities,
     ENTITY_POLICY_SCHEMA,
+    compile_entities,
 )
 from homeassistant.auth.permissions.models import PermissionLookup
-from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.entity_registry import RegistryEntry
 
-from tests.common import mock_registry, mock_device_registry
+from tests.common import mock_device_registry, mock_registry
 
 
 def test_entities_none():

--- a/tests/auth/permissions/test_system_policies.py
+++ b/tests/auth/permissions/test_system_policies.py
@@ -1,8 +1,8 @@
 """Test system policies."""
 from homeassistant.auth.permissions import (
+    POLICY_SCHEMA,
     PolicyPermissions,
     system_policies,
-    POLICY_SCHEMA,
 )
 
 

--- a/tests/auth/providers/test_command_line.py
+++ b/tests/auth/providers/test_command_line.py
@@ -1,13 +1,13 @@
 """Tests for the command_line auth provider."""
 
-from unittest.mock import Mock
 import os
+from unittest.mock import Mock
 import uuid
 
 import pytest
 
 from homeassistant import data_entry_flow
-from homeassistant.auth import auth_store, models as auth_models, AuthManager
+from homeassistant.auth import AuthManager, auth_store, models as auth_models
 from homeassistant.auth.providers import command_line
 from homeassistant.const import CONF_TYPE
 

--- a/tests/auth/providers/test_insecure_example.py
+++ b/tests/auth/providers/test_insecure_example.py
@@ -4,7 +4,7 @@ import uuid
 
 import pytest
 
-from homeassistant.auth import auth_store, models as auth_models, AuthManager
+from homeassistant.auth import AuthManager, auth_store, models as auth_models
 from homeassistant.auth.providers import insecure_example
 
 from tests.common import mock_coro

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -7,11 +7,12 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import auth, data_entry_flow
-from homeassistant.auth import models as auth_models, auth_store, const as auth_const
+from homeassistant.auth import auth_store, const as auth_const, models as auth_models
 from homeassistant.auth.const import MFA_SESSION_EXPIRATION
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
-from tests.common import MockUser, ensure_auth_manager_loaded, flush_store, CLIENT_ID
+
+from tests.common import CLIENT_ID, MockUser, ensure_auth_manager_loaded, flush_store
 
 
 @pytest.fixture

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,32 +1,32 @@
 """Test the helper method for writing tests."""
 import asyncio
 import collections
-import functools as ft
-import json
-import logging
-import os
-import uuid
-import sys
-import threading
-
 from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import timedelta
+import functools as ft
 from io import StringIO
+import json
+import logging
+import os
+import sys
+import threading
 from unittest.mock import MagicMock, Mock, patch
-
-import homeassistant.util.dt as date_util
-import homeassistant.util.yaml.loader as yaml_loader
+import uuid
 
 from homeassistant import auth, config_entries, core as ha, loader
 from homeassistant.auth import (
-    models as auth_models,
     auth_store,
-    providers as auth_providers,
+    models as auth_models,
     permissions as auth_permissions,
+    providers as auth_providers,
 )
 from homeassistant.auth.permissions import system_policies
 from homeassistant.components import mqtt, recorder
+from homeassistant.components.device_automation import (  # noqa: F401
+    _async_get_device_automation_capabilities as async_get_device_automation_capabilities,
+    _async_get_device_automations as async_get_device_automations,
+)
 from homeassistant.components.mqtt.models import Message
 from homeassistant.config import async_process_component_config
 from homeassistant.const import (
@@ -38,8 +38,8 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED,
     SERVER_PORT,
-    STATE_ON,
     STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import State
 from homeassistant.helpers import (
@@ -54,12 +54,10 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component, setup_component
-from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.util.async_ import run_callback_threadsafe
-from homeassistant.components.device_automation import (  # noqa: F401
-    _async_get_device_automations as async_get_device_automations,
-    _async_get_device_automation_capabilities as async_get_device_automation_capabilities,
-)
+import homeassistant.util.dt as date_util
+from homeassistant.util.unit_system import METRIC_SYSTEM
+import homeassistant.util.yaml.loader as yaml_loader
 
 _TEST_INSTANCE_PORT = SERVER_PORT
 _LOGGER = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,22 +9,23 @@ import pytest
 import requests_mock as _requests_mock
 
 from homeassistant import util
-from homeassistant.util import location
 from homeassistant.auth.const import GROUP_ID_ADMIN, GROUP_ID_READ_ONLY
-from homeassistant.auth.providers import legacy_api_password, homeassistant
+from homeassistant.auth.providers import homeassistant, legacy_api_password
+from homeassistant.util import location
 
-pytest.register_assert_rewrite("tests.common")
 from tests.common import (  # noqa: E402 module level import not at top of file
-    async_test_home_assistant,
+    CLIENT_ID,
     INSTANCES,
+    MockUser,
+    async_test_home_assistant,
     mock_coro,
     mock_storage as mock_storage,
-    MockUser,
-    CLIENT_ID,
 )
-from tests.test_util.aiohttp import (
+from tests.test_util.aiohttp import (  # noqa: E402 module level import not at top of file
     mock_aiohttp_client,
-)  # noqa: E402 module level import not at top of file
+)
+
+pytest.register_assert_rewrite("tests.common")
 
 if os.environ.get("UVLOOP") == "1":
     import uvloop

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -6,8 +6,8 @@ import aiohttp
 import pytest
 
 from homeassistant.core import EVENT_HOMEASSISTANT_CLOSE
-from homeassistant.setup import async_setup_component
 import homeassistant.helpers.aiohttp_client as client
+from homeassistant.setup import async_setup_component
 from homeassistant.util.async_ import run_callback_threadsafe
 
 from tests.common import get_test_home_assistant

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -6,7 +6,8 @@ import pytest
 
 from homeassistant.core import callback
 from homeassistant.helpers import area_registry
-from tests.common import mock_area_registry, flush_store
+
+from tests.common import flush_store, mock_area_registry
 
 
 @pytest.fixture

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -2,11 +2,12 @@
 import logging
 from unittest.mock import patch
 
-from homeassistant.helpers.check_config import (
-    async_check_ha_config_file,
-    CheckConfigError,
-)
 from homeassistant.config import YAML_CONFIG_FILE
+from homeassistant.helpers.check_config import (
+    CheckConfigError,
+    async_check_ha_config_file,
+)
+
 from tests.common import patch_yaml_files
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -1,16 +1,17 @@
 """Tests for the Config Entry Flow helper."""
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.helpers import config_entry_flow
+
 from tests.common import (
     MockConfigEntry,
     MockModule,
     mock_coro,
-    mock_integration,
     mock_entity_platform,
+    mock_integration,
 )
 
 

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -1,15 +1,15 @@
 """Tests for the Somfy config flow."""
 import asyncio
 import logging
-from unittest.mock import patch
 import time
+from unittest.mock import patch
 
 import pytest
 
-from homeassistant import data_entry_flow, setup, config_entries
+from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.common import mock_platform, MockConfigEntry
+from tests.common import MockConfigEntry, mock_platform
 
 TEST_DOMAIN = "oauth2_test"
 CLIENT_SECRET = "5678"

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -1,7 +1,7 @@
 """Test deprecation helpers."""
-from homeassistant.helpers.deprecation import deprecated_substitute, get_deprecated
+from unittest.mock import MagicMock, patch
 
-from unittest.mock import patch, MagicMock
+from homeassistant.helpers.deprecation import deprecated_substitute, get_deprecated
 
 
 class MockBaseClass:

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -7,7 +7,8 @@ import pytest
 
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry
-from tests.common import mock_device_registry, flush_store
+
+from tests.common import flush_store, mock_device_registry
 
 
 @pytest.fixture

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -9,12 +9,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 
 from tests.common import (
-    get_test_home_assistant,
     MockModule,
     MockPlatform,
+    get_test_home_assistant,
     mock_coro,
-    mock_integration,
     mock_entity_platform,
+    mock_integration,
 )
 
 

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -4,8 +4,8 @@ import asyncio
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
-    dispatcher_send,
     dispatcher_connect,
+    dispatcher_send,
 )
 
 from tests.common import get_test_home_assistant

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,16 +1,16 @@
 """Test the entity helper."""
 # pylint: disable=protected-access
 import asyncio
-import threading
 from datetime import timedelta
-from unittest.mock import MagicMock, patch, PropertyMock
+import threading
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
-from homeassistant.helpers import entity, entity_registry
-from homeassistant.core import Context
-from homeassistant.const import ATTR_HIDDEN, ATTR_DEVICE_CLASS, STATE_UNAVAILABLE
 from homeassistant.config import DATA_CUSTOMIZE
+from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_HIDDEN, STATE_UNAVAILABLE
+from homeassistant.core import Context
+from homeassistant.helpers import entity, entity_registry
 from homeassistant.helpers.entity_values import EntityValues
 
 from tests.common import get_test_home_assistant, mock_registry

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -1,30 +1,29 @@
 """The tests for the Entity component helper."""
 # pylint: disable=protected-access
 from collections import OrderedDict
-import logging
-from unittest.mock import patch, Mock
 from datetime import timedelta
+import logging
+from unittest.mock import Mock, patch
 
 import asynctest
 import pytest
 
-import homeassistant.core as ha
-from homeassistant.const import ENTITY_MATCH_ALL
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.components import group
+from homeassistant.const import ENTITY_MATCH_ALL
+import homeassistant.core as ha
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import discovery
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.setup import async_setup_component
-
-from homeassistant.helpers import discovery
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    MockPlatform,
-    MockModule,
-    mock_coro,
-    async_fire_time_changed,
-    MockEntity,
     MockConfigEntry,
+    MockEntity,
+    MockModule,
+    MockPlatform,
+    async_fire_time_changed,
+    mock_coro,
     mock_entity_platform,
     mock_integration,
 )

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1,30 +1,29 @@
 """Tests for the EntityPlatform helper."""
 import asyncio
-import logging
-from unittest.mock import patch, Mock, MagicMock
 from datetime import timedelta
+import logging
+from unittest.mock import MagicMock, Mock, patch
 
 import asynctest
 import pytest
 
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import entity_platform, entity_registry
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_component import (
-    EntityComponent,
     DEFAULT_SCAN_INTERVAL,
+    EntityComponent,
 )
-from homeassistant.helpers import entity_platform, entity_registry
-
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    MockPlatform,
-    async_fire_time_changed,
-    mock_registry,
+    MockConfigEntry,
     MockEntity,
     MockEntityPlatform,
-    MockConfigEntry,
+    MockPlatform,
+    async_fire_time_changed,
     mock_entity_platform,
+    mock_registry,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -5,11 +5,10 @@ from unittest.mock import patch
 import asynctest
 import pytest
 
-from homeassistant.core import valid_entity_id, callback
+from homeassistant.core import callback, valid_entity_id
 from homeassistant.helpers import entity_registry
 
-from tests.common import MockConfigEntry, mock_registry, flush_store
-
+from tests.common import MockConfigEntry, flush_store, mock_registry
 
 YAML__OPEN_PATH = "homeassistant.util.yaml.loader.open"
 

--- a/tests/helpers/test_entity_values.py
+++ b/tests/helpers/test_entity_values.py
@@ -1,5 +1,6 @@
 """Test the entity values helper."""
 from collections import OrderedDict
+
 from homeassistant.helpers.entity_values import EntityValues as EV
 
 ent = "test.test"

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -1,5 +1,5 @@
 """The tests for the EntityFilter component."""
-from homeassistant.helpers.entityfilter import generate_filter, FILTER_SCHEMA
+from homeassistant.helpers.entityfilter import FILTER_SCHEMA, generate_filter
 
 
 def test_no_filters_case_1():

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -7,10 +7,10 @@ from unittest.mock import patch
 from astral import Astral
 import pytest
 
-from homeassistant.core import callback
-from homeassistant.setup import async_setup_component
-import homeassistant.core as ha
+from homeassistant.components import sun
 from homeassistant.const import MATCH_ALL
+import homeassistant.core as ha
+from homeassistant.core import callback
 from homeassistant.helpers.event import (
     async_call_later,
     async_track_point_in_time,
@@ -25,7 +25,7 @@ from homeassistant.helpers.event import (
     async_track_utc_time_change,
 )
 from homeassistant.helpers.template import Template
-from homeassistant.components import sun
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -1,11 +1,10 @@
 """Tests for the intent helpers."""
 
+import pytest
 import voluptuous as vol
 
-import pytest
-
 from homeassistant.core import State
-from homeassistant.helpers import intent, config_validation as cv
+from homeassistant.helpers import config_validation as cv, intent
 
 
 class MockIntentHandler(intent.IntentHandler):

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -1,8 +1,8 @@
 """Test network helper."""
 from unittest.mock import Mock, patch
 
-from homeassistant.helpers import network
 from homeassistant.components import cloud
+from homeassistant.helpers import network
 
 
 async def test_get_external_url(hass):

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -8,14 +8,13 @@ from homeassistant.core import CoreState, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.restore_state import (
-    RestoreStateData,
-    RestoreEntity,
-    StoredState,
     DATA_RESTORE_STATE_TASK,
     STORAGE_KEY,
+    RestoreEntity,
+    RestoreStateData,
+    StoredState,
 )
 from homeassistant.util import dt as dt_util
-
 
 from tests.common import mock_coro
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -6,20 +6,18 @@ from unittest import mock
 
 import asynctest
 import jinja2
-import voluptuous as vol
 import pytest
-
-import homeassistant.components.scene as scene
-from homeassistant import exceptions
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
-from homeassistant.core import Context, callback
+import voluptuous as vol
 
 # Otherwise can't test just this file (import order issue)
+from homeassistant import exceptions
+import homeassistant.components.scene as scene
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.core import Context, callback
+from homeassistant.helpers import config_validation as cv, script
 import homeassistant.util.dt as dt_util
-from homeassistant.helpers import script, config_validation as cv
 
 from tests.common import async_fire_time_changed
-
 
 ENTITY_ID = "script.test"
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -5,28 +5,29 @@ from copy import deepcopy
 import unittest
 from unittest.mock import Mock, patch
 
-import voluptuous as vol
 import pytest
+import voluptuous as vol
 
 # To prevent circular import when running just this file
-import homeassistant.components  # noqa: F401
 from homeassistant import core as ha, exceptions
-from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ENTITY_ID, ENTITY_MATCH_ALL
-from homeassistant.setup import async_setup_component
-import homeassistant.helpers.config_validation as cv
 from homeassistant.auth.permissions import PolicyPermissions
+import homeassistant.components  # noqa: F401
+from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, STATE_OFF, STATE_ON
 from homeassistant.helpers import (
-    service,
-    template,
     device_registry as dev_reg,
     entity_registry as ent_reg,
+    service,
+    template,
 )
+import homeassistant.helpers.config_validation as cv
+from homeassistant.setup import async_setup_component
+
 from tests.common import (
     get_test_home_assistant,
-    mock_service,
     mock_coro,
-    mock_registry,
     mock_device_registry,
+    mock_registry,
+    mock_service,
 )
 
 

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -5,21 +5,22 @@ from unittest.mock import patch
 
 import pytest
 
-import homeassistant.core as ha
-from homeassistant.const import SERVICE_TURN_ON, SERVICE_TURN_OFF
-from homeassistant.util import dt as dt_util
-from homeassistant.helpers import state
-from homeassistant.const import (
-    STATE_OPEN,
-    STATE_CLOSED,
-    STATE_LOCKED,
-    STATE_UNLOCKED,
-    STATE_ON,
-    STATE_OFF,
-    STATE_HOME,
-    STATE_NOT_HOME,
-)
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
+from homeassistant.const import (
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_CLOSED,
+    STATE_HOME,
+    STATE_LOCKED,
+    STATE_NOT_HOME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_OPEN,
+    STATE_UNLOCKED,
+)
+import homeassistant.core as ha
+from homeassistant.helpers import state
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_mock_service
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import json
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -11,7 +11,6 @@ from homeassistant.helpers import storage
 from homeassistant.util import dt
 
 from tests.common import async_fire_time_changed, mock_coro
-
 
 MOCK_VERSION = 1
 MOCK_KEY = "storage-test"

--- a/tests/helpers/test_sun.py
+++ b/tests/helpers/test_sun.py
@@ -1,11 +1,11 @@
 """The tests for the Sun helpers."""
 # pylint: disable=protected-access
+from datetime import datetime, timedelta
 from unittest.mock import patch
-from datetime import timedelta, datetime
 
 from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
-import homeassistant.util.dt as dt_util
 import homeassistant.helpers.sun as sun
+import homeassistant.util.dt as dt_util
 
 
 def test_next_events(hass):

--- a/tests/helpers/test_temperature.py
+++ b/tests/helpers/test_temperature.py
@@ -2,11 +2,11 @@
 import pytest
 
 from homeassistant.const import (
-    TEMP_CELSIUS,
-    PRECISION_WHOLE,
-    TEMP_FAHRENHEIT,
     PRECISION_HALVES,
     PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
 )
 from homeassistant.helpers.temperature import display_temp
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1,13 +1,12 @@
 """Test Home Assistant template helper methods."""
+from datetime import datetime
 import math
 import random
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 import pytz
 
-import homeassistant.util.dt as dt_util
 from homeassistant.components import group
 from homeassistant.const import (
     LENGTH_METERS,
@@ -19,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
+import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import UnitSystem
 
 

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -5,9 +5,10 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.generated import config_flows
 import homeassistant.helpers.translation as translation
 from homeassistant.setup import async_setup_component
-from homeassistant.generated import config_flows
+
 from tests.common import mock_coro
 
 

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.scripts import auth as script_auth
 from homeassistant.auth.providers import homeassistant as hass_auth
+from homeassistant.scripts import auth as script_auth
 
 from tests.common import register_auth_provider
 

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -2,8 +2,9 @@
 import logging
 from unittest.mock import patch
 
-import homeassistant.scripts.check_config as check_config
 from homeassistant.config import YAML_CONFIG_FILE
+import homeassistant.scripts.check_config as check_config
+
 from tests.common import get_test_config_dir, patch_yaml_files
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,20 +1,20 @@
 """Test the bootstrapping."""
 # pylint: disable=protected-access
 import asyncio
+import logging
 import os
 from unittest.mock import Mock, patch
-import logging
 
-import homeassistant.config as config_util
 from homeassistant import bootstrap
+import homeassistant.config as config_util
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    patch_yaml_files,
+    MockModule,
     get_test_config_dir,
     mock_coro,
     mock_integration,
-    MockModule,
+    patch_yaml_files,
 )
 
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,39 +1,39 @@
 """Test config utils."""
 # pylint: disable=protected-access
 import asyncio
+from collections import OrderedDict
 import copy
 import os
 import unittest.mock as mock
-from collections import OrderedDict
 
 import asynctest
 import pytest
-from voluptuous import MultipleInvalid, Invalid
+from voluptuous import Invalid, MultipleInvalid
 import yaml
 
-from homeassistant.core import SOURCE_STORAGE, HomeAssistantError
 import homeassistant.config as config_util
-from homeassistant.loader import async_get_integration
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     ATTR_FRIENDLY_NAME,
     ATTR_HIDDEN,
-    ATTR_ASSUMED_STATE,
+    CONF_AUTH_MFA_MODULES,
+    CONF_AUTH_PROVIDERS,
+    CONF_CUSTOMIZE,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_UNIT_SYSTEM,
     CONF_NAME,
-    CONF_CUSTOMIZE,
-    __version__,
-    CONF_UNIT_SYSTEM_METRIC,
-    CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_TEMPERATURE_UNIT,
-    CONF_AUTH_PROVIDERS,
-    CONF_AUTH_MFA_MODULES,
+    CONF_UNIT_SYSTEM,
+    CONF_UNIT_SYSTEM_IMPERIAL,
+    CONF_UNIT_SYSTEM_METRIC,
+    __version__,
 )
+from homeassistant.core import SOURCE_STORAGE, HomeAssistantError
+import homeassistant.helpers.check_config as check_config
+from homeassistant.helpers.entity import Entity
+from homeassistant.loader import async_get_integration
 from homeassistant.util import dt as dt_util
 from homeassistant.util.yaml import SECRET_YAML
-from homeassistant.helpers.entity import Entity
-import homeassistant.helpers.check_config as check_config
 
 from tests.common import get_test_config_dir, patch_yaml_files
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -12,14 +12,14 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.common import (
-    MockModule,
-    mock_coro,
     MockConfigEntry,
-    async_fire_time_changed,
-    MockPlatform,
     MockEntity,
-    mock_integration,
+    MockModule,
+    MockPlatform,
+    async_fire_time_changed,
+    mock_coro,
     mock_entity_platform,
+    mock_integration,
     mock_registry,
 )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,40 +1,40 @@
 """Test to verify that Home Assistant core works."""
 # pylint: disable=protected-access
 import asyncio
+from datetime import datetime, timedelta
 import functools
 import logging
 import os
-import unittest
-from unittest.mock import patch, MagicMock
-from datetime import datetime, timedelta
 from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import MagicMock, patch
 
-import voluptuous as vol
-import pytz
 import pytest
+import pytz
+import voluptuous as vol
 
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    ATTR_NOW,
+    ATTR_SECONDS,
+    CONF_UNIT_SYSTEM,
+    EVENT_CALL_SERVICE,
+    EVENT_CORE_CONFIG_UPDATE,
+    EVENT_HOMEASSISTANT_CLOSE,
+    EVENT_HOMEASSISTANT_STOP,
+    EVENT_SERVICE_REGISTERED,
+    EVENT_SERVICE_REMOVED,
+    EVENT_STATE_CHANGED,
+    EVENT_TIME_CHANGED,
+    EVENT_TIMER_OUT_OF_SYNC,
+    __version__,
+)
 import homeassistant.core as ha
 from homeassistant.exceptions import InvalidEntityFormatError, InvalidStateError
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
-from homeassistant.const import (
-    __version__,
-    EVENT_STATE_CHANGED,
-    ATTR_FRIENDLY_NAME,
-    CONF_UNIT_SYSTEM,
-    ATTR_NOW,
-    EVENT_TIME_CHANGED,
-    EVENT_TIMER_OUT_OF_SYNC,
-    ATTR_SECONDS,
-    EVENT_HOMEASSISTANT_STOP,
-    EVENT_HOMEASSISTANT_CLOSE,
-    EVENT_SERVICE_REGISTERED,
-    EVENT_SERVICE_REMOVED,
-    EVENT_CALL_SERVICE,
-    EVENT_CORE_CONFIG_UPDATE,
-)
 
-from tests.common import get_test_home_assistant, async_mock_service
+from tests.common import async_mock_service, get_test_home_assistant
 
 PST = pytz.timezone("America/Los_Angeles")
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,9 +2,9 @@
 from asynctest.mock import ANY, patch
 import pytest
 
-import homeassistant.loader as loader
 from homeassistant.components import http, hue
 from homeassistant.components.hue import light as hue_light
+import homeassistant.loader as loader
 
 from tests.common import MockModule, async_mock_service, mock_integration
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 """Test methods in __main__."""
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
 from homeassistant import __main__ as main
 from homeassistant.const import REQUIRED_PYTHON_VER

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,20 +1,21 @@
 """Test requirements module."""
 import os
 from pathlib import Path
-from unittest.mock import patch, call
+from unittest.mock import call, patch
+
 from pytest import raises
 
 from homeassistant import setup
 from homeassistant.requirements import (
     CONSTRAINT_FILE,
+    PROGRESS_FILE,
+    RequirementsNotFound,
+    _install,
     async_get_integration_with_requirements,
     async_process_requirements,
-    PROGRESS_FILE,
-    _install,
-    RequirementsNotFound,
 )
 
-from tests.common import get_test_home_assistant, MockModule, mock_integration
+from tests.common import MockModule, get_test_home_assistant, mock_integration
 
 
 def env_without_wheel_links():

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,32 +1,32 @@
 """Test component/platform setup."""
 # pylint: disable=protected-access
 import asyncio
-import os
-from unittest import mock
-import threading
 import logging
+import os
+import threading
+from unittest import mock
 
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_COMPONENT_LOADED
-import homeassistant.config as config_util
 from homeassistant import setup
-import homeassistant.util.dt as dt_util
+import homeassistant.config as config_util
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_HOMEASSISTANT_START
+from homeassistant.core import callback
+from homeassistant.helpers import discovery
 from homeassistant.helpers.config_validation import (
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-from homeassistant.helpers import discovery
+import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    get_test_home_assistant,
     MockModule,
     MockPlatform,
     assert_setup_component,
     get_test_config_dir,
-    mock_integration,
+    get_test_home_assistant,
     mock_entity_platform,
+    mock_integration,
 )
 
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -7,10 +7,9 @@ from unittest import mock
 from urllib.parse import parse_qs
 
 from aiohttp import ClientSession
+from aiohttp.client_exceptions import ClientResponseError
 from aiohttp.streams import StreamReader
 from yarl import URL
-
-from aiohttp.client_exceptions import ClientResponseError
 
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
 

--- a/tests/test_util/test_aiohttp.py
+++ b/tests/test_util/test_aiohttp.py
@@ -1,7 +1,7 @@
 """Tests for our aiohttp mocker."""
-from .aiohttp import AiohttpClientMocker
-
 import pytest
+
+from .aiohttp import AiohttpClientMocker
 
 
 async def test_matching_url():

--- a/tests/testing_config/custom_components/test/alarm_control_panel.py
+++ b/tests/testing_config/custom_components/test/alarm_control_panel.py
@@ -4,6 +4,12 @@ Provide a mock alarm_control_panel platform.
 Call init before using it in your tests to ensure clean test data.
 """
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
+from homeassistant.components.alarm_control_panel.const import (
+    SUPPORT_ALARM_ARM_AWAY,
+    SUPPORT_ALARM_ARM_HOME,
+    SUPPORT_ALARM_ARM_NIGHT,
+    SUPPORT_ALARM_TRIGGER,
+)
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
@@ -11,12 +17,7 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.components.alarm_control_panel.const import (
-    SUPPORT_ALARM_ARM_HOME,
-    SUPPORT_ALARM_ARM_AWAY,
-    SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_TRIGGER,
-)
+
 from tests.common import MockEntity
 
 ENTITIES = {}

--- a/tests/testing_config/custom_components/test/binary_sensor.py
+++ b/tests/testing_config/custom_components/test/binary_sensor.py
@@ -3,9 +3,9 @@ Provide a mock binary sensor platform.
 
 Call init before using it in your tests to ensure clean test data.
 """
-from homeassistant.components.binary_sensor import BinarySensorDevice, DEVICE_CLASSES
-from tests.common import MockEntity
+from homeassistant.components.binary_sensor import DEVICE_CLASSES, BinarySensorDevice
 
+from tests.common import MockEntity
 
 ENTITIES = {}
 

--- a/tests/testing_config/custom_components/test/cover.py
+++ b/tests/testing_config/custom_components/test/cover.py
@@ -4,8 +4,8 @@ Provide a mock cover platform.
 Call init before using it in your tests to ensure clean test data.
 """
 from homeassistant.components.cover import CoverDevice
-from tests.common import MockEntity
 
+from tests.common import MockEntity
 
 ENTITIES = {}
 

--- a/tests/testing_config/custom_components/test/light.py
+++ b/tests/testing_config/custom_components/test/light.py
@@ -3,9 +3,9 @@ Provide a mock light platform.
 
 Call init before using it in your tests to ensure clean test data.
 """
-from homeassistant.const import STATE_ON, STATE_OFF
-from tests.common import MockToggleEntity
+from homeassistant.const import STATE_OFF, STATE_ON
 
+from tests.common import MockToggleEntity
 
 ENTITIES = []
 

--- a/tests/testing_config/custom_components/test/lock.py
+++ b/tests/testing_config/custom_components/test/lock.py
@@ -3,7 +3,8 @@ Provide a mock lock platform.
 
 Call init before using it in your tests to ensure clean test data.
 """
-from homeassistant.components.lock import LockDevice, SUPPORT_OPEN
+from homeassistant.components.lock import SUPPORT_OPEN, LockDevice
+
 from tests.common import MockEntity
 
 ENTITIES = {}

--- a/tests/testing_config/custom_components/test/sensor.py
+++ b/tests/testing_config/custom_components/test/sensor.py
@@ -4,8 +4,8 @@ Provide a mock sensor platform.
 Call init before using it in your tests to ensure clean test data.
 """
 import homeassistant.components.sensor as sensor
-from tests.common import MockEntity
 
+from tests.common import MockEntity
 
 DEVICE_CLASSES = list(sensor.DEVICE_CLASSES)
 DEVICE_CLASSES.append("none")

--- a/tests/testing_config/custom_components/test/switch.py
+++ b/tests/testing_config/custom_components/test/switch.py
@@ -3,9 +3,9 @@ Provide a mock switch platform.
 
 Call init before using it in your tests to ensure clean test data.
 """
-from homeassistant.const import STATE_ON, STATE_OFF
-from tests.common import MockToggleEntity
+from homeassistant.const import STATE_OFF, STATE_ON
 
+from tests.common import MockToggleEntity
 
 ENTITIES = []
 

--- a/tests/testing_config/custom_components/test_package/__init__.py
+++ b/tests/testing_config/custom_components/test_package/__init__.py
@@ -1,7 +1,6 @@
 """Provide a mock package component."""
 from .const import TEST  # noqa: F401
 
-
 DOMAIN = "test_package"
 
 

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -1,8 +1,8 @@
 """Tests for async util methods from Python source."""
 import asyncio
 import sys
-from unittest.mock import MagicMock, patch
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -2,13 +2,13 @@
 
 import pytest
 
-import homeassistant.util.distance as distance_util
 from homeassistant.const import (
+    LENGTH_FEET,
     LENGTH_KILOMETERS,
     LENGTH_METERS,
-    LENGTH_FEET,
     LENGTH_MILES,
 )
+import homeassistant.util.distance as distance_util
 
 INVALID_SYMBOL = "bob"
 VALID_SYMBOL = LENGTH_KILOMETERS

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -1,6 +1,6 @@
 """Test Home Assistant util methods."""
-from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -1,16 +1,15 @@
 """Test Home Assistant json utility functions."""
 from json import JSONEncoder
 import os
-import unittest
-from unittest.mock import Mock
 import sys
 from tempfile import mkdtemp
+import unittest
+from unittest.mock import Mock
 
 import pytest
 
-from homeassistant.util.json import SerializationError, load_json, save_json
 from homeassistant.exceptions import HomeAssistantError
-
+from homeassistant.util.json import SerializationError, load_json, save_json
 
 # Test data that can be saved as JSON
 TEST_JSON_A = {"a": 1, "B": "two"}

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -1,5 +1,5 @@
 """Test Home Assistant location util methods."""
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import aiohttp
 import pytest

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -2,15 +2,14 @@
 import asyncio
 import logging
 import os
-import sys
 from subprocess import PIPE
+import sys
 from unittest.mock import MagicMock, call, patch
 
 import pkg_resources
 import pytest
 
 import homeassistant.util.package as package
-
 
 RESOURCE_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "resources")

--- a/tests/util/test_pressure.py
+++ b/tests/util/test_pressure.py
@@ -2,10 +2,10 @@
 import pytest
 
 from homeassistant.const import (
-    PRESSURE_PA,
     PRESSURE_HPA,
-    PRESSURE_MBAR,
     PRESSURE_INHG,
+    PRESSURE_MBAR,
+    PRESSURE_PA,
     PRESSURE_PSI,
 )
 import homeassistant.util.pressure as pressure_util

--- a/tests/util/test_ruamel_yaml.py
+++ b/tests/util/test_ruamel_yaml.py
@@ -1,13 +1,12 @@
 """Test Home Assistant ruamel.yaml loader."""
 import os
 from tempfile import mkdtemp
-import pytest
 
+import pytest
 from ruamel.yaml import YAML
 
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.ruamel_yaml as util_yaml
-
 
 TEST_YAML_A = """\
 title: My Awesome Home

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -1,20 +1,20 @@
 """Test the unit system helper."""
 import pytest
 
-from homeassistant.util.unit_system import UnitSystem, METRIC_SYSTEM, IMPERIAL_SYSTEM
 from homeassistant.const import (
-    LENGTH_METERS,
-    LENGTH_KILOMETERS,
-    MASS_GRAMS,
-    PRESSURE_PA,
-    VOLUME_LITERS,
-    TEMP_CELSIUS,
     LENGTH,
+    LENGTH_KILOMETERS,
+    LENGTH_METERS,
     MASS,
+    MASS_GRAMS,
     PRESSURE,
+    PRESSURE_PA,
+    TEMP_CELSIUS,
     TEMPERATURE,
     VOLUME,
+    VOLUME_LITERS,
 )
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 SYSTEM_NAME = "TEST"
 INVALID_UNIT = "INVALID"

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -2,13 +2,13 @@
 
 import pytest
 
-import homeassistant.util.volume as volume_util
 from homeassistant.const import (
+    VOLUME_FLUID_OUNCE,
+    VOLUME_GALLONS,
     VOLUME_LITERS,
     VOLUME_MILLILITERS,
-    VOLUME_GALLONS,
-    VOLUME_FLUID_OUNCE,
 )
+import homeassistant.util.volume as volume_util
 
 INVALID_SYMBOL = "bob"
 VALID_SYMBOL = VOLUME_LITERS

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -1,16 +1,17 @@
 """Test Home Assistant yaml loader."""
 import io
+import logging
 import os
 import unittest
-import logging
 from unittest.mock import patch
 
 import pytest
 
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util.yaml import loader as yaml_loader
-import homeassistant.util.yaml as yaml
 from homeassistant.config import YAML_CONFIG_FILE, load_yaml_config_file
+from homeassistant.exceptions import HomeAssistantError
+import homeassistant.util.yaml as yaml
+from homeassistant.util.yaml import loader as yaml_loader
+
 from tests.common import get_test_config_dir, patch_yaml_files
 
 


### PR DESCRIPTION

## Description:

The imports imports of `"tests"` according to PEP8 using isort.

See https://github.com/home-assistant/home-assistant/pull/29739

This PR affects:

- `tests/auth/mfa_modules/test_insecure_example.py` 
- `tests/auth/mfa_modules/test_notify.py` 
- `tests/auth/mfa_modules/test_totp.py` 
- `tests/auth/permissions/test_entities.py` 
- `tests/auth/permissions/test_system_policies.py` 
- `tests/auth/providers/test_command_line.py` 
- `tests/auth/providers/test_insecure_example.py` 
- `tests/auth/test_init.py` 
- `tests/common.py` 
- `tests/conftest.py` 
- `tests/test_bootstrap.py` 
- `tests/test_config.py` 
- `tests/test_config_entries.py` 
- `tests/test_core.py` 
- `tests/test_loader.py` 
- `tests/test_main.py` 
- `tests/test_requirements.py` 
- `tests/test_setup.py` 
- `tests/helpers/test_aiohttp_client.py` 
- `tests/helpers/test_area_registry.py` 
- `tests/helpers/test_check_config.py` 
- `tests/helpers/test_config_entry_flow.py` 
- `tests/helpers/test_config_entry_oauth2_flow.py` 
- `tests/helpers/test_deprecation.py` 
- `tests/helpers/test_device_registry.py` 
- `tests/helpers/test_discovery.py` 
- `tests/helpers/test_dispatcher.py` 
- `tests/helpers/test_entity.py` 
- `tests/helpers/test_entity_component.py` 
- `tests/helpers/test_entity_platform.py` 
- `tests/helpers/test_entity_registry.py` 
- `tests/helpers/test_entity_values.py` 
- `tests/helpers/test_entityfilter.py` 
- `tests/helpers/test_event.py` 
- `tests/helpers/test_intent.py` 
- `tests/helpers/test_network.py` 
- `tests/helpers/test_restore_state.py` 
- `tests/helpers/test_script.py` 
- `tests/helpers/test_service.py` 
- `tests/helpers/test_state.py` 
- `tests/helpers/test_storage.py` 
- `tests/helpers/test_sun.py` 
- `tests/helpers/test_temperature.py` 
- `tests/helpers/test_template.py` 
- `tests/helpers/test_translation.py` 
- `tests/scripts/test_auth.py` 
- `tests/scripts/test_check_config.py` 
- `tests/test_util/aiohttp.py` 
- `tests/test_util/test_aiohttp.py` 
- `tests/testing_config/custom_components/test/alarm_control_panel.py` 
- `tests/testing_config/custom_components/test/binary_sensor.py` 
- `tests/testing_config/custom_components/test/cover.py` 
- `tests/testing_config/custom_components/test/light.py` 
- `tests/testing_config/custom_components/test/lock.py` 
- `tests/testing_config/custom_components/test/sensor.py` 
- `tests/testing_config/custom_components/test/switch.py` 
- `tests/testing_config/custom_components/test_package/__init__.py` 
- `tests/util/test_async.py` 
- `tests/util/test_distance.py` 
- `tests/util/test_init.py` 
- `tests/util/test_json.py` 
- `tests/util/test_location.py` 
- `tests/util/test_package.py` 
- `tests/util/test_pressure.py` 
- `tests/util/test_ruamel_yaml.py` 
- `tests/util/test_unit_system.py` 
- `tests/util/test_volume.py` 
- `tests/util/test_yaml.py` 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
