### PR TITLE
Store capabilities and supported features in entity registry, restore registered entities on startup

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -311,7 +311,9 @@ class Entity(ABC):
 
         start = timer()
 
-        attr = self.capability_attributes or {}
+        attr = self.capability_attributes
+        attr = dict(attr) if attr else {}
+
         if not self.available:
             state = STATE_UNAVAILABLE
         else:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -389,10 +389,16 @@ class EntityPlatform:
         # Make sure it is valid in case an entity set the value themselves
         if not valid_entity_id(entity.entity_id):
             raise HomeAssistantError(f"Invalid entity id: {entity.entity_id}")
-        if (
-            entity.entity_id in self.entities
-            or entity.entity_id in self.hass.states.async_entity_ids(self.domain)
-        ):
+
+        already_exists = entity.entity_id in self.entities
+
+        if not already_exists:
+            existing = self.hass.states.get(entity.entity_id)
+
+            if existing and not existing.attributes.get("restored"):
+                already_exists = True
+
+        if already_exists:
             msg = f"Entity id already exists: {entity.entity_id}"
             if entity.unique_id is not None:
                 msg += ". Platform {} does not generate unique IDs".format(

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -349,6 +349,7 @@ class EntityPlatform:
                 disabled_by=disabled_by,
                 capabilities=entity.capability_attributes,
                 supported_features=entity.supported_features,
+                device_class=entity.device_class,
             )
 
             entity.registry_entry = entry

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -347,6 +347,8 @@ class EntityPlatform:
                 device_id=device_id,
                 known_object_ids=self.entities.keys(),
                 disabled_by=disabled_by,
+                capabilities=entity.capability_attributes,
+                supported_features=entity.supported_features,
             )
 
             entity.registry_entry = entry

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -385,10 +385,10 @@ class EntityRegistry:
             if entry.entity_id in existing or entry.disabled:
                 continue
 
+            attrs = {"restored": True}
+
             if entry.capabilities:
-                attrs = dict(entry.capabilities)
-            else:
-                attrs = {}
+                attrs.update(entry.capabilities)
 
             if entry.supported_features:
                 attrs[ATTR_SUPPORTED_FEATURES] = entry.supported_features

--- a/tests/common.py
+++ b/tests/common.py
@@ -917,6 +917,16 @@ class MockEntity(entity.Entity):
         return self._handle("device_info")
 
     @property
+    def capability_attributes(self):
+        """Info about capabilities."""
+        return self._handle("capability_attributes")
+
+    @property
+    def supported_features(self):
+        """Info about supported features."""
+        return self._handle("supported_features")
+
+    @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry."""
         return self._handle("entity_registry_enabled_default")

--- a/tests/common.py
+++ b/tests/common.py
@@ -922,6 +922,11 @@ class MockEntity(entity.Entity):
         return self._handle("device_info")
 
     @property
+    def device_class(self):
+        """Info how device should be classified."""
+        return self._handle("device_class")
+
+    @property
     def capability_attributes(self):
         """Info about capabilities."""
         return self._handle("capability_attributes")

--- a/tests/common.py
+++ b/tests/common.py
@@ -907,6 +907,11 @@ class MockEntity(entity.Entity):
         return self._handle("unique_id")
 
     @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._handle("state")
+
+    @property
     def available(self):
         """Return True if entity is available."""
         return self._handle("available")

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -130,6 +130,7 @@ async def test_auto_heal_midnight(hass, mock_openzwave):
     time = utc.localize(datetime(2017, 5, 6, 0, 0, 0))
     async_fire_time_changed(hass, time)
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert network.heal.called
     assert len(network.heal.mock_calls) == 1
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -8,7 +8,6 @@ from unittest.mock import Mock, patch
 import asynctest
 import pytest
 
-from homeassistant.components import group
 from homeassistant.const import ENTITY_MATCH_ALL
 import homeassistant.core as ha
 from homeassistant.exceptions import PlatformNotReady
@@ -285,15 +284,13 @@ async def test_extract_from_service_filter_out_non_existing_entities(hass):
 async def test_extract_from_service_no_group_expand(hass):
     """Test not expanding a group."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
-    test_group = await group.Group.async_create_group(
-        hass, "test_group", ["light.Ceiling", "light.Kitchen"]
-    )
-    await component.async_add_entities([test_group])
+    await component.async_add_entities([MockEntity(entity_id="group.test_group")])
 
     call = ha.ServiceCall("test", "service", {"entity_id": ["group.test_group"]})
 
     extracted = await component.async_extract_from_service(call, expand_group=False)
-    assert extracted == [test_group]
+    assert len(extracted) == 1
+    assert extracted[0].entity_id == "group.test_group"
 
 
 async def test_setup_dependencies_platform(hass):

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -800,7 +800,10 @@ async def test_entity_info_added_to_entity_registry(hass):
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
 
     entity_default = MockEntity(
-        unique_id="default", capability_attributes={"max": 100}, supported_features=5
+        unique_id="default",
+        capability_attributes={"max": 100},
+        supported_features=5,
+        device_class="mock-device-class",
     )
 
     await component.async_add_entities([entity_default])
@@ -811,6 +814,7 @@ async def test_entity_info_added_to_entity_registry(hass):
     print(entry_default)
     assert entry_default.capabilities == {"max": 100}
     assert entry_default.supported_features == 5
+    assert entry_default.device_class == "mock-device-class"
 
 
 async def test_override_restored_entities(hass):

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -793,3 +793,21 @@ async def test_entity_disabled_by_integration(hass):
     assert entry_default.disabled_by is None
     entry_disabled = registry.async_get_or_create(DOMAIN, DOMAIN, "disabled")
     assert entry_disabled.disabled_by == "integration"
+
+
+async def test_entity_info_added_to_entity_registry(hass):
+    """Test entity info is written to entity registry."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
+
+    entity_default = MockEntity(
+        unique_id="default", capability_attributes={"max": 100}, supported_features=5
+    )
+
+    await component.async_add_entities([entity_default])
+
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entry_default = registry.async_get_or_create(DOMAIN, DOMAIN, "default")
+    print(entry_default)
+    assert entry_default.capabilities == {"max": 100}
+    assert entry_default.supported_features == 5

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -811,3 +811,22 @@ async def test_entity_info_added_to_entity_registry(hass):
     print(entry_default)
     assert entry_default.capabilities == {"max": 100}
     assert entry_default.supported_features == 5
+
+
+async def test_override_restored_entities(hass):
+    """Test that we allow overriding restored entities."""
+    registry = mock_registry(hass)
+    registry.async_get_or_create(
+        "test_domain", "test_domain", "1234", suggested_object_id="world"
+    )
+
+    hass.states.async_set("test_domain.world", "unavailable", {"restored": True})
+
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    await component.async_add_entities(
+        [MockEntity(unique_id="1234", state="on", entity_id="test_domain.world")], True
+    )
+
+    state = hass.states.get("test_domain.world")
+    assert state.state == "on"

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -525,3 +525,13 @@ async def test_restore_states(hass):
         "device_class": "mock-device-class",
         "restored": True,
     }
+
+    registry.async_remove("light.disabled")
+    registry.async_remove("light.simple")
+    registry.async_remove("light.all_info_set")
+
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.simple") is None
+    assert hass.states.get("light.disabled") is None
+    assert hass.states.get("light.all_info_set") is None

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -511,6 +511,7 @@ async def test_restore_states(hass):
     simple = hass.states.get("light.simple")
     assert simple is not None
     assert simple.state == STATE_UNAVAILABLE
+    assert simple.attributes == {"restored": True}
 
     disabled = hass.states.get("light.disabled")
     assert disabled is None
@@ -522,4 +523,5 @@ async def test_restore_states(hass):
         "max": 100,
         "supported_features": 5,
         "device_class": "mock-device-class",
+        "restored": True,
     }


### PR DESCRIPTION
## Description:
(updated after discussion in https://github.com/home-assistant/architecture/issues/325)
This stores the supported features, device class and capabilities of an entity in the entity registry.

When Home Assistant fires the START event, it will write any entity that does not exist yet as `unavailable` to the state machine, including the known device class/supported features/capabilities. That way we can still know what the entity is capable off.

This allows us to sync entities to Google/Alexa etc even if the entity is currently unavailable.

To do:
 - [x] When an entity registry entry is removed and there is still a restored state in the state machine, remove that one too.

CC @elupus 

Fixes https://github.com/home-assistant/architecture/issues/325

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
