### PR TITLE
Fix setup for tank_utility component

### DIFF
--- a/homeassistant/components/tank_utility/sensor.py
+++ b/homeassistant/components/tank_utility/sensor.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 
 import requests
-import tank_utility
+from tank_utility import auth, device as tank_monitor
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     devices = config.get(CONF_DEVICES)
 
     try:
-        token = tank_utility.auth.get_token(email, password)
+        token = auth.get_token(email, password)
     except requests.exceptions.HTTPError as http_error:
         if (
             http_error.response.status_code
@@ -111,7 +111,7 @@ class TankUtilitySensor(Entity):
 
         data = {}
         try:
-            data = tank_utility.device.get_device_data(self._token, self.device)
+            data = tank_monitor.get_device_data(self._token, self.device)
         except requests.exceptions.HTTPError as http_error:
             if (
                 http_error.response.status_code
@@ -120,10 +120,8 @@ class TankUtilitySensor(Entity):
                 == requests.codes.bad_request  # pylint: disable=no-member
             ):
                 _LOGGER.info("Getting new token")
-                self._token = tank_utility.auth.get_token(
-                    self._email, self._password, force=True
-                )
-                data = tank_utility.device.get_device_data(self._token, self.device)
+                self._token = auth.get_token(self._email, self._password, force=True)
+                data = tank_monitor.get_device_data(self._token, self.device)
             else:
                 raise http_error
         data.update(data.pop("device", {}))


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- caused by #29119
The following does not work for this python package:
```python
import tank_utility
tank_utility.auth.get_token(..)

AttributeError: module 'tank_utility' has no attribute 'auth'
```

- fixed by importing each submodule independently and therefore reverting part of the PR that caused this issue


**Related issue (if applicable):** fixes #29857<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: tank_utility
  email: !secret user_tankutil
  password: !secret pass_tankutil
  devices:
    - !secret key_tankutil
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
