### PR TITLE
Fix homekit handling of 0 light brightness and fan speed

### DIFF
--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -197,7 +197,10 @@ async def test_fan_speed(hass, hk_driver, cls, events):
     )
     await hass.async_block_till_done()
     acc = cls.fan(hass, hk_driver, "Fan", entity_id, 2, None)
-    assert acc.char_speed.value == 0
+
+    # Initial value can be anything but 0. If it is 0, it might cause HomeKit to set the
+    # speed to 100 when turning on a fan on a freshly booted up server.
+    assert acc.char_speed.value != 0
 
     await hass.async_add_job(acc.run)
     assert (

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -101,7 +101,9 @@ async def test_light_brightness(hass, hk_driver, cls, events):
     await hass.async_block_till_done()
     acc = cls.light(hass, hk_driver, "Light", entity_id, 2, None)
 
-    assert acc.char_brightness.value == 0
+    # Initial value can be anything but 0. If it is 0, it might cause HomeKit to set the
+    # brightness to 100 when turning on a light on a freshly booted up server.
+    assert acc.char_brightness.value != 0
 
     await hass.async_add_job(acc.run)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Replaces the fix in #27076.

Background:

When you turn on a HomeKit accessory it will try and restore the last brightness/rotation speed. But if it is set to 0%, HomeKit will update the brightness to 100% as it thinks 0% is off. This leads to unexpected behaviors such as:

- HomeKit "forgets" the brightness setting when it is at the lowest setting.
- On reboot, toggling on the device might cause the brightness to go to 100%.
- The brightness in Home app does not match the actual device brightness.

I tried to do a screen recording to document this bug but it seems I need a proper camera to capture what is going on. It was more obvious on v100, but ever since I updated to v103 I cannot easily show it on the screen recording any more because the actual device brightness de-syncs from the Home app.

How is it fixed:

- The initial value when the accessory is initialized is changed from 0% to 100%. update_state will immediately update it to the proper value after initialization.
- If there is an update to the device brightness or rotation speed from home assistant and it is 0% but the device is reported to still be on, the brightness or rotation speed will be mapped to 1%. If the device is reported to be off, the update is ignored (off devices do not need to update Home app, Home app already knows to show 0%).

Please see code comments to see more details.

## Example entry for `configuration.yaml` (if applicable):
None

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
