### PR TITLE
Fix zha circular import

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -1,7 +1,4 @@
-"""Support for Zigbee Home Automation devices.
-
-isort:skip_file
-"""
+"""Support for Zigbee Home Automation devices."""
 
 import logging
 
@@ -11,7 +8,6 @@ from homeassistant import config_entries, const as ha_const
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 
-from . import config_flow  # noqa: F401 pylint: disable=unused-import
 from . import api
 from .core import ZHAGateway
 from .core.const import (

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -143,5 +143,4 @@ async def async_unload_entry(hass, config_entry):
     for component in COMPONENTS:
         await hass.config_entries.async_forward_entry_unload(config_entry, component)
 
-    del hass.data[DATA_ZHA]
     return True

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -51,9 +51,9 @@ from .core.const import (
     WARNING_DEVICE_STROBE_YES,
 )
 from .core.helpers import (
+    async_get_device_info,
     async_is_bindable_target,
     get_matched_clusters,
-    async_get_device_info,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -50,7 +50,11 @@ from .core.const import (
     WARNING_DEVICE_STROBE_HIGH,
     WARNING_DEVICE_STROBE_YES,
 )
-from .core.helpers import async_is_bindable_target, get_matched_clusters
+from .core.helpers import (
+    async_is_bindable_target,
+    get_matched_clusters,
+    async_get_device_info,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -421,31 +425,6 @@ async def websocket_remove_group_members(hass, connection, msg):
         return
     ret_group = async_get_group_info(hass, zha_gateway, zigpy_group, ha_device_registry)
     connection.send_result(msg[ID], ret_group)
-
-
-@callback
-def async_get_device_info(hass, device, ha_device_registry=None):
-    """Get ZHA device."""
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
-    ret_device = {}
-    ret_device.update(device.device_info)
-    ret_device["entities"] = [
-        {
-            "entity_id": entity_ref.reference_id,
-            ATTR_NAME: entity_ref.device_info[ATTR_NAME],
-        }
-        for entity_ref in zha_gateway.device_registry[device.ieee]
-    ]
-
-    if ha_device_registry is not None:
-        reg_device = ha_device_registry.async_get_device(
-            {(DOMAIN, str(device.ieee))}, set()
-        )
-        if reg_device is not None:
-            ret_device["user_given_name"] = reg_device.name_by_user
-            ret_device["device_reg_id"] = reg_device.id
-            ret_device["area_id"] = reg_device.area_id
-    return ret_device
 
 
 async def get_groups(hass,):

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -15,11 +15,11 @@ import zigpy_zigate.api
 import zigpy_zigate.zigbee
 
 from homeassistant import config_entries
-from .core.const import DEFAULT_BAUDRATE
 
 from .core.const import (
     CONF_RADIO_TYPE,
     CONF_USB_PATH,
+    DEFAULT_BAUDRATE,
     DEFAULT_DATABASE_NAME,
     DOMAIN,
     RadioType,

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -3,27 +3,21 @@ import asyncio
 from collections import OrderedDict
 import os
 
-import bellows.ezsp
-import bellows.zigbee
-
 import voluptuous as vol
-import zigpy_deconz.api
-import zigpy_deconz.zigbee
-import zigpy_xbee.api
-import zigpy_xbee.zigbee
-import zigpy_zigate.api
-import zigpy_zigate.zigbee
 
 from homeassistant import config_entries
 
 from .core.const import (
     CONF_RADIO_TYPE,
     CONF_USB_PATH,
+    CONTROLLER,
     DEFAULT_BAUDRATE,
     DEFAULT_DATABASE_NAME,
     DOMAIN,
+    ZHA_GW_RADIO,
     RadioType,
 )
+from .core.registries import RADIO_TYPES
 
 
 @config_entries.HANDLERS.register(DOMAIN)
@@ -71,21 +65,14 @@ class ZhaFlowHandler(config_entries.ConfigFlow):
 
 async def check_zigpy_connection(usb_path, radio_type, database_path):
     """Test zigpy radio connection."""
-    if radio_type == RadioType.ezsp.name:
-        radio = bellows.ezsp.EZSP()
-        ControllerApplication = bellows.zigbee.application.ControllerApplication
-    elif radio_type == RadioType.xbee.name:
-        radio = zigpy_xbee.api.XBee()
-        ControllerApplication = zigpy_xbee.zigbee.application.ControllerApplication
-    elif radio_type == RadioType.deconz.name:
-        radio = zigpy_deconz.api.Deconz()
-        ControllerApplication = zigpy_deconz.zigbee.application.ControllerApplication
-    elif radio_type == RadioType.zigate.name:
-        radio = zigpy_zigate.api.ZiGate()
-        ControllerApplication = zigpy_zigate.zigbee.application.ControllerApplication
+    try:
+        radio = RADIO_TYPES[radio_type][ZHA_GW_RADIO]()
+        controller_application = RADIO_TYPES[radio_type][CONTROLLER]
+    except KeyError:
+        return False
     try:
         await radio.connect(usb_path, DEFAULT_BAUDRATE)
-        controller = ControllerApplication(radio, database_path)
+        controller = controller_application(radio, database_path)
         await asyncio.wait_for(controller.startup(auto_form=True), timeout=30)
         await controller.shutdown()
     except Exception:  # pylint: disable=broad-except

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -20,7 +20,6 @@ from homeassistant.helpers.device_registry import (
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from ..api import async_get_device_info
 from .const import (
     ATTR_IEEE,
     ATTR_MANUFACTURER,
@@ -65,6 +64,7 @@ from .const import (
 )
 from .device import DeviceStatus, ZHADevice
 from .discovery import async_dispatch_discovery_info, async_process_endpoint
+from .helpers import async_get_device_info
 from .patches import apply_application_controller_patch
 from .registries import RADIO_TYPES
 from .store import async_get_registry

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -12,10 +12,12 @@ import zigpy.types
 from homeassistant.core import callback
 
 from .const import (
+    ATTR_NAME,
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
     DATA_ZHA,
     DATA_ZHA_GATEWAY,
+    DOMAIN,
 )
 from .registries import BINDABLE_CLUSTERS
 
@@ -129,3 +131,28 @@ class LogMixin:
     def error(self, msg, *args):
         """Error level log."""
         return self.log(logging.ERROR, msg, *args)
+
+
+@callback
+def async_get_device_info(hass, device, ha_device_registry=None):
+    """Get ZHA device."""
+    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    ret_device = {}
+    ret_device.update(device.device_info)
+    ret_device["entities"] = [
+        {
+            "entity_id": entity_ref.reference_id,
+            ATTR_NAME: entity_ref.device_info[ATTR_NAME],
+        }
+        for entity_ref in zha_gateway.device_registry[device.ieee]
+    ]
+
+    if ha_device_registry is not None:
+        reg_device = ha_device_registry.async_get_device(
+            {(DOMAIN, str(device.ieee))}, set()
+        )
+        if reg_device is not None:
+            ret_device["user_given_name"] = reg_device.name_by_user
+            ret_device["device_reg_id"] = reg_device.id
+            ret_device["area_id"] = reg_device.area_id
+    return ret_device

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -4,19 +4,10 @@ Helpers for Zigbee Home Automation.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/integrations/zha/
 """
-import asyncio
 import collections
 import logging
 
-import bellows.ezsp
-import bellows.zigbee.application
 import zigpy.types
-import zigpy_deconz.api
-import zigpy_deconz.zigbee.application
-import zigpy_xbee.api
-import zigpy_xbee.zigbee.application
-import zigpy_zigate.api
-import zigpy_zigate.zigbee.application
 
 from homeassistant.core import callback
 
@@ -25,8 +16,6 @@ from .const import (
     CLUSTER_TYPE_OUT,
     DATA_ZHA,
     DATA_ZHA_GATEWAY,
-    DEFAULT_BAUDRATE,
-    RadioType,
 )
 from .registries import BINDABLE_CLUSTERS
 
@@ -54,30 +43,6 @@ async def safe_read(
         return result
     except Exception:  # pylint: disable=broad-except
         return {}
-
-
-async def check_zigpy_connection(usb_path, radio_type, database_path):
-    """Test zigpy radio connection."""
-    if radio_type == RadioType.ezsp.name:
-        radio = bellows.ezsp.EZSP()
-        ControllerApplication = bellows.zigbee.application.ControllerApplication
-    elif radio_type == RadioType.xbee.name:
-        radio = zigpy_xbee.api.XBee()
-        ControllerApplication = zigpy_xbee.zigbee.application.ControllerApplication
-    elif radio_type == RadioType.deconz.name:
-        radio = zigpy_deconz.api.Deconz()
-        ControllerApplication = zigpy_deconz.zigbee.application.ControllerApplication
-    elif radio_type == RadioType.zigate.name:
-        radio = zigpy_zigate.api.ZiGate()
-        ControllerApplication = zigpy_zigate.zigbee.application.ControllerApplication
-    try:
-        await radio.connect(usb_path, DEFAULT_BAUDRATE)
-        controller = ControllerApplication(radio, database_path)
-        await asyncio.wait_for(controller.startup(auto_form=True), timeout=30)
-        await controller.shutdown()
-    except Exception:  # pylint: disable=broad-except
-        return False
-    return True
 
 
 def get_attr_id_by_name(cluster, attr_name):


### PR DESCRIPTION
## Description:
Fixes problem exposed in #29555 and #29784

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html

@dmulcahey on a fence whether we should move `homeassistant.components.zha.core.const` one level up? 