### PR TITLE
Fix update port and api key on deconz discovery config entry update

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -159,12 +159,17 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             title="deCONZ-" + self.deconz_config[CONF_BRIDGEID], data=self.deconz_config
         )
 
-    async def _update_entry(self, entry, host):
+    async def _update_entry(self, entry, host, port, api_key=None):
         """Update existing entry."""
         if entry.data[CONF_HOST] == host:
             return self.async_abort(reason="already_configured")
 
         entry.data[CONF_HOST] = host
+        entry.data[CONF_PORT] = port
+
+        if api_key is not None:
+            entry.data[CONF_API_KEY] = api_key
+
         self.hass.config_entries.async_update_entry(entry)
         return self.async_abort(reason="updated_instance")
 
@@ -181,7 +186,9 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if uuid == entry.data.get(CONF_UUID):
-                return await self._update_entry(entry, parsed_url.hostname)
+                return await self._update_entry(
+                    entry, parsed_url.hostname, parsed_url.port
+                )
 
         bridgeid = discovery_info[ssdp.ATTR_UPNP_SERIAL]
         if any(
@@ -211,7 +218,12 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if bridgeid in gateway_entries:
             entry = gateway_entries[bridgeid]
-            return await self._update_entry(entry, user_input[CONF_HOST])
+            return await self._update_entry(
+                entry,
+                user_input[CONF_HOST],
+                user_input[CONF_PORT],
+                user_input[CONF_API_KEY],
+            )
 
         self._hassio_discovery = user_input
 

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -159,7 +159,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             title="deCONZ-" + self.deconz_config[CONF_BRIDGEID], data=self.deconz_config
         )
 
-    async def _update_entry(self, entry, host, port, api_key=None):
+    def _update_entry(self, entry, host, port, api_key=None):
         """Update existing entry."""
         if entry.data[CONF_HOST] == host:
             return self.async_abort(reason="already_configured")
@@ -186,9 +186,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if uuid == entry.data.get(CONF_UUID):
-                return await self._update_entry(
-                    entry, parsed_url.hostname, parsed_url.port
-                )
+                return self._update_entry(entry, parsed_url.hostname, parsed_url.port)
 
         bridgeid = discovery_info[ssdp.ATTR_UPNP_SERIAL]
         if any(
@@ -218,7 +216,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if bridgeid in gateway_entries:
             entry = gateway_entries[bridgeid]
-            return await self._update_entry(
+            return self._update_entry(
                 entry,
                 user_input[CONF_HOST],
                 user_input[CONF_PORT],

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -322,32 +322,53 @@ async def test_hassio_update_instance(hass):
     """Test we can update an existing config entry."""
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
-        data={config_flow.CONF_BRIDGEID: "id", config_flow.CONF_HOST: "1.2.3.4"},
+        data={
+            config_flow.CONF_BRIDGEID: "id",
+            config_flow.CONF_HOST: "1.2.3.4",
+            config_flow.CONF_PORT: 40850,
+            config_flow.CONF_API_KEY: "secret",
+        },
     )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        data={config_flow.CONF_HOST: "mock-deconz", config_flow.CONF_SERIAL: "id"},
+        data={
+            config_flow.CONF_HOST: "mock-deconz",
+            config_flow.CONF_PORT: 8080,
+            config_flow.CONF_API_KEY: "updated",
+            config_flow.CONF_SERIAL: "id",
+        },
         context={"source": "hassio"},
     )
 
     assert result["type"] == "abort"
     assert result["reason"] == "updated_instance"
     assert entry.data[config_flow.CONF_HOST] == "mock-deconz"
+    assert entry.data[config_flow.CONF_PORT] == 8080
+    assert entry.data[config_flow.CONF_API_KEY] == "updated"
 
 
 async def test_hassio_dont_update_instance(hass):
     """Test we can update an existing config entry."""
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
-        data={config_flow.CONF_BRIDGEID: "id", config_flow.CONF_HOST: "1.2.3.4"},
+        data={
+            config_flow.CONF_BRIDGEID: "id",
+            config_flow.CONF_HOST: "1.2.3.4",
+            config_flow.CONF_PORT: 8080,
+            config_flow.CONF_API_KEY: "secret",
+        },
     )
     entry.add_to_hass(hass)
-
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        data={config_flow.CONF_HOST: "1.2.3.4", config_flow.CONF_SERIAL: "id"},
+        data={
+            config_flow.CONF_HOST: "1.2.3.4",
+            config_flow.CONF_PORT: 8080,
+            config_flow.CONF_API_KEY: "secret",
+            config_flow.CONF_SERIAL: "id",
+        },
         context={"source": "hassio"},
     )
 


### PR DESCRIPTION
# Description:

The deCONZ updates existing configuration entries in case new discovery information comes in, and the bridge ID is already a know/registered config entry.

However, it only updated the host parameter, not the port or API key.

This caused issues during the release of an updated version of the deCONZ Hass.io add-on. That release changed the port number, which didn't update.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
