### PR TITLE
Add template extension coordinates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -694,24 +694,17 @@ def coordinates(
         return coordinates(hass, entity.state, recursion_history)
 
     # Check if state is valid coordinate set
-    if _entity_state_is_valid_coordinate_set(entity.state):
-        return entity.state
-
-    _LOGGER.error(
-        "The state of %s is not a valid set of coordinates: %s", entity_id, entity.state
-    )
-    return None
-
-
-def _entity_state_is_valid_coordinate_set(state: str) -> bool:
-    """Check that the given string is a valid set of coordinates."""
-    schema = vol.Schema(cv.gps)
     try:
-        coords = state.split(",")
-        schema(coords)
-        return True
-    except (vol.MultipleInvalid):
-        return False
+        cv.gps(entity.state.split(","))
+    except vol.Invalid:
+        _LOGGER.error(
+            "The state of %s is not a valid set of coordinates: %s",
+            entity_id,
+            entity.state,
+        )
+        return None
+    else:
+        return entity.state
 
 
 def _get_location_from_attributes(entity: State) -> str:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -656,7 +656,7 @@ def distance(hass, *args):
 
 
 def coordinates(
-    hass, entity_id: str, recursion_history: Optional[list] = None
+    hass: HomeAssistantType, entity_id: str, recursion_history: Optional[list] = None
 ) -> Optional[str]:
     """Get the location from the entity state or attributes."""
     entity = _resolve_state(hass, entity_id)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -670,12 +670,12 @@ def coordinates(
         return _get_location_from_attributes(entity)
 
     # Check if device is in a zone
-    zone_entity = _resolve_state(hass, "zone.{}".format(entity.state))
-    if loc_helper.has_location(zone_entity):
+    zone_entity = _resolve_state(hass, f"zone.{entity.state}")
+    if loc_helper.has_location(zone_entity):  # type: ignore
         _LOGGER.debug(
-            "%s is in %s, getting zone location", entity_id, zone_entity.entity_id
+            "%s is in %s, getting zone location", entity_id, zone_entity.entity_id  # type: ignore
         )
-        return _get_location_from_attributes(zone_entity)
+        return _get_location_from_attributes(zone_entity)  # type: ignore
 
     # Resolve nested entity
     if recursion_history is None:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1290,6 +1290,76 @@ async def test_closest_function_home_vs_group_state(hass):
     )
 
 
+def test_coordinates_function_as_attributes(hass):
+    """Test test_coordinates function."""
+    _set_up_units(hass)
+    hass.states.async_set(
+        "test.object", "happy", {"latitude": 32.87336, "longitude": -117.22943}
+    )
+    tpl = template.Template("{{ coordinates(states.test.object) }}", hass)
+    assert tpl.async_render() == "32.87336,-117.22943"
+
+
+def test_coordinates_function_as_state(hass):
+    """Test test_coordinates function."""
+    _set_up_units(hass)
+    hass.states.async_set("test.object", "32.87336,-117.22943")
+    tpl = template.Template("{{ coordinates(states.test.object) }}", hass)
+    assert tpl.async_render() == "32.87336,-117.22943"
+
+
+def test_coordinates_function_device_tracker_in_zone(hass):
+    """Test test_coordinates function."""
+    _set_up_units(hass)
+    hass.states.async_set(
+        "zone.home", "zoning", {"latitude": 32.87336, "longitude": -117.22943},
+    )
+    hass.states.async_set("device_tracker.device", "home")
+    tpl = template.Template("{{ coordinates(states.device_tracker.device) }}", hass)
+    assert tpl.async_render() == "32.87336,-117.22943"
+
+
+def test_coordinates_function_device_tracker_from_input_select(hass):
+    """Test test_coordinates function."""
+    _set_up_units(hass)
+    hass.states.async_set(
+        "input_select.select",
+        "device_tracker.device",
+        {"options": "device_tracker.device"},
+    )
+    hass.states.async_set("device_tracker.device", "32.87336,-117.22943")
+    tpl = template.Template("{{ coordinates(states.input_select.select) }}", hass)
+    assert tpl.async_render() == "32.87336,-117.22943"
+
+
+def test_coordinates_function_returns_none_on_recursion(hass):
+    """Test test_coordinates function."""
+    _set_up_units(hass)
+    hass.states.async_set(
+        "test.first", "test.second",
+    )
+    hass.states.async_set("test.second", "test.first")
+    tpl = template.Template("{{ coordinates(states.test.first) }}", hass)
+    assert tpl.async_render() == "None"
+
+
+def test_coordinates_function_returns_none_if_invalid_coord(hass):
+    """Test test_coordinates function."""
+    _set_up_units(hass)
+    hass.states.async_set(
+        "test.object", "abc",
+    )
+    tpl = template.Template("{{ coordinates(states.test.object) }}", hass)
+    assert tpl.async_render() == "None"
+
+
+def test_coordinates_function_returns_none_if_invalid_input(hass):
+    """Test test_coordinates function."""
+    _set_up_units(hass)
+    tpl = template.Template("{{ coordinates(states.abc) }}", hass)
+    assert tpl.async_render() == "None"
+
+
 async def test_expand(hass):
     """Test expand function."""
     info = render_to_info(hass, "{{ expand('test.object') }}")


### PR DESCRIPTION
## Description:

This template extension will allow for a clean and reusable way to enable dynamic `travel_time` sensors. The issue was discussed several times in the forum [here](https://community.home-assistant.io/t/custom-component-here-travel-time/125908/152?) and [here](https://community.home-assistant.io/t/waze-travel-time-update/50955/275) as well as in the PRs #27237 #28716.

Using this template the following config is possible:

```yaml
input_select:
  here_destination_preset:
    options:
      - zone.home
      - zone.office
      - zone.somewheredefault

sensor:
  - platform: here_travel_time
    api_key: my_api_key
    name: Reistijd
    origin_template: {{ coordinates('device_tracker.myphone') }}
    destination_template: {{ coordinates('input_select.here_destination_preset') }}

automation:    
  - alias: 'set'
    trigger:
      - platform: homeassistant
        event: start
      - platform: time
        at: 00:00
    action:
       service: input_select.select_option
       data_template:
        entity_id: input_select.here_destination_preset
        option: "{% if is_state('device_tracker.myphone','home') %}zone.office{% elif is_state('device_tracker.myphone','office') %}zone.home{% else %}zone.somewheredefault{% endif %}"
````

The simple case `{{ coordinates('device_tracker.myphone') }}` can already be accomplished with existing methods but now the user does not have to know that a `device_tracker` stores `latitude` and `longitude` as attributes.

The nested case `{{ coordinates('input_select.here_destination_preset') }}` is currently only possible by creating a complex structure of dependent `template_sensors` using complex templates.


**Related issue (if applicable):** fixes #TBD

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11482

## Example entry for `configuration.yaml` (if applicable):

See above.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
