### PR TITLE
Whitelist Android/iOS auth callbacks

### DIFF
--- a/homeassistant/components/auth/indieauth.py
+++ b/homeassistant/components/auth/indieauth.py
@@ -35,8 +35,6 @@ async def verify_redirect_uri(hass, client_id, redirect_uri):
     if redirect_uri == "homeassistant://auth-callback" and client_id in (
         "https://home-assistant.io/android",
         "https://home-assistant.io/iOS",
-        "https://home-assistant.io/iOS/beta-auth",
-        "https://home-assistant.io/iOS/dev-auth",
     ):
         return True
 

--- a/homeassistant/components/auth/indieauth.py
+++ b/homeassistant/components/auth/indieauth.py
@@ -30,6 +30,14 @@ async def verify_redirect_uri(hass, client_id, redirect_uri):
     if is_valid:
         return True
 
+    # Whitelist the iOS and Android callbacks so that people can link apps
+    # without being connected to the internet.
+    if redirect_uri == "homeassistant://auth-callback" and client_id in (
+        "https://home-assistant.io/android",
+        "https://home-assistant.io/iOS",
+    ):
+        return True
+
     # IndieAuth 4.2.2 allows for redirect_uri to be on different domain
     # but needs to be specified in link tag when fetching `client_id`.
     redirect_uris = await fetch_redirect_uris(hass, client_id)

--- a/homeassistant/components/auth/indieauth.py
+++ b/homeassistant/components/auth/indieauth.py
@@ -35,6 +35,8 @@ async def verify_redirect_uri(hass, client_id, redirect_uri):
     if redirect_uri == "homeassistant://auth-callback" and client_id in (
         "https://home-assistant.io/android",
         "https://home-assistant.io/iOS",
+        "https://home-assistant.io/iOS/beta-auth",
+        "https://home-assistant.io/iOS/dev-auth",
     ):
         return True
 

--- a/tests/components/auth/test_indieauth.py
+++ b/tests/components/auth/test_indieauth.py
@@ -166,3 +166,24 @@ async def test_find_link_tag_max_size(hass, mock_session):
     redirect_uris = await indieauth.fetch_redirect_uris(hass, "http://127.0.0.1:8000")
 
     assert redirect_uris == ["http://127.0.0.1:8000/wine"]
+
+
+@pytest.mark.parametrize(
+    "client_id", ["https://home-assistant.io/android", "https://home-assistant.io/iOS"]
+)
+async def test_verify_redirect_uri_android_ios(client_id):
+    """Test that we verify redirect uri correctly for Android/iOS."""
+    with patch.object(
+        indieauth, "fetch_redirect_uris", side_effect=lambda *_: mock_coro([])
+    ):
+        assert await indieauth.verify_redirect_uri(
+            None, client_id, "homeassistant://auth-callback"
+        )
+
+        assert not await indieauth.verify_redirect_uri(
+            None, client_id, "homeassistant://something-else"
+        )
+
+        assert not await indieauth.verify_redirect_uri(
+            None, "https://incorrect.com", "homeassistant://auth-callback"
+        )


### PR DESCRIPTION
## Description:
If Home Assistant cannot connect to the internet, it is unable to verify the auth callback for the iOS and Android apps. This will specifically hardcode the auth callback for Android and iOS. We can still update it in the future by updating the website.

CC @robbiet480 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
