### PR TITLE
Upgrade zeroconf to 0.24.1

### DIFF
--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zeroconf",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
   "requirements": [
-    "zeroconf==0.24.0"
+    "zeroconf==0.24.1"
   ],
   "dependencies": [
     "api"

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,7 +24,7 @@ ruamel.yaml==0.15.100
 sqlalchemy==1.3.11
 voluptuous-serialize==2.3.0
 voluptuous==0.11.7
-zeroconf==0.24.0
+zeroconf==0.24.1
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2086,7 +2086,7 @@ youtube_dl==2019.11.28
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.24.0
+zeroconf==0.24.1
 
 # homeassistant.components.zha
 zha-quirks==0.0.28

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -658,7 +658,7 @@ ya_ma==0.3.8
 yahooweather==0.10
 
 # homeassistant.components.zeroconf
-zeroconf==0.24.0
+zeroconf==0.24.1
 
 # homeassistant.components.zha
 zha-quirks==0.0.28


### PR DESCRIPTION
## Description:
Changelog: https://github.com/jstasiak/python-zeroconf/#0241

## Example entry for `configuration.yaml` (if applicable):
```yaml
default_config:
```

```bash
$ avahi-browse -alr
= enp0 IPv4 Home                                         _home-assistant._tcp local
   hostname = [Home._home-assistant._tcp.local]
   address = [192.168.0.21]
   port = [8123]
   txt = ["requires_api_password=true" "base_url=http://192.168.0.21:8123" "version=0.104.0.dev0"]
[...]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
