### PR TITLE
Guard against future unknown SimpliSafe entity types

### DIFF
--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -177,11 +177,21 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
             self._state = None
 
         last_event = self._simplisafe.last_event_data[self._system.system_id]
+
+        try:
+            last_event_sensor_type = EntityTypes(last_event["sensorType"]).name
+        except ValueError:
+            _LOGGER.warning(
+                'Encountered unknown entity type: "%s". Please report it at '
+                "https://github.com/home-assistant/home-assistant/issues."
+            )
+            last_event_sensor_type = None
+
         self._attrs.update(
             {
                 ATTR_LAST_EVENT_INFO: last_event["info"],
                 ATTR_LAST_EVENT_SENSOR_NAME: last_event["sensorName"],
-                ATTR_LAST_EVENT_SENSOR_TYPE: EntityTypes(last_event["sensorType"]).name,
+                ATTR_LAST_EVENT_SENSOR_TYPE: last_event_sensor_type,
                 ATTR_LAST_EVENT_TIMESTAMP: utc_from_timestamp(
                     last_event["eventTimestamp"]
                 ),

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -182,8 +182,10 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
             last_event_sensor_type = EntityTypes(last_event["sensorType"]).name
         except ValueError:
             _LOGGER.warning(
-                'Encountered unknown entity type: "%s". Please report it at '
-                "https://github.com/home-assistant/home-assistant/issues."
+                'Encountered unknown entity type: %s ("%s"). Please report it at'
+                "https://github.com/home-assistant/home-assistant/issues.",
+                last_event["sensorType"],
+                last_event["sensorName"],
             )
             last_event_sensor_type = None
 


### PR DESCRIPTION
## Description:

Although https://github.com/home-assistant/home-assistant/pull/30055 solved the immediate problem presented in https://github.com/home-assistant/home-assistant/issues/30054, it didn't properly account for the root cause of the underlying exception: if SimpliSafe introduces a new entity type, an exception will be thrown. This PR properly catches that possibility, logs a warning, and invites the user to report the new entity type here.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
