### PR TITLE
Add support for limit_entity_domain and limit_entity_integration in services.yaml service definition

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -223,6 +223,12 @@ async def async_get_all_descriptions(hass):
                 description = descriptions_cache[cache_key] = {
                     "description": yaml_description.get("description", ""),
                     "fields": yaml_description.get("fields", {}),
+                    "limit_entity_domain": cv.ensure_list(
+                        yaml_description.get("limit_entity_domain")
+                    ),
+                    "limit_entity_integration": yaml_description.get(
+                        "limit_entity_integration", ""
+                    ),
                 }
 
             descriptions[domain][service] = description
@@ -239,6 +245,8 @@ def async_set_service_schema(hass, domain, service, schema):
     description = {
         "description": schema.get("description") or "",
         "fields": schema.get("fields") or {},
+        "limit_entity_domain": cv.ensure_list(schema.get("limit_entity_domain")),
+        "limit_entity_integration": schema.get("limit_entity_integration", ""),
     }
 
     hass.data[SERVICE_DESCRIPTION_CACHE]["{}.{}".format(domain, service)] = description

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -271,8 +271,12 @@ def test_async_get_all_descriptions(hass):
 
     assert len(descriptions) == 1
 
-    assert "description" in descriptions["group"]["reload"]
-    assert "fields" in descriptions["group"]["reload"]
+    assert "description" in descriptions[group.DOMAIN]["reload"]
+    assert "fields" in descriptions[group.DOMAIN]["reload"]
+    assert "limit_entity_domain" in descriptions[group.DOMAIN]["reload"]
+    assert "limit_entity_integration" in descriptions[group.DOMAIN]["reload"]
+    assert descriptions[group.DOMAIN]["reload"]["limit_entity_domain"] == []
+    assert descriptions[group.DOMAIN]["reload"]["limit_entity_integration"] == ""
 
     logger = hass.components.logger
     logger_config = {logger.DOMAIN: {}}
@@ -283,6 +287,10 @@ def test_async_get_all_descriptions(hass):
 
     assert "description" in descriptions[logger.DOMAIN]["set_level"]
     assert "fields" in descriptions[logger.DOMAIN]["set_level"]
+    assert "limit_entity_domain" in descriptions[logger.DOMAIN]["set_level"]
+    assert "limit_entity_integration" in descriptions[logger.DOMAIN]["set_level"]
+    assert descriptions[logger.DOMAIN]["set_level"]["limit_entity_domain"] == []
+    assert descriptions[logger.DOMAIN]["set_level"]["limit_entity_integration"] == ""
 
 
 async def test_call_with_required_features(hass, mock_entities):


### PR DESCRIPTION
## Description:
As per home-assistant/architecture#313, I have added support for two new properties `limit_entity_domain` and `limit_entity_integration` to be loaded in for a service definition, with the `limit_entity_domain` parameter always coalescing to a list.

Once this is merged, the frontend can then be updated to use these new properties to give the user a better list of entities to choose from in the entity picker. Right now it's assumed that the entity list should be limited to entities in the same domain as the service. If `limit_entity_domain` is specified, the `ha-entity-picker` should use that list to filter entities instead of the service domain, and if `limit_entity_integration` is specified, the `ha-entity-picker` should filter entities based on the integration they were created by.


**Related issue (if applicable):** home-assistant/architecture#313

**Pull request with documentation for [developers.home-assistant.io](https://github.com/home-assistant/developers.home-assistant) (if applicable):** home-assistant/developers.home-assistant#369

## Example entry for local_file `services.yaml`:
```yaml
update_file_path:
  limit_entity_domain:
    - camera
  description: Use this service to change the file displayed by the camera.
  fields:
    entity_id:
      description: Name of the entity_id of the camera to update.
      example: 'camera.local_file'
    file_path:
      description: The full path to the new image file to be displayed.
      example: '/config/www/images/image.jpg'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [developers.home-assistant.io](https://github.com/home-assistant/developers.home-assistant)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
