### PR TITLE
Defer zha log formatting

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -565,11 +565,15 @@ async def websocket_device_cluster_attributes(hass, connection, msg):
                     {ID: attr_id, ATTR_NAME: attributes[attr_id][0]}
                 )
     _LOGGER.debug(
-        "Requested attributes for: %s %s %s %s",
-        f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
-        f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
-        f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
-        f"{RESPONSE}: [{cluster_attributes}]",
+        "Requested attributes for: %s: %s, %s: '%s', %s: %s, %s: %s",
+        ATTR_CLUSTER_ID,
+        cluster_id,
+        ATTR_CLUSTER_TYPE,
+        cluster_type,
+        ATTR_ENDPOINT_ID,
+        endpoint_id,
+        RESPONSE,
+        cluster_attributes,
     )
 
     connection.send_result(msg[ID], cluster_attributes)
@@ -619,11 +623,15 @@ async def websocket_device_cluster_commands(hass, connection, msg):
                     }
                 )
     _LOGGER.debug(
-        "Requested commands for: %s %s %s %s",
-        f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
-        f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
-        f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
-        f"{RESPONSE}: [{cluster_commands}]",
+        "Requested commands for: %s: %s, %s: '%s', %s: %s, %s: %s",
+        ATTR_CLUSTER_ID,
+        cluster_id,
+        ATTR_CLUSTER_TYPE,
+        cluster_type,
+        ATTR_ENDPOINT_ID,
+        endpoint_id,
+        RESPONSE,
+        cluster_commands,
     )
 
     connection.send_result(msg[ID], cluster_commands)
@@ -663,14 +671,21 @@ async def websocket_read_zigbee_cluster_attributes(hass, connection, msg):
             [attribute], allow_cache=False, only_cache=False, manufacturer=manufacturer
         )
     _LOGGER.debug(
-        "Read attribute for: %s %s %s %s %s %s %s",
-        f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
-        f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
-        f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
-        f"{ATTR_ATTRIBUTE}: [{attribute}]",
-        f"{ATTR_MANUFACTURER}: [{manufacturer}]",
-        "{}: [{}]".format(RESPONSE, str(success.get(attribute))),
-        "{}: [{}]".format("failure", failure),
+        "Read attribute for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s],",
+        ATTR_CLUSTER_ID,
+        cluster_id,
+        ATTR_CLUSTER_TYPE,
+        cluster_type,
+        ATTR_ENDPOINT_ID,
+        endpoint_id,
+        ATTR_ATTRIBUTE,
+        attribute,
+        ATTR_MANUFACTURER,
+        manufacturer,
+        RESPONSE,
+        str(success.get(attribute)),
+        "failure",
+        failure,
     )
     connection.send_result(msg[ID], str(success.get(attribute)))
 
@@ -693,9 +708,11 @@ async def websocket_get_bindable_devices(hass, connection, msg):
     ]
 
     _LOGGER.debug(
-        "Get bindable devices: %s %s",
-        f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
-        "{}: [{}]".format("bindable devices:", devices),
+        "Get bindable devices: %s: [%s], %s: [%s]",
+        ATTR_SOURCE_IEEE,
+        source_ieee,
+        "bindable devices",
+        devices,
     )
 
     connection.send_message(websocket_api.result_message(msg[ID], devices))
@@ -719,9 +736,11 @@ async def websocket_bind_devices(hass, connection, msg):
         zha_gateway, source_ieee, target_ieee, zdo_types.ZDOCmd.Bind_req
     )
     _LOGGER.info(
-        "Issued bind devices: %s %s",
-        f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
-        f"{ATTR_TARGET_IEEE}: [{target_ieee}]",
+        "Devices bound: %s: [%s] %s: [%s]",
+        ATTR_SOURCE_IEEE,
+        source_ieee,
+        ATTR_TARGET_IEEE,
+        target_ieee,
     )
 
 
@@ -743,9 +762,11 @@ async def websocket_unbind_devices(hass, connection, msg):
         zha_gateway, source_ieee, target_ieee, zdo_types.ZDOCmd.Unbind_req
     )
     _LOGGER.info(
-        "Issued unbind devices: %s %s",
-        f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
-        f"{ATTR_TARGET_IEEE}: [{target_ieee}]",
+        "Devices un-bound: %s: [%s] %s: [%s]",
+        ATTR_SOURCE_IEEE,
+        source_ieee,
+        ATTR_TARGET_IEEE,
+        target_ieee,
     )
 
 
@@ -848,14 +869,21 @@ def async_load_api(hass):
                 manufacturer=manufacturer,
             )
         _LOGGER.debug(
-            "Set attribute for: %s %s %s %s %s %s %s",
-            f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
-            f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
-            f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
-            f"{ATTR_ATTRIBUTE}: [{attribute}]",
-            f"{ATTR_VALUE}: [{value}]",
-            f"{ATTR_MANUFACTURER}: [{manufacturer}]",
-            f"{RESPONSE}: [{response}]",
+            "Set attribute for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s]",
+            ATTR_CLUSTER_ID,
+            cluster_id,
+            ATTR_CLUSTER_TYPE,
+            cluster_type,
+            ATTR_ENDPOINT_ID,
+            endpoint_id,
+            ATTR_ATTRIBUTE,
+            attribute,
+            ATTR_VALUE,
+            value,
+            ATTR_MANUFACTURER,
+            manufacturer,
+            RESPONSE,
+            response,
         )
 
     hass.helpers.service.async_register_admin_service(
@@ -890,15 +918,23 @@ def async_load_api(hass):
                 manufacturer=manufacturer,
             )
         _LOGGER.debug(
-            "Issue command for: %s %s %s %s %s %s %s %s",
-            f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
-            f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
-            f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
-            f"{ATTR_COMMAND}: [{command}]",
-            f"{ATTR_COMMAND_TYPE}: [{command_type}]",
-            f"{ATTR_ARGS}: [{args}]",
-            f"{ATTR_MANUFACTURER}: [{manufacturer}]",
-            f"{RESPONSE}: [{response}]",
+            "Issued command for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: %s %s: [%s] %s: %s",
+            ATTR_CLUSTER_ID,
+            cluster_id,
+            ATTR_CLUSTER_TYPE,
+            cluster_type,
+            ATTR_ENDPOINT_ID,
+            endpoint_id,
+            ATTR_COMMAND,
+            command,
+            ATTR_COMMAND_TYPE,
+            command_type,
+            ATTR_ARGS,
+            args,
+            ATTR_MANUFACTURER,
+            manufacturer,
+            RESPONSE,
+            response,
         )
 
     hass.helpers.service.async_register_admin_service(
@@ -925,12 +961,17 @@ def async_load_api(hass):
                 command, *args, manufacturer=manufacturer, expect_reply=True
             )
         _LOGGER.debug(
-            "Issue group command for: %s %s %s %s %s",
-            f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
-            f"{ATTR_COMMAND}: [{command}]",
-            f"{ATTR_ARGS}: [{args}]",
-            f"{ATTR_MANUFACTURER}: [{manufacturer}]",
-            f"{RESPONSE}: [{response}]",
+            "Issued group command for: %s: [%s] %s: [%s] %s: %s %s: [%s] %s: %s",
+            ATTR_CLUSTER_ID,
+            cluster_id,
+            ATTR_COMMAND,
+            command,
+            ATTR_ARGS,
+            args,
+            ATTR_MANUFACTURER,
+            manufacturer,
+            RESPONSE,
+            response,
         )
 
     hass.helpers.service.async_register_admin_service(
@@ -954,20 +995,24 @@ def async_load_api(hass):
                 await channel.squawk(mode, strobe, level)
             else:
                 _LOGGER.error(
-                    "Squawking IASWD: %s is missing the required IASWD channel!",
-                    "{}: [{}]".format(ATTR_IEEE, str(ieee)),
+                    "Squawking IASWD: %s: [%s] is missing the required IASWD channel!",
+                    ATTR_IEEE,
+                    str(ieee),
                 )
         else:
             _LOGGER.error(
-                "Squawking IASWD: %s could not be found!",
-                "{}: [{}]".format(ATTR_IEEE, str(ieee)),
+                "Squawking IASWD: %s: [%s] could not be found!", ATTR_IEEE, str(ieee)
             )
         _LOGGER.debug(
-            "Squawking IASWD: %s %s %s %s",
-            "{}: [{}]".format(ATTR_IEEE, str(ieee)),
-            "{}: [{}]".format(ATTR_WARNING_DEVICE_MODE, mode),
-            "{}: [{}]".format(ATTR_WARNING_DEVICE_STROBE, strobe),
-            "{}: [{}]".format(ATTR_LEVEL, level),
+            "Squawking IASWD: %s: [%s] %s: [%s] %s: [%s] %s: [%s]",
+            ATTR_IEEE,
+            str(ieee),
+            ATTR_WARNING_DEVICE_MODE,
+            mode,
+            ATTR_WARNING_DEVICE_STROBE,
+            strobe,
+            ATTR_LEVEL,
+            level,
         )
 
     hass.helpers.service.async_register_admin_service(
@@ -996,20 +1041,24 @@ def async_load_api(hass):
                 )
             else:
                 _LOGGER.error(
-                    "Warning IASWD: %s is missing the required IASWD channel!",
-                    "{}: [{}]".format(ATTR_IEEE, str(ieee)),
+                    "Warning IASWD: %s: [%s] is missing the required IASWD channel!",
+                    ATTR_IEEE,
+                    str(ieee),
                 )
         else:
             _LOGGER.error(
-                "Warning IASWD: %s could not be found!",
-                "{}: [{}]".format(ATTR_IEEE, str(ieee)),
+                "Warning IASWD: %s: [%s] could not be found!", ATTR_IEEE, str(ieee)
             )
         _LOGGER.debug(
-            "Warning IASWD: %s %s %s %s",
-            "{}: [{}]".format(ATTR_IEEE, str(ieee)),
-            "{}: [{}]".format(ATTR_WARNING_DEVICE_MODE, mode),
-            "{}: [{}]".format(ATTR_WARNING_DEVICE_STROBE, strobe),
-            "{}: [{}]".format(ATTR_LEVEL, level),
+            "Warning IASWD: %s: [%s] %s: [%s] %s: [%s] %s: [%s]",
+            ATTR_IEEE,
+            str(ieee),
+            ATTR_WARNING_DEVICE_MODE,
+            mode,
+            ATTR_WARNING_DEVICE_STROBE,
+            strobe,
+            ATTR_LEVEL,
+            level,
         )
 
     hass.helpers.service.async_register_admin_service(


### PR DESCRIPTION
## Description:
Defer formatting of debug log messages in `zha.api`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
