### PR TITLE
Update adb-shell to 0.1.0 and androidtv to 0.0.36

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,8 +3,8 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
-    "adb-shell==0.0.8",
-    "androidtv==0.0.34",
+    "adb-shell==0.0.9",
+    "androidtv==0.0.35",
     "pure-python-adb==0.2.2.dev0"
   ],
   "dependencies": [],

--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,8 +3,8 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
-    "adb-shell==0.0.9",
-    "androidtv==0.0.35",
+    "adb-shell==0.1.0",
+    "androidtv==0.0.36",
     "pure-python-adb==0.2.2.dev0"
   ],
   "dependencies": [],

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -146,7 +146,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             adb_log = f"using Python ADB implementation with adbkey='{adbkey}'"
 
             aftv = setup(
-                host,
+                config[CONF_HOST],
+                config[CONF_PORT],
                 adbkey,
                 device_class=config[CONF_DEVICE_CLASS],
                 state_detection_rules=config[CONF_STATE_DETECTION_RULES],
@@ -159,7 +160,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             )
 
             aftv = setup(
-                host,
+                config[CONF_HOST],
+                config[CONF_PORT],
                 config[CONF_ADBKEY],
                 device_class=config[CONF_DEVICE_CLASS],
                 state_detection_rules=config[CONF_STATE_DETECTION_RULES],
@@ -171,7 +173,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         adb_log = f"using ADB server at {config[CONF_ADB_SERVER_IP]}:{config[CONF_ADB_SERVER_PORT]}"
 
         aftv = setup(
-            host,
+            config[CONF_HOST],
+            config[CONF_PORT],
             adb_server_ip=config[CONF_ADB_SERVER_IP],
             adb_server_port=config[CONF_ADB_SERVER_PORT],
             device_class=config[CONF_DEVICE_CLASS],

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -133,7 +133,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Android TV / Fire TV platform."""
     hass.data.setdefault(ANDROIDTV_DOMAIN, {})
 
-    host = f"{config[CONF_HOST]}:{config[CONF_PORT]}"
+    address = f"{config[CONF_HOST]}:{config[CONF_PORT]}"
 
     if CONF_ADB_SERVER_IP not in config:
         # Use "adb_shell" (Python ADB implementation)
@@ -192,11 +192,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         else:
             device_name = "Android TV / Fire TV device"
 
-        _LOGGER.warning("Could not connect to %s at %s %s", device_name, host, adb_log)
+        _LOGGER.warning(
+            "Could not connect to %s at %s %s", device_name, address, adb_log
+        )
         raise PlatformNotReady
 
-    if host in hass.data[ANDROIDTV_DOMAIN]:
-        _LOGGER.warning("Platform already setup on %s, skipping", host)
+    if address in hass.data[ANDROIDTV_DOMAIN]:
+        _LOGGER.warning("Platform already setup on %s, skipping", address)
     else:
         if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
             device = AndroidTVDevice(
@@ -220,8 +222,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             device_name = config[CONF_NAME] if CONF_NAME in config else "Fire TV"
 
         add_entities([device])
-        _LOGGER.debug("Setup %s at %s %s", device_name, host, adb_log)
-        hass.data[ANDROIDTV_DOMAIN][host] = device
+        _LOGGER.debug("Setup %s at %s %s", device_name, address, adb_log)
+        hass.data[ANDROIDTV_DOMAIN][address] = device
 
     if hass.services.has_service(ANDROIDTV_DOMAIN, SERVICE_ADB_COMMAND):
         return

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -55,6 +55,7 @@ SUPPORT_ANDROIDTV = (
     | SUPPORT_TURN_OFF
     | SUPPORT_PREVIOUS_TRACK
     | SUPPORT_NEXT_TRACK
+    | SUPPORT_SELECT_SOURCE
     | SUPPORT_STOP
     | SUPPORT_VOLUME_MUTE
     | SUPPORT_VOLUME_STEP
@@ -199,6 +200,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 aftv,
                 config[CONF_NAME],
                 config[CONF_APPS],
+                config[CONF_GET_SOURCES],
                 config.get(CONF_TURN_ON_COMMAND),
                 config.get(CONF_TURN_OFF_COMMAND),
             )
@@ -287,7 +289,9 @@ def adb_decorator(override_available=False):
 class ADBDevice(MediaPlayerDevice):
     """Representation of an Android TV or Fire TV device."""
 
-    def __init__(self, aftv, name, apps, turn_on_command, turn_off_command):
+    def __init__(
+        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+    ):
         """Initialize the Android TV / Fire TV device."""
         self.aftv = aftv
         self._name = name
@@ -296,6 +300,7 @@ class ADBDevice(MediaPlayerDevice):
         self._app_name_to_id = {
             value: key for key, value in self._app_id_to_name.items()
         }
+        self._get_sources = get_sources
         self._keys = KEYS
 
         self._device_properties = self.aftv.device_properties
@@ -325,6 +330,7 @@ class ADBDevice(MediaPlayerDevice):
         self._adb_response = None
         self._available = True
         self._current_app = None
+        self._sources = None
         self._state = None
 
     @property
@@ -356,6 +362,16 @@ class ADBDevice(MediaPlayerDevice):
     def should_poll(self):
         """Device should be polled."""
         return True
+
+    @property
+    def source(self):
+        """Return the current app."""
+        return self._app_id_to_name.get(self._current_app, self._current_app)
+
+    @property
+    def source_list(self):
+        """Return a list of running apps."""
+        return self._sources
 
     @property
     def state(self):
@@ -409,6 +425,20 @@ class ADBDevice(MediaPlayerDevice):
         self.aftv.media_next_track()
 
     @adb_decorator()
+    def select_source(self, source):
+        """Select input source.
+
+        If the source starts with a '!', then it will close the app instead of
+        opening it.
+        """
+        if isinstance(source, str):
+            if not source.startswith("!"):
+                self.aftv.launch_app(self._app_name_to_id.get(source, source))
+            else:
+                source_ = source[1:].lstrip()
+                self.aftv.stop_app(self._app_name_to_id.get(source_, source_))
+
+    @adb_decorator()
     def adb_command(self, cmd):
         """Send an ADB command to an Android TV / Fire TV device."""
         key = self._keys.get(cmd)
@@ -436,9 +466,13 @@ class ADBDevice(MediaPlayerDevice):
 class AndroidTVDevice(ADBDevice):
     """Representation of an Android TV device."""
 
-    def __init__(self, aftv, name, apps, turn_on_command, turn_off_command):
+    def __init__(
+        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+    ):
         """Initialize the Android TV device."""
-        super().__init__(aftv, name, apps, turn_on_command, turn_off_command)
+        super().__init__(
+            aftv, name, apps, get_sources, turn_on_command, turn_off_command
+        )
 
         self._device = None
         self._is_volume_muted = None
@@ -465,24 +499,27 @@ class AndroidTVDevice(ADBDevice):
         (
             state,
             self._current_app,
+            running_apps,
             self._device,
             self._is_volume_muted,
             self._volume_level,
-        ) = self.aftv.update()
+        ) = self.aftv.update(self._get_sources)
 
         self._state = ANDROIDTV_STATES.get(state)
         if self._state is None:
             self._available = False
 
+        if running_apps:
+            self._sources = [
+                self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
+            ]
+        else:
+            self._sources = None
+
     @property
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._is_volume_muted
-
-    @property
-    def source(self):
-        """Return the current playback device."""
-        return self._device
 
     @property
     def supported_features(self):
@@ -518,15 +555,6 @@ class AndroidTVDevice(ADBDevice):
 class FireTVDevice(ADBDevice):
     """Representation of a Fire TV device."""
 
-    def __init__(
-        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
-    ):
-        """Initialize the Fire TV device."""
-        super().__init__(aftv, name, apps, turn_on_command, turn_off_command)
-
-        self._get_sources = get_sources
-        self._sources = None
-
     @adb_decorator(override_available=True)
     def update(self):
         """Update the device state and, if necessary, re-connect."""
@@ -559,16 +587,6 @@ class FireTVDevice(ADBDevice):
             self._sources = None
 
     @property
-    def source(self):
-        """Return the current app."""
-        return self._app_id_to_name.get(self._current_app, self._current_app)
-
-    @property
-    def source_list(self):
-        """Return a list of running apps."""
-        return self._sources
-
-    @property
     def supported_features(self):
         """Flag media player features that are supported."""
         return SUPPORT_FIRETV
@@ -577,17 +595,3 @@ class FireTVDevice(ADBDevice):
     def media_stop(self):
         """Send stop (back) command."""
         self.aftv.back()
-
-    @adb_decorator()
-    def select_source(self, source):
-        """Select input source.
-
-        If the source starts with a '!', then it will close the app instead of
-        opening it.
-        """
-        if isinstance(source, str):
-            if not source.startswith("!"):
-                self.aftv.launch_app(self._app_name_to_id.get(source, source))
-            else:
-                source_ = source[1:].lstrip()
-                self.aftv.stop_app(self._app_name_to_id.get(source_, source_))

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -474,7 +474,6 @@ class AndroidTVDevice(ADBDevice):
             aftv, name, apps, get_sources, turn_on_command, turn_off_command
         )
 
-        self._device = None
         self._is_volume_muted = None
         self._volume_level = None
 
@@ -500,7 +499,7 @@ class AndroidTVDevice(ADBDevice):
             state,
             self._current_app,
             running_apps,
-            self._device,
+            _,
             self._is_volume_muted,
             self._volume_level,
         ) = self.aftv.update(self._get_sources)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -115,7 +115,7 @@ adafruit-blinka==1.2.1
 adafruit-circuitpython-mcp230xx==1.1.2
 
 # homeassistant.components.androidtv
-adb-shell==0.0.9
+adb-shell==0.1.0
 
 # homeassistant.components.adguard
 adguardhome==0.3.0
@@ -215,7 +215,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.35
+androidtv==0.0.36
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -115,7 +115,7 @@ adafruit-blinka==1.2.1
 adafruit-circuitpython-mcp230xx==1.1.2
 
 # homeassistant.components.androidtv
-adb-shell==0.0.8
+adb-shell==0.0.9
 
 # homeassistant.components.adguard
 adguardhome==0.3.0
@@ -215,7 +215,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.34
+androidtv==0.0.35
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -29,7 +29,7 @@ YesssSMS==0.4.1
 abodepy==0.16.7
 
 # homeassistant.components.androidtv
-adb-shell==0.0.9
+adb-shell==0.1.0
 
 # homeassistant.components.adguard
 adguardhome==0.3.0
@@ -84,7 +84,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.35
+androidtv==0.0.36
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -29,7 +29,7 @@ YesssSMS==0.4.1
 abodepy==0.16.7
 
 # homeassistant.components.androidtv
-adb-shell==0.0.8
+adb-shell==0.0.9
 
 # homeassistant.components.adguard
 adguardhome==0.3.0
@@ -84,7 +84,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.34
+androidtv==0.0.35
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -149,5 +149,22 @@ def patch_firetv_update(state, current_app, running_apps):
     )
 
 
-PATCH_LAUNCH_APP = patch("androidtv.firetv.FireTV.launch_app")
-PATCH_STOP_APP = patch("androidtv.firetv.FireTV.stop_app")
+def patch_androidtv_update(
+    state, current_app, running_apps, device, is_volume_muted, volume_level
+):
+    """Patch the `AndroidTV.update()` method."""
+    return patch(
+        "androidtv.androidtv.AndroidTV.update",
+        return_value=(
+            state,
+            current_app,
+            running_apps,
+            device,
+            is_volume_muted,
+            volume_level,
+        ),
+    )
+
+
+PATCH_LAUNCH_APP = patch("androidtv.basetv.BaseTV.launch_app")
+PATCH_STOP_APP = patch("androidtv.basetv.BaseTV.stop_app")

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -3,11 +3,11 @@
 from unittest.mock import mock_open, patch
 
 
-class AdbDeviceFake:
-    """A fake of the `adb_shell.adb_device.AdbDevice` class."""
+class AdbDeviceTcpFake:
+    """A fake of the `adb_shell.adb_device.AdbDeviceTcp` class."""
 
     def __init__(self, *args, **kwargs):
-        """Initialize a fake `adb_shell.adb_device.AdbDevice` instance."""
+        """Initialize a fake `adb_shell.adb_device.AdbDeviceTcp` instance."""
         self.available = False
 
     def close(self):
@@ -74,39 +74,39 @@ class DeviceFake:
 
 
 def patch_connect(success):
-    """Mock the `adb_shell.adb_device.AdbDevice` and `ppadb.client.Client` classes."""
+    """Mock the `adb_shell.adb_device.AdbDeviceTcp` and `ppadb.client.Client` classes."""
 
     def connect_success_python(self, *args, **kwargs):
-        """Mock the `AdbDeviceFake.connect` method when it succeeds."""
+        """Mock the `AdbDeviceTcpFake.connect` method when it succeeds."""
         self.available = True
 
     def connect_fail_python(self, *args, **kwargs):
-        """Mock the `AdbDeviceFake.connect` method when it fails."""
+        """Mock the `AdbDeviceTcpFake.connect` method when it fails."""
         raise OSError
 
     if success:
         return {
             "python": patch(
-                f"{__name__}.AdbDeviceFake.connect", connect_success_python
+                f"{__name__}.AdbDeviceTcpFake.connect", connect_success_python
             ),
             "server": patch("androidtv.adb_manager.Client", ClientFakeSuccess),
         }
     return {
-        "python": patch(f"{__name__}.AdbDeviceFake.connect", connect_fail_python),
+        "python": patch(f"{__name__}.AdbDeviceTcpFake.connect", connect_fail_python),
         "server": patch("androidtv.adb_manager.Client", ClientFakeFail),
     }
 
 
 def patch_shell(response=None, error=False):
-    """Mock the `AdbDeviceFake.shell` and `DeviceFake.shell` methods."""
+    """Mock the `AdbDeviceTcpFake.shell` and `DeviceFake.shell` methods."""
 
     def shell_success(self, cmd):
-        """Mock the `AdbDeviceFake.shell` and `DeviceFake.shell` methods when they are successful."""
+        """Mock the `AdbDeviceTcpFake.shell` and `DeviceFake.shell` methods when they are successful."""
         self.shell_cmd = cmd
         return response
 
     def shell_fail_python(self, cmd):
-        """Mock the `AdbDeviceFake.shell` method when it fails."""
+        """Mock the `AdbDeviceTcpFake.shell` method when it fails."""
         self.shell_cmd = cmd
         raise AttributeError
 
@@ -117,16 +117,16 @@ def patch_shell(response=None, error=False):
 
     if not error:
         return {
-            "python": patch(f"{__name__}.AdbDeviceFake.shell", shell_success),
+            "python": patch(f"{__name__}.AdbDeviceTcpFake.shell", shell_success),
             "server": patch(f"{__name__}.DeviceFake.shell", shell_success),
         }
     return {
-        "python": patch(f"{__name__}.AdbDeviceFake.shell", shell_fail_python),
+        "python": patch(f"{__name__}.AdbDeviceTcpFake.shell", shell_fail_python),
         "server": patch(f"{__name__}.DeviceFake.shell", shell_fail_server),
     }
 
 
-PATCH_ADB_DEVICE = patch("androidtv.adb_manager.AdbDevice", AdbDeviceFake)
+PATCH_ADB_DEVICE_TCP = patch("androidtv.adb_manager.AdbDeviceTcp", AdbDeviceTcpFake)
 PATCH_ANDROIDTV_OPEN = patch("androidtv.adb_manager.open", mock_open())
 PATCH_KEYGEN = patch("homeassistant.components.androidtv.media_player.keygen")
 PATCH_SIGNER = patch("androidtv.adb_manager.PythonRSASigner")

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -287,9 +287,9 @@ async def test_setup_with_adbkey(hass):
         assert state.state == STATE_OFF
 
 
-async def test_androidtv_sources(hass):
-    """Test that sources (i.e., apps) are handled correctly for Android TV devices."""
-    config = CONFIG_ANDROIDTV_ADB_SERVER.copy()
+async def _test_sources(hass, config0):
+    """Test that sources (i.e., apps) are handled correctly for Android TV and Fire TV devices."""
+    config = config0.copy()
     config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
     patch_key, entity_id = _setup(hass, config)
 
@@ -302,34 +302,66 @@ async def test_androidtv_sources(hass):
         assert state is not None
         assert state.state == STATE_OFF
 
-    with patchers.patch_androidtv_update(
-        "playing", "com.app.test1", ["com.app.test1", "com.app.test2"], "hdmi", False, 1
-    ):
+    if config[DOMAIN].get(CONF_DEVICE_CLASS) != "firetv":
+        patch_update = patchers.patch_androidtv_update(
+            "playing",
+            "com.app.test1",
+            ["com.app.test1", "com.app.test2"],
+            "hdmi",
+            False,
+            1,
+        )
+    else:
+        patch_update = patchers.patch_firetv_update(
+            "playing", "com.app.test1", ["com.app.test1", "com.app.test2"]
+        )
+
+    with patch_update:
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_PLAYING
         assert state.attributes["source"] == "TEST 1"
         assert state.attributes["source_list"] == ["TEST 1", "com.app.test2"]
-        assert not state.attributes["is_volume_muted"]
-        assert state.attributes["volume_level"] == 1
 
-    with patchers.patch_androidtv_update(
-        "playing", "com.app.test2", ["com.app.test2", "com.app.test1"], "hdmi", True, 0
-    ):
+    if config[DOMAIN].get(CONF_DEVICE_CLASS) != "firetv":
+        patch_update = patchers.patch_androidtv_update(
+            "playing",
+            "com.app.test2",
+            ["com.app.test2", "com.app.test1"],
+            "hdmi",
+            True,
+            0,
+        )
+    else:
+        patch_update = patchers.patch_firetv_update(
+            "playing", "com.app.test2", ["com.app.test2", "com.app.test1"]
+        )
+
+    with patch_update:
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_PLAYING
         assert state.attributes["source"] == "com.app.test2"
         assert state.attributes["source_list"] == ["com.app.test2", "TEST 1"]
-        assert state.attributes["is_volume_muted"]
-        assert state.attributes["volume_level"] == 0
+
+    return True
 
 
-async def _test_androidtv_select_source(hass, source, expected_arg, method_patch):
-    """Test that the `AndroidTV.launch_app` and `AndroidTV.stop_app` methods are called with the right parameter."""
-    config = CONFIG_ANDROIDTV_ADB_SERVER.copy()
+async def test_androidtv_sources(hass):
+    """Test that sources (i.e., apps) are handled correctly for Android TV devices."""
+    assert await _test_sources(hass, CONFIG_ANDROIDTV_ADB_SERVER)
+
+
+async def test_firetv_sources(hass):
+    """Test that sources (i.e., apps) are handled correctly for Fire TV devices."""
+    assert await _test_sources(hass, CONFIG_FIRETV_ADB_SERVER)
+
+
+async def _test_select_source(hass, config0, source, expected_arg, method_patch):
+    """Test that the methods for launching and stopping apps are called correctly when selecting a source."""
+    config = config0.copy()
     config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
     patch_key, entity_id = _setup(hass, config)
 
@@ -356,146 +388,131 @@ async def _test_androidtv_select_source(hass, source, expected_arg, method_patch
 
 async def test_androidtv_select_source_launch_app_id(hass):
     """Test that an app can be launched using its app ID."""
-    assert await _test_androidtv_select_source(
-        hass, "com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_androidtv_select_source_launch_app_name(hass):
     """Test that an app can be launched using its friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "TEST 1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_androidtv_select_source_launch_app_id_no_name(hass):
     """Test that an app can be launched using its app ID when it has no friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "com.app.test2", "com.app.test2", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_androidtv_select_source_stop_app_id(hass):
     """Test that an app can be stopped using its app ID."""
-    assert await _test_androidtv_select_source(
-        hass, "!com.app.test1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "!com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_andoirdtv_select_source_stop_app_name(hass):
     """Test that an app can be stopped using its friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "!TEST 1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "!TEST 1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_androidtv_select_source_stop_app_id_no_name(hass):
     """Test that an app can be stopped using its app ID when it has no friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "!com.app.test2", "com.app.test2", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "!com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_STOP_APP,
     )
-
-
-async def test_firetv_sources(hass):
-    """Test that sources (i.e., apps) are handled correctly for Fire TV devices."""
-    config = CONFIG_FIRETV_ADB_SERVER.copy()
-    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
-    patch_key, entity_id = _setup(hass, config)
-
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell("")[patch_key]:
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_OFF
-
-    with patchers.patch_firetv_update(
-        "playing", "com.app.test1", ["com.app.test1", "com.app.test2"]
-    ):
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_PLAYING
-        assert state.attributes["source"] == "TEST 1"
-        assert state.attributes["source_list"] == ["TEST 1", "com.app.test2"]
-
-    with patchers.patch_firetv_update(
-        "playing", "com.app.test2", ["com.app.test2", "com.app.test1"]
-    ):
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_PLAYING
-        assert state.attributes["source"] == "com.app.test2"
-        assert state.attributes["source_list"] == ["com.app.test2", "TEST 1"]
-
-
-async def _test_firetv_select_source(hass, source, expected_arg, method_patch):
-    """Test that the `FireTV.launch_app` and `FireTV.stop_app` methods are called with the right parameter."""
-    config = CONFIG_FIRETV_ADB_SERVER.copy()
-    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
-    patch_key, entity_id = _setup(hass, config)
-
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell("")[patch_key]:
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_OFF
-
-    with method_patch as method_patch_:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: source},
-            blocking=True,
-        )
-        method_patch_.assert_called_with(expected_arg)
-
-    return True
 
 
 async def test_firetv_select_source_launch_app_id(hass):
     """Test that an app can be launched using its app ID."""
-    assert await _test_firetv_select_source(
-        hass, "com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_firetv_select_source_launch_app_name(hass):
     """Test that an app can be launched using its friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "TEST 1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_firetv_select_source_launch_app_id_no_name(hass):
     """Test that an app can be launched using its app ID when it has no friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "com.app.test2", "com.app.test2", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_firetv_select_source_stop_app_id(hass):
     """Test that an app can be stopped using its app ID."""
-    assert await _test_firetv_select_source(
-        hass, "!com.app.test1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "!com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_firetv_select_source_stop_app_name(hass):
     """Test that an app can be stopped using its friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "!TEST 1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "!TEST 1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_firetv_select_source_stop_app_id_no_name(hass):
     """Test that an app can be stopped using its app ID when it has no friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "!com.app.test2", "com.app.test2", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "!com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_STOP_APP,
     )

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -96,7 +96,7 @@ async def _test_reconnect(hass, caplog, config):
     """
     patch_key, entity_id = _setup(hass, config)
 
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell("")[
         patch_key
@@ -167,7 +167,7 @@ async def _test_adb_shell_returns_none(hass, config):
     """
     patch_key, entity_id = _setup(hass, config)
 
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell("")[
         patch_key
@@ -275,7 +275,7 @@ async def test_setup_with_adbkey(hass):
     config[DOMAIN][CONF_ADBKEY] = hass.config.path("user_provided_adbkey")
     patch_key, entity_id = _setup(hass, config)
 
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell("")[
         patch_key
@@ -293,7 +293,7 @@ async def _test_sources(hass, config0):
     config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
     patch_key, entity_id = _setup(hass, config)
 
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
@@ -365,7 +365,7 @@ async def _test_select_source(hass, config0, source, expected_arg, method_patch)
     config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
     patch_key, entity_id = _setup(hass, config)
 
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
@@ -516,3 +516,30 @@ async def test_firetv_select_source_stop_app_id_no_name(hass):
         "com.app.test2",
         patchers.PATCH_STOP_APP,
     )
+
+
+async def _test_setup_fail(hass, config):
+    """Test that the entity is not created when the ADB connection is not established."""
+    patch_key, entity_id = _setup(hass, config)
+
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(False)[
+        patch_key
+    ], patchers.patch_shell("")[
+        patch_key
+    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.helpers.entity_component.async_update_entity(entity_id)
+        state = hass.states.get(entity_id)
+        assert state is None
+
+    return True
+
+
+async def test_setup_fail_androidtv(hass):
+    """Test that the Android TV entity is not created when the ADB connection is not established."""
+    assert await _test_setup_fail(hass, CONFIG_ANDROIDTV_PYTHON_ADB)
+
+
+async def test_setup_fail_firetv(hass):
+    """Test that the Fire TV entity is not created when the ADB connection is not established."""
+    assert await _test_setup_fail(hass, CONFIG_FIRETV_PYTHON_ADB)

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -430,7 +430,7 @@ async def test_androidtv_select_source_stop_app_id(hass):
     )
 
 
-async def test_andoirdtv_select_source_stop_app_name(hass):
+async def test_androidtv_select_source_stop_app_name(hass):
     """Test that an app can be stopped using its friendly name."""
     assert await _test_select_source(
         hass,


### PR DESCRIPTION
## Description:

I just want to see if all the tests pass.  https://github.com/home-assistant/home-assistant/pull/29579 needs to get merged in before this.  I'll create a new pull request once it's merged in.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
