### PR TITLE
Add option to ignore flows

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -75,7 +75,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_bridges")
 
         # Find already configured hosts
-        already_configured = self._async_current_ids()
+        already_configured = self._async_current_ids(False)
         bridges = [bridge for bridge in bridges if bridge.id not in already_configured]
 
         if not bridges:

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -6,7 +6,7 @@ import aiohue
 import pytest
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.hue import config_flow, const
 
 from tests.common import MockConfigEntry, mock_coro
@@ -95,6 +95,11 @@ async def test_flow_one_bridge_discovered(hass, aioclient_mock):
 
 async def test_flow_two_bridges_discovered(hass, aioclient_mock):
     """Test config flow discovers two bridges."""
+    # Add ignored config entry. Should still show up as option.
+    MockConfigEntry(
+        domain="hue", source=config_entries.SOURCE_IGNORE, unique_id="bla"
+    ).add_to_hass(hass)
+
     aioclient_mock.get(
         const.API_NUPNP,
         json=[


### PR DESCRIPTION
## Description:
Add option to create "ignored" config entries. Can be created based off any config flow in progress that have a unique ID set. Includes websocket API for this too.

Hue has been updated to still show the ignored hosts as options to configure when starting a manual configuration.

Config entry that is ignored will not be set up and thus not be passed to `async_setup_entry`.

@bramkragten will work on a UI piece for this.

Only config flows that have unique IDs can be ignored. Since it depends per integration on what is a unique ID, we can't automatically fill this in. Each integration needs to add it themselves. Example of Hue inside `ssdp` and `homekit`:

https://github.com/home-assistant/home-assistant/blob/58b5833d64cd66401d313206595ce582125f8f9f/homeassistant/components/hue/config_flow.py#L167-L168

Calling `self.async_set_unique_id` will by default abort the current config flow if another config flow is already in progress. To abort if the unique ID is part of a config entry, call `self._abort_if_unique_id_configured()`.

I am not 100% sure yet if this is the right abstraction or that we can move the "abort if in progress" part to the `self._abort_if…` call. I'll revisit this pattern if a few more config flows are updated.

Builds on top of #29806 and #30000.

CC @Jc2k

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/250

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** TBD


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
