### PR TITLE
Fix example value for Todoist service

### DIFF
--- a/homeassistant/components/todoist/services.yaml
+++ b/homeassistant/components/todoist/services.yaml
@@ -21,5 +21,5 @@ new_task:
       example: en
     due_date:
       description: The day this task is due, in format YYYY-MM-DD.
-      example: 2019-10-22
+      example: "2019-10-22"
 


### PR DESCRIPTION


## Description:

This PR fixes the example value for the todoist `new_task` service.  Something in homeassistant changed between `0.102.3` and `0.103.0` that now parses the `due_date` as a `datetime.date` instead of a `str`.  Quotes are now uses to ensure it gets parsed as a `str`.

This caused the `homeassistant.components.websocket_api` component to not be able to serialize the service ( [example error](https://pastebin.com/KP120rbU)).  This unfortunately completely breaks the UI and the only way to get around it is to remove the component from `configuration.yaml`

**Related issue (if applicable):** fixes #29876




## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

