### PR TITLE
Install discovery requirements if used

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -7,6 +7,7 @@ from pydeconz.utils import async_discovery, async_get_api_key, async_get_gateway
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -169,10 +170,6 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered deCONZ bridge."""
-        # Import it here, because only now do we know ssdp integration loaded.
-        # pylint: disable=import-outside-toplevel
-        from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
-
         if discovery_info[ATTR_MANUFACTURERURL] != DECONZ_MANUFACTURERURL:
             return self.async_abort(reason="not_deconz_bridge")
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -8,6 +8,7 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
@@ -134,9 +135,6 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         This flow is triggered by the SSDP component. It will check if the
         host is already configured and delegate to the import step if not.
         """
-        # pylint: disable=import-outside-toplevel
-        from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_NAME
-
         if discovery_info[ATTR_MANUFACTURERURL] != HUE_MANUFACTURERURL:
             return self.async_abort(reason="not_hue_bridge")
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -195,21 +195,44 @@ class Integration:
         hass: "HomeAssistant",
         pkg_path: str,
         file_path: pathlib.Path,
-        manifest: Dict,
+        manifest: Dict[str, Any],
     ):
         """Initialize an integration."""
         self.hass = hass
         self.pkg_path = pkg_path
         self.file_path = file_path
-        self.name: str = manifest["name"]
-        self.domain: str = manifest["domain"]
-        self.dependencies: List[str] = manifest["dependencies"]
-        self.after_dependencies: Optional[List[str]] = manifest.get(
-            "after_dependencies"
-        )
-        self.requirements: List[str] = manifest["requirements"]
-        self.config_flow: bool = manifest.get("config_flow", False)
+        self.manifest = manifest
         _LOGGER.info("Loaded %s from %s", self.domain, pkg_path)
+
+    @property
+    def name(self) -> str:
+        """Return name."""
+        return cast(str, self.manifest["name"])
+
+    @property
+    def domain(self) -> str:
+        """Return domain."""
+        return cast(str, self.manifest["domain"])
+
+    @property
+    def dependencies(self) -> List[str]:
+        """Return dependencies."""
+        return cast(List[str], self.manifest["dependencies"])
+
+    @property
+    def after_dependencies(self) -> Optional[List[str]]:
+        """Return after_dependencies."""
+        return cast(Optional[List[str]], self.manifest.get("after_dependencies"))
+
+    @property
+    def requirements(self) -> List[str]:
+        """Return requirements."""
+        return cast(List[str], self.manifest["requirements"])
+
+    @property
+    def config_flow(self) -> bool:
+        """Return config_flow."""
+        return cast(bool, self.manifest.get("config_flow", False))
 
     @property
     def is_built_in(self) -> bool:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -217,17 +217,17 @@ class Integration:
     @property
     def dependencies(self) -> List[str]:
         """Return dependencies."""
-        return cast(List[str], self.manifest["dependencies"])
+        return cast(List[str], self.manifest.get("dependencies", []))
 
     @property
-    def after_dependencies(self) -> Optional[List[str]]:
+    def after_dependencies(self) -> List[str]:
         """Return after_dependencies."""
-        return cast(Optional[List[str]], self.manifest.get("after_dependencies"))
+        return cast(Optional[List[str]], self.manifest.get("after_dependencies", []))
 
     @property
     def requirements(self) -> List[str]:
         """Return requirements."""
-        return cast(List[str], self.manifest["requirements"])
+        return cast(List[str], self.manifest.get("requirements", []))
 
     @property
     def config_flow(self) -> bool:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -222,7 +222,7 @@ class Integration:
     @property
     def after_dependencies(self) -> List[str]:
         """Return after_dependencies."""
-        return cast(Optional[List[str]], self.manifest.get("after_dependencies", []))
+        return cast(List[str], self.manifest.get("after_dependencies", []))
 
     @property
     def requirements(self) -> List[str]:

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Iterable
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -15,6 +15,10 @@ DATA_PKG_CACHE = "pkg_cache"
 CONSTRAINT_FILE = "package_constraints.txt"
 PROGRESS_FILE = ".pip_progress"
 _LOGGER = logging.getLogger(__name__)
+DISCOVERY_INTEGRATIONS: Dict[str, Iterable[str]] = {
+    "ssdp": ("ssdp",),
+    "zeroconf": ("zeroconf", "homekit"),
+}
 
 
 class RequirementsNotFound(HomeAssistantError):
@@ -30,7 +34,7 @@ class RequirementsNotFound(HomeAssistantError):
 async def async_get_integration_with_requirements(
     hass: HomeAssistant, domain: str, done: Set[str] = None
 ) -> Integration:
-    """Get an integration with installed requirements.
+    """Get an integration with all requirements installed, including the dependencies.
 
     This can raise IntegrationNotFound if manifest or integration
     is invalid, RequirementNotFound if there was some type of
@@ -56,6 +60,14 @@ async def async_get_integration_with_requirements(
         for dep in integration.dependencies + (integration.after_dependencies or [])
         if dep not in done
     ]
+
+    for check_domain, to_check in DISCOVERY_INTEGRATIONS.items():
+        if (
+            check_domain not in done
+            and check_domain not in deps_to_check
+            and any(check in integration.manifest for check in to_check)
+        ):
+            deps_to_check.append(check_domain)
 
     if deps_to_check:
         await asyncio.gather(

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -57,7 +57,7 @@ async def async_get_integration_with_requirements(
 
     deps_to_check = [
         dep
-        for dep in integration.dependencies + (integration.after_dependencies or [])
+        for dep in integration.dependencies + integration.after_dependencies
         if dep not in done
     ]
 


### PR DESCRIPTION
## Description:
If an integration is discoverable via SSDP, Zeroconf or Homekit, make sure we install the requirements for those discovery integrations so that we can import from those integrations as normal.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
