### PR TITLE
Add preset scheduling to radiothermostat

### DIFF
--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -56,12 +56,6 @@ PRESET_SLEEP = "sleep"
 # Device is reacting to activity (e.g. movement sensors)
 PRESET_ACTIVITY = "activity"
 
-# Device in holday mode (Eid, Rosh Hashanah, etc)
-PRESET_HOLIDAY = "holiday"
-
-# Device is in alternate program mode
-PRESET_ALTERNATE = "alternate"
-
 # Possible fan state
 FAN_ON = "on"
 FAN_OFF = "off"

--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -56,6 +56,11 @@ PRESET_SLEEP = "sleep"
 # Device is reacting to activity (e.g. movement sensors)
 PRESET_ACTIVITY = "activity"
 
+# Device in holday mode (Eid, Rosh Hashanah, etc)
+PRESET_HOLIDAY = "holiday"
+
+# Device is in alternate program mode
+PRESET_ALTERNATE = "alternate"
 
 # Possible fan state
 FAN_ON = "on"

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -15,9 +15,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
-    PRESET_ALTERNATE,
     PRESET_AWAY,
-    PRESET_HOLIDAY,
     PRESET_HOME,
     SUPPORT_FAN_MODE,
     SUPPORT_PRESET_MODE,
@@ -38,6 +36,10 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_FAN_ACTION = "fan_action"
 
 CONF_HOLD_TEMP = "hold_temp"
+
+PRESET_HOLIDAY = "holiday"
+
+PRESET_ALTERNATE = "alternate"
 
 STATE_CIRCULATE = "circulate"
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     CONF_HOST,
     PRECISION_HALVES,
     STATE_ON,
+    TEMP_FAHRENHEIT
 )
 from homeassistant.util import dt as dt_util
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -62,8 +62,8 @@ TEMP_MODE_TO_CODE = {v: k for k, v in CODE_TO_TEMP_MODE.items()}
 
 # Programmed fan mode (circulate is supported by CT80 models)
 CODE_TO_FAN_MODE = {
-    0: HVAC_MODE_AUTO, 
-    1: STATE_CIRCULATE, 
+    0: HVAC_MODE_AUTO,
+    1: STATE_CIRCULATE,
     2: STATE_ON
 }
 FAN_MODE_TO_CODE = {v: k for k, v in CODE_TO_FAN_MODE.items()}
@@ -71,35 +71,34 @@ FAN_MODE_TO_CODE = {v: k for k, v in CODE_TO_FAN_MODE.items()}
 # Active thermostat state (is it heating or cooling?).  In the future
 # this should probably made into heat and cool binary sensors.
 CODE_TO_TEMP_STATE = {
-    0: CURRENT_HVAC_IDLE, 
-    1: CURRENT_HVAC_HEAT, 
+    0: CURRENT_HVAC_IDLE,
+    1: CURRENT_HVAC_HEAT,
     2: CURRENT_HVAC_COOL
 }
 
 # Active fan state.  This is if the fan is actually on or not.  In the
 # future this should probably made into a binary sensor for the fan.
 CODE_TO_FAN_STATE = {
-    0: FAN_OFF, 
+    0: FAN_OFF,
     1: FAN_ON
 }
 
 PRESET_MODE_TO_CODE = {
-   "home": 0,
-   "alternate": 1,
-   "away": 2,
-   "holiday": 3
+    "home": 0,
+    "alternate": 1,
+    "away": 2,
+    "holiday": 3
 }
 
 CODE_TO_PRESET_MODE = {
-   0: "home",
-   1: "alternate",
-   2: "away",
-   3: "holiday"
+    0: "home",
+    1: "alternate",
+    2: "away",
+    3: "holiday"
 }
 
 def round_temp(temperature):
     """Round a temperature to the resolution of the thermostat.
-
     RadioThermostats can handle 0.5 degree temps so the input
     temperature is rounded to that value and returned.
     """
@@ -111,6 +110,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_HOLD_TEMP, default=False): cv.boolean,
     }
 )
+
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_PRESET_MODE
 
@@ -384,6 +384,7 @@ class RadioThermostat(ClimateDevice):
             self.device.t_heat = self._target_temperature
 
     def set_preset_mode(self, preset_mode):
+        """Set Preset mode (Home, Alternate, Away, Holiday)"""
         if preset_mode in (PRESET_MODES):
             self.device.program_mode = PRESET_MODE_TO_CODE[preset_mode]
         else: 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -20,14 +20,13 @@ from homeassistant.components.climate.const import (
     PRESET_HOME,
     SUPPORT_FAN_MODE,
     SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_TARGET_TEMPERATURE
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_HOST,
     PRECISION_HALVES,
     STATE_ON,
-    TEMP_FAHRENHEIT,
 )
 from homeassistant.util import dt as dt_util
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -61,8 +61,8 @@ CODE_TO_TEMP_MODE = {
 TEMP_MODE_TO_CODE = {v: k for k, v in CODE_TO_TEMP_MODE.items()}
 
 # Programmed fan mode (circulate is supported by CT80 models)
-CODE_TO_FAN_MODE = {0: HVAC_MODE_AUTO, 1: STATE_CIRCULATE, 2: STATE_ON
-                   }
+CODE_TO_FAN_MODE = {0: HVAC_MODE_AUTO, 1: STATE_CIRCULATE, 2: STATE_ON}
+
 FAN_MODE_TO_CODE = {v: k for k, v in CODE_TO_FAN_MODE.items()}
 
 # Active thermostat state (is it heating or cooling?).  In the future

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -61,20 +61,13 @@ CODE_TO_TEMP_MODE = {
 TEMP_MODE_TO_CODE = {v: k for k, v in CODE_TO_TEMP_MODE.items()}
 
 # Programmed fan mode (circulate is supported by CT80 models)
-CODE_TO_FAN_MODE = {
-    0: HVAC_MODE_AUTO,
-    1: STATE_CIRCULATE,
-    2: STATE_ON
-}
+CODE_TO_FAN_MODE = {0: HVAC_MODE_AUTO, 1: STATE_CIRCULATE, 2: STATE_ON
+                   }
 FAN_MODE_TO_CODE = {v: k for k, v in CODE_TO_FAN_MODE.items()}
 
 # Active thermostat state (is it heating or cooling?).  In the future
 # this should probably made into heat and cool binary sensors.
-CODE_TO_TEMP_STATE = {
-    0: CURRENT_HVAC_IDLE,
-    1: CURRENT_HVAC_HEAT,
-    2: CURRENT_HVAC_COOL
-}
+CODE_TO_TEMP_STATE = {0: CURRENT_HVAC_IDLE, 1: CURRENT_HVAC_HEAT, 2: CURRENT_HVAC_COOL}
 
 # Active fan state.  This is if the fan is actually on or not.  In the
 # future this should probably made into a binary sensor for the fan.
@@ -83,19 +76,9 @@ CODE_TO_FAN_STATE = {
     1: FAN_ON
 }
 
-PRESET_MODE_TO_CODE = {
-    "home": 0,
-    "alternate": 1,
-    "away": 2,
-    "holiday": 3
-}
+PRESET_MODE_TO_CODE = {"home": 0, "alternate": 1, "away": 2, "holiday": 3}
 
-CODE_TO_PRESET_MODE = {
-    0: "home",
-    1: "alternate",
-    2: "away",
-    3: "holiday"
-}
+CODE_TO_PRESET_MODE = {0: "home", 1: "alternate", 2: "away", 3: "holiday"}
 
 
 def round_temp(temperature):

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -142,6 +142,7 @@ class RadioThermostat(ClimateDevice):
         self._hold_set = False
         self._prev_temp = None
         self._program_mode = None
+        self._preset_mode = None
         self._is_away = False
 
         # Fan circulate mode is only supported by the CT80 models.
@@ -367,4 +368,4 @@ class RadioThermostat(ClimateDevice):
         if preset_mode in (PRESET_MODES):
             self.device.program_mode = PRESET_MODE_TO_CODE[preset_mode]
         else:
-            _LOGGER.error("preset_mode " + preset_mode + " not in PRESET_MODES")
+            _LOGGER.error("preset_mode  %s not in PRESET_MODES", preset_mode,)

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -4,31 +4,22 @@ import logging
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
-from homeassistant.components.climate.const import (
-    CURRENT_HVAC_COOL,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE,
-    FAN_OFF,
-    FAN_ON,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-    PRESET_ALTERNATE,
-    PRESET_AWAY,
-    PRESET_HOLIDAY,
-    PRESET_HOME,
-    SUPPORT_FAN_MODE,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-)
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_HOST,
-    PRECISION_HALVES,
-    STATE_ON,
-    TEMP_FAHRENHEIT,
-)
+from homeassistant.components.climate.const import (CURRENT_HVAC_COOL,
+                                                    CURRENT_HVAC_HEAT,
+                                                    CURRENT_HVAC_IDLE, FAN_OFF,
+                                                    FAN_ON, HVAC_MODE_AUTO,
+                                                    HVAC_MODE_COOL,
+                                                    HVAC_MODE_HEAT,
+                                                    HVAC_MODE_OFF,
+                                                    PRESET_ALTERNATE,
+                                                    PRESET_AWAY,
+                                                    PRESET_HOLIDAY,
+                                                    PRESET_HOME,
+                                                    SUPPORT_FAN_MODE,
+                                                    SUPPORT_PRESET_MODE,
+                                                    SUPPORT_TARGET_TEMPERATURE)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, PRECISION_HALVES,
+                                 STATE_ON, TEMP_FAHRENHEIT)
 from homeassistant.util import dt as dt_util
 
 import radiotherm

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -71,10 +71,7 @@ CODE_TO_TEMP_STATE = {0: CURRENT_HVAC_IDLE, 1: CURRENT_HVAC_HEAT, 2: CURRENT_HVA
 
 # Active fan state.  This is if the fan is actually on or not.  In the
 # future this should probably made into a binary sensor for the fan.
-CODE_TO_FAN_STATE = {
-    0: FAN_OFF,
-    1: FAN_ON
-}
+CODE_TO_FAN_STATE = {0: FAN_OFF, 1: FAN_ON}
 
 PRESET_MODE_TO_CODE = {"home": 0, "alternate": 1, "away": 2, "holiday": 3}
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -370,4 +370,4 @@ class RadioThermostat(ClimateDevice):
         else:
             _LOGGER.error(
                 "preset_mode  %s not in PRESET_MODES", preset_mode,
-            
+            )

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -97,12 +97,15 @@ CODE_TO_PRESET_MODE = {
     3: "holiday"
 }
 
+
 def round_temp(temperature):
     """Round a temperature to the resolution of the thermostat.
+    
     RadioThermostats can handle 0.5 degree temps so the input
     temperature is rounded to that value and returned.
     """
     return round(temperature * 2.0) / 2.0
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -265,10 +268,6 @@ class RadioThermostat(ClimateDevice):
         """Return a list of available preset modes."""
         return PRESET_MODES
 
-    def set_preset_mode(self, preset_mode):
-        """Set new preset mode."""
-        pass
-
     def update(self):
         """Update and validate the data from the thermostat."""
         # Radio thermostats are very slow, and sometimes don't respond
@@ -384,7 +383,7 @@ class RadioThermostat(ClimateDevice):
             self.device.t_heat = self._target_temperature
 
     def set_preset_mode(self, preset_mode):
-        """Set Preset mode (Home, Alternate, Away, Holiday)"""
+        """Set Preset mode (Home, Alternate, Away, Holiday)."""
         if preset_mode in (PRESET_MODES):
             self.device.program_mode = PRESET_MODE_TO_CODE[preset_mode]
         else: 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -4,23 +4,33 @@ import logging
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
-from homeassistant.components.climate.const import (CURRENT_HVAC_COOL,
-                                                    CURRENT_HVAC_HEAT,
-                                                    CURRENT_HVAC_IDLE, FAN_OFF,
-                                                    FAN_ON, HVAC_MODE_AUTO,
-                                                    HVAC_MODE_COOL,
-                                                    HVAC_MODE_HEAT,
-                                                    HVAC_MODE_OFF,
-                                                    PRESET_ALTERNATE,
-                                                    PRESET_AWAY,
-                                                    PRESET_HOLIDAY,
-                                                    PRESET_HOME,
-                                                    SUPPORT_FAN_MODE,
-                                                    SUPPORT_PRESET_MODE,
-                                                    SUPPORT_TARGET_TEMPERATURE)
-from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, PRECISION_HALVES,
-                                 STATE_ON, TEMP_FAHRENHEIT)
+from homeassistant.components.climate.const import (
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    FAN_OFF,
+    FAN_ON,
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    PRESET_ALTERNATE,
+    PRESET_AWAY,
+    PRESET_HOLIDAY,
+    PRESET_HOME,
+    SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_HOST,
+    PRECISION_HALVES,
+    STATE_ON,
+    TEMP_FAHRENHEIT,
+)
 from homeassistant.util import dt as dt_util
+
 
 import radiotherm
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -1,28 +1,37 @@
 """Support for Radio Thermostat wifi-enabled home thermostats."""
 import logging
 
-import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
-from homeassistant.components.climate.const import (CURRENT_HVAC_COOL,
-                                                    CURRENT_HVAC_HEAT,
-                                                    CURRENT_HVAC_IDLE, FAN_OFF,
-                                                    FAN_ON, HVAC_MODE_AUTO,
-                                                    HVAC_MODE_COOL,
-                                                    HVAC_MODE_HEAT,
-                                                    HVAC_MODE_OFF,
-                                                    PRESET_ALTERNATE,
-                                                    PRESET_AWAY,
-                                                    PRESET_HOLIDAY,
-                                                    PRESET_HOME,
-                                                    SUPPORT_FAN_MODE,
-                                                    SUPPORT_PRESET_MODE,
-                                                    SUPPORT_TARGET_TEMPERATURE)
-from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, PRECISION_HALVES,
-                                 STATE_ON, TEMP_FAHRENHEIT)
-from homeassistant.util import dt as dt_util
-
 import radiotherm
+import voluptuous as vol
+
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
+from homeassistant.components.climate.const import (
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    FAN_OFF,
+    FAN_ON,
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    PRESET_ALTERNATE,
+    PRESET_AWAY,
+    PRESET_HOLIDAY,
+    PRESET_HOME,
+    SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_HOST,
+    PRECISION_HALVES,
+    STATE_ON,
+    TEMP_FAHRENHEIT,
+)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -1,37 +1,28 @@
 """Support for Radio Thermostat wifi-enabled home thermostats."""
 import logging
 
-import voluptuous as vol
-import radiotherm
-
-from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
-from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-    FAN_ON,
-    FAN_OFF,
-    CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_COOL,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_FAN_MODE,
-    SUPPORT_PRESET_MODE,
-    PRESET_HOME,
-    PRESET_ALTERNATE,
-    PRESET_AWAY,
-    PRESET_HOLIDAY,
-)
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_HOST,
-    PRECISION_HALVES,
-    TEMP_FAHRENHEIT,
-    STATE_ON,
-)
-from homeassistant.util import dt as dt_util
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
+from homeassistant.components.climate.const import (CURRENT_HVAC_COOL,
+                                                    CURRENT_HVAC_HEAT,
+                                                    CURRENT_HVAC_IDLE, FAN_OFF,
+                                                    FAN_ON, HVAC_MODE_AUTO,
+                                                    HVAC_MODE_COOL,
+                                                    HVAC_MODE_HEAT,
+                                                    HVAC_MODE_OFF,
+                                                    PRESET_ALTERNATE,
+                                                    PRESET_AWAY,
+                                                    PRESET_HOLIDAY,
+                                                    PRESET_HOME,
+                                                    SUPPORT_FAN_MODE,
+                                                    SUPPORT_PRESET_MODE,
+                                                    SUPPORT_TARGET_TEMPERATURE)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, PRECISION_HALVES,
+                                 STATE_ON, TEMP_FAHRENHEIT)
+from homeassistant.util import dt as dt_util
+
+import radiotherm
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -100,7 +100,7 @@ CODE_TO_PRESET_MODE = {
 
 def round_temp(temperature):
     """Round a temperature to the resolution of the thermostat.
-    
+
     RadioThermostats can handle 0.5 degree temps so the input
     temperature is rounded to that value and returned.
     """
@@ -386,5 +386,5 @@ class RadioThermostat(ClimateDevice):
         """Set Preset mode (Home, Alternate, Away, Holiday)."""
         if preset_mode in (PRESET_MODES):
             self.device.program_mode = PRESET_MODE_TO_CODE[preset_mode]
-        else: 
+        else:
             _LOGGER.error("preset_mode " + preset_mode + " not in PRESET_MODES")

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -20,17 +20,16 @@ from homeassistant.components.climate.const import (
     PRESET_HOME,
     SUPPORT_FAN_MODE,
     SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE
+    SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_HOST,
     PRECISION_HALVES,
     STATE_ON,
-    TEMP_FAHRENHEIT
+    TEMP_FAHRENHEIT,
 )
 from homeassistant.util import dt as dt_util
-
 
 import radiotherm
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -141,8 +141,8 @@ class RadioThermostat(ClimateDevice):
         self._hold_temp = hold_temp
         self._hold_set = False
         self._prev_temp = None
-        self._program_mode = None
         self._preset_mode = None
+        self._program_mode = None
         self._is_away = False
 
         # Fan circulate mode is only supported by the CT80 models.
@@ -368,4 +368,6 @@ class RadioThermostat(ClimateDevice):
         if preset_mode in (PRESET_MODES):
             self.device.program_mode = PRESET_MODE_TO_CODE[preset_mode]
         else:
-            _LOGGER.error("preset_mode  %s not in PRESET_MODES", preset_mode,)
+            _LOGGER.error(
+                "preset_mode  %s not in PRESET_MODES", preset_mode,
+            


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
None Expected

## Description:

Adds preset schedules to RadioThermostat Thermostats as described in the V1.3 API Document. 
This adds a standard A schedule, and alternate B schedule, a Sabbath/Religious Holiday schedule, and a Vacation mode (which reuses the existing AWAY mode). 

As a result two additional modes had to be added to climate/const.py 
"PRESET_ALTERNATE" maps to Program B on a Radiothermostat CT80
"PRESET_HOLIDAY" maps to the Sabbath/Holiday mode on a Radiothermostat CT80

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [n/a] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
