### PR TITLE
Fix invalid JSON syntax in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
-// See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
   "name": "Home Assistant Dev",
   "context": "..",


### PR DESCRIPTION
## Description:

Removes a comment from the top of the file.
While "ignored" by some parsers, comments are not part of the JSON spec, and this is not valid JSON.

In prep for adding JSON validation in our CI.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
