### PR TITLE
Revert "Sort import for tests/components/feedreader/test_init.py"

### DIFF
--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -1,13 +1,12 @@
 """The tests for the feedreader component."""
 from datetime import timedelta
+from genericpath import exists
 from logging import getLogger
 from os import remove
 import time
 import unittest
 from unittest import mock
 from unittest.mock import patch
-
-from genericpath import exists
 
 from homeassistant.components import feedreader
 from homeassistant.components.feedreader import (


### PR DESCRIPTION
Reverts home-assistant/home-assistant#29878

#29878 causes isort pre-commit hook to fail: https://dev.azure.com/home-assistant/Home%20Assistant/_build/results?buildId=19825&view=logs&jobId=4e214fed-f310-53fa-0018-b38e7beb405b&j=4e214fed-f310-53fa-0018-b38e7beb405b&t=b826438c-e413-57c7-174a-d3bdede8f334

https://dev.azure.com/home-assistant/Home%20Assistant/_build/results?buildId=19828&view=logs&jobId=4e214fed-f310-53fa-0018-b38e7beb405b&j=4e214fed-f310-53fa-0018-b38e7beb405b&t=b826438c-e413-57c7-174a-d3bdede8f334
