### PR TITLE
Don't error on removal of an ignored homekit_controller config entry

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -232,5 +232,9 @@ async def async_unload_entry(hass, entry):
 
 async def async_remove_entry(hass, entry):
     """Cleanup caches before removing config entry."""
+    if "AccessoryPairingID" not in entry.data:
+        # If no pairing idea its probably a "ignore" config entry
+        # So there is nothing to do
+        return
     hkid = entry.data["AccessoryPairingID"]
     hass.data[ENTITY_MAP].async_delete_map(hkid)

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -232,9 +232,5 @@ async def async_unload_entry(hass, entry):
 
 async def async_remove_entry(hass, entry):
     """Cleanup caches before removing config entry."""
-    if "AccessoryPairingID" not in entry.data:
-        # If no pairing idea its probably a "ignore" config entry
-        # So there is nothing to do
-        return
     hkid = entry.data["AccessoryPairingID"]
     hass.data[ENTITY_MAP].async_delete_map(hkid)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -246,6 +246,10 @@ class ConfigEntry:
 
         Returns if unload is possible and was successful.
         """
+        if self.source == SOURCE_IGNORE:
+            self.state = ENTRY_STATE_NOT_LOADED
+            return True
+
         if integration is None:
             integration = await loader.async_get_integration(hass, self.domain)
 
@@ -292,6 +296,9 @@ class ConfigEntry:
 
     async def async_remove(self, hass: HomeAssistant) -> None:
         """Invoke remove callback on component."""
+        if self.source == SOURCE_IGNORE:
+            return
+
         integration = await loader.async_get_integration(hass, self.domain)
         component = integration.get_component()
         if not hasattr(component, "async_remove_entry"):


### PR DESCRIPTION
## Description:

I've been testing the new "Ignore" button in home-assistant-polymer dev with homekit_controller. It's working apart from when you "unignore" an ignored discovery - it calls `async_remote_entry` in `homekit_controller`. Because its not actually a pairing it shouldn't, so we need to bail early if the config entry data is missing an expected key.

A slight UX niggle ->At the moment the only way to re-discover an ignored and unignored discovery seems to be to power cycle HA or the accessory. This is probably not a regular activity but I thought it worth pointing out.

CC @balloob 

RE: #30035 #29806

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
