### PR TITLE
Fix input_text initialization with empty config.

### DIFF
--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -23,7 +23,9 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
 CONF_INITIAL = "initial"
 CONF_MIN = "min"
+CONF_MIN_VALUE = 0
 CONF_MAX = "max"
+CONF_MAX_VALUE = 100
 
 MODE_TEXT = "text"
 MODE_PASSWORD = "password"
@@ -59,8 +61,8 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.All(
                     {
                         vol.Optional(CONF_NAME): cv.string,
-                        vol.Optional(CONF_MIN, default=0): vol.Coerce(int),
-                        vol.Optional(CONF_MAX, default=100): vol.Coerce(int),
+                        vol.Optional(CONF_MIN, default=CONF_MIN_VALUE): vol.Coerce(int),
+                        vol.Optional(CONF_MAX, default=CONF_MAX_VALUE): vol.Coerce(int),
                         vol.Optional(CONF_INITIAL, ""): cv.string,
                         vol.Optional(CONF_ICON): cv.icon,
                         vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
@@ -121,8 +123,8 @@ async def _async_process_config(config):
         if cfg is None:
             cfg = {}
         name = cfg.get(CONF_NAME)
-        minimum = cfg.get(CONF_MIN)
-        maximum = cfg.get(CONF_MAX)
+        minimum = cfg.get(CONF_MIN, CONF_MIN_VALUE)
+        maximum = cfg.get(CONF_MAX, CONF_MAX_VALUE)
         initial = cfg.get(CONF_INITIAL)
         icon = cfg.get(CONF_ICON)
         unit = cfg.get(ATTR_UNIT_OF_MEASUREMENT)

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -100,8 +100,7 @@ async def test_mode(hass):
     assert "password" == state.attributes["mode"]
 
 
-@asyncio.coroutine
-def test_restore_state(hass):
+async def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -110,10 +109,8 @@ def test_restore_state(hass):
 
     hass.state = CoreState.starting
 
-    yield from async_setup_component(
-        hass,
-        DOMAIN,
-        {DOMAIN: {"b1": {"min": 0, "max": 10}, "b2": {"min": 0, "max": 10}}},
+    assert await async_setup_component(
+        hass, DOMAIN, {DOMAIN: {"b1": None, "b2": {"min": 0, "max": 10}}},
     )
 
     state = hass.states.get("input_text.b1")


### PR DESCRIPTION
## Description:
With an empty config `input_text` is not getting initialized properly with the defaults for `min` and `max` parameters, resulting in the following traceback:
```
2019-12-04 20:00:37 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/home/lex/lex/src/ac-hass/homeassistant/helpers/entity_platform.py", line 406, in _async_add_entity
    await entity.async_added_to_hass()
  File "/home/lex/lex/src/ac-hass/homeassistant/components/input_text/__init__.py", line 178, in async_added_to_hass
    if value is not None and self._minimum <= len(value) <= self._maximum:
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
```

**Related issue (if applicable):** fixes #29492

## Example entry for `configuration.yaml` (if applicable):
```yaml
input_text:
  text_1:
  text_2:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
