### PR TITLE
Update binary_sensor.py

### DIFF
--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 SENSOR_TYPES = {
     "lids": ["Doors", "opening", "mdi:car-door-lock"],
     "windows": ["Windows", "opening", "mdi:car-door"],
-    "door_lock_state": ["Door lock state", "safety", "mdi:car-key"],
+    "door_lock_state": ["Door lock state", "lock", "mdi:car-key"],
     "lights_parking": ["Parking lights", "light", "mdi:car-parking-lights"],
     "condition_based_services": ["Condition based services", "problem", "mdi:wrench"],
     "check_control_messages": ["Control messages", "problem", "mdi:car-tire-alert"],


### PR DESCRIPTION
Change sensor type for central locking from 'safety' to 'lock'.

## Breaking Change:
Depending on how an automation might be setup the possible states of the sensor change. 

## Description:

Type of sensor is incorrect, this PR fixes this error. 

## Example entry for `configuration.yaml` (if applicable):
```yaml
bmw_connected_drive:
  name:
    username: !secret bmw_connected_drive_username
    password: !secret bmw_connected_drive_password
    region: "rest_of_world"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
