### PR TITLE
Add unit_of_measurement to various Transmission sensors

### DIFF
--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -2,14 +2,14 @@
 DOMAIN = "transmission"
 
 SENSOR_TYPES = {
-    "active_torrents": ["Active Torrents", "Counts"],
+    "active_torrents": ["Active Torrents", "Torrents"],
     "current_status": ["Status", None],
     "download_speed": ["Down Speed", "MB/s"],
-    "paused_torrents": ["Paused Torrents", "Counts"],
-    "total_torrents": ["Total Torrents", "Counts"],
+    "paused_torrents": ["Paused Torrents", "Torrents"],
+    "total_torrents": ["Total Torrents", "Torrents"],
     "upload_speed": ["Up Speed", "MB/s"],
-    "completed_torrents": ["Completed Torrents", "Counts"],
-    "started_torrents": ["Started Torrents", "Counts"],
+    "completed_torrents": ["Completed Torrents", "Torrents"],
+    "started_torrents": ["Started Torrents", "Torrents"],
 }
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -2,14 +2,14 @@
 DOMAIN = "transmission"
 
 SENSOR_TYPES = {
-    "active_torrents": ["Active Torrents", None],
+    "active_torrents": ["Active Torrents", "Counts"],
     "current_status": ["Status", None],
     "download_speed": ["Down Speed", "MB/s"],
-    "paused_torrents": ["Paused Torrents", None],
-    "total_torrents": ["Total Torrents", None],
+    "paused_torrents": ["Paused Torrents", "Counts"],
+    "total_torrents": ["Total Torrents", "Counts"],
     "upload_speed": ["Up Speed", "MB/s"],
-    "completed_torrents": ["Completed Torrents", None],
-    "started_torrents": ["Started Torrents", None],
+    "completed_torrents": ["Completed Torrents", "Counts"],
+    "started_torrents": ["Started Torrents", "Counts"],
 }
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 


### PR DESCRIPTION

## Breaking Change:

n/a

## Description:

Without unit_of_measurement, the history graph card will not show those sensors as line chart.


## Example entry for `configuration.yaml` (if applicable):

n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
