### PR TITLE
Add "autobypass" option when arming AlarmDecoder integration

### DIFF
--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -24,6 +24,7 @@ CONF_DEVICE_BAUD = "baudrate"
 CONF_DEVICE_PATH = "path"
 CONF_DEVICE_PORT = "port"
 CONF_DEVICE_TYPE = "type"
+CONF_AUTO_BYPASS = "autobypass"
 CONF_PANEL_DISPLAY = "panel_display"
 CONF_ZONE_NAME = "name"
 CONF_ZONE_TYPE = "type"
@@ -39,6 +40,7 @@ DEFAULT_DEVICE_PORT = 10000
 DEFAULT_DEVICE_PATH = "/dev/ttyUSB0"
 DEFAULT_DEVICE_BAUD = 115200
 
+DEFAULT_AUTO_BYPASS = False
 DEFAULT_PANEL_DISPLAY = False
 
 DEFAULT_ZONE_TYPE = "opening"
@@ -101,6 +103,9 @@ CONFIG_SCHEMA = vol.Schema(
                 ),
                 vol.Optional(
                     CONF_PANEL_DISPLAY, default=DEFAULT_PANEL_DISPLAY
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_AUTO_BYPASS, default=DEFAULT_AUTO_BYPASS
                 ): cv.boolean,
                 vol.Optional(CONF_ZONES): {vol.Coerce(int): ZONE_SCHEMA},
             }

--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -104,9 +104,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(
                     CONF_PANEL_DISPLAY, default=DEFAULT_PANEL_DISPLAY
                 ): cv.boolean,
-                vol.Optional(
-                    CONF_AUTO_BYPASS, default=DEFAULT_AUTO_BYPASS
-                ): cv.boolean,
+                vol.Optional(CONF_AUTO_BYPASS, default=DEFAULT_AUTO_BYPASS): cv.boolean,
                 vol.Optional(CONF_ZONES): {vol.Coerce(int): ZONE_SCHEMA},
             }
         )

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -35,8 +35,7 @@ ALARM_KEYPRESS_SCHEMA = vol.Schema({vol.Required(ATTR_KEYPRESS): cv.string})
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up for AlarmDecoder alarm panels."""
-    device = AlarmDecoderAlarmPanel()
-    device.setAutoBypass(discovery_info['autobypass'])
+    device = AlarmDecoderAlarmPanel(discovery_info["autobypass"])
     add_entities([device])
 
     def alarm_toggle_chime_handler(service):
@@ -67,7 +66,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class AlarmDecoderAlarmPanel(AlarmControlPanel):
     """Representation of an AlarmDecoder-based alarm panel."""
 
-    def __init__(self):
+    def __init__(self, auto_bypass=False):
         """Initialize the alarm panel."""
         self._display = ""
         self._name = "Alarm Panel"
@@ -81,10 +80,7 @@ class AlarmDecoderAlarmPanel(AlarmControlPanel):
         self._programming_mode = None
         self._ready = None
         self._zone_bypassed = None
-        self._auto_bypass = False
-
-    def setAutoBypass(self, autoBypass):
-        self._auto_bypass = autoBypass
+        self._auto_bypass = auto_bypass
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -66,7 +66,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class AlarmDecoderAlarmPanel(AlarmControlPanel):
     """Representation of an AlarmDecoder-based alarm panel."""
 
-    def __init__(self, auto_bypass=False):
+    def __init__(self, auto_bypass):
         """Initialize the alarm panel."""
         self._display = ""
         self._name = "Alarm Panel"

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -36,6 +36,7 @@ ALARM_KEYPRESS_SCHEMA = vol.Schema({vol.Required(ATTR_KEYPRESS): cv.string})
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up for AlarmDecoder alarm panels."""
     device = AlarmDecoderAlarmPanel()
+    device.setAutoBypass(discovery_info['autobypass'])
     add_entities([device])
 
     def alarm_toggle_chime_handler(service):
@@ -80,6 +81,10 @@ class AlarmDecoderAlarmPanel(AlarmControlPanel):
         self._programming_mode = None
         self._ready = None
         self._zone_bypassed = None
+        self._auto_bypass = False
+
+    def setAutoBypass(self, autoBypass):
+        self._auto_bypass = autoBypass
 
     async def async_added_to_hass(self):
         """Register callbacks."""
@@ -158,11 +163,15 @@ class AlarmDecoderAlarmPanel(AlarmControlPanel):
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
         if code:
+            if self._auto_bypass:
+                self.hass.data[DATA_AD].send(f"{code!s}6#")
             self.hass.data[DATA_AD].send(f"{code!s}2")
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
         if code:
+            if self._auto_bypass:
+                self.hass.data[DATA_AD].send(f"{code!s}6#")
             self.hass.data[DATA_AD].send(f"{code!s}3")
 
     def alarm_arm_night(self, code=None):


### PR DESCRIPTION
## Description:
Added a new configuration option in the AlarmDecoder integration, that allows one to force a bypass of all open zones at the time of arming their alarm.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11470

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarmdecoder:
  device:
    type: socket
    host: 192.168.1.1
    port: 10000
  autobypass: True
  panel_display: On
```

## Checklist:
  - [Y ] The code change is tested and works locally.
  - [Y] There is no commented out code in this PR.
  - [Y] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [Y] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
