### PR TITLE
Update Tahoma component's tahoma-api requirement's version

### DIFF
--- a/homeassistant/components/tahoma/manifest.json
+++ b/homeassistant/components/tahoma/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tahoma",
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "tahoma-api==0.0.14"
+    "tahoma-api==0.0.16"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1907,7 +1907,7 @@ swisshydrodata==0.0.3
 synology-srm==0.0.7
 
 # homeassistant.components.tahoma
-tahoma-api==0.0.14
+tahoma-api==0.0.16
 
 # homeassistant.components.tank_utility
 tank_utility==1.4.0


### PR DESCRIPTION
## Description:

After reverting the PR for removing Tahoma component, an update to the component's tahoma-api requirement must be done.

**Related issue (if applicable):** #29744 #29840 

## Example entry for `configuration.yaml` (if applicable):
```yaml
tahoma:
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html