### PR TITLE
Bump shodan to 1.21.0

### DIFF
--- a/homeassistant/components/shodan/manifest.json
+++ b/homeassistant/components/shodan/manifest.json
@@ -2,11 +2,7 @@
   "domain": "shodan",
   "name": "Shodan",
   "documentation": "https://www.home-assistant.io/integrations/shodan",
-  "requirements": [
-    "shodan==1.20.0"
-  ],
+  "requirements": ["shodan==1.21.0"],
   "dependencies": [],
-  "codeowners": [
-    "@fabaff"
-  ]
+  "codeowners": ["@fabaff"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1795,7 +1795,7 @@ sense_energy==0.7.0
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.shodan
-shodan==1.20.0
+shodan==1.21.0
 
 # homeassistant.components.simplepush
 simplepush==1.1.4


### PR DESCRIPTION
## Description:

Bump shodan to 1.21.0, changelog: <https://github.com/achillean/shodan-python/blob/master/CHANGELOG.md#1210>


## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: shodan
    api_key: !secret shodan_api
    query: 'home-assistant'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
