### PR TITLE
Make hassfest import detection better

### DIFF
--- a/homeassistant/components/filter/manifest.json
+++ b/homeassistant/components/filter/manifest.json
@@ -3,8 +3,6 @@
   "name": "Filter",
   "documentation": "https://www.home-assistant.io/integrations/filter",
   "requirements": [],
-  "dependencies": [],
-  "codeowners": [
-    "@dgomes"
-  ]
+  "dependencies": ["history"],
+  "codeowners": ["@dgomes"]
 }

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -8,7 +8,7 @@ import time
 from sqlalchemy import and_, func
 import voluptuous as vol
 
-from homeassistant.components import recorder, script
+from homeassistant.components import recorder
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.recorder.models import States
 from homeassistant.components.recorder.util import execute, session_scope
@@ -430,4 +430,4 @@ def _is_significant(state):
     Will only test for things that are not filtered out in SQL.
     """
     # scripts that are not cancellable will never change state
-    return state.domain != "script" or state.attributes.get(script.ATTR_CAN_CANCEL)
+    return state.domain != "script" or state.attributes.get("can_cancel")

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -28,6 +28,7 @@ class TestFilterSensor(unittest.TestCase):
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+        self.hass.config.components.add("history")
         raw_values = [20, 19, 18, 21, 22, 0]
         self.values = []
 

--- a/tests/hassfest/__init__.py
+++ b/tests/hassfest/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for hassfest."""

--- a/tests/hassfest/test_dependencies.py
+++ b/tests/hassfest/test_dependencies.py
@@ -1,0 +1,120 @@
+"""Tests for hassfest dependency finder."""
+import ast
+
+import pytest
+from script.hassfest.dependencies import ImportCollector
+
+
+@pytest.fixture
+def mock_collector():
+    """Fixture with import collector that adds all referenced nodes."""
+    collector = ImportCollector(None)
+    collector.maybe_add_reference = collector.referenced.add
+    return collector
+
+
+def test_child_import(mock_collector):
+    """Test detecting a child_import reference."""
+    mock_collector.visit(
+        ast.parse(
+            """
+from homeassistant.components import child_import
+"""
+        )
+    )
+    assert mock_collector.referenced == {"child_import"}
+
+
+def test_subimport(mock_collector):
+    """Test detecting a subimport reference."""
+    mock_collector.visit(
+        ast.parse(
+            """
+from homeassistant.components.subimport.smart_home import EVENT_ALEXA_SMART_HOME
+"""
+        )
+    )
+    assert mock_collector.referenced == {"subimport"}
+
+
+def test_child_import_field(mock_collector):
+    """Test detecting a child_import_field reference."""
+    mock_collector.visit(
+        ast.parse(
+            """
+from homeassistant.components.child_import_field import bla
+"""
+        )
+    )
+    assert mock_collector.referenced == {"child_import_field"}
+
+
+def test_renamed_absolute(mock_collector):
+    """Test detecting a renamed_absolute reference."""
+    mock_collector.visit(
+        ast.parse(
+            """
+import homeassistant.components.renamed_absolute as hue
+"""
+        )
+    )
+    assert mock_collector.referenced == {"renamed_absolute"}
+
+
+def test_hass_components_var(mock_collector):
+    """Test detecting a hass_components_var reference."""
+    mock_collector.visit(
+        ast.parse(
+            """
+def bla(hass):
+    hass.components.hass_components_var.async_do_something()
+"""
+        )
+    )
+    assert mock_collector.referenced == {"hass_components_var"}
+
+
+def test_hass_components_class(mock_collector):
+    """Test detecting a hass_components_class reference."""
+    mock_collector.visit(
+        ast.parse(
+            """
+class Hello:
+    def something(self):
+        self.hass.components.hass_components_class.async_yo()
+"""
+        )
+    )
+    assert mock_collector.referenced == {"hass_components_class"}
+
+
+def test_all_imports(mock_collector):
+    """Test all imports together."""
+    mock_collector.visit(
+        ast.parse(
+            """
+from homeassistant.components import child_import
+
+from homeassistant.components.subimport.smart_home import EVENT_ALEXA_SMART_HOME
+
+from homeassistant.components.child_import_field import bla
+
+import homeassistant.components.renamed_absolute as hue
+
+def bla(hass):
+    hass.components.hass_components_var.async_do_something()
+
+class Hello:
+    def something(self):
+        self.hass.components.hass_components_class.async_yo()
+"""
+        )
+    )
+    assert mock_collector.referenced == {
+        "child_import",
+        "subimport",
+        "child_import_field",
+        "renamed_absolute",
+        "hass_components_var",
+        "hass_components_class",
+    }


### PR DESCRIPTION
## Description:
Update the Hassfest dependency finder to parse the Python files into an AST and find all referenced integrations.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/29913

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
