### PR TITLE
Add exterior blind display category for Alexa

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -91,7 +91,10 @@ class DisplayCategory:
 
     # Indicates a doorbell.
     DOORBELL = "DOORBELL"
-
+    
+    # Indicates an exterior blind.
+    EXTERIOR_BLIND = "EXTERIOR_BLIND"
+    
     # Indicates a fan.
     FAN = "FAN"
 
@@ -320,6 +323,8 @@ class CoverCapabilities(AlexaEntity):
         device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
         if device_class in (cover.DEVICE_CLASS_GARAGE, cover.DEVICE_CLASS_DOOR):
             return [DisplayCategory.DOOR]
+        elif device_class in (cover.DEVICE_CLASS_BLIND)
+            return [DisplayCategory.EXTERIOR_BLIND]
         return [DisplayCategory.OTHER]
 
     def interfaces(self):


### PR DESCRIPTION
## Breaking Change:

Add "EXTERIOR_BLIND" display category for Hassio "DEVICE_CLASS_BLIND" which is supported by Alexa, see https://developer.amazon.com/de-DE/docs/alexa/device-apis/alexa-discovery.html#display-categories

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
