### PR TITLE
Fix build, invalid JSON file in icloud component

### DIFF
--- a/homeassistant/components/icloud/strings.json
+++ b/homeassistant/components/icloud/strings.json
@@ -25,13 +25,13 @@
                 }
             }
         },
-        "error":{
+        "error": {
             "username_exists": "Account already configured",
             "login": "Login error: please check your email & password",
             "send_verification_code": "Failed to send verification code",
-            "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again",
+            "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again"
         },
-        "abort":{
+        "abort": {
             "username_exists": "Account already configured"
         }
     }


### PR DESCRIPTION
## Description:

Our language uploads in the CI currently fail.
This is due to an invalid (JSON) translation file introduced in #28968

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

**Example entry for `configuration.yaml` (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
