### PR TITLE
Declare dependency to pymssql

### DIFF
--- a/homeassistant/components/recorder/manifest.json
+++ b/homeassistant/components/recorder/manifest.json
@@ -3,7 +3,8 @@
   "name": "Recorder",
   "documentation": "https://www.home-assistant.io/integrations/recorder",
   "requirements": [
-    "sqlalchemy==1.3.11"
+    "sqlalchemy==1.3.11",
+    "pymssql==2.1.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/recorder/manifest.json
+++ b/homeassistant/components/recorder/manifest.json
@@ -3,9 +3,10 @@
   "name": "Recorder",
   "documentation": "https://www.home-assistant.io/integrations/recorder",
   "requirements": [
-    "sqlalchemy==1.3.11",
+    "sqlalchemy==1.3.11"
+  ],
+  "dependencies": [
     "pymssql==2.1.4"
   ],
-  "dependencies": [],
   "codeowners": []
 }


### PR DESCRIPTION
Fixes #29837

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
With release 0.103.0 the dependency declaration to pymssql is missing.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
N/A
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
