### PR TITLE
Make Python deprecation notice easier to maintain

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -11,7 +11,11 @@ from typing import Any, Dict, Optional, Set
 import voluptuous as vol
 
 from homeassistant import config as conf_util, config_entries, core, loader
-from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_CLOSE,
+    REQUIRED_NEXT_PYTHON_DATE,
+    REQUIRED_NEXT_PYTHON_VER,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.util.logging import AsyncHandler
@@ -95,11 +99,14 @@ async def async_from_config_dict(
     stop = time()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop - start)
 
-    if sys.version_info[:3] < (3, 7, 0):
+    if REQUIRED_NEXT_PYTHON_DATE and sys.version_info[:3] < REQUIRED_NEXT_PYTHON_VER:
         msg = (
-            "Python 3.6 support is deprecated and will "
-            "be removed in the first release after December 15, 2019. Please "
-            "upgrade Python to 3.7.0 or higher."
+            "Support for the running Python version "
+            f"{'.'.join(str(x) for x in sys.version_info[:3])} is deprecated and will "
+            f"be removed in the first release after {REQUIRED_NEXT_PYTHON_DATE}. "
+            "Please upgrade Python to "
+            f"{'.'.join(str(x) for x in REQUIRED_NEXT_PYTHON_VER)} or "
+            "higher."
         )
         _LOGGER.warning(msg)
         hass.components.persistent_notification.async_create(

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,6 +5,9 @@ PATCH_VERSION = "0.dev0"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 6, 1)
+# Truthy date string triggers showing related deprecation warning messages.
+REQUIRED_NEXT_PYTHON_VER = (3, 7, 0)
+REQUIRED_NEXT_PYTHON_DATE = "December 15, 2019"
 
 # Format for platform files
 PLATFORM_FORMAT = "{platform}.{domain}"


### PR DESCRIPTION
## Description:

One place fewer to touch when deprecating Python versions.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
