### PR TITLE
Add onewire devices and owserver remote host support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -235,6 +235,7 @@ homeassistant/components/obihai/* @dshokouhi
 homeassistant/components/ohmconnect/* @robbiet480
 homeassistant/components/ombi/* @larssont
 homeassistant/components/onboarding/* @home-assistant/core
+homeassistant/components/onewire/* @garbled1
 homeassistant/components/opentherm_gw/* @mvn23
 homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff

--- a/homeassistant/components/onewire/manifest.json
+++ b/homeassistant/components/onewire/manifest.json
@@ -2,7 +2,9 @@
   "domain": "onewire",
   "name": "Onewire",
   "documentation": "https://www.home-assistant.io/integrations/onewire",
-  "requirements": [],
+  "requirements": [
+    "pyownet==0.10.0.post1"
+  ],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/onewire/manifest.json
+++ b/homeassistant/components/onewire/manifest.json
@@ -6,5 +6,7 @@
     "pyownet==0.10.0.post1"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@garbled1"
+  ]
 }

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -236,7 +236,7 @@ class OneWireProxy(OneWire):
     def _read_value_ownet(self):
         """Read a value from the owserver."""
         if self._owproxy:
-            return bytes.decode(self._owproxy.read(self._device_file)).lstrip()
+            return self._owproxy.read(self._device_file).decode().lstrip()
         return None
 
     def update(self):

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -113,7 +113,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             devices = []
         for device in devices:
             _LOGGER.debug("found device: %s", device)
-            family = bytes.decode(owproxy.read(f"{device}family"))
+            family = owproxy.read(f"{device}family").decode()
             dev_type = "std"
             if "EF" in family:
                 dev_type = "HobbyBoard"
@@ -130,7 +130,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 if "moisture" in sensor_key:
                     s_id = sensor_key.split("_")[1]
                     is_leaf = int(
-                        bytes.decode(owproxy.read(f"{device}moisture/is_leaf.{s_id}"))
+                        owproxy.read(f"{device}moisture/is_leaf.{s_id}").decode()
                     )
                     if is_leaf:
                         sensor_key = f"wetness_{id}"

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -217,7 +217,7 @@ class OneWire(Entity):
         """Read a value from the owserver."""
         if self._owproxy:
             return bytes.decode(self._owproxy.read(self._device_file)).lstrip()
-        return False
+        return None
 
     @property
     def name(self):

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -133,14 +133,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             owproxy = protocol.proxy(host=owhost, port=owport)
             devices = owproxy.dir()
         except protocol.Error as exc:
-            _LOGGER.error(
-                "Cannot connect to owserver on {0}:{1}, got:{2}".format(
-                    owhost, owport, exc
-                )
-            )
-
+            _LOGGER.error(f"Cannot connect to owserver on {owhost}:{owport}, got:{exc}")
         for device in devices:
-            _LOGGER.debug("found device={0}".format(device))
+            _LOGGER.debug(f"found device={device}")
             family = bytes.decode(owproxy.read(device + "family"))
             type = "std"
             if "EF" in family:
@@ -170,9 +165,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     )
             else:
                 _LOGGER.warning(
-                    "Ignoring unknown family ({0}) of sensor found for device: {1}".format(
-                        family, device
-                    )
+                    f"Ignoring unknown family ({family}) of sensor found for device: {device}"
                 )
 
     # We have a raw GPIO ow sensor on a Pi
@@ -276,7 +269,7 @@ class OneWireProxy(OneWire):
             if len(value_read) > 0:
                 value = round(float(value_read), 1)
         except protocol.Error as exc:
-            _LOGGER.error("Owserver failure in read(), got:{0}".format(exc))
+            _LOGGER.error(f"Owserver failure in read(), got:{exc}")
 
         self._state = value
 
@@ -309,8 +302,8 @@ class OneWireOWFS(OneWire):
             if len(value_read) == 1:
                 value = round(float(value_read[0]), 1)
         except ValueError:
-            _LOGGER.warning("Invalid value read from %s", self._device_file)
+            _LOGGER.warning(f"Invalid value read from {self._device_file}")
         except FileNotFoundError:
-            _LOGGER.warning("Cannot read from sensor: %s", self._device_file)
+            _LOGGER.warning(f"Cannot read from sensor: {self._device_file}")
 
         self._state = value

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -1,15 +1,25 @@
 """Support for 1-Wire environment sensors."""
-from glob import glob
-import logging
 import os
 import time
+import logging
+from glob import glob
+
+from pyownet import protocol
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import TEMP_CELSIUS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.const import (
+    TEMP_CELSIUS,
+    CONF_HOST,
+    CONF_PORT,
+    STATE_PROBLEM,
+    STATE_OK,
+    STATE_ON,
+    STATE_OFF,
+)
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,33 +40,134 @@ DEVICE_SENSORS = {
     "28": {"temperature": "temperature"},
     "3B": {"temperature": "temperature"},
     "42": {"temperature": "temperature"},
+    "1D": {
+        "counter_a": "counter.A",
+        "counter_b": "counter.B",
+    },
+    "EF": {"HobbyBoard": "special"},
+}
+
+# EF sensors are usually hobbyboards specialized sensors.
+# These can only be read by OWFS.  Currently this driver only supports them
+# via owserver (network protocol)
+
+HOBBYBOARD_EF = {
+    "HobbyBoards_EF": {
+        "humidity": "humidity/humidity_corrected",
+        "humidity_raw": "humidity/humidity_raw",
+        "temperature": "humidity/temperature",
+    },
+    "HB_MOISTURE_METER": {
+        "moisture_0": "moisture/sensor.0",
+        "moisture_1": "moisture/sensor.1",
+        "moisture_2": "moisture/sensor.2",
+        "moisture_3": "moisture/sensor.3",
+    },
+    "HB_HUB": {
+        "branch_0": "hub/branch.0",
+        "branch_1": "hub/branch.1",
+        "branch_2": "hub/branch.2",
+        "branch_3": "hub/branch.3",
+        "short_0": "hub/short.0",
+        "short_1": "hub/short.1",
+        "short_2": "hub/short.2",
+        "short_3": "hub/short.3",
+    },
 }
 
 SENSOR_TYPES = {
     "temperature": ["temperature", TEMP_CELSIUS],
     "humidity": ["humidity", "%"],
+    "humidity_raw": ["humidity", "%"],
     "pressure": ["pressure", "mb"],
     "illuminance": ["illuminance", "lux"],
+    "wetness_0": ["wetness", "%"],
+    "wetness_1": ["wetness", "%"],
+    "wetness_2": ["wetness", "%"],
+    "wetness_3": ["wetness", "%"],
+    "moisture_0": ["moisture", "cb"],
+    "moisture_1": ["moisture", "cb"],
+    "moisture_2": ["moisture", "cb"],
+    "moisture_3": ["moisture", "cb"],
+    "counter_a": ["counter", "count"],
+    "counter_b": ["counter", "count"],
+    "HobbyBoard": ["none", "none"],
+    "branch_0": ["presense", "present"],
+    "branch_1": ["presense", "present"],
+    "branch_2": ["presense", "present"],
+    "branch_3": ["presense", "present"],
+    "short_0": ["problem", "short"],
+    "short_1": ["problem", "short"],
+    "short_2": ["problem", "short"],
+    "short_3": ["problem", "short"],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAMES): {cv.string: cv.string},
         vol.Optional(CONF_MOUNT_DIR, default=DEFAULT_MOUNT_DIR): cv.string,
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=4304): cv.port,
     }
 )
 
+def info_from_type(type="std"):
+    if 'std' in type:
+        return DEVICE_SENSORS
+    if 'HobbyBoard' in type:
+        return HOBBYBOARD_EF
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the one wire Sensors."""
     base_dir = config.get(CONF_MOUNT_DIR)
+    owport = config.get(CONF_PORT)
+    owhost = config.get(CONF_HOST)
     devs = []
     device_names = {}
     if "names" in config:
         if isinstance(config["names"], dict):
             device_names = config["names"]
 
-    if base_dir == DEFAULT_MOUNT_DIR:
+    # We have an owserver on a remote(or local) host/port
+    if owhost:
+        try:
+            owproxy = protocol.proxy(host=owhost, port=owport)
+            devices = owproxy.dir()
+        except protocol.Error as exc:
+            _LOGGER.error('Cannot connect to owserver on {0}:{1}, got:{2}'.format(owhost, owport, exc))
+
+        for device in devices:
+            _LOGGER.debug('found device={0}'.format(device))
+            family = bytes.decode(owproxy.read(device + 'family'))
+            type = 'std'
+            if 'EF' in family:
+                type = 'HobbyBoard'
+                family = bytes.decode(owproxy.read(device + 'type'))
+
+            if family in info_from_type(type):
+                for sensor_key, sensor_value in info_from_type(type)[family].items():
+                    if 'moisture' in sensor_key:
+                        id = sensor_key.split('_')[1]
+                        is_leaf = int(bytes.decode(owproxy.read(device + 'moisture/is_leaf.' + id)))
+                        if is_leaf:
+                            sensor_key = 'wetness_' + id
+                    sensor_id = os.path.split(os.path.split(device)[0])[1]
+                    device_file = os.path.join(
+                        os.path.split(device)[0], sensor_value
+                    )
+                    devs.append(
+                        OneWireProxy(
+                            device_names.get(sensor_id, sensor_id),
+                            device_file,
+                            sensor_key,
+                            owproxy=owproxy,
+                        )
+                    )
+            else:
+                _LOGGER.warning('Ignoring unknown family ({0}) of sensor found for device: {1}'.format(family, device))
+
+    # We have a raw GPIO ow sensor on a Pi
+    elif base_dir == DEFAULT_MOUNT_DIR:
         for device_family in DEVICE_SENSORS:
             for device_folder in glob(os.path.join(base_dir, device_family + "[.-]*")):
                 sensor_id = os.path.split(device_folder)[1]
@@ -68,10 +179,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                         "temperature",
                     )
                 )
+
+    # We have an owfs mounted
     else:
         for family_file_path in glob(os.path.join(base_dir, "*", "family")):
             with open(family_file_path, "r") as family_file:
                 family = family_file.read()
+            if 'EF' in family:
+                next
             if family in DEVICE_SENSORS:
                 for sensor_key, sensor_value in DEVICE_SENSORS[family].items():
                     sensor_id = os.path.split(os.path.split(family_file_path)[0])[1]
@@ -100,18 +215,24 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class OneWire(Entity):
     """Implementation of an One wire Sensor."""
 
-    def __init__(self, name, device_file, sensor_type):
+    def __init__(self, name, device_file, sensor_type, owproxy=None):
         """Initialize the sensor."""
         self._name = name + " " + sensor_type.capitalize()
         self._device_file = device_file
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
         self._state = None
+        self._owproxy = owproxy
 
     def _read_value_raw(self):
         """Read the value as it is returned by the sensor."""
         with open(self._device_file, "r") as ds_device_file:
             lines = ds_device_file.readlines()
         return lines
+
+    def _read_value_ownet(self):
+        """Read a value from the owserver."""
+        if self._owproxy:
+            return bytes.decode(self._owproxy.read(self._device_file)).lstrip()
 
     @property
     def name(self):
@@ -121,12 +242,33 @@ class OneWire(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
+        if 'count' in self._unit_of_measurement:
+            return int(self._state)
+        if 'short' in self._unit_of_measurement:
+            return STATE_PROBLEM if int(self._state) else STATE_OK
+        if 'present' in self._unit_of_measurement:
+            return STATE_ON if int(self._state) else STATE_OFF
         return self._state
 
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
+
+
+class OneWireProxy(OneWire):
+    """Implementation of a One wire Sensor through owserver."""
+    def update(self):
+        """Get the latest data from the device."""
+        value = None
+        try:
+            value_read = self._read_value_ownet()
+            if len(value_read) > 0:
+                value = round(float(value_read), 1)
+        except protocol.Error as exc:
+            _LOGGER.error('Owserver failure in read(), got:{0}'.format(exc))
+
+        self._state = value
 
 
 class OneWireDirect(OneWire):

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -102,6 +102,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             device_names = config["names"]
 
     # We have an owserver on a remote(or local) host/port
+    # pylint: disable=too-many-nested-blocks
     if owhost:
         try:
             owproxy = protocol.proxy(host=owhost, port=owport)
@@ -124,9 +125,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     family
                 ].items():
                     if "moisture" in sensor_key:
-                        id = sensor_key.split("_")[1]
+                        s_id = sensor_key.split("_")[1]
                         is_leaf = int(
-                            bytes.decode(owproxy.read(f"{device}moisture/is_leaf.{id}"))
+                            bytes.decode(
+                                owproxy.read(f"{device}moisture/is_leaf.{s_id}")
+                            )
                         )
                         if is_leaf:
                             sensor_key = f"wetness_{id}"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1428,6 +1428,9 @@ pyowlet==1.0.3
 # homeassistant.components.openweathermap
 pyowm==2.10.0
 
+# homeassistant.components.onewire
+pyownet==0.10.0.post1
+
 # homeassistant.components.elv
 pypca==0.0.7
 


### PR DESCRIPTION
## Description:
Currently there is no support for some of the advanced (and highly custom) HobbyBoards onewire sensors. Some of us still use those.  Additionally, this change adds support for a remote owserver instance.  This allows you to run your onewire on a pi in a remote location, and then connect to the owserver on port 4304 rather than require local access to the device.

Add support for HobbyBoards sensors: Hub, Humidity, Moisture, PulseCounter
Add support for an owserver running on a remote host

**Related issue (if applicable):**  NA

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11460

## Example entry for `configuration.yaml` (if applicable):
```yaml

sensor:
  - platform: onewire
    host: my.pi.net
    port: 4304
    names:
      1D.03A70D000000: 'Sprinkler Water Usage'
      EF.F49020150000: 'Lawn'
      EF.BCA620150000: 'Cave Hub'
      EF.F06120150000: 'Sprinkler Box'

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
