### PR TITLE
Add unique ID to config entries

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant import core, config_entries
+from homeassistant import config_entries, core
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant import core, config_entries
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
@@ -102,7 +102,9 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
+async def async_setup_entry(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+):
     """Set up a bridge from a config entry."""
     host = entry.data["host"]
     config = hass.data[DATA_CONFIGS].get(host)
@@ -122,6 +124,7 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     hass.data[DOMAIN][host] = bridge
     config = bridge.api.config
 
+    # For backwards compat
     if entry.unique_id is None:
         hass.config_entries.async_update_entry(
             entry, unique_id=normalize_bridge_id(config.bridgeid)

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
-from .bridge import HueBridge
+from .bridge import HueBridge, normalize_bridge_id
 from .config_flow import (  # Loading the config flow file will register the flow
     configured_hosts,
 )
@@ -102,7 +102,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass, entry):
+async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     """Set up a bridge from a config entry."""
     host = entry.data["host"]
     config = hass.data[DATA_CONFIGS].get(host)
@@ -121,6 +121,12 @@ async def async_setup_entry(hass, entry):
 
     hass.data[DOMAIN][host] = bridge
     config = bridge.api.config
+
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(
+            entry, unique_id=normalize_bridge_id(config.bridgeid)
+        )
+
     device_registry = await dr.async_get_registry(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -201,3 +201,25 @@ async def get_bridge(hass, host, username=None):
     except aiohue.AiohueException:
         LOGGER.exception("Unknown Hue linking error occurred")
         raise AuthenticationRequired
+
+
+def normalize_bridge_id(bridge_id: str):
+    """Normalize a bridge identifier.
+
+    There are three sources where we receive bridge ID from:
+     - ssdp/upnp: <host>/description.xml, field root/device/serialNumber
+     - nupnp: "id" field
+     - Hue Bridge API: config.bridgeid
+
+    The SSDP/UPNP source does not contain the middle 4 characters compared
+    to the other sources. In all our tests the middle 4 characters are "fffe".
+    """
+    if len(bridge_id) == 16:
+        return bridge_id[0:6] + bridge_id[-6:]
+
+    if len(bridge_id) == 12:
+        return bridge_id
+
+    LOGGER.warning("Unexpected bridge id number found: %s", bridge_id)
+
+    return bridge_id

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
-from .bridge import get_bridge
+from .bridge import get_bridge, normalize_bridge_id
 from .const import DOMAIN, LOGGER
 from .errors import AuthenticationRequired, CannotConnect
 
@@ -154,17 +154,15 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if host in configured_hosts(self.hass):
             return self.async_abort(reason="already_configured")
 
-        # This value is based off host/description.xml and is, weirdly, missing
-        # 4 characters in the middle of the serial compared to results returned
-        # from the NUPNP API or when querying the bridge API for bridgeid.
-        # (on first gen Hue hub)
-        serial = discovery_info.get("serial")
+        bridge_id = discovery_info.get("serial")
+
+        await self.async_set_unique_id(normalize_bridge_id(bridge_id))
 
         return await self.async_step_import(
             {
                 "host": host,
                 # This format is the legacy format that Hue used for discovery
-                "path": f"phue-{serial}.conf",
+                "path": f"phue-{bridge_id}.conf",
             }
         )
 
@@ -179,6 +177,10 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if host in configured_hosts(self.hass):
             return self.async_abort(reason="already_configured")
+
+        await self.async_set_unique_id(
+            normalize_bridge_id(homekit_info["properties"]["id"].replace(":", ""))
+        )
 
         return await self.async_step_import({"host": host})
 
@@ -234,18 +236,9 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         host = bridge.host
         bridge_id = bridge.config.bridgeid
 
-        same_hub_entries = [
-            entry.entry_id
-            for entry in self.hass.config_entries.async_entries(DOMAIN)
-            if entry.data["bridge_id"] == bridge_id or entry.data["host"] == host
-        ]
-
-        if same_hub_entries:
-            await asyncio.wait(
-                [
-                    self.hass.config_entries.async_remove(entry_id)
-                    for entry_id in same_hub_entries
-                ]
+        if self.unique_id is None:
+            await self.async_set_unique_id(
+                normalize_bridge_id(bridge_id), raise_on_progress=False
             )
 
         return self.async_create_entry(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -611,7 +611,7 @@ class ConfigEntries:
         if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
             return result
 
-        # TODO check if config entry exists with unique ID. Unload it.
+        # Check if config entry exists with unique ID. Unload it.
         existing_entry = None
         unique_id = flow.context.get("unique_id")
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -754,6 +754,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     def _async_current_entries(self) -> List[ConfigEntry]:
         """Return current entries."""
         assert self.hass is not None
+        # pylint: disable=no-member
         return self.hass.config_entries.async_entries(self.handler)
 
     @callback
@@ -763,6 +764,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         return [
             flw
             for flw in self.hass.config_entries.flow.async_progress()
+            # pylint: disable=no-member
             if flw["handler"] == self.handler and flw["flow_id"] != self.flow_id
         ]
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -75,10 +75,6 @@ class OperationNotAllowed(ConfigError):
     """Raised when a config entry operation is not allowed."""
 
 
-class UniqueIdExists(data_entry_flow.AbortFlow):
-    """Error to indicate that the unique Id already exists."""
-
-
 class UniqueIdInProgress(data_entry_flow.AbortFlow):
     """Error to indicate that the unique Id is in progress."""
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -542,7 +542,7 @@ class ConfigEntries:
         self,
         entry: ConfigEntry,
         *,
-        unique_id: Union[str, dict] = _UNDEF,
+        unique_id: Union[str, dict, None] = _UNDEF,
         data: dict = _UNDEF,
         options: dict = _UNDEF,
         system_options: dict = _UNDEF,
@@ -625,6 +625,9 @@ class ConfigEntries:
                     existing_entry = check_entry
                     break
 
+        # Unload the entry before setting up the new one.
+        # We will remove it only after the other one is set up,
+        # so that device customizations are not getting lost.
         if (
             existing_entry is not None
             and existing_entry.state not in UNRECOVERABLE_STATES
@@ -761,7 +764,6 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     def _async_current_entries(self) -> List[ConfigEntry]:
         """Return current entries."""
         assert self.hass is not None
-        # pylint: disable=no-member
         return self.hass.config_entries.async_entries(self.handler)
 
     @callback
@@ -771,7 +773,6 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         return [
             flw
             for flw in self.hass.config_entries.flow.async_progress()
-            # pylint: disable=no-member
             if flw["handler"] == self.handler and flw["flow_id"] != self.flow_id
         ]
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -37,7 +37,7 @@ class UnknownStep(FlowError):
 
 
 class AbortFlow(FlowError):
-    """Class to indicate a flow needs to be aborted."""
+    """Exception to indicate a flow needs to be aborted."""
 
     def __init__(self, reason: str, description_placeholders: Optional[Dict] = None):
         """Initialize an abort flow exception."""

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -1,6 +1,6 @@
 """Classes to help gather user submissions."""
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, cast
 import uuid
 
 import voluptuous as vol
@@ -187,7 +187,7 @@ class FlowHandler:
     # Set by flow manager
     flow_id: str = None  # type: ignore
     hass: Optional[HomeAssistant] = None
-    handler: str = None  # type: ignore
+    handler: Optional[str] = None
     cur_step: Optional[Dict[str, str]] = None
     context: Dict
 
@@ -244,7 +244,7 @@ class FlowHandler:
     ) -> Dict[str, Any]:
         """Abort the config flow."""
         return _create_abort_data(
-            self.flow_id, self.handler, reason, description_placeholders
+            self.flow_id, cast(str, self.handler), reason, description_placeholders
         )
 
     @callback

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -187,7 +187,7 @@ class FlowHandler:
     # Set by flow manager
     flow_id: str = None  # type: ignore
     hass: Optional[HomeAssistant] = None
-    handler: str
+    handler: str = None  # type: ignore
     cur_step: Optional[Dict[str, str]] = None
     context: Dict
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -187,7 +187,7 @@ class FlowHandler:
     # Set by flow manager
     flow_id: str = None  # type: ignore
     hass: Optional[HomeAssistant] = None
-    handler: Optional[str] = None
+    handler: str
     cur_step: Optional[Dict[str, str]] = None
     context: Dict
 
@@ -243,7 +243,6 @@ class FlowHandler:
         self, *, reason: str, description_placeholders: Optional[Dict] = None
     ) -> Dict[str, Any]:
         """Abort the config flow."""
-        assert self.handler is not None
         return _create_abort_data(
             self.flow_id, self.handler, reason, description_placeholders
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -671,6 +671,7 @@ class MockConfigEntry(config_entries.ConfigEntry):
         options={},
         system_options={},
         connection_class=config_entries.CONN_CLASS_UNKNOWN,
+        unique_id=None,
     ):
         """Initialize a mock config entry."""
         kwargs = {
@@ -682,6 +683,7 @@ class MockConfigEntry(config_entries.ConfigEntry):
             "version": version,
             "title": title,
             "connection_class": connection_class,
+            "unique_id": unique_id,
         }
         if source is not None:
             kwargs["source"] = source

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -175,3 +175,19 @@ async def test_unload_entry(hass):
     assert await hue.async_unload_entry(hass, entry)
     assert len(mock_bridge.return_value.async_reset.mock_calls) == 1
     assert hass.data[hue.DOMAIN] == {}
+
+
+async def test_setting_unique_id(hass):
+    """Test we set unique ID if not set yet."""
+    entry = MockConfigEntry(domain=hue.DOMAIN, data={"host": "0.0.0.0"})
+    entry.add_to_hass(hass)
+
+    with patch.object(hue, "HueBridge") as mock_bridge, patch(
+        "homeassistant.helpers.device_registry.async_get_registry",
+        return_value=mock_coro(Mock()),
+    ):
+        mock_bridge.return_value.async_setup.return_value = mock_coro(True)
+        mock_bridge.return_value.api.config = Mock(bridgeid="mock-id")
+        assert await async_setup_component(hass, hue.DOMAIN, {}) is True
+
+    assert entry.unique_id == "mock-id"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1031,9 +1031,27 @@ async def test_unqiue_id_persisted(hass, manager):
 
 
 async def test_unique_id_existing_entry(hass, manager):
-    """Test that we abort if there already is an entry with unique ID."""
-    MockConfigEntry(domain="comp", unique_id="mock-unique-id").add_to_hass(hass)
-    mock_integration(hass, MockModule("comp"))
+    """Test that we remove an entry if there already is an entry with unique ID."""
+    hass.config.components.add("comp")
+    MockConfigEntry(
+        domain="comp",
+        state=config_entries.ENTRY_STATE_LOADED,
+        unique_id="mock-unique-id",
+    ).add_to_hass(hass)
+
+    async_setup_entry = MagicMock(side_effect=lambda _, _2: mock_coro(True))
+    async_unload_entry = MagicMock(side_effect=lambda _, _2: mock_coro(True))
+    async_remove_entry = MagicMock(side_effect=lambda _, _2: mock_coro(True))
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=async_unload_entry,
+            async_remove_entry=async_remove_entry,
+        ),
+    )
     mock_entity_platform(hass, "config_flow.comp", None)
 
     class TestFlow(config_entries.ConfigFlow):
@@ -1041,16 +1059,26 @@ async def test_unique_id_existing_entry(hass, manager):
         VERSION = 1
 
         async def async_step_user(self, user_input=None):
-            await self.async_set_unique_id("mock-unique-id")
-            return self.async_create_entry(title="mock-title", data={})
+            existing_entry = await self.async_set_unique_id("mock-unique-id")
+
+            assert existing_entry is not None
+
+            return self.async_create_entry(title="mock-title", data={"via": "flow"})
 
     with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    entries = hass.config_entries.async_entries("comp")
+    assert len(entries) == 1
+    assert entries[0].data == {"via": "flow"}
+
+    assert len(async_setup_entry.mock_calls) == 1
+    assert len(async_unload_entry.mock_calls) == 1
+    assert len(async_remove_entry.mock_calls) == 1
 
 
 async def test_unique_id_in_progress(hass, manager):

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -94,7 +94,7 @@ async def test_configure_two_steps(manager):
 
 
 async def test_show_form(manager):
-    """Test that abort removes the flow from progress."""
+    """Test that we can show a form."""
     schema = vol.Schema({vol.Required("username"): str, vol.Required("password"): str})
 
     @manager.mock_reg_handler("test")
@@ -271,3 +271,17 @@ async def test_external_step(hass, manager):
     result = await manager.async_configure(result["flow_id"])
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Hello"
+
+
+async def test_abort_flow_exception(manager):
+    """Test that the AbortFlow exception works."""
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        async def async_step_init(self, user_input=None):
+            raise data_entry_flow.AbortFlow("mock-reason", {"placeholder": "yo"})
+
+    form = await manager.async_init("test")
+    assert form["type"] == "abort"
+    assert form["reason"] == "mock-reason"
+    assert form["description_placeholders"] == {"placeholder": "yo"}


### PR DESCRIPTION
## Description:


- Add a new `AbortFlow` exception to allow aborting config flows via an exception
- Add a new `async_set_unique_id` function to `ConfigFlow`. This will automatically check if an entry with same unique ID is already in progress and abort if so.
- If flow with unique ID is finished, unload existing entry with same unique ID and remove it. 

To do: update Hue to add unique ID.

~~Marked as WIP because the current checks by `async_set_unique_id` do not work well. Example where it's not useful: Hue bridges can remove auth credentials for Home Assistant. The Hue config entry will detect this while being set up and open a new config flow to authorize. Now during authorization, setting the unique ID will abort the flow because the bridge is already configured (but with no longer valid auth). We can't just go ahead and delete the entry, because that will remove all customization, instead of the current approach where the new config entry takes over the old devices/entities. Will need some more thought.~~

This is a first step in allowing config entries to be ignored for https://github.com/home-assistant/architecture/issues/250. The next step will be to allow ignoring config flows that have a unique ID set.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
