### PR TITLE
Fix 'pytest.register_assert_rewrite("tests.common")' warning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@ from homeassistant.auth.const import GROUP_ID_ADMIN, GROUP_ID_READ_ONLY
 from homeassistant.auth.providers import homeassistant, legacy_api_password
 from homeassistant.util import location
 
-from tests.common import (  # noqa: E402 module level import not at top of file
+pytest.register_assert_rewrite("tests.common")
+
+from tests.common import (  # noqa: E402, isort:skip
     CLIENT_ID,
     INSTANCES,
     MockUser,
@@ -21,11 +23,7 @@ from tests.common import (  # noqa: E402 module level import not at top of file
     mock_coro,
     mock_storage as mock_storage,
 )
-from tests.test_util.aiohttp import (  # noqa: E402 module level import not at top of file
-    mock_aiohttp_client,
-)
-
-pytest.register_assert_rewrite("tests.common")
+from tests.test_util.aiohttp import mock_aiohttp_client  # noqa: E402, isort:skip
 
 if os.environ.get("UVLOOP") == "1":
     import uvloop


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant/pull/29791/files/fea243c035f117275fda1895720d30e7f977aa9c#r355533273


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
