### PR TITLE
Fix isort on a small set of misc files

### DIFF
--- a/docs/source/_ext/edit_on_github.py
+++ b/docs/source/_ext/edit_on_github.py
@@ -8,7 +8,6 @@ Loosely based on https://github.com/astropy/astropy/pull/347
 import os
 import warnings
 
-
 __licence__ = 'BSD (3 clause)'
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,11 +17,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import sys
-import os
 import inspect
+import os
+import sys
 
-from homeassistant.const import __version__, __short_version__
+from homeassistant.const import __short_version__, __version__
 
 PROJECT_NAME = 'Home Assistant'
 PROJECT_PACKAGE_NAME = 'homeassistant'

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -58,7 +58,6 @@ from .const import (
     SERVICE_SET_VOLUME,
 )
 
-
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Xiaomi Miio Device"

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -1,13 +1,12 @@
 """The tests for the feedreader component."""
 from datetime import timedelta
+from genericpath import exists
 from logging import getLogger
 from os import remove
 import time
 import unittest
 from unittest import mock
 from unittest.mock import patch
-
-from genericpath import exists
 
 from homeassistant.components import feedreader
 from homeassistant.components.feedreader import (

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -1,23 +1,22 @@
 """Tests for the iCloud config flow."""
-from unittest.mock import patch, Mock, MagicMock
-import pytest
+from unittest.mock import MagicMock, Mock, patch
 
 from pyicloud.exceptions import PyiCloudFailedLoginException
+import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.icloud import config_flow
-
 from homeassistant.components.icloud.config_flow import (
     CONF_TRUSTED_DEVICE,
     CONF_VERIFICATION_CODE,
 )
 from homeassistant.components.icloud.const import (
-    DOMAIN,
     CONF_ACCOUNT_NAME,
     CONF_GPS_ACCURACY_THRESHOLD,
     CONF_MAX_INTERVAL,
     DEFAULT_GPS_ACCURACY_THRESHOLD,
     DEFAULT_MAX_INTERVAL,
+    DOMAIN,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.typing import HomeAssistantType

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -8,9 +8,9 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
-
 from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
+
+from tests.common import async_fire_time_changed
 
 MELACHA_PARAMS = [
     make_nyc_test_params(dt(2018, 9, 1, 16, 0), STATE_ON),

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -7,9 +7,9 @@ from homeassistant.components import jewish_calendar
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
-
 from . import alter_time, make_jerusalem_test_params, make_nyc_test_params
+
+from tests.common import async_fire_time_changed
 
 
 async def test_jewish_calendar_min_config(hass):

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -1,6 +1,6 @@
 """The tests for the Xiaomi vacuum platform."""
 import asyncio
-from datetime import timedelta, time
+from datetime import time, timedelta
 from unittest import mock
 
 import pytest
@@ -22,26 +22,26 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.components.xiaomi_miio.vacuum import (
     ATTR_CLEANED_AREA,
+    ATTR_CLEANED_TOTAL_AREA,
+    ATTR_CLEANING_COUNT,
     ATTR_CLEANING_TIME,
+    ATTR_CLEANING_TOTAL_TIME,
     ATTR_DO_NOT_DISTURB,
-    ATTR_DO_NOT_DISTURB_START,
     ATTR_DO_NOT_DISTURB_END,
+    ATTR_DO_NOT_DISTURB_START,
     ATTR_ERROR,
+    ATTR_FILTER_LEFT,
     ATTR_MAIN_BRUSH_LEFT,
     ATTR_SIDE_BRUSH_LEFT,
-    ATTR_FILTER_LEFT,
-    ATTR_CLEANING_COUNT,
-    ATTR_CLEANED_TOTAL_AREA,
-    ATTR_CLEANING_TOTAL_TIME,
     CONF_HOST,
     CONF_NAME,
     CONF_TOKEN,
     DOMAIN as XIAOMI_DOMAIN,
+    SERVICE_CLEAN_ZONE,
     SERVICE_MOVE_REMOTE_CONTROL,
     SERVICE_MOVE_REMOTE_CONTROL_STEP,
     SERVICE_START_REMOTE_CONTROL,
     SERVICE_STOP_REMOTE_CONTROL,
-    SERVICE_CLEAN_ZONE,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,


### PR DESCRIPTION
## Description:

After all the isorting we have done today, some files are left behind, or, where merged between this whole transition.

This is a semi-final cleanup/leftover PR.


**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
