### PR TITLE
UniFi - honor detection time when UniFi wire bug happens

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -125,6 +125,7 @@ class UniFiClientTracker(ScannerEntity):
         self.client = client
         self.controller = controller
         self.is_wired = self.client.mac not in controller.wireless_clients
+        self.wired_bug = None
 
     @property
     def entity_registry_enabled_default(self):
@@ -167,13 +168,18 @@ class UniFiClientTracker(ScannerEntity):
 
         If is_wired and client.is_wired differ it means that the device is offline and UniFi bug shows device as wired.
         """
-        if self.is_wired == self.client.is_wired and (
-            (
-                dt_util.utcnow()
-                - dt_util.utc_from_timestamp(float(self.client.last_seen))
+        if self.is_wired != self.client.is_wired:
+            if not self.wired_bug:
+                self.wired_bug = dt_util.utcnow()
+            since_last_seen = dt_util.utcnow() - self.wired_bug
+
+        else:
+            self.wired_bug = None
+            since_last_seen = dt_util.utcnow() - dt_util.utc_from_timestamp(
+                float(self.client.last_seen)
             )
-            < self.controller.option_detection_time
-        ):
+
+        if since_last_seen < self.controller.option_detection_time:
             return True
 
         return False

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -2,6 +2,8 @@
 from copy import copy
 from datetime import timedelta
 
+from asynctest import patch
+
 from homeassistant import config_entries
 from homeassistant.components import unifi
 from homeassistant.components.unifi.const import (
@@ -17,8 +19,6 @@ import homeassistant.components.device_tracker as device_tracker
 import homeassistant.util.dt as dt_util
 
 from .test_controller import ENTRY_CONFIG, SITES, setup_unifi_integration
-
-DEFAULT_DETECTION_TIME = timedelta(seconds=300)
 
 CLIENT_1 = {
     "essid": "ssid",
@@ -203,7 +203,20 @@ async def test_wireless_client_go_wired_issue(hass):
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
-    assert client_1.state == "not_home"
+    assert client_1.state == "home"
+
+    with patch.object(
+        unifi.device_tracker.dt_util,
+        "utcnow",
+        return_value=(dt_util.utcnow() + timedelta(minutes=5)),
+    ):
+        controller.mock_client_responses.append([client_1_client])
+        controller.mock_device_responses.append({})
+        await controller.async_update()
+        await hass.async_block_till_done()
+
+        client_1 = hass.states.get("device_tracker.client_1")
+        assert client_1.state == "not_home"
 
     client_1_client["is_wired"] = False
     client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())


### PR DESCRIPTION
## Description:
The Wire bug means that wireless devices gets marked as wired when they go away from the network, its a known issue Ubiquiti has chosen to not fix yet.

**Related issue (if applicable):** fixes #29167

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
