### PR TITLE
Handle min max sensor all UNKNOWN when type is LAST

### DIFF
--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -207,3 +207,5 @@ class MinMaxSensor(Entity):
         self.min_value = calc_min(sensor_values)
         self.max_value = calc_max(sensor_values)
         self.mean = calc_mean(sensor_values, self._round_digits)
+        if self._sensor_type == ATTR_LAST and all(state in [STATE_UNKNOWN, STATE_UNAVAILABLE] for state in self.states.values()):
+            self.last = STATE_UNKNOWN


### PR DESCRIPTION
## Breaking Change:
it might break someone's setups because they just didn't know their min_max sensor became `unknown` but essentially it's just a fix that should improve the sensors's reliability.

## Description:
If the sensor's type is last, the current code retains the last numeric value even if all monitored entities became unknown/unavailable.
I believe in this case the sensor's state should be unknown, too.
Not sure if my code is efficient enough, but it does the job.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
