### PR TITLE
[WIP] Add all_day filter to Caldav custom calendars

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -32,6 +32,7 @@ CONF_CALENDARS = "calendars"
 CONF_CUSTOM_CALENDARS = "custom_calendars"
 CONF_CALENDAR = "calendar"
 CONF_SEARCH = "search"
+CONF_ALL_DAY = 'all_day'
 
 OFFSET = "!!"
 
@@ -50,6 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                         vol.Required(CONF_CALENDAR): cv.string,
                         vol.Required(CONF_NAME): cv.string,
                         vol.Required(CONF_SEARCH): cv.string,
+                        vol.Optional(CONF_ALL_DAY, default=True): cv.boolean
                     }
                 )
             ],
@@ -94,7 +96,7 @@ def setup_platform(hass, config, add_entities, disc_info=None):
             entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id, hass=hass)
             calendar_devices.append(
                 WebDavCalendarEventDevice(
-                    name, calendar, entity_id, True, cust_calendar[CONF_SEARCH]
+                    name, calendar, entity_id, cust_calendar.get(CONF_ALL_DAY,True), cust_calendar[CONF_SEARCH]
                 )
             )
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -96,7 +96,7 @@ def setup_platform(hass, config, add_entities, disc_info=None):
             entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id, hass=hass)
             calendar_devices.append(
                 WebDavCalendarEventDevice(
-                    name, calendar, entity_id, cust_calendar.get(CONF_ALL_DAY,True), cust_calendar[CONF_SEARCH]
+                    name, calendar, entity_id, cust_calendar.get(CONF_ALL_DAY, True), cust_calendar[CONF_SEARCH]
                 )
             )
 


### PR DESCRIPTION
## Description:
In https://github.com/home-assistant/home-assistant/pull/11272, the ability to filter out all_day events from calendars (which was not functioning correctly), was removed.

Since there is a resonable (and likely common) use case for this functionality, I'd like to propose it being added back:
- A calendar may have an all-day, even multi-day event, such as vacation, or other calendar events.
- In the same calendar, one may have appointments/ meetings/ events during that same day that one would e.g., like to be reminded about.

As such, I believe it's reasonable to be able to filter out all_day events from custom calendars.

The configuration would be optional and thus not a breaking change.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11469

## Example entry for `configuration.yaml` (if applicable):
```yaml
calendar:
  - platform: caldav
    url: https://baikal.my-server.net/cal.php/calendars/john.doe@test.com/default
    username: john.doe@test.com
    password: !secret caldav
    custom_calendars:
      - name: 'HomeOffice'
        calendar: 'Agenda'
        search: 'HomeOffice'
        all_day: True
      - name: 'Agenda'
        calendar: 'Agenda'
        search: '*'
        all_day: False
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
