### PR TITLE
Ignore stale gps information

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -488,6 +488,8 @@ class Device(RestoreEntity):
             return
         if self.location_name:
             self._state = self.location_name
+        elif self.stale():
+            self.mark_stale()
         elif self.gps is not None and self.source_type == SOURCE_TYPE_GPS:
             zone_state = async_active_zone(
                 self.hass, self.gps[0], self.gps[1], self.gps_accuracy
@@ -498,8 +500,6 @@ class Device(RestoreEntity):
                 self._state = STATE_HOME
             else:
                 self._state = zone_state.name
-        elif self.stale():
-            self.mark_stale()
         else:
             self._state = STATE_HOME
             self.last_update_home = True


### PR DESCRIPTION

## Description:

If the GPS position is outdated, the device should be marked as stale. Currently GPS devices are not marked as stale because their branch has higher priority in the async_update function. I fail to understand why and I don't see that explained in commit messages or other pull requests, maybe I missed the information or maybe this is just a bug.

Testing and discussion is welcome

**Related issue:** fixes #26684

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html

