### PR TITLE
Bump Roku to 4.0

### DIFF
--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -3,8 +3,8 @@
   "name": "Roku",
   "documentation": "https://www.home-assistant.io/integrations/roku",
   "requirements": [
-        "roku==4.0"
-    ],
-    "dependencies": [],
-    "codeowners": []
+    "roku==4.0"
+  ],
+  "dependencies": [],
+  "codeowners": []
 }

--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -3,8 +3,8 @@
   "name": "Roku",
   "documentation": "https://www.home-assistant.io/integrations/roku",
   "requirements": [
-    "roku==3.1"
-  ],
-  "dependencies": [],
-  "codeowners": []
+        "roku==4.0"
+    ],
+    "dependencies": [],
+    "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1751,7 +1751,7 @@ rjpl==0.3.5
 rocketchat-API==0.6.1
 
 # homeassistant.components.roku
-roku==3.1
+roku==4.0
 
 # homeassistant.components.roomba
 roombapy==1.4.2


### PR DESCRIPTION
## Description:
- Bump Roku to 4.0 to fix invalid raised exceptions on successful execution of the turn_on/off service

**Related issue (if applicable):** fixes #29591<home-assistant issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
