### PR TITLE
Bump pytest to 5.3.2

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,6 +14,6 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
-pytest==5.3.1
+pytest==5.3.2
 requests_mock==1.7.0
 responses==0.10.6


### PR DESCRIPTION
## Description:

Release notes: <https://github.com/pytest-dev/pytest/releases/tag/5.3.2>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
