### PR TITLE
Add JSON files validation to hassfest

### DIFF
--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -2,10 +2,28 @@
 import pathlib
 import sys
 
-from . import codeowners, config_flow, dependencies, manifest, services, ssdp, zeroconf
+from . import (
+    codeowners,
+    config_flow,
+    dependencies,
+    json,
+    manifest,
+    services,
+    ssdp,
+    zeroconf,
+)
 from .model import Config, Integration
 
-PLUGINS = [codeowners, config_flow, dependencies, manifest, services, ssdp, zeroconf]
+PLUGINS = [
+    json,
+    codeowners,
+    config_flow,
+    dependencies,
+    manifest,
+    services,
+    ssdp,
+    zeroconf,
+]
 
 
 def get_config() -> Config:

--- a/script/hassfest/json.py
+++ b/script/hassfest/json.py
@@ -1,0 +1,29 @@
+"""Validate integration JSON files."""
+import json
+from typing import Dict
+
+from .model import Integration
+
+
+def validate_json_files(integration: Integration):
+    """Validate JSON files for integration."""
+    for json_file in integration.path.glob("**/*.json"):
+        if not json_file.is_file():
+            continue
+
+        try:
+            json.loads(json_file.read_text())
+        except json.JSONDecodeError:
+            relative_path = json_file.relative_to(integration.path)
+            integration.add_error("json", f"Invalid JSON file {relative_path}")
+
+    return
+
+
+def validate(integrations: Dict[str, Integration], config):
+    """Handle JSON files inside integrations."""
+    for integration in integrations.values():
+        if not integration.manifest:
+            continue
+
+        validate_json_files(integration)


### PR DESCRIPTION
## Description:

Adds a simple JSON validation plugin to `hassfest`.

![image](https://user-images.githubusercontent.com/195327/70471097-d48ecb80-1acc-11ea-9e7f-62e1945d430b.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
