### PR TITLE
Log ZHA bind/unbind operations status

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -70,8 +70,6 @@ ATTR_IEEE_ADDRESS = "ieee_address"
 ATTR_IEEE = "ieee"
 ATTR_SOURCE_IEEE = "source_ieee"
 ATTR_TARGET_IEEE = "target_ieee"
-BIND_REQUEST = 0x0021
-UNBIND_REQUEST = 0x0022
 
 SERVICE_PERMIT = "permit"
 SERVICE_REMOVE = "remove"
@@ -717,7 +715,9 @@ async def websocket_bind_devices(hass, connection, msg):
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     source_ieee = msg[ATTR_SOURCE_IEEE]
     target_ieee = msg[ATTR_TARGET_IEEE]
-    await async_binding_operation(zha_gateway, source_ieee, target_ieee, BIND_REQUEST)
+    await async_binding_operation(
+        zha_gateway, source_ieee, target_ieee, zdo_types.ZDOCmd.Bind_req
+    )
     _LOGGER.info(
         "Issued bind devices: %s %s",
         f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
@@ -739,7 +739,9 @@ async def websocket_unbind_devices(hass, connection, msg):
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     source_ieee = msg[ATTR_SOURCE_IEEE]
     target_ieee = msg[ATTR_TARGET_IEEE]
-    await async_binding_operation(zha_gateway, source_ieee, target_ieee, UNBIND_REQUEST)
+    await async_binding_operation(
+        zha_gateway, source_ieee, target_ieee, zdo_types.ZDOCmd.Unbind_req
+    )
     _LOGGER.info(
         "Issued unbind devices: %s %s",
         f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
@@ -764,8 +766,9 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
 
         zdo = cluster_pair.source_cluster.endpoint.device.zdo
 
-        op_msg = "bind/unbind operation for: %s: [%s] %s [%s] cluster: %s"
+        op_msg = "%s operation for: %s: [%s] %s [%s] cluster: %s"
         op_params = (
+            operation.name,
             ATTR_SOURCE_IEEE,
             source_ieee,
             ATTR_TARGET_IEEE,

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -788,12 +788,12 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
             )
         )
     res = await asyncio.gather(*(t[0] for t in bind_tasks), return_exceptions=True)
-    for r, op in zip(res, bind_tasks):
-        if isinstance(r, Exception):
-            fmt = op[1] + " failed: %s"
+    for outcome, log_msg in zip(res, bind_tasks):
+        if isinstance(outcome, Exception):
+            fmt = log_msg[1] + " failed: %s"
         else:
-            fmt = op[1] + " completed: %s"
-        zdo.debug(fmt, *(op[2] + (r,)))
+            fmt = log_msg[1] + " completed: %s"
+        zdo.debug(fmt, *(log_msg[2] + (outcome,)))
 
 
 def async_load_api(hass):

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -766,16 +766,13 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
 
         zdo = cluster_pair.source_cluster.endpoint.device.zdo
 
-        op_msg = "%s operation for: %s: [%s] %s [%s] cluster: %s"
+        op_msg = "cluster: %s %s --> [%s]"
         op_params = (
-            operation.name,
-            ATTR_SOURCE_IEEE,
-            source_ieee,
-            ATTR_TARGET_IEEE,
-            target_ieee,
             cluster_pair.source_cluster.cluster_id,
+            operation.name,
+            target_ieee,
         )
-        _LOGGER.debug("processing " + op_msg, *op_params)
+        zdo.debug("processing " + op_msg, *op_params)
 
         bind_tasks.append(
             (
@@ -796,7 +793,7 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
             fmt = op[1] + " failed: %s"
         else:
             fmt = op[1] + " completed: %s"
-        _LOGGER.debug(fmt, *(op[2] + (r,)))
+        zdo.debug(fmt, *(op[2] + (r,)))
 
 
 def async_load_api(hass):


### PR DESCRIPTION
## Description:
Add debug logging to capture result of ZHA bind/unbind operations.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
