### PR TITLE
Upgrade Sphinx to 2.2.2 and sphinx-autodoc-typehints to 1.10.3

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
-Sphinx==2.1.2
-sphinx-autodoc-typehints==1.6.0
+Sphinx==2.2.2
+sphinx-autodoc-typehints==1.10.3
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## Description:
Upgrade Sphinx to 2.2.2 and sphinx-autodoc-typehints to 1.10.3

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

