### PR TITLE
Fix Withings sleep state

### DIFF
--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -259,8 +259,8 @@ class WithingsDataManager:
 
     async def update_sleep(self) -> SleepGetResponse:
         """Update the sleep data."""
-        end_date = int(time.time())
-        start_date = end_date - (6 * 60 * 60)
+        end_date = dt.now()
+        start_date = end_date - datetime.timedelta(hours=2)
 
         def function():
             return self._api.sleep_get(startdate=start_date, enddate=end_date)

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -1,4 +1,6 @@
 """Tests for the Withings component."""
+from datetime import timedelta
+
 from asynctest import MagicMock
 import pytest
 from withings_api import WithingsApi
@@ -8,15 +10,20 @@ from homeassistant.components.withings.common import (
     NotAuthenticatedError,
     WithingsDataManager,
 )
+from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.util import dt
 
 
 @pytest.fixture(name="withings_api")
 def withings_api_fixture() -> WithingsApi:
     """Provide withings api."""
     withings_api = WithingsApi.__new__(WithingsApi)
-    withings_api.get_measures = MagicMock()
-    withings_api.get_sleep = MagicMock()
+    withings_api.user_get_device = MagicMock()
+    withings_api.measure_get_meas = MagicMock()
+    withings_api.sleep_get = MagicMock()
+    withings_api.sleep_get_summary = MagicMock()
     return withings_api
 
 
@@ -101,3 +108,27 @@ async def test_data_manager_call_throttle_disabled(
     assert result == "HELLO2"
 
     assert hello_func.call_count == 2
+
+
+async def test_data_manager_update_sleep_date_range(
+    hass: HomeAssistant, data_manager: WithingsDataManager,
+) -> None:
+    """Test method."""
+    await async_process_ha_core_config(
+        hass=hass, config={"time_zone": "America/Los_Angeles"}
+    )
+
+    update_start_time = dt.now()
+    await data_manager.update_sleep()
+
+    call_args = data_manager.api.sleep_get.call_args_list[0][1]
+    startdate = call_args.get("startdate")
+    enddate = call_args.get("enddate")
+
+    assert startdate.tzname() == "PST"
+
+    assert enddate.tzname() == "PST"
+    assert startdate.tzname() == "PST"
+    assert update_start_time < enddate
+    assert enddate < update_start_time + timedelta(seconds=1)
+    assert enddate > startdate


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Fixing timezone issue which caused wrong selection of data to be used.

**Related issue (if applicable):**  fixes #29397 fixes #28370

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
