### PR TITLE
Don't use the "locals" parameter on exec.

### DIFF
--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -175,6 +175,7 @@ def execute(hass, filename, source, data=None):
     builtins["sorted"] = sorted
     builtins["time"] = TimeWrapper()
     builtins["dt_util"] = dt_util
+    logger = logging.getLogger(f"{__name__}.{filename}")
     restricted_globals = {
         "__builtins__": builtins,
         "_print_": StubPrinter,
@@ -184,14 +185,15 @@ def execute(hass, filename, source, data=None):
         "_getitem_": default_guarded_getitem,
         "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
         "_unpack_sequence_": guarded_unpack_sequence,
+        "hass": hass,
+        "data": data or {},
+        "logger": logger,
     }
-    logger = logging.getLogger(f"{__name__}.{filename}")
-    local = {"hass": hass, "data": data or {}, "logger": logger}
 
     try:
         _LOGGER.info("Executing %s: %s", filename, data)
         # pylint: disable=exec-used
-        exec(compiled.code, restricted_globals, local)
+        exec(compiled.code, restricted_globals)
     except ScriptError as err:
         logger.error("Error executing script: %s", err)
     except Exception as err:  # pylint: disable=broad-except


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #24704, fixes #13653

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** not applicable because the documentation of `python_script` does not go into the details of how `exec` is called.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

## Discussion:

The `exec` call prior to this PR uses a dictionary for the global scope and another one for the local scope. That's problematic because this code fails:

```
def a():
    pass

def b():
    a()

b()
```

`b` will get called but the call to `a` from inside `b` will fail.

The problem above is resolved if a local dictionary is not used. The documentation for `exec` states:

> Remember that at module level, globals and locals are the same dictionary. If exec gets two separate objects as `globals` and `locals`, the code will be executed as if it were embedded in a class definition.

The latter case is what happened prior to this PR. It seems to me that there's no reason the code executed through `python_script` should run as if it were inside a class definition. I see no benefit. Conversely, it violates the principle of least surprise. The scripts that are run through `python_script` appear a the top level of the `.py` file in which they are put. They look just like modules. That they don't *behave* like modules is unexpected.

I've checked the git history of `python_script`'s implementation, the issue reports, and the discussion forum but found no discussion anywhere of how the call to `exec` came to be the way it was.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
