### PR TITLE
Add Apprise file attachment support

### DIFF
--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -5,6 +5,7 @@ import apprise
 import voluptuous as vol
 
 from homeassistant.components.notify import (
+    ATTR_DATA,
     ATTR_TARGET,
     ATTR_TITLE,
     ATTR_TITLE_DEFAULT,
@@ -17,6 +18,9 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_FILE = "config"
 CONF_URL = "url"
+
+# Optional Attachments
+ATTR_ATTACHMENTS = "attachments"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -66,6 +70,20 @@ class AppriseNotificationService(BaseNotificationService):
         However, if any tags are specified, then they will be applied
         to the notification causing filtering (if set up that way).
         """
+
         targets = kwargs.get(ATTR_TARGET)
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-        self.apprise.notify(body=message, title=title, tag=targets)
+
+        data = kwargs.get(ATTR_DATA)
+        attachments = data.get(ATTR_ATTACHMENTS) if data else None
+
+        # Default Attachment
+        attach = None
+        if attachments:
+            # Support file attachments (such as security camera images,
+            # documents, icons, etc). The attachments can be a list and/or
+            # a string.  The AppriseAttachment() object accepts both
+            attach = apprise.AppriseAttachment()
+            attach.add(attachments)
+
+        self.apprise.notify(body=message, title=title, tag=targets, attach=attach)

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -86,4 +86,10 @@ class AppriseNotificationService(BaseNotificationService):
             attach = apprise.AppriseAttachment()
             attach.add(attachments)
 
+            # Iterate over detected attachments to verify that they have been
+            # whitelisted.
+            attach.attachments = [
+                a for a in attach if a and self.hass.config.is_allowed_path(a.path)
+            ]
+
         self.apprise.notify(body=message, title=title, tag=targets, attach=attach)

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -1,6 +1,6 @@
 """The tests for the apprise notification platform."""
+import apprise
 from unittest.mock import MagicMock, patch
-
 from homeassistant.setup import async_setup_component
 
 BASE_COMPONENT = "notify"
@@ -41,12 +41,18 @@ async def test_apprise_config_load_okay(hass, tmp_path):
     """Test apprise configuration failures."""
 
     # Test cases where our URL is invalid
-    d = tmp_path / "apprise-config"
-    d.mkdir()
-    f = d / "apprise"
-    f.write_text("mailto://user:pass@example.com/")
+    a_dir = tmp_path / "apprise-config"
+    a_dir.mkdir()
+    configuration = a_dir / "apprise"
+    configuration.write_text("mailto://user:pass@example.com/")
 
-    config = {BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": str(f)}}
+    config = {
+        BASE_COMPONENT: {
+            "name": "test",
+            "platform": "apprise",
+            "config": str(configuration),
+        }
+    }
 
     assert await async_setup_component(hass, BASE_COMPONENT, config)
     await hass.async_block_till_done()
@@ -105,7 +111,66 @@ async def test_apprise_notification(hass):
         # Validate calls were made under the hood correctly
         obj.add.assert_called_once_with([config[BASE_COMPONENT]["url"]])
         obj.notify.assert_called_once_with(
-            **{"body": data["message"], "title": data["title"], "tag": None}
+            **{
+                "body": data["message"],
+                "title": data["title"],
+                "tag": None,
+                "attach": None,
+            }
+        )
+
+
+async def test_apprise_notification_with_attachment(hass, tmp_path):
+    """Test apprise notification containing attachments."""
+
+    config = {
+        BASE_COMPONENT: {
+            "name": "test",
+            "platform": "apprise",
+            "url": "mailto://user:pass@example.com",
+        }
+    }
+
+    # Create a temporary attachment to work with
+    a_dir = tmp_path / "apprise-attach"
+    a_dir.mkdir()
+    attachment = a_dir / "security-camera.jpeg"
+    attachment.write_text("jpeg test content")
+
+    # Our Message
+    data = {
+        "title": "Test Title",
+        "message": "Test Message",
+        "data": {"attachments": [str(attachment)]},
+    }
+
+    with patch("apprise.Apprise") as mock_apprise:
+        obj = MagicMock()
+        obj.add.return_value = True
+        obj.notify.return_value = True
+        mock_apprise.return_value = obj
+        assert await async_setup_component(hass, BASE_COMPONENT, config)
+        await hass.async_block_till_done()
+
+        # Test the existance of our service
+        assert hass.services.has_service(BASE_COMPONENT, "test")
+
+        # Test the call to our underlining notify() call
+        await hass.services.async_call(BASE_COMPONENT, "test", data)
+        await hass.async_block_till_done()
+
+        # Validate calls were made under the hood correctly
+        obj.add.assert_called_once_with([config[BASE_COMPONENT]["url"]])
+
+        assert "body" in obj.notify.call_args_list[0][1]
+        assert obj.notify.call_args_list[0][1]["body"] == data["message"]
+        assert "title" in obj.notify.call_args_list[0][1]
+        assert obj.notify.call_args_list[0][1]["title"] == data["title"]
+        assert "tag" in obj.notify.call_args_list[0][1]
+        assert obj.notify.call_args_list[0][1]["tag"] is None
+        assert "attach" in obj.notify.call_args_list[0][1]
+        assert isinstance(
+            obj.notify.call_args_list[0][1]["attach"], apprise.AppriseAttachment
         )
 
 
@@ -113,15 +178,21 @@ async def test_apprise_notification_with_target(hass, tmp_path):
     """Test apprise notification with a target."""
 
     # Test cases where our URL is invalid
-    d = tmp_path / "apprise-config"
-    d.mkdir()
-    f = d / "apprise"
+    a_dir = tmp_path / "apprise-config"
+    a_dir.mkdir()
+    configuration = a_dir / "apprise"
 
     # Write 2 config entries each assigned to different tags
-    f.write_text("devops=mailto://user:pass@example.com/\r\n")
-    f.write_text("system,alert=syslog://\r\n")
+    configuration.write_text("devops=mailto://user:pass@example.com/\r\n")
+    configuration.write_text("system,alert=syslog://\r\n")
 
-    config = {BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": str(f)}}
+    config = {
+        BASE_COMPONENT: {
+            "name": "test",
+            "platform": "apprise",
+            "config": str(configuration),
+        }
+    }
 
     # Our Message, only notify the services tagged with "devops"
     data = {"title": "Test Title", "message": "Test Message", "target": ["devops"]}
@@ -143,5 +214,10 @@ async def test_apprise_notification_with_target(hass, tmp_path):
 
         # Validate calls were made under the hood correctly
         apprise_obj.notify.assert_called_once_with(
-            **{"body": data["message"], "title": data["title"], "tag": data["target"]}
+            **{
+                "body": data["message"],
+                "title": data["title"],
+                "tag": data["target"],
+                "attach": None,
+            }
         )

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -1,6 +1,8 @@
 """The tests for the apprise notification platform."""
-import apprise
 from unittest.mock import MagicMock, patch
+
+import apprise
+
 from homeassistant.setup import async_setup_component
 
 BASE_COMPONENT = "notify"


### PR DESCRIPTION
## Breaking Change:

No breaking change

## Description:
Up until now Apprise offered an additional 50+ Notifications supported for Home Assistant.  With this small addition, users can now also specify file attachments (to be sent with the notifications).  At this time only [Discord](https://github.com/caronc/apprise/wiki/Notify_discord), [Slack](https://github.com/caronc/apprise/wiki/Notify_slack), [Email](https://github.com/caronc/apprise/wiki/Notify_email), [PushBullet](https://github.com/caronc/apprise/wiki/Notify_pushbullet), and [Telegram](https://github.com/caronc/apprise/wiki/Notify_telegram) support file attachments.  But more and more attachment support is being added all the time to Apprise.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11461
## Example entry for `configuration.yaml` (if applicable):
```yaml
- service: notify.apprise
  data:
    message: "A message from Home Assistant"
    data:
       attachments:
            - `/path/to/file/you/want/to/attach`
            - `/there/is/no/limit/to/the/number/of/attachments`
            - `http://[url to file, photo, security camera etc]`
```
This rich experience can allow you to fetch a live camera image (for example) by it's URL.  You can retrieve just about anything and stick it with the message/notification you pass along.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
