### PR TITLE
Add Here travel time arrival departure

### DIFF
--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -110,7 +110,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Exclusive(CONF_ORIGIN_ENTITY_ID, "origin"): cv.entity_id,
         vol.Exclusive(CONF_ARRIVAL, "arrival_departure"): cv.time,
         vol.Exclusive(CONF_DEPARTURE, "arrival_departure"): cv.time,
-        vol.Optional(CONF_DEPARTURE, default="now"): cv.time,
+        vol.Optional(CONF_DEPARTURE): cv.time,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_MODE, default=TRAVEL_MODE_CAR): vol.In(TRAVEL_MODE),
         vol.Optional(CONF_ROUTE_MODE, default=ROUTE_MODE_FASTEST): vol.In(ROUTE_MODE),

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -108,8 +108,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Inclusive(CONF_ORIGIN_LONGITUDE, "origin_coordinates"): cv.longitude,
         vol.Exclusive(CONF_ORIGIN_LATITUDE, "origin"): cv.latitude,
         vol.Exclusive(CONF_ORIGIN_ENTITY_ID, "origin"): cv.entity_id,
-        vol.Exclusive(CONF_ARRIVAL, "arrival_departure"): cv.time,
-        vol.Exclusive(CONF_DEPARTURE, "arrival_departure"): cv.time,
         vol.Optional(CONF_DEPARTURE): cv.time,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_MODE, default=TRAVEL_MODE_CAR): vol.In(TRAVEL_MODE),
@@ -122,14 +120,22 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 PLATFORM_SCHEMA = vol.All(
     cv.has_at_least_one_key(CONF_DESTINATION_LATITUDE, CONF_DESTINATION_ENTITY_ID),
     cv.has_at_least_one_key(CONF_ORIGIN_LATITUDE, CONF_ORIGIN_ENTITY_ID),
-    vol.Any(
-        PLATFORM_SCHEMA.extend(
-            {
-                vol.Required(CONF_MODE): vol.Match(TRAVEL_MODE_PUBLIC_TIME_TABLE),
-                vol.Required(CONF_ARRIVAL): cv.time,
-            }
-        ),
-        PLATFORM_SCHEMA,
+    cv.key_value_schemas(
+        CONF_MODE,
+        {
+            None: PLATFORM_SCHEMA,
+            TRAVEL_MODE_BICYCLE: PLATFORM_SCHEMA,
+            TRAVEL_MODE_CAR: PLATFORM_SCHEMA,
+            TRAVEL_MODE_PEDESTRIAN: PLATFORM_SCHEMA,
+            TRAVEL_MODE_PUBLIC: PLATFORM_SCHEMA,
+            TRAVEL_MODE_TRUCK: PLATFORM_SCHEMA,
+            TRAVEL_MODE_PUBLIC_TIME_TABLE: PLATFORM_SCHEMA.extend(
+                {
+                    vol.Exclusive(CONF_ARRIVAL, "arrival_departure"): cv.time,
+                    vol.Exclusive(CONF_DEPARTURE, "arrival_departure"): cv.time,
+                }
+            ),
+        },
     ),
 )
 

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -37,6 +37,8 @@ from homeassistant.components.here_travel_time.sensor import (
     TRAVEL_MODE_PUBLIC,
     TRAVEL_MODE_PUBLIC_TIME_TABLE,
     TRAVEL_MODE_TRUCK,
+    UNIT_OF_MEASUREMENT,
+    convert_time_to_isodate,
 )
 from homeassistant.const import ATTR_ICON, EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
@@ -1056,10 +1058,11 @@ async def test_arrival(hass, requests_mock_credentials_check):
     """Test that arrival works."""
     origin = "41.9798,-87.8801"
     destination = "41.9043,-87.9216"
-    arrival = "2013-07-04T17:00:00+02:00"
+    arrival = "01:00:00"
+    arrival_isodate = convert_time_to_isodate(arrival)
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_PUBLIC_TIME_TABLE, TRAFFIC_MODE_DISABLED]
     response_url = _build_mock_url(
-        origin, destination, modes, API_KEY, arrival=arrival
+        origin, destination, modes, API_KEY, arrival=arrival_isodate
     )
     requests_mock_credentials_check.get(
         response_url,
@@ -1092,10 +1095,11 @@ async def test_departure(hass, requests_mock_credentials_check):
     """Test that arrival works."""
     origin = "41.9798,-87.8801"
     destination = "41.9043,-87.9216"
-    departure = "2013-07-04T17:00:00+02:00"
+    departure = "23:00:00"
+    departure_isodate = convert_time_to_isodate(departure)
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_PUBLIC_TIME_TABLE, TRAFFIC_MODE_DISABLED]
     response_url = _build_mock_url(
-        origin, destination, modes, API_KEY, departure=departure
+        origin, destination, modes, API_KEY, departure=departure_isodate
     )
     requests_mock_credentials_check.get(
         response_url,

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -66,7 +66,7 @@ CAR_DESTINATION_LATITUDE = "39.0"
 CAR_DESTINATION_LONGITUDE = "-77.1"
 
 
-def _build_mock_url(origin, destination, modes, api_key, departure):
+def _build_mock_url(origin, destination, modes, api_key, departure=None, arrival=None):
     """Construct a url for HERE."""
     base_url = "https://route.ls.hereapi.com/routing/7.2/calculateroute.json?"
     parameters = {
@@ -74,9 +74,13 @@ def _build_mock_url(origin, destination, modes, api_key, departure):
         "waypoint1": f"geo!{destination}",
         "mode": ";".join(str(herepy.RouteMode[mode]) for mode in modes),
         "apikey": api_key,
-        "departure": departure,
     }
+    if arrival is not None:
+        parameters["arrival"] = arrival
+    if departure is not None:
+        parameters["departure"] = departure
     url = base_url + urllib.parse.urlencode(parameters)
+    print(url)
     return url
 
 
@@ -117,7 +121,6 @@ def requests_mock_credentials_check(requests_mock):
         ",".join([CAR_DESTINATION_LATITUDE, CAR_DESTINATION_LONGITUDE]),
         modes,
         API_KEY,
-        "now",
     )
     requests_mock.get(
         response_url, text=load_fixture("here_travel_time/car_response.json")
@@ -134,7 +137,6 @@ def requests_mock_truck_response(requests_mock_credentials_check):
         ",".join([TRUCK_DESTINATION_LATITUDE, TRUCK_DESTINATION_LONGITUDE]),
         modes,
         API_KEY,
-        "now",
     )
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/truck_response.json")
@@ -150,7 +152,6 @@ def requests_mock_car_disabled_response(requests_mock_credentials_check):
         ",".join([CAR_DESTINATION_LATITUDE, CAR_DESTINATION_LONGITUDE]),
         modes,
         API_KEY,
-        "now",
     )
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/car_response.json")
@@ -214,7 +215,6 @@ async def test_traffic_mode_enabled(hass, requests_mock_credentials_check):
         ",".join([CAR_DESTINATION_LATITUDE, CAR_DESTINATION_LONGITUDE]),
         modes,
         API_KEY,
-        "now",
     )
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/car_enabled_response.json")
@@ -272,7 +272,7 @@ async def test_route_mode_shortest(hass, requests_mock_credentials_check):
     origin = "38.902981,-77.048338"
     destination = "39.042158,-77.119116"
     modes = [ROUTE_MODE_SHORTEST, TRAVEL_MODE_CAR, TRAFFIC_MODE_DISABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/car_shortest_response.json")
     )
@@ -303,7 +303,7 @@ async def test_route_mode_fastest(hass, requests_mock_credentials_check):
     origin = "38.902981,-77.048338"
     destination = "39.042158,-77.119116"
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_CAR, TRAFFIC_MODE_ENABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/car_enabled_response.json")
     )
@@ -357,7 +357,7 @@ async def test_public_transport(hass, requests_mock_credentials_check):
     origin = "41.9798,-87.8801"
     destination = "41.9043,-87.9216"
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_PUBLIC, TRAFFIC_MODE_DISABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/public_response.json")
     )
@@ -406,7 +406,7 @@ async def test_public_transport_time_table(hass, requests_mock_credentials_check
     origin = "41.9798,-87.8801"
     destination = "41.9043,-87.9216"
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_PUBLIC_TIME_TABLE, TRAFFIC_MODE_DISABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url,
         text=load_fixture("here_travel_time/public_time_table_response.json"),
@@ -456,7 +456,7 @@ async def test_pedestrian(hass, requests_mock_credentials_check):
     origin = "41.9798,-87.8801"
     destination = "41.9043,-87.9216"
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_PEDESTRIAN, TRAFFIC_MODE_DISABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/pedestrian_response.json")
     )
@@ -508,7 +508,7 @@ async def test_bicycle(hass, requests_mock_credentials_check):
     origin = "41.9798,-87.8801"
     destination = "41.9043,-87.9216"
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_BICYCLE, TRAFFIC_MODE_DISABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/bike_response.json")
     )
@@ -841,7 +841,7 @@ async def test_route_not_found(hass, requests_mock_credentials_check, caplog):
     origin = "52.516,13.3779"
     destination = "47.013399,-10.171986"
     modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_CAR, TRAFFIC_MODE_DISABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url,
         text=load_fixture("here_travel_time/routing_error_no_route_found.json"),
@@ -914,7 +914,6 @@ async def test_invalid_credentials(hass, requests_mock, caplog):
         ",".join([CAR_DESTINATION_LATITUDE, CAR_DESTINATION_LONGITUDE]),
         modes,
         API_KEY,
-        "now",
     )
     requests_mock.get(
         response_url,
@@ -942,7 +941,7 @@ async def test_attribution(hass, requests_mock_credentials_check):
     origin = "50.037751372637686,14.39233448220898"
     destination = "50.07993838201255,14.42582157361062"
     modes = [ROUTE_MODE_SHORTEST, TRAVEL_MODE_PUBLIC_TIME_TABLE, TRAFFIC_MODE_ENABLED]
-    response_url = _build_mock_url(origin, destination, modes, API_KEY, "now")
+    response_url = _build_mock_url(origin, destination, modes, API_KEY)
     requests_mock_credentials_check.get(
         response_url, text=load_fixture("here_travel_time/attribution_response.json")
     )
@@ -1051,3 +1050,75 @@ async def test_delayed_update(hass, requests_mock_truck_response, caplog):
     await hass.async_block_till_done()
 
     assert "Unable to find entity" not in caplog.text
+
+
+async def test_arrival(hass, requests_mock_credentials_check):
+    """Test that arrival works."""
+    origin = "41.9798,-87.8801"
+    destination = "41.9043,-87.9216"
+    arrival = "2013-07-04T17:00:00+02:00"
+    modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_PUBLIC_TIME_TABLE, TRAFFIC_MODE_DISABLED]
+    response_url = _build_mock_url(
+        origin, destination, modes, API_KEY, arrival=arrival
+    )
+    requests_mock_credentials_check.get(
+        response_url,
+        text=load_fixture("here_travel_time/public_time_table_response.json"),
+    )
+
+    config = {
+        DOMAIN: {
+            "platform": PLATFORM,
+            "name": "test",
+            "origin_latitude": origin.split(",")[0],
+            "origin_longitude": origin.split(",")[1],
+            "destination_latitude": destination.split(",")[0],
+            "destination_longitude": destination.split(",")[1],
+            "api_key": API_KEY,
+            "mode": TRAVEL_MODE_PUBLIC_TIME_TABLE,
+            "arrival": arrival,
+        }
+    }
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    sensor = hass.states.get("sensor.test")
+    assert sensor.state == "80"
+
+
+async def test_departure(hass, requests_mock_credentials_check):
+    """Test that arrival works."""
+    origin = "41.9798,-87.8801"
+    destination = "41.9043,-87.9216"
+    departure = "2013-07-04T17:00:00+02:00"
+    modes = [ROUTE_MODE_FASTEST, TRAVEL_MODE_PUBLIC_TIME_TABLE, TRAFFIC_MODE_DISABLED]
+    response_url = _build_mock_url(
+        origin, destination, modes, API_KEY, departure=departure
+    )
+    requests_mock_credentials_check.get(
+        response_url,
+        text=load_fixture("here_travel_time/public_time_table_response.json"),
+    )
+
+    config = {
+        DOMAIN: {
+            "platform": PLATFORM,
+            "name": "test",
+            "origin_latitude": origin.split(",")[0],
+            "origin_longitude": origin.split(",")[1],
+            "destination_latitude": destination.split(",")[0],
+            "destination_longitude": destination.split(",")[1],
+            "api_key": API_KEY,
+            "mode": TRAVEL_MODE_PUBLIC_TIME_TABLE,
+            "departure": departure,
+        }
+    }
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    sensor = hass.states.get("sensor.test")
+    assert sensor.state == "80"


### PR DESCRIPTION
## Description:

Add the modes `arrival` and `departure`.

~~Depends on #29966~~

**Related issue (if applicable):** fixes #29529 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11449

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: here_travel_time
    app_key: "YOUR_API_KEY"
    name: Work to Home By Train This evening
    origin_entity_id: zone.work
    destination_latitude: 59.2842
    destination_longitude: 59.2642
    mode: publicTransportTimeTable
    arrival: "17:00:00"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
