### PR TITLE
Fix setup error for logbook

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.util import get_local_ip
 from homeassistant.util.decorator import Registry
 
+from .accessories import HomeBridge, HomeDriver
 from .const import (
     BRIDGE_NAME,
     CONF_ADVERTISE_IP,
@@ -302,11 +303,6 @@ class HomeKit:
 
     def setup(self):
         """Set up bridge and accessory driver."""
-        # pylint: disable=import-outside-toplevel
-        from .accessories import (
-            HomeBridge,
-            HomeDriver,
-        )
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.stop)
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -29,7 +29,6 @@ from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.util import get_local_ip
 from homeassistant.util.decorator import Registry
 
-from .accessories import HomeBridge, HomeDriver
 from .const import (
     BRIDGE_NAME,
     CONF_ADVERTISE_IP,
@@ -303,6 +302,11 @@ class HomeKit:
 
     def setup(self):
         """Set up bridge and accessory driver."""
+        # pylint: disable=import-outside-toplevel
+        from .accessories import (
+            HomeBridge,
+            HomeDriver,
+        )
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.stop)
 

--- a/homeassistant/components/logbook/manifest.json
+++ b/homeassistant/components/logbook/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/logbook",
   "requirements": [],
   "dependencies": ["frontend", "http", "recorder"],
+  "after_dependencies": ["homekit"],
   "codeowners": []
 }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- caused by: #29560
- fixed by moving imports back into the setup function of the homekit integration

**Related issue (if applicable):** fixes #29845<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
