### PR TITLE
Add separate command and state topics for mqtt lock

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -135,6 +135,8 @@ ABBREVIATIONS = {
     "stat_off": "state_off",
     "stat_on": "state_on",
     "stat_open": "state_open",
+    "stat_locked": "state_locked",
+    "stat_unlocked": "state_unlocked",
     "stat_t": "state_topic",
     "stat_tpl": "state_template",
     "stat_val_tpl": "state_value_template",

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -57,7 +57,9 @@ PLATFORM_SCHEMA = (
                 CONF_PAYLOAD_UNLOCK, default=DEFAULT_PAYLOAD_UNLOCK
             ): cv.string,
             vol.Optional(CONF_STATE_LOCKED, default=DEFAULT_STATE_LOCKED): cv.string,
-            vol.Optional(CONF_STATE_UNLOCKED, default=DEFAULT_STATE_UNLOCKED): cv.string,
+            vol.Optional(
+                CONF_STATE_UNLOCKED, default=DEFAULT_STATE_UNLOCKED
+            ): cv.string,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
     )

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -36,10 +36,16 @@ _LOGGER = logging.getLogger(__name__)
 CONF_PAYLOAD_LOCK = "payload_lock"
 CONF_PAYLOAD_UNLOCK = "payload_unlock"
 
+CONF_STATE_LOCKED = "state_locked"
+CONF_STATE_UNLOCKED = "state_unlocked"
+
 DEFAULT_NAME = "MQTT Lock"
 DEFAULT_OPTIMISTIC = False
 DEFAULT_PAYLOAD_LOCK = "LOCK"
 DEFAULT_PAYLOAD_UNLOCK = "UNLOCK"
+DEFAULT_STATE_LOCKED = "LOCKED"
+DEFAULT_STATE_UNLOCKED = "UNLOCKED"
+
 PLATFORM_SCHEMA = (
     mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
         {
@@ -50,6 +56,8 @@ PLATFORM_SCHEMA = (
             vol.Optional(
                 CONF_PAYLOAD_UNLOCK, default=DEFAULT_PAYLOAD_UNLOCK
             ): cv.string,
+            vol.Optional(CONF_STATE_LOCKED, default=DEFAULT_STATE_LOCKED): cv.string,
+            vol.Optional(CONF_STATE_UNLOCKED, default=DEFAULT_STATE_UNLOCKED): cv.string,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
     )
@@ -152,9 +160,9 @@ class MqttLock(
             payload = msg.payload
             if value_template is not None:
                 payload = value_template.async_render_with_possible_json_value(payload)
-            if payload == self._config[CONF_PAYLOAD_LOCK]:
+            if payload == self._config[CONF_STATE_LOCKED]:
                 self._state = True
-            elif payload == self._config[CONF_PAYLOAD_UNLOCK]:
+            elif payload == self._config[CONF_STATE_UNLOCKED]:
                 self._state = False
 
             self.async_write_ha_state()

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -123,7 +123,9 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
     assert state.state is STATE_UNLOCKED
 
 
-async def test_controlling_non_default_state_via_topic_and_json_message(hass, mqtt_mock):
+async def test_controlling_non_default_state_via_topic_and_json_message(
+    hass, mqtt_mock
+):
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -53,6 +53,39 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
+    
+async def test_controlling_non_default_state_via_topic(hass, mqtt_mock):
+    """Test the controlling state via topic."""
+    assert await async_setup_component(
+        hass,
+        lock.DOMAIN,
+        {
+            lock.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "state-topic",
+                "command_topic": "command-topic",
+                "payload_lock": "LOCK",
+                "payload_unlock": "UNLOCK",
+                "state_locked": "closed",
+                "state_unlocked": "open",
+            }
+        },
+    )
+
+    state = hass.states.get("lock.test")
+    assert state.state is STATE_UNLOCKED
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, "state-topic", "closed")
+
+    state = hass.states.get("lock.test")
+    assert state.state is STATE_LOCKED
+
+    async_fire_mqtt_message(hass, "state-topic", "open")
+
+    state = hass.states.get("lock.test")
+    assert state.state is STATE_UNLOCKED
 
 
 async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
@@ -84,6 +117,39 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
     assert state.state is STATE_LOCKED
 
     async_fire_mqtt_message(hass, "state-topic", '{"val":"UNLOCKED"}')
+
+    state = hass.states.get("lock.test")
+    assert state.state is STATE_UNLOCKED
+    
+async def test_controlling_non_default_state_via_topic_and_json_message(hass, mqtt_mock):
+    """Test the controlling state via topic and JSON message."""
+    assert await async_setup_component(
+        hass,
+        lock.DOMAIN,
+        {
+            lock.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "state-topic",
+                "command_topic": "command-topic",
+                "payload_lock": "LOCK",
+                "payload_unlock": "UNLOCK",
+                "state_locked": "closed",
+                "state_unlocked": "open",
+                "value_template": "{{ value_json.val }}",
+            }
+        },
+    )
+
+    state = hass.states.get("lock.test")
+    assert state.state is STATE_UNLOCKED
+
+    async_fire_mqtt_message(hass, "state-topic", '{"val":"closed"}')
+
+    state = hass.states.get("lock.test")
+    assert state.state is STATE_LOCKED
+
+    async_fire_mqtt_message(hass, "state-topic", '{"val":"open"}')
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -53,7 +53,8 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
-    
+
+
 async def test_controlling_non_default_state_via_topic(hass, mqtt_mock):
     """Test the controlling state via topic."""
     assert await async_setup_component(
@@ -120,7 +121,8 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
-    
+
+
 async def test_controlling_non_default_state_via_topic_and_json_message(hass, mqtt_mock):
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -34,6 +34,8 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
                 "command_topic": "command-topic",
                 "payload_lock": "LOCK",
                 "payload_unlock": "UNLOCK",
+                "state_locked": "LOCKED",
+                "state_unlocked": "UNLOCKED",
             }
         },
     )
@@ -42,12 +44,12 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     assert state.state is STATE_UNLOCKED
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
-    async_fire_mqtt_message(hass, "state-topic", "LOCK")
+    async_fire_mqtt_message(hass, "state-topic", "LOCKED")
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_LOCKED
 
-    async_fire_mqtt_message(hass, "state-topic", "UNLOCK")
+    async_fire_mqtt_message(hass, "state-topic", "UNLOCKED")
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
@@ -66,6 +68,8 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
                 "command_topic": "command-topic",
                 "payload_lock": "LOCK",
                 "payload_unlock": "UNLOCK",
+                "state_locked": "LOCKED",
+                "state_unlocked": "UNLOCKED",
                 "value_template": "{{ value_json.val }}",
             }
         },
@@ -74,12 +78,12 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
 
-    async_fire_mqtt_message(hass, "state-topic", '{"val":"LOCK"}')
+    async_fire_mqtt_message(hass, "state-topic", '{"val":"LOCKED"}')
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_LOCKED
 
-    async_fire_mqtt_message(hass, "state-topic", '{"val":"UNLOCK"}')
+    async_fire_mqtt_message(hass, "state-topic", '{"val":"UNLOCKED"}')
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
@@ -97,6 +101,8 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
                 "command_topic": "command-topic",
                 "payload_lock": "LOCK",
                 "payload_unlock": "UNLOCK",
+                "state_locked": "LOCKED",
+                "state_unlocked": "UNLOCKED",
             }
         },
     )
@@ -135,6 +141,8 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
                 "command_topic": "command-topic",
                 "payload_lock": "LOCK",
                 "payload_unlock": "UNLOCK",
+                "state_locked": "LOCKED",
+                "state_unlocked": "UNLOCKED",
                 "optimistic": True,
             }
         },
@@ -206,6 +214,8 @@ async def test_custom_availability_payload(hass, mqtt_mock):
                 "command_topic": "command-topic",
                 "payload_lock": "LOCK",
                 "payload_unlock": "UNLOCK",
+                "state_locked": "LOCKED",
+                "state_unlocked": "UNLOCKED",
                 "availability_topic": "availability-topic",
                 "payload_available": "good",
                 "payload_not_available": "nogood",


### PR DESCRIPTION
Allow different command and state topic + different command and state values.

## Breaking Change:
Two new properties were introduced with **state_locked** (default: _LOCKED_) and **state_unlocked** (default: _UNLOCKED_). If you were using the same topic as **state_topic** as for the **command_topic** you can reestablish the old behaviour by setting **state_locked** to _LOCK_ and **state_unlocked** to _UNLOCK_.
Effectively this change allows you to distinguish commands and states in two topics with different values.

## Description:
Allows to separate command and state topics effectively. The configuration.yaml below results in action payloads to be LOCK / UNLOCK and expects a JSON in the state topic that contains at least a state field, e.g.:

```json
{
  "state": "locked"
}
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11420

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: mqtt
    command_topic: "/dev/ha/lock/cmd"
    state_topic:   "/dev/ha/lock/state"
    value_template: "{{ value_json.state }}"
    state_locked: "locked"
    state_unlocked: "unlocked"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [n/a] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [n/a] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [n/a] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
