### PR TITLE
Add neato boundary name to state if it exists

### DIFF
--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -212,7 +212,9 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                     "boundary" in self._state["cleaning"]
                     and "name" in self._state["cleaning"]["boundary"]
                 ):
-                    self._status_state += " " + self._state["cleaning"]["boundary"]["name"]
+                    self._status_state += (
+                        " " + self._state["cleaning"]["boundary"]["name"]
+                    )
             else:
                 self._status_state = robot_alert
         elif self._state["state"] == 3:

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -208,9 +208,11 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                     + " "
                     + ACTION.get(self._state["action"])
                 )
-                if "boundary" in self._state["cleaning"] and "name" in self._state["cleaning"]["boundary"]:
-                    self._status_state += " " + self._state["cleaning"]["boundary"]["name"]
-                    
+                if (
+                    "boundary" in self._state["cleaning"]
+                    and "name" in self._state["cleaning"]["boundary"]
+                ):
+                    self._status_state += " " + self._state["cleaning"]["boundary"]["name"]    
             else:
                 self._status_state = robot_alert
         elif self._state["state"] == 3:

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -208,6 +208,9 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                     + " "
                     + ACTION.get(self._state["action"])
                 )
+                if "boundary" in self._state["cleaning"] and "name" in self._state["cleaning"]["boundary"]:
+                    self._status_state += " " + self._state["cleaning"]["boundary"]["name"]
+                    
             else:
                 self._status_state = robot_alert
         elif self._state["state"] == 3:

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -212,7 +212,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                     "boundary" in self._state["cleaning"]
                     and "name" in self._state["cleaning"]["boundary"]
                 ):
-                    self._status_state += " " + self._state["cleaning"]["boundary"]["name"]    
+                    self._status_state += " " + self._state["cleaning"]["boundary"]["name"]
             else:
                 self._status_state = robot_alert
         elif self._state["state"] == 3:


### PR DESCRIPTION
## Breaking Change:
The entity state attribute `status` was changed to add the name of the area, if the robot is cleaning a pre defined area with a name.

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Just adding more info to the state attribute if it is available

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
