### PR TITLE
Support multiple vera controllers

### DIFF
--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -1,214 +1,112 @@
 """Support for Vera devices."""
-from collections import defaultdict
 import logging
 
-import pyvera as veraApi
 from requests.exceptions import RequestException
 import voluptuous as vol
 
-from homeassistant.const import (
-    ATTR_ARMED,
-    ATTR_BATTERY_LEVEL,
-    ATTR_LAST_TRIP_TIME,
-    ATTR_TRIPPED,
-    CONF_EXCLUDE,
-    CONF_LIGHTS,
-    EVENT_HOMEASSISTANT_STOP,
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_EXCLUDE, CONF_LIGHTS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+
+from .common import (
+    get_configured_platforms,
+    get_controller_data_by_config,
+    initialize_controller,
+    set_controller_data,
 )
-from homeassistant.helpers import config_validation as cv, discovery
-from homeassistant.helpers.entity import Entity
-from homeassistant.util import convert, slugify
-from homeassistant.util.dt import utc_from_timestamp
+from .const import CONF_BASE_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "vera"
-
-VERA_CONTROLLER = "vera_controller"
-
-CONF_CONTROLLER = "vera_controller_url"
-
-VERA_ID_FORMAT = "{}_{}"
-
-ATTR_CURRENT_POWER_W = "current_power_w"
-ATTR_CURRENT_ENERGY_KWH = "current_energy_kwh"
-
-VERA_DEVICES = "vera_devices"
-VERA_SCENES = "vera_scenes"
 
 VERA_ID_LIST_SCHEMA = vol.Schema([int])
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_CONTROLLER): cv.url,
-                vol.Optional(CONF_EXCLUDE, default=[]): VERA_ID_LIST_SCHEMA,
-                vol.Optional(CONF_LIGHTS, default=[]): VERA_ID_LIST_SCHEMA,
-            }
+            [
+                {
+                    vol.Required(CONF_BASE_URL): cv.url,
+                    vol.Optional(CONF_EXCLUDE, default=[]): VERA_ID_LIST_SCHEMA,
+                    vol.Optional(CONF_LIGHTS, default=[]): VERA_ID_LIST_SCHEMA,
+                }
+            ]
         )
     },
     extra=vol.ALLOW_EXTRA,
 )
 
-VERA_COMPONENTS = [
-    "binary_sensor",
-    "sensor",
-    "light",
-    "switch",
-    "lock",
-    "climate",
-    "cover",
-    "scene",
-]
+
+def setup(hass: HomeAssistant, base_config: dict) -> bool:
+    """Set up for Vera controllers."""
+    configs = base_config.get(DOMAIN, [])
+
+    # Normalize the base urls.
+    base_urls = []
+    for config in configs:
+        config[CONF_BASE_URL] = config.get(CONF_BASE_URL).rstrip("/")
+        base_urls.append(config[CONF_BASE_URL])
+
+    # Check if there are duplicate base urls.
+    if len(base_urls) != len(configs):
+        raise Exception("Duplicate vera controller base urls detected.")
+
+    # Build a map of already configured controllers.
+    base_url_entries_map = {}
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        base_url = config_entry.data.get(CONF_BASE_URL)
+        base_url_entries_map[base_url] = config_entry
+
+    for config in configs:
+        base_url = config.get(CONF_BASE_URL)
+
+        entry = base_url_entries_map.get(base_url)
+        if entry:
+            _LOGGER.debug("Updating existing config for %s", base_url)
+            hass.config_entries.async_update_entry(entry=entry, data=config)
+            continue
+
+        _LOGGER.debug("Creating new config for %s", base_url)
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config,
+            )
+        )
+
+    return True
 
 
-def setup(hass, base_config):
-    """Set up for Vera devices."""
-
-    def stop_subscription(event):
-        """Shutdown Vera subscriptions and subscription thread on exit."""
-        _LOGGER.info("Shutting down subscriptions")
-        hass.data[VERA_CONTROLLER].stop()
-
-    config = base_config.get(DOMAIN)
-
-    # Get Vera specific configuration.
-    base_url = config.get(CONF_CONTROLLER)
-    light_ids = config.get(CONF_LIGHTS)
-    exclude_ids = config.get(CONF_EXCLUDE)
-
-    # Initialize the Vera controller.
-    controller, _ = veraApi.init_controller(base_url)
-    hass.data[VERA_CONTROLLER] = controller
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
-
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Do setup of vera."""
     try:
-        all_devices = controller.get_devices()
-
-        all_scenes = controller.get_scenes()
+        controller_data = initialize_controller(hass, config_entry.data)
     except RequestException:
         # There was a network related error connecting to the Vera controller.
         _LOGGER.exception("Error communicating with Vera API")
         return False
 
-    # Exclude devices unwanted by user.
-    devices = [device for device in all_devices if device.device_id not in exclude_ids]
+    set_controller_data(hass, controller_data)
 
-    vera_devices = defaultdict(list)
-    for device in devices:
-        device_type = map_vera_device(device, light_ids)
-        if device_type is None:
-            continue
-
-        vera_devices[device_type].append(device)
-    hass.data[VERA_DEVICES] = vera_devices
-
-    vera_scenes = []
-    for scene in all_scenes:
-        vera_scenes.append(scene)
-    hass.data[VERA_SCENES] = vera_scenes
-
-    for component in VERA_COMPONENTS:
-        discovery.load_platform(hass, component, DOMAIN, {}, base_config)
+    # Forward the config data to the necessary platforms.
+    for platform in get_configured_platforms(controller_data):
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, platform)
+        )
 
     return True
 
 
-def map_vera_device(vera_device, remap):
-    """Map vera classes to Home Assistant types."""
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload Withings config entry."""
+    controller_data = get_controller_data_by_config(hass=hass, entry=config_entry)
 
-    if isinstance(vera_device, veraApi.VeraDimmer):
-        return "light"
-    if isinstance(vera_device, veraApi.VeraBinarySensor):
-        return "binary_sensor"
-    if isinstance(vera_device, veraApi.VeraSensor):
-        return "sensor"
-    if isinstance(vera_device, veraApi.VeraArmableDevice):
-        return "switch"
-    if isinstance(vera_device, veraApi.VeraLock):
-        return "lock"
-    if isinstance(vera_device, veraApi.VeraThermostat):
-        return "climate"
-    if isinstance(vera_device, veraApi.VeraCurtain):
-        return "cover"
-    if isinstance(vera_device, veraApi.VeraSceneController):
-        return "sensor"
-    if isinstance(vera_device, veraApi.VeraSwitch):
-        if vera_device.device_id in remap:
-            return "light"
-        return "switch"
-    return None
+    if not controller_data:
+        return True
 
-
-class VeraDevice(Entity):
-    """Representation of a Vera device entity."""
-
-    def __init__(self, vera_device, controller):
-        """Initialize the device."""
-        self.vera_device = vera_device
-        self.controller = controller
-
-        self._name = self.vera_device.name
-        # Append device id to prevent name clashes in HA.
-        self.vera_id = VERA_ID_FORMAT.format(
-            slugify(vera_device.name), vera_device.device_id
+    for platform in get_configured_platforms(controller_data):
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_unload(config_entry, platform)
         )
 
-        self.controller.register(vera_device, self._update_callback)
-
-    def _update_callback(self, _device):
-        """Update the state."""
-        self.schedule_update_ha_state(True)
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def should_poll(self):
-        """Get polling requirement from vera device."""
-        return self.vera_device.should_poll
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the device."""
-        attr = {}
-
-        if self.vera_device.has_battery:
-            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level
-
-        if self.vera_device.is_armable:
-            armed = self.vera_device.is_armed
-            attr[ATTR_ARMED] = "True" if armed else "False"
-
-        if self.vera_device.is_trippable:
-            last_tripped = self.vera_device.last_trip
-            if last_tripped is not None:
-                utc_time = utc_from_timestamp(int(last_tripped))
-                attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
-            else:
-                attr[ATTR_LAST_TRIP_TIME] = None
-            tripped = self.vera_device.is_tripped
-            attr[ATTR_TRIPPED] = "True" if tripped else "False"
-
-        power = self.vera_device.power
-        if power:
-            attr[ATTR_CURRENT_POWER_W] = convert(power, float, 0.0)
-
-        energy = self.vera_device.energy
-        if energy:
-            attr[ATTR_CURRENT_ENERGY_KWH] = convert(energy, float, 0.0)
-
-        attr["Vera Device Id"] = self.vera_device.vera_device_id
-
-        return attr
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID.
-
-        The Vera assigns a unique and immutable ID number to each device.
-        """
-        return str(self.vera_device.vera_device_id)
+    return True

--- a/homeassistant/components/vera/binary_sensor.py
+++ b/homeassistant/components/vera/binary_sensor.py
@@ -1,21 +1,33 @@
 """Support for Vera binary sensors."""
 import logging
+from typing import Callable, List
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorDevice
+from homeassistant.components.binary_sensor import (
+    DOMAIN as PLATFORM_DOMAIN,
+    ENTITY_ID_FORMAT,
+    BinarySensorDevice,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 
-from . import VERA_CONTROLLER, VERA_DEVICES, VeraDevice
+from .common import VeraDevice, setup_device_entities
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Perform the setup for Vera controller devices."""
-    add_entities(
-        [
-            VeraBinarySensor(device, hass.data[VERA_CONTROLLER])
-            for device in hass.data[VERA_DEVICES]["binary_sensor"]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_device_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraBinarySensor,
     )
 
 

--- a/homeassistant/components/vera/climate.py
+++ b/homeassistant/components/vera/climate.py
@@ -1,7 +1,12 @@
 """Support for Vera thermostats."""
 import logging
+from typing import Callable, List
 
-from homeassistant.components.climate import ENTITY_ID_FORMAT, ClimateDevice
+from homeassistant.components.climate import (
+    DOMAIN as PLATFORM_DOMAIN,
+    ENTITY_ID_FORMAT,
+    ClimateDevice,
+)
 from homeassistant.components.climate.const import (
     FAN_AUTO,
     FAN_ON,
@@ -12,10 +17,13 @@ from homeassistant.components.climate.const import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.util import convert
 
-from . import VERA_CONTROLLER, VERA_DEVICES, VeraDevice
+from .common import VeraDevice, setup_device_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,14 +33,18 @@ SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
 SUPPORT_HVAC = [HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL, HVAC_MODE_OFF]
 
 
-def setup_platform(hass, config, add_entities_callback, discovery_info=None):
-    """Set up of Vera thermostats."""
-    add_entities_callback(
-        [
-            VeraThermostat(device, hass.data[VERA_CONTROLLER])
-            for device in hass.data[VERA_DEVICES]["climate"]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_device_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraThermostat,
     )
 
 

--- a/homeassistant/components/vera/common.py
+++ b/homeassistant/components/vera/common.py
@@ -1,0 +1,299 @@
+"""Common vera code."""
+from collections import defaultdict
+import logging
+from typing import Callable, DefaultDict, List, NamedTuple, Optional, Union
+
+import pyvera as pv
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN, Scene
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ARMED,
+    ATTR_BATTERY_LEVEL,
+    ATTR_LAST_TRIP_TIME,
+    ATTR_TRIPPED,
+    CONF_EXCLUDE,
+    CONF_LIGHTS,
+    EVENT_HOMEASSISTANT_STOP,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import convert, slugify
+from homeassistant.util.dt import utc_from_timestamp
+
+from .const import (
+    ATTR_CURRENT_ENERGY_KWH,
+    ATTR_CURRENT_POWER_W,
+    CONF_BASE_URL,
+    CONTROLLER_DATAS,
+    DOMAIN,
+    VERA_ID_FORMAT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+ControllerData = NamedTuple(
+    "ControllerData",
+    (
+        ("controller", pv.VeraController),
+        ("devices", DefaultDict[str, List[pv.VeraDevice]]),
+        ("scenes", List[pv.VeraScene]),
+    ),
+)
+
+
+class VeraDevice(Entity):
+    """Representation of a Vera device entity."""
+
+    def __init__(self, vera_device: pv.VeraDevice, controller: pv.VeraController):
+        """Initialize the device."""
+        self.vera_device = vera_device
+        self.controller = controller
+
+        self._name = self.vera_device.name
+        # Append device id to prevent name clashes in HA.
+        self.vera_id = VERA_ID_FORMAT.format(
+            slugify(vera_device.name), vera_device.device_id
+        )
+        self._unique_id = f"{controller.serial_number}_{vera_device.vera_device_id}"
+
+        self.controller.register(vera_device, self._update_callback)
+
+    def _update_callback(self, _device):
+        """Update the state."""
+        self.schedule_update_ha_state(True)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Get polling requirement from vera device."""
+        return self.vera_device.should_poll
+
+    @property
+    def device_info(self):
+        """Return information about the device."""
+        return {
+            "name": self._name,
+            "model": "Unknown",
+            "manufacturer": "Unknown",
+            "connections": {("serial_id", self._unique_id)},
+            "identifiers": {self._unique_id},
+            "battery": self.vera_device.battery_level,
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        attr = {}
+
+        if self.vera_device.has_battery:
+            attr[ATTR_BATTERY_LEVEL] = self.vera_device.battery_level
+
+        if self.vera_device.is_armable:
+            armed = self.vera_device.is_armed
+            attr[ATTR_ARMED] = "True" if armed else "False"
+
+        if self.vera_device.is_trippable:
+            last_tripped = self.vera_device.last_trip
+            if last_tripped is not None:
+                utc_time = utc_from_timestamp(int(last_tripped))
+                attr[ATTR_LAST_TRIP_TIME] = utc_time.isoformat()
+            else:
+                attr[ATTR_LAST_TRIP_TIME] = None
+            tripped = self.vera_device.is_tripped
+            attr[ATTR_TRIPPED] = "True" if tripped else "False"
+
+        power = self.vera_device.power
+        if power:
+            attr[ATTR_CURRENT_POWER_W] = convert(power, float, 0.0)
+
+        energy = self.vera_device.energy
+        if energy:
+            attr[ATTR_CURRENT_ENERGY_KWH] = convert(energy, float, 0.0)
+
+        attr["Vera Device Id"] = self.vera_device.vera_device_id
+
+        return attr
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID.
+
+        The Vera assigns a unique and immutable ID number to each device.
+        """
+        return self._unique_id
+
+
+def initialize_controller(hass: HomeAssistant, config: dict) -> ControllerData:
+    """Initialize a controller."""
+    # Get Vera specific configuration.
+    base_url = config.get(CONF_BASE_URL)
+    light_ids = config.get(CONF_LIGHTS)
+    exclude_ids = config.get(CONF_EXCLUDE)
+
+    # Initialize the Vera controller.
+    controller = pv.VeraController(base_url)
+    controller.start()
+
+    hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP, lambda event: controller.stop()
+    )
+
+    controller.refresh_data()
+    all_devices = controller.get_devices()
+    all_scenes = controller.get_scenes()
+    # Exclude devices unwanted by user.
+    devices = [device for device in all_devices if device.device_id not in exclude_ids]
+
+    vera_devices = defaultdict(list)
+    for device in devices:
+        device_type = map_vera_device(device, light_ids)
+        if device_type is None:
+            continue
+
+        vera_devices[device_type].append(device)
+
+    vera_scenes = []
+    for scene in all_scenes:
+        vera_scenes.append(scene)
+
+    return ControllerData(
+        controller=controller, devices=vera_devices, scenes=vera_scenes
+    )
+
+
+EntityDeviceGenerator = Callable[[pv.VeraDevice, pv.VeraController], Entity]
+EntitySceneGenerator = Callable[[pv.VeraDevice, pv.VeraController], Scene]
+EntityGenerator = Union[EntityDeviceGenerator, EntitySceneGenerator]
+ItemCollector = Callable[
+    [ControllerData, str], List[Union[pv.VeraDevice, pv.VeraScene]]
+]
+
+
+def setup_device_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+    platform: str,
+    generator: EntityDeviceGenerator,
+):
+    """Create and add vera entities for devices in a platform."""
+
+    _setup_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=platform,
+        generator=generator,
+        item_collector=lambda controller_data, platform: controller_data.devices.get(
+            platform
+        ),
+    )
+
+
+def setup_scene_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+    platform: str,
+    generator: EntitySceneGenerator,
+):
+    """Create and add vera scenes."""
+    _setup_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=platform,
+        generator=generator,
+        item_collector=lambda controller_data, platform: controller_data.scenes,
+    )
+
+
+def _setup_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+    platform: str,
+    generator: EntityGenerator,
+    item_collector: ItemCollector,
+) -> None:
+    """Create and add vera entities for a given platform."""
+    controller_data = get_controller_data_by_config(hass=hass, entry=entry)
+
+    entities = []
+    items = item_collector(controller_data, platform)
+
+    for item in items or []:
+        entities.append(generator(item, controller_data.controller))
+
+    async_add_entities(entities, True)
+
+
+def map_vera_device(vera_device, remap):
+    """Map vera classes to Home Assistant types."""
+
+    if isinstance(vera_device, pv.VeraDimmer):
+        return LIGHT_DOMAIN
+    if isinstance(vera_device, pv.VeraBinarySensor):
+        return BINARY_SENSOR_DOMAIN
+    if isinstance(vera_device, pv.VeraSensor):
+        return SENSOR_DOMAIN
+    if isinstance(vera_device, pv.VeraArmableDevice):
+        return SWITCH_DOMAIN
+    if isinstance(vera_device, pv.VeraLock):
+        return LOCK_DOMAIN
+    if isinstance(vera_device, pv.VeraThermostat):
+        return CLIMATE_DOMAIN
+    if isinstance(vera_device, pv.VeraCurtain):
+        return COVER_DOMAIN
+    if isinstance(vera_device, pv.VeraSceneController):
+        return SENSOR_DOMAIN
+    if isinstance(vera_device, pv.VeraSwitch):
+        if vera_device.device_id in remap:
+            return LIGHT_DOMAIN
+        return SWITCH_DOMAIN
+    return None
+
+
+def get_controller_data_by_config(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> Optional[ControllerData]:
+    """Get controller data from hass data."""
+    base_url = entry.data.get(CONF_BASE_URL)
+    for controller_data in hass.data[DOMAIN][CONTROLLER_DATAS].values():
+        if controller_data.controller.base_url == base_url:
+            return controller_data
+
+    return None
+
+
+def set_controller_data(hass: HomeAssistant, controller_data: ControllerData) -> None:
+    """Set controller data in hass data."""
+    serial_number = controller_data.controller.serial_number
+    hass.data[DOMAIN] = hass.data.get(DOMAIN, {})
+    hass.data[DOMAIN][CONTROLLER_DATAS] = hass.data[DOMAIN].get(CONTROLLER_DATAS, {})
+    hass.data[DOMAIN][CONTROLLER_DATAS][serial_number] = controller_data
+
+
+def get_configured_platforms(controller_data: ControllerData) -> List[str]:
+    """Get configured platforms for a controller."""
+    platforms = []
+    for platform in controller_data.devices.keys():
+        platforms.append(platform)
+
+    if controller_data.scenes:
+        platforms.append(SCENE_DOMAIN)
+
+    return set(platforms)

--- a/homeassistant/components/vera/config_flow.py
+++ b/homeassistant/components/vera/config_flow.py
@@ -1,0 +1,13 @@
+"""Config flow for Vera."""
+from homeassistant import config_entries
+
+from .const import CONF_BASE_URL, DOMAIN
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class VeraFlowHandler(config_entries.ConfigFlow):
+    """Vera config flow."""
+
+    async def async_step_import(self, config: dict):
+        """Handle a flow initialized by import."""
+        return self.async_create_entry(title=config.get(CONF_BASE_URL), data=config)

--- a/homeassistant/components/vera/const.py
+++ b/homeassistant/components/vera/const.py
@@ -1,0 +1,11 @@
+"""Vera constants."""
+DOMAIN = "vera"
+
+CONF_BASE_URL = "base_url"
+
+VERA_ID_FORMAT = "{}_{}"
+
+ATTR_CURRENT_POWER_W = "current_power_w"
+ATTR_CURRENT_ENERGY_KWH = "current_energy_kwh"
+
+CONTROLLER_DATAS = "controller_datas"

--- a/homeassistant/components/vera/cover.py
+++ b/homeassistant/components/vera/cover.py
@@ -1,21 +1,34 @@
 """Support for Vera cover - curtains, rollershutters etc."""
 import logging
+from typing import Callable, List
 
-from homeassistant.components.cover import ATTR_POSITION, ENTITY_ID_FORMAT, CoverDevice
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DOMAIN as PLATFORM_DOMAIN,
+    ENTITY_ID_FORMAT,
+    CoverDevice,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 
-from . import VERA_CONTROLLER, VERA_DEVICES, VeraDevice
+from .common import VeraDevice, setup_device_entities
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Vera covers."""
-    add_entities(
-        [
-            VeraCover(device, hass.data[VERA_CONTROLLER])
-            for device in hass.data[VERA_DEVICES]["cover"]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_device_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraCover,
     )
 
 

--- a/homeassistant/components/vera/light.py
+++ b/homeassistant/components/vera/light.py
@@ -1,29 +1,38 @@
 """Support for Vera lights."""
 import logging
+from typing import Callable, List
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
+    DOMAIN as PLATFORM_DOMAIN,
     ENTITY_ID_FORMAT,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     Light,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 import homeassistant.util.color as color_util
 
-from . import VERA_CONTROLLER, VERA_DEVICES, VeraDevice
+from .common import VeraDevice, setup_device_entities
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Vera lights."""
-    add_entities(
-        [
-            VeraLight(device, hass.data[VERA_CONTROLLER])
-            for device in hass.data[VERA_DEVICES]["light"]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_device_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraLight,
     )
 
 

--- a/homeassistant/components/vera/lock.py
+++ b/homeassistant/components/vera/lock.py
@@ -1,10 +1,18 @@
 """Support for Vera locks."""
 import logging
+from typing import Callable, List
 
-from homeassistant.components.lock import ENTITY_ID_FORMAT, LockDevice
+from homeassistant.components.lock import (
+    DOMAIN as PLATFORM_DOMAIN,
+    ENTITY_ID_FORMAT,
+    LockDevice,
+)
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 
-from . import VERA_CONTROLLER, VERA_DEVICES, VeraDevice
+from .common import VeraDevice, setup_device_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -12,14 +20,18 @@ ATTR_LAST_USER_NAME = "changed_by_name"
 ATTR_LOW_BATTERY = "low_battery"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Find and return Vera locks."""
-    add_entities(
-        [
-            VeraLock(device, hass.data[VERA_CONTROLLER])
-            for device in hass.data[VERA_DEVICES]["lock"]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_device_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraLock,
     )
 
 

--- a/homeassistant/components/vera/scene.py
+++ b/homeassistant/components/vera/scene.py
@@ -1,22 +1,31 @@
 """Support for Vera scenes."""
 import logging
+from typing import Callable, List
 
-from homeassistant.components.scene import Scene
+from homeassistant.components.scene import DOMAIN as PLATFORM_DOMAIN, Scene
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
-from . import VERA_CONTROLLER, VERA_ID_FORMAT, VERA_SCENES
+from .common import setup_scene_entities
+from .const import VERA_ID_FORMAT
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Vera scenes."""
-    add_entities(
-        [
-            VeraScene(scene, hass.data[VERA_CONTROLLER])
-            for scene in hass.data[VERA_SCENES]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_scene_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraScene,
     )
 
 

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -1,29 +1,36 @@
 """Support for Vera sensors."""
 from datetime import timedelta
 import logging
+from typing import Callable, List
 
 import pyvera as veraApi
 
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN, ENTITY_ID_FORMAT
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import convert
 
-from . import VERA_CONTROLLER, VERA_DEVICES, VeraDevice
+from .common import VeraDevice, setup_device_entities
 
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Vera controller devices."""
-    add_entities(
-        [
-            VeraSensor(device, hass.data[VERA_CONTROLLER])
-            for device in hass.data[VERA_DEVICES]["sensor"]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_device_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraSensor,
     )
 
 

--- a/homeassistant/components/vera/strings.json
+++ b/homeassistant/components/vera/strings.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "title": "Vera"
+  }
+}

--- a/homeassistant/components/vera/switch.py
+++ b/homeassistant/components/vera/switch.py
@@ -1,22 +1,34 @@
 """Support for Vera switches."""
 import logging
+from typing import Callable, List
 
-from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice
+from homeassistant.components.switch import (
+    DOMAIN as PLATFORM_DOMAIN,
+    ENTITY_ID_FORMAT,
+    SwitchDevice,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.util import convert
 
-from . import VERA_CONTROLLER, VERA_DEVICES, VeraDevice
+from .common import VeraDevice, setup_device_entities
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Vera switches."""
-    add_entities(
-        [
-            VeraSwitch(device, hass.data[VERA_CONTROLLER])
-            for device in hass.data[VERA_DEVICES]["switch"]
-        ],
-        True,
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up the sensor config entry."""
+    setup_device_entities(
+        hass=hass,
+        entry=entry,
+        async_add_entities=async_add_entities,
+        platform=PLATFORM_DOMAIN,
+        generator=VeraSwitch,
     )
 
 

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -1,61 +1,107 @@
 """Common code for tests."""
 
-from typing import Callable, NamedTuple, Tuple
+from typing import Callable, Dict, List, NamedTuple, Tuple
 
 from mock import MagicMock
-from pyvera import VeraController, VeraDevice, VeraScene
+import pyvera as pv
 
-from homeassistant.components.vera import CONF_CONTROLLER, DOMAIN
+from homeassistant.components.vera.const import CONF_BASE_URL, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-ComponentData = NamedTuple("ComponentData", (("controller", VeraController),))
+SetupCallback = Callable[[pv.VeraController], None]
+
+ControllerData = NamedTuple(
+    "ControllerData", (("controller", pv.VeraController), ("update_callback", Callable))
+)
+
+ComponentData = NamedTuple(
+    "ComponentData", (("controller_datas", Tuple[ControllerData, ...]),)
+)
+
+ControllerConfig = NamedTuple(
+    "ControllerConfig",
+    (
+        ("config", Dict),
+        ("serial_number", str),
+        ("devices", Tuple[pv.VeraDevice, ...]),
+        ("scenes", Tuple[pv.VeraScene, ...]),
+        ("setup_callback", SetupCallback),
+    ),
+)
+
+
+def new_simple_controller_config(
+    base_url="http://127.0.0.1:123",
+    serial_number="1111",
+    devices: Tuple[pv.VeraDevice, ...] = (),
+    scenes: Tuple[pv.VeraScene, ...] = (),
+    setup_callback: SetupCallback = None,
+) -> ControllerConfig:
+    """Create simple contorller config."""
+    return ControllerConfig(
+        config={CONF_BASE_URL: base_url},
+        serial_number=serial_number,
+        devices=devices,
+        scenes=scenes,
+        setup_callback=setup_callback,
+    )
 
 
 class ComponentFactory:
     """Factory class."""
 
-    def __init__(self, init_controller_mock):
-        """Initialize component factory."""
-        self.init_controller_mock = init_controller_mock
+    def __init__(self, vera_controller_class_mock):
+        """Constructor."""
+        self.vera_controller_class_mock = vera_controller_class_mock
 
     async def configure_component(
-        self,
-        hass: HomeAssistant,
-        devices: Tuple[VeraDevice] = (),
-        scenes: Tuple[VeraScene] = (),
-        setup_callback: Callable[[VeraController], None] = None,
+        self, hass: HomeAssistant, controller_configs: Tuple[ControllerConfig, ...]
     ) -> ComponentData:
         """Configure the component with specific mock data."""
-        controller_url = "http://127.0.0.1:123"
-
         hass_config = {
-            DOMAIN: {CONF_CONTROLLER: controller_url},
+            DOMAIN: [cc.config for cc in controller_configs or []],
         }
 
-        controller = MagicMock(spec=VeraController)  # type: VeraController
-        controller.base_url = controller_url
-        controller.register = MagicMock()
-        controller.get_devices = MagicMock(return_value=devices or ())
-        controller.get_scenes = MagicMock(return_value=scenes or ())
+        controllers = []
+        for controller_config in controller_configs:
+            controller = MagicMock(spec=pv.VeraController)  # type: pv.VeraController
+            controller.base_url = controller_config.config.get(CONF_BASE_URL)
+            controller.register = MagicMock()
+            controller.start = MagicMock()
+            controller.stop = MagicMock()
+            controller.refresh_data = MagicMock()
+            controller.temperature_units = "C"
+            controller.serial_number = controller_config.serial_number
+            controller.get_devices = MagicMock(return_value=controller_config.devices)
+            controller.get_scenes = MagicMock(return_value=controller_config.scenes)
 
-        for vera_obj in controller.get_devices() + controller.get_scenes():
-            vera_obj.vera_controller = controller
+            for vera_obj in controller.get_devices() + controller.get_scenes():
+                vera_obj.vera_controller = controller
 
-        controller.get_devices.reset_mock()
-        controller.get_scenes.reset_mock()
+            controller.get_devices.reset_mock()
+            controller.get_scenes.reset_mock()
 
-        if setup_callback:
-            setup_callback(controller, hass_config)
+            if controller_config.setup_callback:
+                controller_config.setup_callback(controller, hass_config)
 
-        def init_controller(base_url: str) -> list:
-            nonlocal controller
-            return [controller, True]
+            controllers.append(controller)
 
-        self.init_controller_mock.side_effect = init_controller
+        self.vera_controller_class_mock.side_effect = controllers
 
         # Setup home assistant.
         assert await async_setup_component(hass, DOMAIN, hass_config)
         await hass.async_block_till_done()
 
-        return ComponentData(controller=controller)
+        controller_datas = []  # type: List[ControllerData]
+        for controller in controllers:
+            update_callback = (
+                controller.register.call_args_list[0][0][1]
+                if controller.register.call_args_list
+                else None
+            )
+            controller_datas.append(
+                ControllerData(controller=controller, update_callback=update_callback)
+            )
+
+        return ComponentData(controller_datas=tuple(controller_datas))

--- a/tests/components/vera/conftest.py
+++ b/tests/components/vera/conftest.py
@@ -9,5 +9,5 @@ from .common import ComponentFactory
 @pytest.fixture()
 def vera_component_factory():
     """Return a factory for initializing the vera component."""
-    with patch("pyvera.init_controller") as init_controller_mock:
-        yield ComponentFactory(init_controller_mock)
+    with patch("pyvera.VeraController") as vera_controller_class_mock:
+        yield ComponentFactory(vera_controller_class_mock)

--- a/tests/components/vera/test_binary_sensor.py
+++ b/tests/components/vera/test_binary_sensor.py
@@ -5,7 +5,7 @@ from pyvera import VeraBinarySensor
 
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_binary_sensor(
@@ -14,25 +14,23 @@ async def test_binary_sensor(
     """Test function."""
     vera_device = MagicMock(spec=VeraBinarySensor)  # type: VeraBinarySensor
     vera_device.device_id = 1
+    vera_device.vera_device_id = 1
     vera_device.name = "dev1"
     vera_device.is_tripped = False
     entity_id = "binary_sensor.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,)
+        hass=hass,
+        controller_configs=(new_simple_controller_config(devices=(vera_device,)),),
     )
-    controller = component_data.controller
-
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     vera_device.is_tripped = False
     update_callback(vera_device)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == "off"
-    controller.register.reset_mock()
 
     vera_device.is_tripped = True
     update_callback(vera_device)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == "on"
-    controller.register.reset_mock()

--- a/tests/components/vera/test_climate.py
+++ b/tests/components/vera/test_climate.py
@@ -13,7 +13,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_climate(
@@ -31,10 +31,10 @@ async def test_climate(
     entity_id = "climate.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,),
+        hass=hass,
+        controller_configs=(new_simple_controller_config(devices=(vera_device,)),),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     assert hass.states.get(entity_id).state == HVAC_MODE_OFF
 
@@ -137,10 +137,14 @@ async def test_climate_f(
         controller.temperature_units = "F"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,), setup_callback=setup_callback
+        hass=hass,
+        controller_configs=(
+            new_simple_controller_config(
+                devices=(vera_device,), setup_callback=setup_callback
+            ),
+        ),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     await hass.services.async_call(
         "climate", "set_temperature", {"entity_id": entity_id, "temperature": 30},

--- a/tests/components/vera/test_cover.py
+++ b/tests/components/vera/test_cover.py
@@ -5,7 +5,7 @@ from pyvera import CATEGORY_CURTAIN, VeraCurtain
 
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_cover(
@@ -21,10 +21,10 @@ async def test_cover(
     entity_id = "cover.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,),
+        hass=hass,
+        controller_configs=(new_simple_controller_config(devices=(vera_device,)),),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     assert hass.states.get(entity_id).state == "closed"
     assert hass.states.get(entity_id).attributes["current_position"] == 0

--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -1,78 +1,76 @@
 """Vera tests."""
 from unittest.mock import MagicMock
 
-from pyvera import (
-    VeraArmableDevice,
-    VeraBinarySensor,
-    VeraController,
-    VeraCurtain,
-    VeraDevice,
-    VeraDimmer,
-    VeraLock,
-    VeraScene,
-    VeraSceneController,
-    VeraSensor,
-    VeraSwitch,
-    VeraThermostat,
-)
+from pyvera import VeraBinarySensor
 
-from homeassistant.components.vera import (
-    CONF_EXCLUDE,
-    CONF_LIGHTS,
-    DOMAIN,
-    VERA_DEVICES,
-)
+from homeassistant.components.vera import DOMAIN, async_unload_entry
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
-
-
-def new_vera_device(cls, device_id: int) -> VeraDevice:
-    """Create new mocked vera device.."""
-    vera_device = MagicMock(spec=cls)  # type: VeraDevice
-    vera_device.device_id = device_id
-    vera_device.name = f"dev${device_id}"
-    return vera_device
-
-
-def assert_hass_vera_devices(hass: HomeAssistant, platform: str, arr_len: int) -> None:
-    """Assert vera devices are present.."""
-    assert hass.data[VERA_DEVICES][platform]
-    assert len(hass.data[VERA_DEVICES][platform]) == arr_len
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_init(
     hass: HomeAssistant, vera_component_factory: ComponentFactory
 ) -> None:
     """Test function."""
+    vera_device1 = MagicMock(spec=VeraBinarySensor)  # type: VeraBinarySensor
+    vera_device1.device_id = 1
+    vera_device1.vera_device_id = 1
+    vera_device1.name = "first_dev"
+    vera_device1.is_tripped = False
+    entity1_id = "binary_sensor.first_dev_1"
 
-    def setup_callback(controller: VeraController, hass_config: dict) -> None:
-        hass_config[DOMAIN][CONF_EXCLUDE] = [11]
-        hass_config[DOMAIN][CONF_LIGHTS] = [10]
+    vera_device2 = MagicMock(spec=VeraBinarySensor)  # type: VeraBinarySensor
+    vera_device2.device_id = 2
+    vera_device2.vera_device_id = 2
+    vera_device2.name = "second_dev"
+    vera_device2.is_tripped = False
+    entity2_id = "binary_sensor.second_dev_2"
 
     await vera_component_factory.configure_component(
         hass=hass,
-        devices=(
-            new_vera_device(VeraDimmer, 1),
-            new_vera_device(VeraBinarySensor, 2),
-            new_vera_device(VeraSensor, 3),
-            new_vera_device(VeraArmableDevice, 4),
-            new_vera_device(VeraLock, 5),
-            new_vera_device(VeraThermostat, 6),
-            new_vera_device(VeraCurtain, 7),
-            new_vera_device(VeraSceneController, 8),
-            new_vera_device(VeraSwitch, 9),
-            new_vera_device(VeraSwitch, 10),
-            new_vera_device(VeraSwitch, 11),
+        controller_configs=(
+            new_simple_controller_config(
+                base_url="http://127.0.0.1:111",
+                serial_number="first_serial",
+                devices=(vera_device1,),
+            ),
+            new_simple_controller_config(
+                base_url="http://127.0.0.1:222",
+                serial_number="second_serial",
+                devices=(vera_device2,),
+            ),
         ),
-        scenes=(MagicMock(spec=VeraScene),),
-        setup_callback=setup_callback,
     )
 
-    assert_hass_vera_devices(hass, "light", 2)
-    assert_hass_vera_devices(hass, "binary_sensor", 1)
-    assert_hass_vera_devices(hass, "sensor", 2)
-    assert_hass_vera_devices(hass, "switch", 2)
-    assert_hass_vera_devices(hass, "lock", 1)
-    assert_hass_vera_devices(hass, "climate", 1)
-    assert_hass_vera_devices(hass, "cover", 1)
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entry1 = entity_registry.async_get(entity1_id)
+    entry2 = entity_registry.async_get(entity2_id)
+
+    assert entry1
+    assert entry1.unique_id == "first_serial_1"
+
+    assert entry2
+    assert entry2.unique_id == "second_serial_2"
+
+
+async def test_unload(
+    hass: HomeAssistant, vera_component_factory: ComponentFactory
+) -> None:
+    """Test function."""
+    vera_device1 = MagicMock(spec=VeraBinarySensor)  # type: VeraBinarySensor
+    vera_device1.device_id = 1
+    vera_device1.vera_device_id = 1
+    vera_device1.name = "first_dev"
+    vera_device1.is_tripped = False
+
+    component_data = await vera_component_factory.configure_component(
+        hass=hass, controller_configs=(new_simple_controller_config(),)
+    )
+    component_data.controller_datas[0].controller.stop()
+
+    config_entries = hass.config_entries.async_entries(DOMAIN)
+    assert config_entries
+
+    for config_entry in config_entries:
+        await async_unload_entry(hass, config_entry)

--- a/tests/components/vera/test_light.py
+++ b/tests/components/vera/test_light.py
@@ -6,7 +6,7 @@ from pyvera import CATEGORY_DIMMER, VeraDimmer
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_HS_COLOR
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_light(
@@ -24,10 +24,10 @@ async def test_light(
     entity_id = "light.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,),
+        hass=hass,
+        controller_configs=(new_simple_controller_config(devices=(vera_device,)),),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     assert hass.states.get(entity_id).state == "off"
 

--- a/tests/components/vera/test_lock.py
+++ b/tests/components/vera/test_lock.py
@@ -6,7 +6,7 @@ from pyvera import CATEGORY_LOCK, VeraLock
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_lock(
@@ -21,10 +21,10 @@ async def test_lock(
     entity_id = "lock.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,),
+        hass=hass,
+        controller_configs=(new_simple_controller_config(devices=(vera_device,)),),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     assert hass.states.get(entity_id).state == STATE_UNLOCKED
 

--- a/tests/components/vera/test_scene.py
+++ b/tests/components/vera/test_scene.py
@@ -5,7 +5,7 @@ from pyvera import VeraScene
 
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_scene(
@@ -18,7 +18,8 @@ async def test_scene(
     entity_id = "scene.dev1_1"
 
     await vera_component_factory.configure_component(
-        hass=hass, scenes=(vera_scene,),
+        hass=hass,
+        controller_configs=(new_simple_controller_config(scenes=(vera_scene,)),),
     )
 
     await hass.services.async_call(

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -15,7 +15,7 @@ from pyvera import (
 
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def run_sensor_test(
@@ -36,10 +36,14 @@ async def run_sensor_test(
     entity_id = "sensor.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,), setup_callback=setup_callback
+        hass=hass,
+        controller_configs=(
+            new_simple_controller_config(
+                devices=(vera_device,), setup_callback=setup_callback
+            ),
+        ),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     for (initial_value, state_value) in assert_states:
         setattr(vera_device, class_property, initial_value)
@@ -187,10 +191,10 @@ async def test_scene_controller_sensor(
     entity_id = "sensor.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,),
+        hass=hass,
+        controller_configs=(new_simple_controller_config(devices=(vera_device,)),),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     vera_device.get_last_scene_time = "1111"
     update_callback(vera_device)

--- a/tests/components/vera/test_switch.py
+++ b/tests/components/vera/test_switch.py
@@ -5,7 +5,7 @@ from pyvera import CATEGORY_SWITCH, VeraSwitch
 
 from homeassistant.core import HomeAssistant
 
-from .common import ComponentFactory
+from .common import ComponentFactory, new_simple_controller_config
 
 
 async def test_switch(
@@ -20,10 +20,10 @@ async def test_switch(
     entity_id = "switch.dev1_1"
 
     component_data = await vera_component_factory.configure_component(
-        hass=hass, devices=(vera_device,),
+        hass=hass,
+        controller_configs=(new_simple_controller_config(devices=(vera_device,)),),
     )
-    controller = component_data.controller
-    update_callback = controller.register.call_args_list[0][0][1]
+    update_callback = component_data.controller_datas[0].update_callback
 
     assert hass.states.get(entity_id).state == "off"
 


### PR DESCRIPTION
## Breaking Change:

Upgrading will result in all new entities being added, old entities will have to be manually removed. There sadly is no way around this as the older vera entities provided a unique_id that was not unique. It was in fact a generated (incremental) device number provided by the controller. Leaving this be would result in a collision with a second controller. Supporting multiple controllers is more reliable than vera's linked controllers feature which tends to stop working and has nearly zero documentation.

## Description:
Adding support for multiple vera controllers.
Converting to a component with device info. Now we can assign entities to areas.
Fixing bug where vera entities had an 2 digit int for the unique_id.

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11424

## Example entry for `configuration.yaml` (if applicable):
```yaml
vera:
  - base_url: http://192.168.1.161:3480/
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
