### PR TITLE
Register 'androidtv.download' and 'androidtv.upload' services

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
     "adb-shell==0.1.0",
-    "androidtv==0.0.36",
+    "androidtv==0.0.37",
     "pure-python-adb==0.2.2.dev0"
   ],
   "dependencies": [],

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -278,9 +278,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         def service_adb_filesync(service):
             """Transfer a file between your HA instance and an Android TV / Fire TV device."""
+            local_path = service.data.get(ATTR_LOCAL_PATH)
+            if not hass.config.is_allowed_path(local_path):
+                _LOGGER.warning("'%s' is not secure to load data from!", local_path)
+                return
+
             direction = service.data.get(ATTR_DIRECTION)
             device_path = service.data.get(ATTR_DEVICE_PATH)
-            local_path = service.data.get(ATTR_LOCAL_PATH)
             entity_id = service.data.get(ATTR_ENTITY_ID)
             target_devices = [
                 dev

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -157,6 +157,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     address = f"{config[CONF_HOST]}:{config[CONF_PORT]}"
 
+    if address in hass.data[ANDROIDTV_DOMAIN]:
+        _LOGGER.warning("Platform already setup on %s, skipping", address)
+        return
+
     if CONF_ADB_SERVER_IP not in config:
         # Use "adb_shell" (Python ADB implementation)
         if CONF_ADBKEY not in config:
@@ -218,10 +222,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             "Could not connect to %s at %s %s", device_name, address, adb_log
         )
         raise PlatformNotReady
-
-    if address in hass.data[ANDROIDTV_DOMAIN]:
-        _LOGGER.warning("Platform already setup on %s, skipping", address)
-        return
 
     device_args = [
         aftv,

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -291,10 +291,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             ]
 
             for target_device in target_devices:
-                if direction == DIRECTION_PULL:
-                    target_device.adb_pull(local_path, device_path)
-                else:
-                    target_device.adb_push(local_path, device_path)
+                target_device.adb_filesync(direction, local_path, device_path)
 
         hass.services.register(
             ANDROIDTV_DOMAIN,

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -217,6 +217,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if address in hass.data[ANDROIDTV_DOMAIN]:
         _LOGGER.warning("Platform already setup on %s, skipping", address)
+        return
     else:
         if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
             device = AndroidTVDevice(

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -12,6 +12,7 @@ from adb_shell.exceptions import (
 )
 from androidtv import ha_state_detection_rules_validator, setup
 from androidtv.constants import APPS, KEYS
+from androidtv.exceptions import LockNotAcquiredException
 import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
@@ -43,10 +44,6 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
-
-
-class LockNotAcquiredException(Exception):
-    """The ADB lock could not be acquired."""
 
 
 ANDROIDTV_DOMAIN = "androidtv"

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -319,6 +319,9 @@ def adb_decorator(override_available=False):
                 return func(self, *args, **kwargs)
             except LockNotAcquiredException:
                 # If the ADB lock could not be acquired, skip this command
+                _LOGGER.info(
+                    "ADB command not executed because the connection is currently in use"
+                )
                 return
             except self.exceptions as err:
                 _LOGGER.error(

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -218,31 +218,31 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if address in hass.data[ANDROIDTV_DOMAIN]:
         _LOGGER.warning("Platform already setup on %s, skipping", address)
         return
-    else:
-        if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
-            device = AndroidTVDevice(
-                aftv,
-                config[CONF_NAME],
-                config[CONF_APPS],
-                config[CONF_GET_SOURCES],
-                config.get(CONF_TURN_ON_COMMAND),
-                config.get(CONF_TURN_OFF_COMMAND),
-            )
-            device_name = config[CONF_NAME] if CONF_NAME in config else "Android TV"
-        else:
-            device = FireTVDevice(
-                aftv,
-                config[CONF_NAME],
-                config[CONF_APPS],
-                config[CONF_GET_SOURCES],
-                config.get(CONF_TURN_ON_COMMAND),
-                config.get(CONF_TURN_OFF_COMMAND),
-            )
-            device_name = config[CONF_NAME] if CONF_NAME in config else "Fire TV"
 
-        add_entities([device])
-        _LOGGER.debug("Setup %s at %s %s", device_name, address, adb_log)
-        hass.data[ANDROIDTV_DOMAIN][address] = device
+    if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
+        device = AndroidTVDevice(
+            aftv,
+            config[CONF_NAME],
+            config[CONF_APPS],
+            config[CONF_GET_SOURCES],
+            config.get(CONF_TURN_ON_COMMAND),
+            config.get(CONF_TURN_OFF_COMMAND),
+        )
+        device_name = config[CONF_NAME] if CONF_NAME in config else "Android TV"
+    else:
+        device = FireTVDevice(
+            aftv,
+            config[CONF_NAME],
+            config[CONF_APPS],
+            config[CONF_GET_SOURCES],
+            config.get(CONF_TURN_ON_COMMAND),
+            config.get(CONF_TURN_OFF_COMMAND),
+        )
+        device_name = config[CONF_NAME] if CONF_NAME in config else "Fire TV"
+
+    add_entities([device])
+    _LOGGER.debug("Setup %s at %s %s", device_name, address, adb_log)
+    hass.data[ANDROIDTV_DOMAIN][address] = device
 
     if not hass.services.has_service(ANDROIDTV_DOMAIN, SERVICE_ADB_COMMAND):
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -45,7 +45,6 @@ from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 
-
 ANDROIDTV_DOMAIN = "androidtv"
 
 _LOGGER = logging.getLogger(__name__)
@@ -152,7 +151,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Android TV / Fire TV platform."""
     hass.data.setdefault(ANDROIDTV_DOMAIN, {})
 
-    host = f"{config[CONF_HOST]}:{config[CONF_PORT]}"
+    address = f"{config[CONF_HOST]}:{config[CONF_PORT]}"
 
     if CONF_ADB_SERVER_IP not in config:
         # Use "adb_shell" (Python ADB implementation)
@@ -211,11 +210,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         else:
             device_name = "Android TV / Fire TV device"
 
-        _LOGGER.warning("Could not connect to %s at %s %s", device_name, host, adb_log)
+        _LOGGER.warning(
+            "Could not connect to %s at %s %s", device_name, address, adb_log
+        )
         raise PlatformNotReady
 
-    if host in hass.data[ANDROIDTV_DOMAIN]:
-        _LOGGER.warning("Platform already setup on %s, skipping", host)
+    if address in hass.data[ANDROIDTV_DOMAIN]:
+        _LOGGER.warning("Platform already setup on %s, skipping", address)
     else:
         if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
             device = AndroidTVDevice(
@@ -239,8 +240,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             device_name = config[CONF_NAME] if CONF_NAME in config else "Fire TV"
 
         add_entities([device])
-        _LOGGER.debug("Setup %s at %s %s", device_name, host, adb_log)
-        hass.data[ANDROIDTV_DOMAIN][host] = device
+        _LOGGER.debug("Setup %s at %s %s", device_name, address, adb_log)
+        hass.data[ANDROIDTV_DOMAIN][address] = device
 
     if not hass.services.has_service(ANDROIDTV_DOMAIN, SERVICE_ADB_COMMAND):
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -219,26 +219,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.warning("Platform already setup on %s, skipping", address)
         return
 
+    device_args = [
+        aftv,
+        config[CONF_NAME],
+        config[CONF_APPS],
+        config[CONF_GET_SOURCES],
+        config.get(CONF_TURN_ON_COMMAND),
+        config.get(CONF_TURN_OFF_COMMAND),
+    ]
+
     if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
-        device = AndroidTVDevice(
-            aftv,
-            config[CONF_NAME],
-            config[CONF_APPS],
-            config[CONF_GET_SOURCES],
-            config.get(CONF_TURN_ON_COMMAND),
-            config.get(CONF_TURN_OFF_COMMAND),
-        )
-        device_name = config[CONF_NAME] if CONF_NAME in config else "Android TV"
+        device = AndroidTVDevice(*device_args)
+        device_name = config.get(CONF_NAME, "Android TV")
     else:
-        device = FireTVDevice(
-            aftv,
-            config[CONF_NAME],
-            config[CONF_APPS],
-            config[CONF_GET_SOURCES],
-            config.get(CONF_TURN_ON_COMMAND),
-            config.get(CONF_TURN_OFF_COMMAND),
-        )
-        device_name = config[CONF_NAME] if CONF_NAME in config else "Fire TV"
+        device = FireTVDevice(*device_args)
+        device_name = config.get(CONF_NAME, "Fire TV")
 
     add_entities([device])
     _LOGGER.debug("Setup %s at %s %s", device_name, address, adb_log)

--- a/homeassistant/components/androidtv/services.yaml
+++ b/homeassistant/components/androidtv/services.yaml
@@ -20,7 +20,7 @@ adb_filesync:
       example: 'push'
     device_path:
       description: The filepath on the Android TV / Fire TV device.
-      example: '/home/example/path.txt'
+      example: '/storage/emulated/0/Download/example.txt'
     local_path:
       description: The filepath on your Home Assistant instance.
-      example: '/config/example/path.txt'
+      example: '/config/example.txt'

--- a/homeassistant/components/androidtv/services.yaml
+++ b/homeassistant/components/androidtv/services.yaml
@@ -9,15 +9,24 @@ adb_command:
     command:
       description: Either a key command or an ADB shell command.
       example: 'HOME'
-adb_filesync:
-  description: Transfer a file between your Home Assistant instance and an Android TV / Fire TV device.
+download:
+  description: Download a file from your Android TV / Fire TV device to your Home Assistant instance.
+  fields:
+    entity_id:
+      description: Name of Android TV / Fire TV entity.
+      example: 'media_player.android_tv_living_room'
+    device_path:
+      description: The filepath on the Android TV / Fire TV device.
+      example: '/storage/emulated/0/Download/example.txt'
+    local_path:
+      description: The filepath on your Home Assistant instance.
+      example: '/config/example.txt'
+upload:
+  description: Upload a file from your Home Assistant instance to an Android TV / Fire TV device.
   fields:
     entity_id:
       description: Name(s) of Android TV / Fire TV entities.
       example: 'media_player.android_tv_living_room'
-    direction:
-      description: Whether to push a file to the device or pull a file from the device; must be `push` or `pull`.
-      example: 'push'
     device_path:
       description: The filepath on the Android TV / Fire TV device.
       example: '/storage/emulated/0/Download/example.txt'

--- a/homeassistant/components/androidtv/services.yaml
+++ b/homeassistant/components/androidtv/services.yaml
@@ -9,3 +9,18 @@ adb_command:
     command:
       description: Either a key command or an ADB shell command.
       example: 'HOME'
+adb_filesync:
+  description: Transfer a file between your Home Assistant instance and an Android TV / Fire TV device.
+  fields:
+    entity_id:
+      description: Name(s) of Android TV / Fire TV entities.
+      example: 'media_player.android_tv_living_room'
+    direction:
+      description: Whether to push a file to the device or pull a file from the device; must be `push` or `pull`.
+      example: 'push'
+    device_path:
+      description: The filepath on the Android TV / Fire TV device.
+      example: '/home/example/path.txt'
+    local_path:
+      description: The filepath on your Home Assistant instance.
+      example: '/config/example/path.txt'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -214,7 +214,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.36
+androidtv==0.0.37
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -84,7 +84,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.36
+androidtv==0.0.37
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -6,6 +6,7 @@ from androidtv.exceptions import LockNotAcquiredException
 
 from homeassistant.components.androidtv.media_player import (
     ANDROIDTV_DOMAIN,
+    ATTR_COMMAND,
     ATTR_DEVICE_PATH,
     ATTR_LOCAL_PATH,
     CONF_ADB_SERVER_IP,
@@ -612,7 +613,7 @@ async def test_adb_command(hass):
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
             SERVICE_ADB_COMMAND,
-            {ATTR_ENTITY_ID: entity_id, "command": command},
+            {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: command},
             blocking=True,
         )
 
@@ -640,7 +641,7 @@ async def test_adb_command_key(hass):
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
             SERVICE_ADB_COMMAND,
-            {ATTR_ENTITY_ID: entity_id, "command": command},
+            {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: command},
             blocking=True,
         )
 
@@ -668,7 +669,7 @@ async def test_adb_command_get_properties(hass):
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
             SERVICE_ADB_COMMAND,
-            {ATTR_ENTITY_ID: entity_id, "command": command},
+            {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: command},
             blocking=True,
         )
 

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -6,10 +6,15 @@ from androidtv.exceptions import LockNotAcquiredException
 
 from homeassistant.components.androidtv.media_player import (
     ANDROIDTV_DOMAIN,
+    ATTR_DEVICE_PATH,
+    ATTR_LOCAL_PATH,
     CONF_ADB_SERVER_IP,
     CONF_ADBKEY,
     CONF_APPS,
     KEYS,
+    SERVICE_ADB_COMMAND,
+    SERVICE_DOWNLOAD,
+    SERVICE_UPLOAD,
 )
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,
@@ -582,6 +587,8 @@ async def test_setup_same_device_twice(hass):
         state = hass.states.get(entity_id)
         assert state is not None
 
+    assert hass.services.has_service(ANDROIDTV_DOMAIN, SERVICE_ADB_COMMAND)
+
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell("")[patch_key]:
@@ -604,7 +611,7 @@ async def test_adb_command(hass):
     ) as patch_shell:
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "adb_command",
+            SERVICE_ADB_COMMAND,
             {ATTR_ENTITY_ID: entity_id, "command": command},
             blocking=True,
         )
@@ -632,7 +639,7 @@ async def test_adb_command_key(hass):
     ) as patch_shell:
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "adb_command",
+            SERVICE_ADB_COMMAND,
             {ATTR_ENTITY_ID: entity_id, "command": command},
             blocking=True,
         )
@@ -660,7 +667,7 @@ async def test_adb_command_get_properties(hass):
     ) as patch_get_props:
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "adb_command",
+            SERVICE_ADB_COMMAND,
             {ATTR_ENTITY_ID: entity_id, "command": command},
             blocking=True,
         )
@@ -717,11 +724,11 @@ async def test_download(hass):
     with patch("androidtv.basetv.BaseTV.adb_pull") as patch_pull:
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "download",
+            SERVICE_DOWNLOAD,
             {
                 ATTR_ENTITY_ID: entity_id,
-                "device_path": device_path,
-                "local_path": local_path,
+                ATTR_DEVICE_PATH: device_path,
+                ATTR_LOCAL_PATH: local_path,
             },
             blocking=True,
         )
@@ -733,11 +740,11 @@ async def test_download(hass):
     ):
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "download",
+            SERVICE_DOWNLOAD,
             {
                 ATTR_ENTITY_ID: entity_id,
-                "device_path": device_path,
-                "local_path": local_path,
+                ATTR_DEVICE_PATH: device_path,
+                ATTR_LOCAL_PATH: local_path,
             },
             blocking=True,
         )
@@ -759,11 +766,11 @@ async def test_upload(hass):
     with patch("androidtv.basetv.BaseTV.adb_push") as patch_push:
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "upload",
+            SERVICE_UPLOAD,
             {
                 ATTR_ENTITY_ID: entity_id,
-                "device_path": device_path,
-                "local_path": local_path,
+                ATTR_DEVICE_PATH: device_path,
+                ATTR_LOCAL_PATH: local_path,
             },
             blocking=True,
         )
@@ -775,11 +782,11 @@ async def test_upload(hass):
     ):
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "upload",
+            SERVICE_UPLOAD,
             {
                 ATTR_ENTITY_ID: entity_id,
-                "device_path": device_path,
-                "local_path": local_path,
+                ATTR_DEVICE_PATH: device_path,
+                ATTR_LOCAL_PATH: local_path,
             },
             blocking=True,
         )

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -2,13 +2,14 @@
 import logging
 from unittest.mock import patch
 
+from androidtv.exceptions import LockNotAcquiredException
+
 from homeassistant.components.androidtv.media_player import (
     ANDROIDTV_DOMAIN,
     CONF_ADB_SERVER_IP,
     CONF_ADBKEY,
     CONF_APPS,
     KEYS,
-    LockNotAcquiredException,
 )
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,


### PR DESCRIPTION
## Description:

Register the `androidtv.download` and `androidtv.upload` services that allow users to transfer files between their Android TV / Fire TV device and their HA instance.  

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11501

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
