### PR TITLE
Add config flow to Meteo-France

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -413,7 +413,10 @@ omit =
     homeassistant/components/mediaroom/media_player.py
     homeassistant/components/message_bird/notify.py
     homeassistant/components/met/weather.py
-    homeassistant/components/meteo_france/*
+    homeassistant/components/meteo_france/__init__.py
+    homeassistant/components/meteo_france/const.py
+    homeassistant/components/meteo_france/sensor.py
+    homeassistant/components/meteo_france/weather.py
     homeassistant/components/meteoalarm/*
     homeassistant/components/metoffice/sensor.py
     homeassistant/components/metoffice/weather.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -206,7 +206,7 @@ homeassistant/components/mcp23017/* @jardiamj
 homeassistant/components/mediaroom/* @dgomes
 homeassistant/components/melissa/* @kennedyshead
 homeassistant/components/met/* @danielhiversen
-homeassistant/components/meteo_france/* @victorcerutti @oncleben31
+homeassistant/components/meteo_france/* @victorcerutti @oncleben31 @Quentame
 homeassistant/components/meteoalarm/* @rolfberkenbosch
 homeassistant/components/miflora/* @danielhiversen @ChristianKuehnel
 homeassistant/components/mikrotik/* @engrbm87

--- a/homeassistant/components/meteo_france/.translations/en.json
+++ b/homeassistant/components/meteo_france/.translations/en.json
@@ -1,9 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "City already configured"
-        },
-        "error": {
+            "already_configured": "City already configured",
             "unknown": "Unknown error: please retry later"
         },
         "step": {

--- a/homeassistant/components/meteo_france/.translations/en.json
+++ b/homeassistant/components/meteo_france/.translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "city_exists": "City already configured"
+        },
+        "error": {
+            "city_exists": "City already configured",
+            "unknown": "Unknown error: please retry later"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "city": "City"
+                },
+                "description": "Enter your city",
+                "title": "M\u00e9t\u00e9o-France"
+            }
+        },
+        "title": "M\u00e9t\u00e9o-France"
+    }
+}

--- a/homeassistant/components/meteo_france/.translations/en.json
+++ b/homeassistant/components/meteo_france/.translations/en.json
@@ -1,10 +1,9 @@
 {
     "config": {
         "abort": {
-            "city_exists": "City already configured"
+            "already_configured": "City already configured"
         },
         "error": {
-            "city_exists": "City already configured",
             "unknown": "Unknown error: please retry later"
         },
         "step": {

--- a/homeassistant/components/meteo_france/.translations/en.json
+++ b/homeassistant/components/meteo_france/.translations/en.json
@@ -9,9 +9,8 @@
         "step": {
             "user": {
                 "data": {
-                    "city": "City"
+                    "city": "City or postal code"
                 },
-                "description": "Enter your city",
                 "title": "M\u00e9t\u00e9o-France"
             }
         },

--- a/homeassistant/components/meteo_france/.translations/en.json
+++ b/homeassistant/components/meteo_france/.translations/en.json
@@ -9,7 +9,7 @@
                 "data": {
                     "city": "City"
                 },
-                "description": "Enter the postal code (only for France, recommanded) or city name",
+                "description": "Enter the postal code (only for France, recommended) or city name",
                 "title": "M\u00e9t\u00e9o-France"
             }
         },

--- a/homeassistant/components/meteo_france/.translations/en.json
+++ b/homeassistant/components/meteo_france/.translations/en.json
@@ -7,8 +7,9 @@
         "step": {
             "user": {
                 "data": {
-                    "city": "City or postal code"
+                    "city": "City"
                 },
+                "description": "Enter the postal code (only for France, recommanded) or city name",
                 "title": "M\u00e9t\u00e9o-France"
             }
         },

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -36,11 +36,11 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     """Set up Meteo-France from legacy config file."""
 
-    confs = config.get(DOMAIN)
-    if confs is None:
+    conf = config.get(DOMAIN)
+    if conf is None:
         return True
 
-    for city_conf in confs:
+    for city_conf in conf:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_IMPORT}, data=city_conf.copy()

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -1,4 +1,5 @@
 """Support for Meteo-France weather data."""
+import asyncio
 import datetime
 import logging
 
@@ -74,6 +75,22 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         )
     _LOGGER.debug("meteo_france sensor platform loaded for %s", city)
     return True
+
+
+async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.data[CONF_CITY])
+
+    return unload_ok
 
 
 class MeteoFranceUpdater:

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -81,7 +81,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         client = meteofranceClient(city)
     except meteofranceError as exp:
         _LOGGER.error("Unexpected error when creating the meteofrance proxy: %s", exp)
-        return
+        return False
 
     client.need_rain_forecast = bool(
         CONF_MONITORED_CONDITIONS in entry.data

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -7,26 +7,18 @@ from vigilancemeteo import VigilanceMeteoError, VigilanceMeteoFranceProxy
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_MONITORED_CONDITIONS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util import Throttle
 
-from .const import CONF_CITY, DOMAIN, SENSOR_TYPES
+from .const import CONF_CITY, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = datetime.timedelta(minutes=5)
 
 
-CITY_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_CITY): cv.string,
-        vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES)]
-        ),
-    }
-)
+CITY_SCHEMA = vol.Schema({vol.Required(CONF_CITY): cv.string})
 
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [CITY_SCHEMA]))}, extra=vol.ALLOW_EXTRA,
@@ -54,54 +46,33 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     """Set up an Meteo-France account from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    # Check if at least weather alert have to be monitored for one location/entry.
-    # If weather alert monitoring is expected initiate a client to be used by all weather_alert entities.
-    if (
-        CONF_MONITORED_CONDITIONS in entry.data
-        and "weather_alert" in entry.data[CONF_MONITORED_CONDITIONS]
-        and hass.data[DOMAIN].get("weather_alert_client") is not None
-    ):
-        _LOGGER.debug("Weather Alert monitoring expected. Loading vigilancemeteo")
-
-        weather_alert_client = await hass.async_add_executor_job(
-            VigilanceMeteoFranceProxy
+    # Weather alert
+    weather_alert_client = await hass.async_add_executor_job(VigilanceMeteoFranceProxy)
+    try:
+        weather_alert_client.update_data()
+    except VigilanceMeteoError as exp:
+        _LOGGER.error(
+            "Unexpected error when creating the vigilance_meteoFrance proxy: %s ", exp
         )
-        try:
-            weather_alert_client.update_data()
-        except VigilanceMeteoError as exp:
-            _LOGGER.error(
-                "Unexpected error when creating the vigilance_meteoFrance proxy: %s ",
-                exp,
-            )
-    else:
-        weather_alert_client = None
+        return False
     hass.data[DOMAIN]["weather_alert_client"] = weather_alert_client
 
+    # Weather
     city = entry.data[CONF_CITY]
-
     try:
         client = await hass.async_add_executor_job(meteofranceClient, city)
     except meteofranceError as exp:
         _LOGGER.error("Unexpected error when creating the meteofrance proxy: %s", exp)
         return False
 
-    client.need_rain_forecast = bool(
-        CONF_MONITORED_CONDITIONS in entry.data
-        and "next_rain" in entry.data[CONF_MONITORED_CONDITIONS]
-    )
-
     hass.data[DOMAIN][city] = MeteoFranceUpdater(client)
     hass.data[DOMAIN][city].update()
 
-    if CONF_MONITORED_CONDITIONS in entry.data:
-        _LOGGER.debug("meteo_france sensor platform loaded for %s", city)
+    for platform in PLATFORMS:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, "sensor")
+            hass.config_entries.async_forward_entry_setup(entry, platform)
         )
-
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "weather")
-    )
+    _LOGGER.debug("meteo_france sensor platform loaded for %s", city)
     return True
 
 

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -48,9 +48,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     hass.data.setdefault(DOMAIN, {})
 
     # Weather alert
-    weather_alert_client = await hass.async_add_executor_job(VigilanceMeteoFranceProxy)
+    weather_alert_client = VigilanceMeteoFranceProxy()
     try:
-        weather_alert_client.update_data()
+        await hass.async_add_executor_job(weather_alert_client.update_data)
     except VigilanceMeteoError as exp:
         _LOGGER.error(
             "Unexpected error when creating the vigilance_meteoFrance proxy: %s ", exp
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         return False
 
     hass.data[DOMAIN][city] = MeteoFranceUpdater(client)
-    hass.data[DOMAIN][city].update()
+    await hass.async_add_executor_job(hass.data[DOMAIN][city].update)
 
     for platform in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -6,62 +6,61 @@ from meteofrance.client import meteofranceClient, meteofranceError
 from vigilancemeteo import VigilanceMeteoError, VigilanceMeteoFranceProxy
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util import Throttle
 
-from .const import CONF_CITY, DATA_METEO_FRANCE, DOMAIN, SENSOR_TYPES
+from .const import CONF_CITY, DOMAIN, SENSOR_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = datetime.timedelta(minutes=5)
 
 
-def has_all_unique_cities(value):
-    """Validate that all cities are unique."""
-    cities = [location[CONF_CITY] for location in value]
-    vol.Schema(vol.Unique())(cities)
-    return value
-
+CITY_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CITY): cv.string,
+        vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(
+            cv.ensure_list, [vol.In(SENSOR_TYPES)]
+        ),
+    }
+)
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.ensure_list,
-            [
-                vol.Schema(
-                    {
-                        vol.Required(CONF_CITY): cv.string,
-                        vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(
-                            cv.ensure_list, [vol.In(SENSOR_TYPES)]
-                        ),
-                    }
-                )
-            ],
-            has_all_unique_cities,
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
+    {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [CITY_SCHEMA]))}, extra=vol.ALLOW_EXTRA,
 )
 
 
-def setup(hass, config):
-    """Set up the Meteo-France component."""
-    hass.data[DATA_METEO_FRANCE] = {}
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Set up Meteo-France from legacy config file."""
 
-    # Check if at least weather alert have to be monitored for one location.
-    need_weather_alert_watcher = False
-    for location in config[DOMAIN]:
-        if (
-            CONF_MONITORED_CONDITIONS in location
-            and "weather_alert" in location[CONF_MONITORED_CONDITIONS]
-        ):
-            need_weather_alert_watcher = True
+    confs = config.get(DOMAIN)
+    if confs is None:
+        return True
 
-    # If weather alert monitoring is expected initiate a client to be used by
-    # all weather_alert entities.
-    if need_weather_alert_watcher:
+    for city_conf in confs:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=city_conf.copy()
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Set up an Meteo-France account from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    # Check if at least weather alert have to be monitored for one location/entry.
+    # If weather alert monitoring is expected initiate a client to be used by all weather_alert entities.
+    if (
+        CONF_MONITORED_CONDITIONS in entry.data
+        and "weather_alert" in entry.data[CONF_MONITORED_CONDITIONS]
+        and hass.data[DOMAIN].get("weather_alert_client") is not None
+    ):
         _LOGGER.debug("Weather Alert monitoring expected. Loading vigilancemeteo")
 
         weather_alert_client = VigilanceMeteoFranceProxy()
@@ -74,48 +73,40 @@ def setup(hass, config):
             )
     else:
         weather_alert_client = None
-    hass.data[DATA_METEO_FRANCE]["weather_alert_client"] = weather_alert_client
+    hass.data[DOMAIN]["weather_alert_client"] = weather_alert_client
 
-    for location in config[DOMAIN]:
+    city = entry.data[CONF_CITY]
 
-        city = location[CONF_CITY]
+    try:
+        client = meteofranceClient(city)
+    except meteofranceError as exp:
+        _LOGGER.error("Unexpected error when creating the meteofrance proxy: %s", exp)
+        return
 
-        try:
-            client = meteofranceClient(city)
-        except meteofranceError as exp:
-            _LOGGER.error(
-                "Unexpected error when creating the meteofrance proxy: %s", exp
-            )
-            return
+    client.need_rain_forecast = bool(
+        CONF_MONITORED_CONDITIONS in entry.data
+        and "next_rain" in entry.data[CONF_MONITORED_CONDITIONS]
+    )
 
-        client.need_rain_forecast = bool(
-            CONF_MONITORED_CONDITIONS in location
-            and "next_rain" in location[CONF_MONITORED_CONDITIONS]
+    hass.data[DOMAIN][city] = MeteoFranceUpdater(client)
+    hass.data[DOMAIN][city].update()
+
+    if CONF_MONITORED_CONDITIONS in entry.data:
+        _LOGGER.debug("meteo_france sensor platform loaded for %s", city)
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, "sensor")
         )
 
-        hass.data[DATA_METEO_FRANCE][city] = MeteoFranceUpdater(client)
-        hass.data[DATA_METEO_FRANCE][city].update()
-
-        if CONF_MONITORED_CONDITIONS in location:
-            monitored_conditions = location[CONF_MONITORED_CONDITIONS]
-            _LOGGER.debug("meteo_france sensor platform loaded for %s", city)
-            load_platform(
-                hass,
-                "sensor",
-                DOMAIN,
-                {CONF_CITY: city, CONF_MONITORED_CONDITIONS: monitored_conditions},
-                config,
-            )
-
-        load_platform(hass, "weather", DOMAIN, {CONF_CITY: city}, config)
-
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "weather")
+    )
     return True
 
 
 class MeteoFranceUpdater:
     """Update data from Meteo-France."""
 
-    def __init__(self, client):
+    def __init__(self, client: meteofranceClient):
         """Initialize the data object."""
         self._client = client
 

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -63,7 +63,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     ):
         _LOGGER.debug("Weather Alert monitoring expected. Loading vigilancemeteo")
 
-        weather_alert_client = VigilanceMeteoFranceProxy()
+        weather_alert_client = await hass.async_add_executor_job(
+            VigilanceMeteoFranceProxy
+        )
         try:
             weather_alert_client.update_data()
         except VigilanceMeteoError as exp:
@@ -78,7 +80,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     city = entry.data[CONF_CITY]
 
     try:
-        client = meteofranceClient(city)
+        client = await hass.async_add_executor_job(meteofranceClient, city)
     except meteofranceError as exp:
         _LOGGER.error("Unexpected error when creating the meteofrance proxy: %s", exp)
         return False

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -48,7 +48,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is None:
-            return await self._show_setup_form(user_input, errors)
+            return await self._show_setup_form(user_input, None)
 
         city = user_input[CONF_CITY]
         monitored_conditions = user_input.get(

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -5,10 +5,9 @@ from meteofrance.client import meteofranceClient, meteofranceError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.data_entry_flow import AbortFlow
 
-from .const import CONF_CITY, SENSOR_TYPES
+from .const import CONF_CITY
 from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,9 +41,6 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self._show_setup_form(user_input, errors)
 
         city = user_input[CONF_CITY]  # Might be a city name or a postal code
-        monitored_conditions = user_input.get(
-            CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES)
-        )
         city_name = None
 
         try:
@@ -60,13 +56,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(city_name)
         self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(
-            title=city_name,
-            data={
-                CONF_CITY: city_name,
-                CONF_MONITORED_CONDITIONS: monitored_conditions,
-            },
-        )
+        return self.async_create_entry(title=city_name, data={CONF_CITY: city_name})
 
     async def async_step_import(self, user_input):
         """Import a config entry."""

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -1,0 +1,80 @@
+"""Config flow to configure the Meteo-France integration."""
+import logging
+
+from meteofrance.client import meteofranceClient, meteofranceError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_MONITORED_CONDITIONS
+
+from .const import CONF_CITY, SENSOR_TYPES
+from .const import DOMAIN  # pylint: disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Meteo-France config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize Meteo-France config flow."""
+
+    def _configuration_exists(self, city_name: str) -> bool:
+        """Return True if city_name exists in configuration."""
+        for entry in self._async_current_entries():
+            if entry.data[CONF_CITY] == city_name:
+                return True
+        return False
+
+    async def _show_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user."""
+
+        if user_input is None:
+            user_input = {}
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_CITY, default=user_input.get(CONF_CITY, "")): str}
+            ),
+            errors=errors or {},
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        if user_input is None:
+            return await self._show_setup_form(user_input, errors)
+
+        city = user_input[CONF_CITY]
+        monitored_conditions = user_input.get(
+            CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES)
+        )
+        if self._configuration_exists(city):
+            errors[CONF_CITY] = "city_exists"
+            return await self._show_setup_form(user_input, errors)
+
+        try:
+            await self.hass.async_add_executor_job(meteofranceClient, city)
+        except meteofranceError as exp:
+            _LOGGER.error(
+                "Unexpected error when creating the meteofrance proxy: %s", exp
+            )
+            errors["base"] = "unknown"
+            return await self._show_setup_form(user_input, errors)
+
+        return self.async_create_entry(
+            title=city,
+            data={CONF_CITY: city, CONF_MONITORED_CONDITIONS: monitored_conditions},
+        )
+
+    async def async_step_import(self, user_input):
+        """Import a config entry."""
+        if self._configuration_exists(user_input[CONF_CITY]):
+            return self.async_abort(reason="city_exists")
+
+        return await self.async_step_user(user_input)

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -5,7 +5,6 @@ from meteofrance.client import meteofranceClient, meteofranceError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import AbortFlow
 
 from .const import CONF_CITY
 from .const import DOMAIN  # pylint: disable=unused-import
@@ -50,7 +49,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.error(
                 "Unexpected error when creating the meteofrance proxy: %s", exp
             )
-            raise AbortFlow("unknown")
+            return self.async_abort(reason="unknown")
 
         # Check if already configured
         await self.async_set_unique_id(city_name)

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -55,7 +55,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(city_name)
         self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(title=city_name, data={CONF_CITY: city_name})
+        return self.async_create_entry(title=city_name, data={CONF_CITY: city})
 
     async def async_step_import(self, user_input):
         """Import a config entry."""

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -19,10 +19,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    def __init__(self):
-        """Initialize Meteo-France config flow."""
-
-    async def _show_setup_form(self, user_input=None, errors=None):
+    def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
 
         if user_input is None:
@@ -41,7 +38,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is None:
-            return await self._show_setup_form(user_input, None)
+            return self._show_setup_form(user_input, None)
 
         city = user_input[CONF_CITY]
         monitored_conditions = user_input.get(
@@ -59,7 +56,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 "Unexpected error when creating the meteofrance proxy: %s", exp
             )
             errors["base"] = "unknown"
-            return await self._show_setup_form(user_input, errors)
+            return self._show_setup_form(user_input, errors)
 
         return self.async_create_entry(
             title=city,

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.data_entry_flow import AbortFlow
 
 from .const import CONF_CITY, SENSOR_TYPES
 from .const import DOMAIN  # pylint: disable=unused-import
@@ -38,7 +39,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is None:
-            return self._show_setup_form(user_input, None)
+            return self._show_setup_form(user_input, errors)
 
         city = user_input[CONF_CITY]  # Might be a city name or a postal code
         monitored_conditions = user_input.get(
@@ -53,8 +54,7 @@ class MeteoFranceFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.error(
                 "Unexpected error when creating the meteofrance proxy: %s", exp
             )
-            errors["base"] = "unknown"
-            return self._show_setup_form(user_input, errors)
+            raise AbortFlow("unknown")
 
         # Check if already configured
         await self.async_set_unique_id(city_name)

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -3,6 +3,7 @@
 from homeassistant.const import TEMP_CELSIUS
 
 DOMAIN = "meteo_france"
+PLATFORMS = ["sensor", "weather"]
 ATTRIBUTION = "Data provided by Météo-France"
 
 CONF_CITY = "city"

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -3,7 +3,6 @@
 from homeassistant.const import TEMP_CELSIUS
 
 DOMAIN = "meteo_france"
-DATA_METEO_FRANCE = "data_meteo_france"
 ATTRIBUTION = "Data provided by Météo-France"
 
 CONF_CITY = "city"

--- a/homeassistant/components/meteo_france/manifest.json
+++ b/homeassistant/components/meteo_france/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/meteo_france",
   "requirements": ["meteofrance==0.3.7", "vigilancemeteo==3.0.0"],
   "dependencies": [],
-  "codeowners": ["@victorcerutti", "@oncleben31"]
+  "codeowners": ["@victorcerutti", "@oncleben31", "@Quentame"]
 }

--- a/homeassistant/components/meteo_france/manifest.json
+++ b/homeassistant/components/meteo_france/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "meteo_france",
   "name": "Météo-France",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/meteo_france",
   "requirements": ["meteofrance==0.3.7", "vigilancemeteo==3.0.0"],
   "dependencies": [],

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -78,12 +78,12 @@ class MeteoFranceSensor(Entity):
 
     def __init__(
         self,
-        type: str,
+        sensor_type: str,
         client: meteofranceClient,
         alert_watcher: VigilanceMeteoFranceProxy,
     ):
         """Initialize the Meteo-France sensor."""
-        self._type = type
+        self._type = sensor_type
         self._client = client
         self._alert_watcher = alert_watcher
         self._state = None

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -55,7 +55,6 @@ async def async_setup_entry(
                 datas["dept"],
                 exp,
             )
-            alert_watcher = None
     else:
         _LOGGER.warning(
             "No 'dept' key found for '%s'. So weather alert information won't be available",

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -37,13 +37,13 @@ async def async_setup_entry(
 
     alert_watcher = None
     if "weather_alert" in monitored_conditions:
-        datas = hass.data[DOMAIN][city].get_data()
+        datas = client.get_data()
         # Check if a department code is available for this city.
         if "dept" in datas:
             try:
                 # If yes create the watcher DepartmentWeatherAlert object.
-                alert_watcher = DepartmentWeatherAlert(
-                    datas["dept"], weather_alert_client
+                alert_watcher = await hass.async_add_executor_job(
+                    DepartmentWeatherAlert, datas["dept"], weather_alert_client
                 )
             except ValueError as exp:
                 _LOGGER.error(

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -26,11 +26,6 @@ STATE_ATTR_FORECAST = "1h rain forecast"
 STATE_ATTR_BULLETIN_TIME = "Bulletin date"
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Old way of setting up the Meteo-France platform."""
-    pass
-
-
 async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -43,6 +43,11 @@ async def async_setup_entry(
             alert_watcher = await hass.async_add_executor_job(
                 DepartmentWeatherAlert, datas["dept"], weather_alert_client
             )
+            _LOGGER.info(
+                "Weather alert watcher added for %s in department %s",
+                city,
+                datas["dept"],
+            )
         except ValueError as exp:
             _LOGGER.error(
                 "Unexpected error when creating the weather alert sensor for %s in department %s: %s",
@@ -51,12 +56,6 @@ async def async_setup_entry(
                 exp,
             )
             alert_watcher = None
-        else:
-            _LOGGER.info(
-                "Weather alert watcher added for %s in department %s",
-                city,
-                datas["dept"],
-            )
     else:
         _LOGGER.warning(
             "No 'dept' key found for '%s'. So weather alert information won't be available",
@@ -153,8 +152,7 @@ class MeteoFranceSensor(Entity):
                     self._alert_watcher.update_department_status()
                     self._state = self._alert_watcher.department_color
                     _LOGGER.debug(
-                        "weather alert watcher for %s updated. Proxy"
-                        " have the status: %s",
+                        "weather alert watcher for %s updated. Proxy have the status: %s",
                         self._data["name"],
                         self._alert_watcher.proxy.status,
                     )

--- a/homeassistant/components/meteo_france/strings.json
+++ b/homeassistant/components/meteo_france/strings.json
@@ -4,7 +4,7 @@
         "step": {
             "user": {
                 "title": "Météo-France",
-                "description": "Enter the postal code (only for France, recommanded) or city name",
+                "description": "Enter the postal code (only for France, recommended) or city name",
                 "data": {
                     "city": "City"
                 }

--- a/homeassistant/components/meteo_france/strings.json
+++ b/homeassistant/components/meteo_france/strings.json
@@ -11,11 +11,10 @@
             }
         },
         "error":{
-            "city_exists": "City already configured",
             "unknown": "Unknown error: please retry later"
         },
         "abort":{
-            "city_exists": "City already configured"
+            "already_configured": "City already configured"
         }
     }
 }

--- a/homeassistant/components/meteo_france/strings.json
+++ b/homeassistant/components/meteo_france/strings.json
@@ -4,9 +4,8 @@
         "step": {
             "user": {
                 "title": "Météo-France",
-                "description": "Enter your city",
                 "data": {
-                    "city": "City"
+                    "city": "City or postal code"
                 }
             }
         },

--- a/homeassistant/components/meteo_france/strings.json
+++ b/homeassistant/components/meteo_france/strings.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "title": "Météo-France",
+        "step": {
+            "user": {
+                "title": "Météo-France",
+                "description": "Enter your city",
+                "data": {
+                    "city": "City"
+                }
+            }
+        },
+        "error":{
+            "city_exists": "City already configured",
+            "unknown": "Unknown error: please retry later"
+        },
+        "abort":{
+            "city_exists": "City already configured"
+        }
+    }
+}

--- a/homeassistant/components/meteo_france/strings.json
+++ b/homeassistant/components/meteo_france/strings.json
@@ -4,8 +4,9 @@
         "step": {
             "user": {
                 "title": "Météo-France",
+                "description": "Enter the postal code (only for France, recommanded) or city name",
                 "data": {
-                    "city": "City or postal code"
+                    "city": "City"
                 }
             }
         },

--- a/homeassistant/components/meteo_france/strings.json
+++ b/homeassistant/components/meteo_france/strings.json
@@ -9,11 +9,9 @@
                 }
             }
         },
-        "error":{
-            "unknown": "Unknown error: please retry later"
-        },
         "abort":{
-            "already_configured": "City already configured"
+            "already_configured": "City already configured",
+            "unknown": "Unknown error: please retry later"
         }
     }
 }

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -21,11 +21,6 @@ from .const import ATTRIBUTION, CONDITION_CLASSES, CONF_CITY, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Old way of setting up the Meteo-France platform."""
-    pass
-
-
 async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 import logging
 
+from meteofrance.client import meteofranceClient
+
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_TEMP,
@@ -9,29 +11,35 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TIME,
     WeatherEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.dt as dt_util
 
-from .const import ATTRIBUTION, CONDITION_CLASSES, CONF_CITY, DATA_METEO_FRANCE
+from .const import ATTRIBUTION, CONDITION_CLASSES, CONF_CITY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Old way of setting up the Meteo-France platform."""
+    pass
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+) -> None:
     """Set up the Meteo-France weather platform."""
-    if discovery_info is None:
-        return
+    city = entry.data[CONF_CITY]
+    client = hass.data[DOMAIN][city]
 
-    city = discovery_info[CONF_CITY]
-    client = hass.data[DATA_METEO_FRANCE][city]
-
-    add_entities([MeteoFranceWeather(client)], True)
+    async_add_entities([MeteoFranceWeather(client)], True)
 
 
 class MeteoFranceWeather(WeatherEntity):
     """Representation of a weather condition."""
 
-    def __init__(self, client):
+    def __init__(self, client: meteofranceClient):
         """Initialise the platform with a data instance and station name."""
         self._client = client
         self._data = {}
@@ -45,6 +53,11 @@ class MeteoFranceWeather(WeatherEntity):
     def name(self):
         """Return the name of the sensor."""
         return self._data["name"]
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the sensor."""
+        return self.name
 
     @property
     def condition(self):

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -54,6 +54,7 @@ FLOWS = [
     "luftdaten",
     "mailgun",
     "met",
+    "meteo_france",
     "mikrotik",
     "mobile_app",
     "mqtt",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -298,6 +298,9 @@ luftdaten==0.6.3
 # homeassistant.components.mythicbeastsdns
 mbddns==0.1.2
 
+# homeassistant.components.meteo_france
+meteofrance==0.3.7
+
 # homeassistant.components.mfi
 mficlient==0.3.0
 
@@ -662,6 +665,9 @@ url-normalize==1.4.1
 
 # homeassistant.components.uvc
 uvcclient==0.11.0
+
+# homeassistant.components.meteo_france
+vigilancemeteo==3.0.0
 
 # homeassistant.components.verisure
 vsure==1.5.4

--- a/tests/components/meteo_france/__init__.py
+++ b/tests/components/meteo_france/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Meteo-France component."""

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -147,5 +147,5 @@ async def test_client_failed(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_CITY: CITY_1_POSTAL},
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "unknown"}
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "unknown"

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -42,7 +42,7 @@ def mock_controller_client_2():
 async def test_user(hass, client_1):
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=None,
+        DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -5,13 +5,14 @@ from meteofrance.client import meteofranceError
 import pytest
 
 from homeassistant import data_entry_flow
-from homeassistant.components.meteo_france import config_flow
 from homeassistant.components.meteo_france.const import CONF_CITY, DOMAIN, SENSOR_TYPES
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 
 from tests.common import MockConfigEntry
 
 CITY = "74220"
+CITY_2 = "69004"
 MONITORED_CONDITIONS = ["temperature", "weather"]
 DEFAULT_MONITORED_CONDITIONS = list(SENSOR_TYPES)
 
@@ -23,24 +24,20 @@ def mock_controller_client():
         yield
 
 
-def init_config_flow(hass):
-    """Init a configuration flow."""
-    flow = config_flow.MeteoFranceFlowHandler()
-    flow.hass = hass
-    return flow
-
-
 async def test_user(hass, client):
     """Test user config."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_user()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=None,
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
     # test with all provided
-    result = await flow.async_step_user({CONF_CITY: CITY})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_CITY: CITY},
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == CITY
     assert result["title"] == CITY
     assert result["data"][CONF_CITY] == CITY
     assert result["data"][CONF_MONITORED_CONDITIONS] == DEFAULT_MONITORED_CONDITIONS
@@ -48,49 +45,58 @@ async def test_user(hass, client):
 
 async def test_import(hass, client):
     """Test import step."""
-    flow = init_config_flow(hass)
-
     # import with city
-    result = await flow.async_step_import({CONF_CITY: CITY})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_CITY: CITY},
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == CITY
     assert result["title"] == CITY
     assert result["data"][CONF_CITY] == CITY
     assert result["data"][CONF_MONITORED_CONDITIONS] == DEFAULT_MONITORED_CONDITIONS
 
     # import with all
-    result = await flow.async_step_import(
-        {CONF_CITY: CITY, CONF_MONITORED_CONDITIONS: MONITORED_CONDITIONS}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_CITY: CITY_2, CONF_MONITORED_CONDITIONS: MONITORED_CONDITIONS},
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == CITY
-    assert result["data"][CONF_CITY] == CITY
+    assert result["result"].unique_id == CITY_2
+    assert result["title"] == CITY_2
+    assert result["data"][CONF_CITY] == CITY_2
     assert result["data"][CONF_MONITORED_CONDITIONS] == MONITORED_CONDITIONS
 
 
 async def test_abort_if_already_setup(hass, client):
     """Test we abort if already setup."""
-    flow = init_config_flow(hass)
-    MockConfigEntry(domain=DOMAIN, data={CONF_CITY: CITY}).add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN, data={CONF_CITY: CITY}, unique_id=CITY).add_to_hass(
+        hass
+    )
 
     # Should fail, same CITY (import)
-    result = await flow.async_step_import({CONF_CITY: CITY})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_CITY: CITY},
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "city_exists"
+    assert result["reason"] == "already_configured"
 
     # Should fail, same CITY (flow)
-    result = await flow.async_step_user({CONF_CITY: CITY})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_CITY: "city_exists"}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_CITY: CITY},
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_on_client_failed(hass):
     """Test when we have errors during client fetch."""
-    flow = init_config_flow(hass)
-
     with patch(
-        "meteofrance.client.meteofranceClient._init_codes",
+        "homeassistant.components.meteo_france.config_flow.meteofranceClient",
         side_effect=meteofranceError(),
     ):
-        result = await flow.async_step_user({CONF_CITY: CITY})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data={CONF_CITY: CITY},
+        )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {"base": "unknown"}

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -5,9 +5,8 @@ from meteofrance.client import meteofranceError
 import pytest
 
 from homeassistant import data_entry_flow
-from homeassistant.components.meteo_france.const import CONF_CITY, DOMAIN, SENSOR_TYPES
+from homeassistant.components.meteo_france.const import CONF_CITY, DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import CONF_MONITORED_CONDITIONS
 
 from tests.common import MockConfigEntry
 
@@ -16,8 +15,6 @@ CITY_1_NAME = "La Clusaz"
 CITY_2_POSTAL_DISTRICT_1 = "69001"
 CITY_2_POSTAL_DISTRICT_4 = "69004"
 CITY_2_NAME = "Lyon"
-MONITORED_CONDITIONS = ["temperature", "weather"]
-DEFAULT_MONITORED_CONDITIONS = list(SENSOR_TYPES)
 
 
 @pytest.fixture(name="client_1")
@@ -58,12 +55,11 @@ async def test_user(hass, client_1):
     assert result["result"].unique_id == CITY_1_NAME
     assert result["title"] == CITY_1_NAME
     assert result["data"][CONF_CITY] == CITY_1_NAME
-    assert result["data"][CONF_MONITORED_CONDITIONS] == DEFAULT_MONITORED_CONDITIONS
 
 
 async def test_import(hass, client_1):
     """Test import step."""
-    # import with city
+    # import with all
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_CITY: CITY_1_POSTAL},
     )
@@ -71,25 +67,6 @@ async def test_import(hass, client_1):
     assert result["result"].unique_id == CITY_1_NAME
     assert result["title"] == CITY_1_NAME
     assert result["data"][CONF_CITY] == CITY_1_NAME
-    assert result["data"][CONF_MONITORED_CONDITIONS] == DEFAULT_MONITORED_CONDITIONS
-
-
-async def test_import_all(hass, client_2):
-    """Test import step."""
-    # import with all
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_CITY: CITY_2_POSTAL_DISTRICT_4,
-            CONF_MONITORED_CONDITIONS: MONITORED_CONDITIONS,
-        },
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["result"].unique_id == CITY_2_NAME
-    assert result["title"] == CITY_2_NAME
-    assert result["data"][CONF_CITY] == CITY_2_NAME
-    assert result["data"][CONF_MONITORED_CONDITIONS] == MONITORED_CONDITIONS
 
 
 async def test_abort_if_already_setup(hass, client_1):

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -54,7 +54,7 @@ async def test_user(hass, client_1):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == CITY_1_NAME
     assert result["title"] == CITY_1_NAME
-    assert result["data"][CONF_CITY] == CITY_1_NAME
+    assert result["data"][CONF_CITY] == CITY_1_POSTAL
 
 
 async def test_import(hass, client_1):
@@ -66,7 +66,7 @@ async def test_import(hass, client_1):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == CITY_1_NAME
     assert result["title"] == CITY_1_NAME
-    assert result["data"][CONF_CITY] == CITY_1_NAME
+    assert result["data"][CONF_CITY] == CITY_1_POSTAL
 
 
 async def test_abort_if_already_setup(hass, client_1):

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -1,0 +1,96 @@
+"""Tests for the Meteo-France config flow."""
+from unittest.mock import patch
+
+from meteofrance.client import meteofranceError
+import pytest
+
+from homeassistant import data_entry_flow
+from homeassistant.components.meteo_france import config_flow
+from homeassistant.components.meteo_france.const import CONF_CITY, DOMAIN, SENSOR_TYPES
+from homeassistant.const import CONF_MONITORED_CONDITIONS
+
+from tests.common import MockConfigEntry
+
+CITY = "74220"
+MONITORED_CONDITIONS = ["temperature", "weather"]
+DEFAULT_MONITORED_CONDITIONS = list(SENSOR_TYPES)
+
+
+@pytest.fixture(name="client")
+def mock_controller_client():
+    """Mock a successful client."""
+    with patch("meteofrance.client.meteofranceClient", update=False):
+        yield
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    flow = config_flow.MeteoFranceFlowHandler()
+    flow.hass = hass
+    return flow
+
+
+async def test_user(hass, client):
+    """Test user config."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # test with all provided
+    result = await flow.async_step_user({CONF_CITY: CITY})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == CITY
+    assert result["data"][CONF_CITY] == CITY
+    assert result["data"][CONF_MONITORED_CONDITIONS] == DEFAULT_MONITORED_CONDITIONS
+
+
+async def test_import(hass, client):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with city
+    result = await flow.async_step_import({CONF_CITY: CITY})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == CITY
+    assert result["data"][CONF_CITY] == CITY
+    assert result["data"][CONF_MONITORED_CONDITIONS] == DEFAULT_MONITORED_CONDITIONS
+
+    # import with all
+    result = await flow.async_step_import(
+        {CONF_CITY: CITY, CONF_MONITORED_CONDITIONS: MONITORED_CONDITIONS}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == CITY
+    assert result["data"][CONF_CITY] == CITY
+    assert result["data"][CONF_MONITORED_CONDITIONS] == MONITORED_CONDITIONS
+
+
+async def test_abort_if_already_setup(hass, client):
+    """Test we abort if already setup."""
+    flow = init_config_flow(hass)
+    MockConfigEntry(domain=DOMAIN, data={CONF_CITY: CITY}).add_to_hass(hass)
+
+    # Should fail, same CITY (import)
+    result = await flow.async_step_import({CONF_CITY: CITY})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "city_exists"
+
+    # Should fail, same CITY (flow)
+    result = await flow.async_step_user({CONF_CITY: CITY})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_CITY: "city_exists"}
+
+
+async def test_on_client_failed(hass):
+    """Test when we have errors during client fetch."""
+    flow = init_config_flow(hass)
+
+    with patch(
+        "meteofrance.client.meteofranceClient._init_codes",
+        side_effect=meteofranceError(),
+    ):
+        result = await flow.async_step_user({CONF_CITY: CITY})
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "unknown"}


### PR DESCRIPTION
## Breaking Change:

No more `monitored_conditions`, all sensors will be added --> [ADR-03](https://github.com/home-assistant/architecture/blob/master/adr/0003-monitor-condition-and-data-selectors.md)

## Description:

Adding config flow to Météo-France

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) :** home-assistant/home-assistant.io#11474

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
