### PR TITLE
do not import exists from genericpath but use os.path

### DIFF
--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -1,8 +1,8 @@
 """The tests for the feedreader component."""
 from datetime import timedelta
-from genericpath import exists
 from logging import getLogger
 from os import remove
+from os.path import exists
 import time
 import unittest
 from unittest import mock


### PR DESCRIPTION
`genericpath` is an internal Python module and shouldn't be imported according to core Python devs. (see [this](https://bugs.python.org/msg358136) comment)

For a reason unknown to me, @exxamalte introduced this in https://github.com/home-assistant/home-assistant/pull/14342.

The problem is that Linux and macOS implement `os.path` differently, one imports from [`ntpath.py`](https://github.com/python/cpython/blob/master/Lib/ntpath.py) and the other one from [`posixpath.py`](https://github.com/python/cpython/blob/master/Lib/posixpath.py), and both these files use [`genericpath.py`](https://github.com/python/cpython/blob/master/Lib/genericpath.py).

Somehow, `isort` on macOS will see `genericpath` as a third party library and sort it accordingly.
Other Unix-based OSes will correctly treat `genericpath` as an internal library.

This problem led to a sorting sequence in the following commits:

- ca0fad2cbb0544125d87d21ffe308cf3addcde5a
- f5d4878992d63683d3da661ef02ae7b51421beb4
- 7d68e88d31246e268db809225e3d924acb1fc352
- 1fee400dcd94229db56a2ada5e3c335aa139146f

This supersedes https://github.com/home-assistant/home-assistant/pull/29893.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
