### PR TITLE
Add homematic host port config for HMIP-only CCUs

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -298,6 +298,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_HOSTS, default={}): {
                     cv.match_all: {
                         vol.Required(CONF_HOST): cv.string,
+                        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                         vol.Optional(
                             CONF_USERNAME, default=DEFAULT_USERNAME
                         ): cv.string,
@@ -392,7 +393,7 @@ def setup(hass, config):
     for sname, sconfig in conf[CONF_HOSTS].items():
         remotes[sname] = {
             "ip": sconfig.get(CONF_HOST),
-            "port": DEFAULT_PORT,
+            "port": sconfig.get(CONF_PORT),
             "username": sconfig.get(CONF_USERNAME),
             "password": sconfig.get(CONF_PASSWORD),
             "connect": False,

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -393,7 +393,7 @@ def setup(hass, config):
     for sname, sconfig in conf[CONF_HOSTS].items():
         remotes[sname] = {
             "ip": sconfig.get(CONF_HOST),
-            "port": sconfig.get(CONF_PORT),
+            "port": sconfig[CONF_PORT],
             "username": sconfig.get(CONF_USERNAME),
             "password": sconfig.get(CONF_PASSWORD),
             "connect": False,


### PR DESCRIPTION
Description:

When adding a host (CCU) to the homematic component currently the hardcoded port 2001 is used to communicate with it.
However that port is only available on the target if the target supports HM (wireless) protocol which is not the case e.g. for
the Hass.io Homematic CCU addon when running in HMIP-only mode with the HMIP-RFUSB stick.

This allows to change the port home assistant uses to talk to the CCU in order to provide services under the homematic domain, e.g. homematic.set_variable_value

The default value for this option is the old hardcoded value this the change should be backwards compatible with existing configurations.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11498

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
