### PR TITLE
Adding vera device info support.

### DIFF
--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -84,6 +84,10 @@ def setup(hass, base_config):
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_subscription)
 
     try:
+        # Load controller information like serial number.
+        controller.refresh_data()
+
+        # Get devices.
         all_devices = controller.get_devices()
 
         all_scenes = controller.get_scenes()
@@ -170,6 +174,19 @@ class VeraDevice(Entity):
     def should_poll(self):
         """Get polling requirement from vera device."""
         return self.vera_device.should_poll
+
+    @property
+    def device_info(self):
+        """Return information about the device."""
+        unique_id = f"{self.controller.serial_number}_{self.vera_device.vera_device_id}"
+        return {
+            "name": self._name,
+            "model": "Unknown",
+            "manufacturer": "Unknown",
+            "connections": {("serial_id", unique_id)},
+            "identifiers": {unique_id},
+            "battery": self.vera_device.battery_level,
+        }
 
     @property
     def device_state_attributes(self):

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -35,6 +35,7 @@ class ComponentFactory:
 
         controller = MagicMock(spec=VeraController)  # type: VeraController
         controller.base_url = controller_url
+        controller.serial_number = "1111"
         controller.register = MagicMock()
         controller.get_devices = MagicMock(return_value=devices or ())
         controller.get_scenes = MagicMock(return_value=scenes or ())

--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -21,6 +21,7 @@ from homeassistant.components.vera import (
     CONF_LIGHTS,
     DOMAIN,
     VERA_DEVICES,
+    VeraDevice as VeraDeviceEntity,
 )
 from homeassistant.core import HomeAssistant
 
@@ -76,3 +77,24 @@ async def test_init(
     assert_hass_vera_devices(hass, "lock", 1)
     assert_hass_vera_devices(hass, "climate", 1)
     assert_hass_vera_devices(hass, "cover", 1)
+
+
+def test_vera_device_entity():
+    """Test function."""
+    controller = MagicMock(spec=VeraController)  # type: VeraController
+    controller.serial_number = "SN"
+    device = MagicMock(spec=VeraDevice)  # type: VeraDevice
+    device.name = "first device"
+    device.device_id = "1"
+    device.vera_device_id = "1"
+    device.battery_level = 23
+
+    entity = VeraDeviceEntity(device, controller)
+    assert entity.device_info == {
+        "name": device.name,
+        "model": "Unknown",
+        "manufacturer": "Unknown",
+        "connections": {("serial_id", "SN_1")},
+        "identifiers": {"SN_1"},
+        "battery": 23,
+    }


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Adding device info support to vera device entity.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
