### PR TITLE
Bump python-miio version to 0.4.8

### DIFF
--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
   "requirements": [
     "construct==2.9.45",
-    "python-miio==0.4.7"
+    "python-miio==0.4.8"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1579,7 +1579,7 @@ python-juicenet==0.1.6
 # python-lirc==1.2.3
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.4.7
+python-miio==0.4.8
 
 # homeassistant.components.mpd
 python-mpd2==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -522,7 +522,7 @@ python-forecastio==1.4.0
 python-izone==1.1.1
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.4.7
+python-miio==0.4.8
 
 # homeassistant.components.nest
 python-nest==4.1.0


### PR DESCRIPTION
## Breaking Change:

None.

## Description:

Bump python-miio to v0.4.8.

**Related issue (if applicable):** None.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** None.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
