### PR TITLE
Remove stream from camera after deps

### DIFF
--- a/homeassistant/components/camera/manifest.json
+++ b/homeassistant/components/camera/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/camera",
   "requirements": [],
   "dependencies": ["http"],
-  "after_dependencies": ["stream", "media_player"],
+  "after_dependencies": ["media_player"],
   "codeowners": []
 }

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -102,6 +102,7 @@ ALLOWED_USED_COMPONENTS = {
     "discovery",
     # Other
     "mjpeg",  # base class, has no reqs or component to load.
+    "stream",  # Stream cannot install on all systems, can be imported without reqs.
 }
 
 IGNORE_VIOLATIONS = [


### PR DESCRIPTION
## Description:
Accidentally added `stream` to the `camera` after dependencies. This means that the default config no longer installs on Windows. `stream` can be referenced without installing its requirements.

