### PR TITLE
Remove uvloop event policy

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -19,8 +19,6 @@ def set_loop() -> None:
     import asyncio
     from asyncio.events import BaseDefaultEventLoopPolicy
 
-    policy = None
-
     if sys.platform == "win32":
         if hasattr(asyncio, "WindowsProactorEventLoopPolicy"):
             # pylint: disable=no-member
@@ -34,7 +32,6 @@ def set_loop() -> None:
 
             policy = ProactorPolicy()
 
-    if policy is not None:
         asyncio.set_event_loop_policy(policy)
 
 

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 def set_loop() -> None:
-    """Attempt to use uvloop."""
+    """Attempt to use different loop."""
     import asyncio
     from asyncio.events import BaseDefaultEventLoopPolicy
 
@@ -33,13 +33,6 @@ def set_loop() -> None:
                 _loop_factory = asyncio.ProactorEventLoop
 
             policy = ProactorPolicy()
-    else:
-        try:
-            import uvloop
-        except ImportError:
-            pass
-        else:
-            policy = uvloop.EventLoopPolicy()
 
     if policy is not None:
         asyncio.set_event_loop_policy(policy)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,10 +25,6 @@ from tests.common import (  # noqa: E402, isort:skip
 )
 from tests.test_util.aiohttp import mock_aiohttp_client  # noqa: E402, isort:skip
 
-if os.environ.get("UVLOOP") == "1":
-    import uvloop
-
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 logging.basicConfig(level=logging.DEBUG)
 logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 """Set up some common test helper things."""
-import asyncio
 import functools
 import logging
-import os
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
## Breaking Change:

It's not possible anymore to use uvloop/libuv as asyncio event loop.

## Description:

We had too many issues with uvloop inside Home Assistant. At the end, our process has so many different processes handling that the complexity is out of the scope for those projects. We had also a long time a patch inside for python/asyncio to make it working with HA.
