### PR TITLE
UniFi - Add more logging to help future debug situations

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -1,5 +1,6 @@
 """Track devices using UniFi controllers."""
 import logging
+from pprint import pformat
 
 from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
@@ -153,13 +154,16 @@ class UniFiClientTracker(ScannerEntity):
 
         Make sure to update self.is_wired if client is wireless, there is an issue when clients go offline that they get marked as wired.
         """
-        LOGGER.debug(
-            "Updating UniFi tracked client %s (%s)", self.entity_id, self.client.mac
-        )
         await self.controller.request_update()
 
         if self.is_wired and self.client.mac in self.controller.wireless_clients:
             self.is_wired = False
+
+        LOGGER.debug(
+            "Updating UniFi tracked client %s\n%s",
+            self.entity_id,
+            pformat(self.client.raw),
+        )
 
     @property
     def is_connected(self):
@@ -239,10 +243,13 @@ class UniFiDeviceTracker(ScannerEntity):
 
     async def async_update(self):
         """Synchronize state with controller."""
-        LOGGER.debug(
-            "Updating UniFi tracked device %s (%s)", self.entity_id, self.device.mac
-        )
         await self.controller.request_update()
+
+        LOGGER.debug(
+            "Updating UniFi tracked device %s\n%s",
+            self.entity_id,
+            pformat(self.device.raw),
+        )
 
     @property
     def is_connected(self):

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -1,5 +1,6 @@
 """Support for devices connected to UniFi POE."""
 import logging
+from pprint import pformat
 
 from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.components.switch import SwitchDevice
@@ -192,6 +193,16 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchDevice, RestoreEntity):
 
         if not self.client.sw_port:
             self.client.raw["sw_port"] = state.attributes["port"]
+
+    async def async_update(self):
+        """Log client information after update."""
+        await super().async_update()
+
+        LOGGER.debug(
+            "Updating UniFi POE controlled client %s\n%s",
+            self.entity_id,
+            pformat(self.client.raw),
+        )
 
     @property
     def unique_id(self):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
