### PR TITLE
Fix modbus service description

### DIFF
--- a/homeassistant/components/modbus/services.yaml
+++ b/homeassistant/components/modbus/services.yaml
@@ -1,7 +1,7 @@
 write_coil:
   description: Write to a modbus coil.
   fields:
-    address: {description: Address of the register to read., example: 0}
+    address: {description: Address of the register to write to., example: 0}
     state: {description: State to write., example: false}
     unit: {description: Address of the modbus unit., example: 21}
 write_register:


### PR DESCRIPTION
## Description:
This change fixes description for **write_coil** Modbus service.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]