### PR TITLE
Add battery sensor to iCloud

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -321,6 +321,7 @@ omit =
     homeassistant/components/iaqualink/switch.py
     homeassistant/components/icloud/__init__.py
     homeassistant/components/icloud/device_tracker.py
+    homeassistant/components/icloud/sensor.py
     homeassistant/components/izone/climate.py
     homeassistant/components/izone/discovery.py
     homeassistant/components/izone/__init__.py

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -561,11 +561,6 @@ class IcloudDevice:
         return self._device_id
 
     @property
-    def dev_id(self) -> str:
-        """Return the device ID."""
-        return self._device_id
-
-    @property
     def name(self) -> str:
         """Return the Apple device name."""
         return self._name

--- a/homeassistant/components/icloud/const.py
+++ b/homeassistant/components/icloud/const.py
@@ -14,8 +14,7 @@ DEFAULT_GPS_ACCURACY_THRESHOLD = 500  # meters
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
 
-# Next PR will add sensor
-ICLOUD_COMPONENTS = ["device_tracker"]
+ICLOUD_COMPONENTS = ["device_tracker", "sensor"]
 
 # pyicloud.AppleDevice status
 DEVICE_BATTERY_LEVEL = "batteryLevel"

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -1,8 +1,10 @@
 """Support for tracking for iCloud devices."""
 import logging
+from typing import Dict
 
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
@@ -26,7 +28,9 @@ async def async_setup_scanner(
     pass
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+):
     """Configure a dispatcher connection based on a config entry."""
     username = entry.data[CONF_USERNAME]
 
@@ -49,12 +53,12 @@ class IcloudTrackerEntity(TrackerEntity):
         self._unsub_dispatcher = None
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return a unique ID."""
-        return f"{self._device.unique_id}_tracker"
+        return self._device.unique_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the device."""
         return self._device.name
 
@@ -74,36 +78,36 @@ class IcloudTrackerEntity(TrackerEntity):
         return self._device.location[DEVICE_LOCATION_LONGITUDE]
 
     @property
-    def should_poll(self):
+    def should_poll(self) -> bool:
         """No polling needed."""
         return False
 
     @property
-    def battery_level(self):
+    def battery_level(self) -> int:
         """Return the battery level of the device."""
         return self._device.battery_level
 
     @property
-    def source_type(self):
+    def source_type(self) -> str:
         """Return the source type, eg gps or router, of the device."""
         return SOURCE_TYPE_GPS
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon."""
         return icon_for_icloud_device(self._device)
 
     @property
-    def device_state_attributes(self):
+    def device_state_attributes(self) -> Dict[str, any]:
         """Return the device state attributes."""
         return self._device.state_attributes
 
     @property
-    def device_info(self):
+    def device_info(self) -> Dict[str, any]:
         """Return the device information."""
         return {
             "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
+            "name": self._device.name,
             "manufacturer": "Apple",
             "model": self._device.device_model,
         }

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
 
     for device in hass.data[DOMAIN][username].devices.values():
         if device.location is None:
-            _LOGGER.debug("No position found for device %s", device.name)
+            _LOGGER.debug("No position found for %s", device.name)
             continue
 
         _LOGGER.debug("Adding device_tracker for %s", device.name)
@@ -106,7 +106,7 @@ class IcloudTrackerEntity(TrackerEntity):
     def device_info(self) -> Dict[str, any]:
         """Return the device information."""
         return {
-            "identifiers": {(DOMAIN, self.unique_id)},
+            "identifiers": {(DOMAIN, self._device.unique_id)},
             "name": self._device.name,
             "manufacturer": "Apple",
             "model": self._device.device_model,

--- a/homeassistant/components/icloud/sensor.py
+++ b/homeassistant/components/icloud/sensor.py
@@ -1,0 +1,96 @@
+"""Support for iCloud sensors."""
+import logging
+from typing import Dict
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_USERNAME, DEVICE_CLASS_BATTERY
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import IcloudDevice
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up iCloud devices sensors based on a config entry."""
+    username = entry.data[CONF_USERNAME]
+    icloud = hass.data[DOMAIN][username]
+
+    devices = []
+    for device_name, icloud_device in icloud.devices.items():
+        if icloud_device.battery_level is not None:
+            _LOGGER.debug("Adding sensors from iCloud device=%s", device_name)
+            devices.append(
+                IcloudDeviceBatterySensor(hass, icloud.username, icloud_device)
+            )
+
+    async_add_entities(devices, True)
+
+
+class IcloudDeviceBatterySensor(Entity):
+    """Representation of a iCloud device battery sensor."""
+
+    def __init__(self, hass: HomeAssistantType, username: str, device: IcloudDevice):
+        """Initialize the battery sensor."""
+        self._hass = hass
+        self._username = username
+        self._device = device
+
+    def update(self):
+        """Fetch new state data for the sensor."""
+        self._device = self._hass.data[DOMAIN][self._username].devices[
+            self._device.unique_id
+        ]
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._device.unique_id
+
+    @property
+    def name(self) -> str:
+        """Sensor name."""
+        return self._device.name + " battery state"
+
+    @property
+    def device_class(self) -> str:
+        """Return the device class of the sensor."""
+        return DEVICE_CLASS_BATTERY
+
+    @property
+    def state(self) -> int:
+        """Battery state percentage."""
+        return self._device.battery_level
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Battery state measured in percentage."""
+        return "%"
+
+    @property
+    def icon(self) -> str:
+        """Battery state icon handling."""
+        return icon_for_battery_level(
+            battery_level=self._device.battery_level,
+            charging=self._device.battery_status == "Charging",
+        )
+
+    @property
+    def device_state_attributes(self) -> Dict[str, any]:
+        """Return default attributes for the iCloud device entity."""
+        return self._device.state_attributes
+
+    @property
+    def device_info(self) -> Dict[str, any]:
+        """Return the device information."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self._device.name,
+            "manufacturer": "Apple",
+            "model": self._device.device_model,
+        }

--- a/homeassistant/components/icloud/sensor.py
+++ b/homeassistant/components/icloud/sensor.py
@@ -44,7 +44,7 @@ class IcloudDeviceBatterySensor(Entity):
     @property
     def name(self) -> str:
         """Sensor name."""
-        return self._device.name + " battery state"
+        return f"{self._device.name} battery state"
 
     @property
     def device_class(self) -> str:


### PR DESCRIPTION
## Breaking Change:

None, addition 

## Description:

Follows #28968

Add battery sensor for each iDevice of your account.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) :** home-assistant/home-assistant.io#11434

iCloud device list
<img width="1415" alt="Capture d’écran 2019-12-10 à 13 50 09" src="https://user-images.githubusercontent.com/14821482/70531306-f338a500-1b54-11ea-9bdb-da5b66ff8402.png">

iCloud device details
<img width="1235" alt="Capture d’écran 2019-12-10 à 13 50 04" src="https://user-images.githubusercontent.com/14821482/70531325-ffbcfd80-1b54-11ea-8402-e532b4649f39.png">


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
