### PR TITLE
Add check-json to CI and Pre-commit

### DIFF
--- a/.pre-commit-config-all.yaml
+++ b/.pre-commit-config-all.yaml
@@ -39,6 +39,10 @@ repos:
     rev: v4.3.21
     hooks:
     -   id: isort
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: check-json
 # Using a local "system" mypy instead of the mypy hook, because its
 # results depend on what is installed. And the mypy hook runs in a
 # virtualenv of its own, meaning we'd need to install and maintain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
 -   repo: https://github.com/PyCQA/bandit
     rev: 1.6.2
     hooks:
-      - id: bandit
+    -   id: bandit
         args:
           - --quiet
           - --format=custom
@@ -35,3 +35,7 @@ repos:
     rev: v4.3.21
     hooks:
     -   id: isort
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: check-json

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -58,6 +58,10 @@ stages:
         . venv/bin/activate
         pre-commit run isort --all-files
       displayName: 'Run isort'
+    - script: |
+        . venv/bin/activate
+        pre-commit run check-json --all-files
+      displayName: 'Run check-json'
   - job: 'Validate'
     pool:
       vmImage: 'ubuntu-latest'

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -65,6 +65,8 @@ enum34==1000000000.0.0
 pycrypto==1000000000.0.0
 """
 
+IGNORE_PRE_COMMIT_HOOK_ID = ("check-json",)
+
 
 def has_tests(module: str):
     """Test if a module has tests.
@@ -256,8 +258,9 @@ def requirements_pre_commit_output():
     reqs = []
     for repo in (x for x in pre_commit_conf["repos"] if x.get("rev")):
         for hook in repo["hooks"]:
-            reqs.append(f"{hook['id']}=={repo['rev']}")
-            reqs.extend(x for x in hook.get("additional_dependencies", ()))
+            if hook["id"] not in IGNORE_PRE_COMMIT_HOOK_ID:
+                reqs.append(f"{hook['id']}=={repo['rev']}")
+                reqs.extend(x for x in hook.get("additional_dependencies", ()))
     output = [
         f"# Automatically generated "
         f"from {source} by {Path(__file__).name}, do not edit",


### PR DESCRIPTION
## Description:

Adds Check-JSON to our CI & Pre-commit.

This will prevent the adding of invalid JSON files in general.

Requires to be merged before this build passes: #29910 #29911

## Checklist:
  - [x] The code change is tested and works locally.
pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
