### PR TITLE
Add integration platform helper

### DIFF
--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -1,0 +1,46 @@
+"""Helpers to help with integration platforms."""
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable
+
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.loader import IntegrationNotFound, async_get_integration, bind_hass
+from homeassistant.setup import ATTR_COMPONENT, EVENT_COMPONENT_LOADED
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@bind_hass
+async def async_process_integration_platforms(
+    hass: HomeAssistant,
+    platform_name: str,
+    # Any = platform.
+    process_platform: Callable[[HomeAssistant, str, Any], Awaitable[None]],
+) -> None:
+    """Process a specific platform for all current and future loaded integrations."""
+
+    async def _process(component_name: str) -> None:
+        """Process the intents of a component."""
+        try:
+            integration = await async_get_integration(hass, component_name)
+            platform = integration.get_platform(platform_name)
+        except (IntegrationNotFound, ImportError):
+            return
+
+        try:
+            await process_platform(hass, component_name, platform)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Error processing platform %s.%s", component_name, platform_name
+            )
+
+    async def async_component_loaded(event: Event) -> None:
+        """Handle a new component loaded."""
+        await _process(event.data[ATTR_COMPONENT])
+
+    hass.bus.async_listen(EVENT_COMPONENT_LOADED, async_component_loaded)
+
+    tasks = [_process(comp) for comp in hass.config.components]
+
+    if tasks:
+        await asyncio.gather(*tasks)

--- a/tests/helpers/test_integration_platform.py
+++ b/tests/helpers/test_integration_platform.py
@@ -1,0 +1,37 @@
+"""Test integration platform helpers."""
+from unittest.mock import Mock
+
+from homeassistant.setup import ATTR_COMPONENT, EVENT_COMPONENT_LOADED
+
+from tests.common import mock_platform
+
+
+async def test_process_integration_platforms(hass):
+    """Test processing integrations."""
+    loaded_platform = Mock()
+    mock_platform(hass, "loaded.platform_to_check", loaded_platform)
+    hass.config.components.add("loaded")
+
+    event_platform = Mock()
+    mock_platform(hass, "event.platform_to_check", event_platform)
+
+    processed = []
+
+    async def _process_platform(hass, domain, platform):
+        """Process platform."""
+        processed.append((domain, platform))
+
+    await hass.helpers.integration_platform.async_process_integration_platforms(
+        "platform_to_check", _process_platform
+    )
+
+    assert len(processed) == 1
+    assert processed[0][0] == "loaded"
+    assert processed[0][1] == loaded_platform
+
+    hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: "event"})
+    await hass.async_block_till_done()
+
+    assert len(processed) == 2
+    assert processed[1][0] == "event"
+    assert processed[1][1] == event_platform


### PR DESCRIPTION
## Description:
Extract the integration platform helper from the intent integration into a generic helper for #29913.

Allows an integration to easily call a function on a platform for all existing integrations and when integrations are loaded.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
