### PR TITLE
Allow Calendar event offset to be stored in config

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -79,7 +79,33 @@ def normalize_event(event):
 
 
 def calculate_offset(event, offset):
-    """Calculate event offset.
+    """Choose the appropriate offset function based on contents of the offset variable."""
+    if re.match("[+-]\\d\\d?:\\d\\d?:\\d\\d?", offset):
+        # offset contains the actual offset
+        return _calculate_offset_absolute(event, offset)
+
+    # offset is a marker string for finding the actual offset in
+    # the event title
+    return _calculate_offset_title(event, offset)
+
+
+def _calculate_offset_absolute(event, offset):
+    """Calculate offset based on the time delta in the supplied offset string."""
+    negative = offset[0] == "-"
+    offset = offset[1:]
+    hours, minutes, seconds = (int(x) for x in offset.split(":"))
+    delta = dt.dt.timedelta(hours=hours, minutes=minutes, seconds=seconds)
+    if negative:
+        delta *= -1
+    event["offset_time"] = delta
+    return event
+
+
+def _calculate_offset_title(event, offset):
+    """Calculate event offset from event title.
+
+    The offset parameter contains a marker string (defaults to !!)
+    which is used to find the actual offset in the event title.
 
     Return the updated event with the offset_time included.
     """


### PR DESCRIPTION
## Description:
Currently the calendar integration allows the title of an event to be scanned for an offset eg if offset is "!!" then adding
"!!-10" to the event title will result in the sensor showing true 10 minutes before the start of the event.

Its not always possible to change the title of an event, especially when shared/business calendars are involved. This commit
allows the actual offset to be stored in the offset config option, while not breaking existing usage of that option.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11453

## Example entry for `configuration.yaml` (if applicable):
```yaml
- cal_id: "*****@group.calendar.google.com"
  entities:
  - device_id: test_everything
    name: Give me everything
    track: true
- cal_id: "*****@group.calendar.google.com"
  entities:
  - device_id: test_important
    name: Important Stuff
    track: true
    search: "#Important"
    offset: "!!"
  - device_id: test_unimportant
    name: UnImportant Stuff
    track: true
    search: "#UnImportant"
    offset: "-00:10:00"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
