### PR TITLE
Remove deprecated rflink configs

### DIFF
--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.deprecation import get_deprecated
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -33,12 +32,9 @@ ATTR_EVENT = "event"
 ATTR_STATE = "state"
 
 CONF_ALIASES = "aliases"
-CONF_ALIASSES = "aliasses"
 CONF_GROUP_ALIASES = "group_aliases"
-CONF_GROUP_ALIASSES = "group_aliasses"
 CONF_GROUP = "group"
 CONF_NOGROUP_ALIASES = "nogroup_aliases"
-CONF_NOGROUP_ALIASSES = "nogroup_aliasses"
 CONF_DEVICE_DEFAULTS = "device_defaults"
 CONF_DEVICE_ID = "device_id"
 CONF_DEVICES = "devices"
@@ -563,18 +559,3 @@ class SwitchableRflinkDevice(RflinkCommand, RestoreEntity):
     def async_turn_off(self, **kwargs):
         """Turn the device off."""
         return self._async_handle_command("turn_off")
-
-
-DEPRECATED_CONFIG_OPTIONS = [CONF_ALIASSES, CONF_GROUP_ALIASSES, CONF_NOGROUP_ALIASSES]
-REPLACEMENT_CONFIG_OPTIONS = [CONF_ALIASES, CONF_GROUP_ALIASES, CONF_NOGROUP_ALIASES]
-
-
-def remove_deprecated(config):
-    """Remove deprecated config options from device config."""
-    for index, deprecated_option in enumerate(DEPRECATED_CONFIG_OPTIONS):
-        if deprecated_option in config:
-            replacement_option = REPLACEMENT_CONFIG_OPTIONS[index]
-            # generate deprecation warning
-            get_deprecated(config, replacement_option, deprecated_option)
-            # remove old config value replacing new one
-            config[replacement_option] = config.pop(deprecated_option)

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -14,23 +14,19 @@ import homeassistant.helpers.config_validation as cv
 
 from . import (
     CONF_ALIASES,
-    CONF_ALIASSES,
     CONF_AUTOMATIC_ADD,
     CONF_DEVICE_DEFAULTS,
     CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_GROUP,
     CONF_GROUP_ALIASES,
-    CONF_GROUP_ALIASSES,
     CONF_NOGROUP_ALIASES,
-    CONF_NOGROUP_ALIASSES,
     CONF_SIGNAL_REPETITIONS,
     DATA_DEVICE_REGISTER,
     DEVICE_DEFAULTS_SCHEMA,
     EVENT_KEY_COMMAND,
     EVENT_KEY_ID,
     SwitchableRflinkDevice,
-    remove_deprecated,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,14 +61,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(CONF_FIRE_EVENT): cv.boolean,
                     vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
                     vol.Optional(CONF_GROUP, default=True): cv.boolean,
-                    # deprecated config options
-                    vol.Optional(CONF_ALIASSES): vol.All(cv.ensure_list, [cv.string]),
-                    vol.Optional(CONF_GROUP_ALIASSES): vol.All(
-                        cv.ensure_list, [cv.string]
-                    ),
-                    vol.Optional(CONF_NOGROUP_ALIASSES): vol.All(
-                        cv.ensure_list, [cv.string]
-                    ),
                 }
             )
         },
@@ -131,7 +119,6 @@ def devices_from_config(domain_config):
         entity_class = entity_class_for_type(entity_type)
 
         device_config = dict(domain_config[CONF_DEVICE_DEFAULTS], **config)
-        remove_deprecated(device_config)
 
         is_hybrid = entity_class is HybridRflinkLight
 

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
     CONF_ALIASES,
-    CONF_ALIASSES,
     CONF_AUTOMATIC_ADD,
     CONF_DEVICES,
     DATA_DEVICE_REGISTER,
@@ -27,7 +26,6 @@ from . import (
     SIGNAL_HANDLE_EVENT,
     TMP_ENTITY,
     RflinkDevice,
-    remove_deprecated,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,8 +50,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(CONF_ALIASES, default=[]): vol.All(
                         cv.ensure_list, [cv.string]
                     ),
-                    # deprecated config options
-                    vol.Optional(CONF_ALIASSES): vol.All(cv.ensure_list, [cv.string]),
                 }
             )
         },
@@ -80,7 +76,6 @@ def devices_from_config(domain_config):
             config[ATTR_UNIT_OF_MEASUREMENT] = lookup_unit_for_sensor_type(
                 config[CONF_SENSOR_TYPE]
             )
-        remove_deprecated(config)
         device = RflinkSensor(device_id, **config)
         devices.append(device)
 

--- a/homeassistant/components/rflink/switch.py
+++ b/homeassistant/components/rflink/switch.py
@@ -9,19 +9,15 @@ import homeassistant.helpers.config_validation as cv
 
 from . import (
     CONF_ALIASES,
-    CONF_ALIASSES,
     CONF_DEVICE_DEFAULTS,
     CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_GROUP,
     CONF_GROUP_ALIASES,
-    CONF_GROUP_ALIASSES,
     CONF_NOGROUP_ALIASES,
-    CONF_NOGROUP_ALIASSES,
     CONF_SIGNAL_REPETITIONS,
     DEVICE_DEFAULTS_SCHEMA,
     SwitchableRflinkDevice,
-    remove_deprecated,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,14 +43,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(CONF_FIRE_EVENT): cv.boolean,
                     vol.Optional(CONF_SIGNAL_REPETITIONS): vol.Coerce(int),
                     vol.Optional(CONF_GROUP, default=True): cv.boolean,
-                    # deprecated config options
-                    vol.Optional(CONF_ALIASSES): vol.All(cv.ensure_list, [cv.string]),
-                    vol.Optional(CONF_GROUP_ALIASSES): vol.All(
-                        cv.ensure_list, [cv.string]
-                    ),
-                    vol.Optional(CONF_NOGROUP_ALIASSES): vol.All(
-                        cv.ensure_list, [cv.string]
-                    ),
                 }
             )
         },
@@ -68,7 +56,6 @@ def devices_from_config(domain_config):
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
         device_config = dict(domain_config[CONF_DEVICE_DEFAULTS], **config)
-        remove_deprecated(device_config)
         device = RflinkSwitch(device_id, **device_config)
         devices.append(device)
 

--- a/tests/components/rflink/test_sensor.py
+++ b/tests/components/rflink/test_sensor.py
@@ -115,8 +115,8 @@ async def test_entity_availability(hass, monkeypatch):
     assert hass.states.get("sensor.test").state == STATE_UNKNOWN
 
 
-async def test_aliasses(hass, monkeypatch):
-    """Validate the response to sensor's alias (with aliasses)."""
+async def test_aliases(hass, monkeypatch):
+    """Validate the response to sensor's alias (with aliases)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
         DOMAIN: {
@@ -125,7 +125,7 @@ async def test_aliasses(hass, monkeypatch):
                 "test_02": {
                     "name": "test_02",
                     "sensor_type": "humidity",
-                    "aliasses": ["test_alias_02_0"],
+                    "aliases": ["test_alias_02_0"],
                 }
             },
         },


### PR DESCRIPTION

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

The misspelled RFLink configuration variable names `aliasses`, `group_aliasses`, and `nogroup_aliasses` have been removed. They have been deprecated and automatically converted to the correct spelling form since Juiy 2017.

## Description:

They've been deprecated and automatically replaced since July 2017
already, fe6a4b8ae5953c8d565dc93acc9d34c715a80aee

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11452

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
