### PR TITLE
0.103.3

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -188,7 +188,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if uuid == entry.data.get(CONF_UUID):
                 return self._update_entry(
-                    entry, discovery_info[CONF_HOST], discovery_info[CONF_PORT]
+                    entry, discovery_info[CONF_HOST], entry.data.get[CONF_PORT]
                 )
 
         bridgeid = discovery_info[ATTR_SERIAL]

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -188,7 +188,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if uuid == entry.data.get(CONF_UUID):
                 return self._update_entry(
-                    entry, discovery_info[CONF_HOST], entry.data.get[CONF_PORT]
+                    entry, discovery_info[CONF_HOST], entry.data.get(CONF_PORT)
                 )
 
         bridgeid = discovery_info[ATTR_SERIAL]

--- a/homeassistant/components/dsmr_reader/definitions.py
+++ b/homeassistant/components/dsmr_reader/definitions.py
@@ -3,7 +3,9 @@
 
 def dsmr_transform(value):
     """Transform DSMR version value to right format."""
-    return float(value) / 10
+    if value.isdigit():
+        return float(value) / 10
+    return value
 
 
 def tariff_transform(value):

--- a/homeassistant/components/rachio/binary_sensor.py
+++ b/homeassistant/components/rachio/binary_sensor.py
@@ -63,7 +63,7 @@ class RachioControllerBinarySensor(BinarySensorDevice):
             return
 
         # For this device
-        self._handle_update()
+        self._handle_update(args, kwargs)
 
     @abstractmethod
     def _poll_update(self, data=None) -> bool:
@@ -119,9 +119,9 @@ class RachioControllerOnlineBinarySensor(RachioControllerBinarySensor):
 
     def _handle_update(self, *args, **kwargs) -> None:
         """Handle an update to the state of this sensor."""
-        if args[0][KEY_SUBTYPE] == SUBTYPE_ONLINE:
+        if args[0][0][KEY_SUBTYPE] == SUBTYPE_ONLINE:
             self._state = True
-        elif args[0][KEY_SUBTYPE] == SUBTYPE_OFFLINE:
+        elif args[0][0][KEY_SUBTYPE] == SUBTYPE_OFFLINE:
             self._state = False
 
         self.schedule_update_ha_state()

--- a/homeassistant/components/rachio/switch.py
+++ b/homeassistant/components/rachio/switch.py
@@ -107,7 +107,7 @@ class RachioStandbySwitch(RachioSwitch):
         dispatcher_connect(
             hass, SIGNAL_RACHIO_CONTROLLER_UPDATE, self._handle_any_update
         )
-        super().__init__(controller, poll=False)
+        super().__init__(controller, poll=True)
         self._poll_update(controller.init_data)
 
     @property
@@ -134,9 +134,9 @@ class RachioStandbySwitch(RachioSwitch):
 
     def _handle_update(self, *args, **kwargs) -> None:
         """Update the state using webhook data."""
-        if args[0][KEY_SUBTYPE] == SUBTYPE_SLEEP_MODE_ON:
+        if args[0][0][KEY_SUBTYPE] == SUBTYPE_SLEEP_MODE_ON:
             self._state = True
-        elif args[0][KEY_SUBTYPE] == SUBTYPE_SLEEP_MODE_OFF:
+        elif args[0][0][KEY_SUBTYPE] == SUBTYPE_SLEEP_MODE_OFF:
             self._state = False
 
         self.schedule_update_ha_state()

--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -2,11 +2,7 @@
   "domain": "ring",
   "name": "Ring",
   "documentation": "https://www.home-assistant.io/integrations/ring",
-  "requirements": [
-    "ring_doorbell==0.2.3"
-  ],
-  "dependencies": [
-    "ffmpeg"
-  ],
+  "requirements": ["ring_doorbell==0.2.5"],
+  "dependencies": ["ffmpeg"],
   "codeowners": []
 }

--- a/homeassistant/components/starlingbank/manifest.json
+++ b/homeassistant/components/starlingbank/manifest.json
@@ -2,9 +2,7 @@
   "domain": "starlingbank",
   "name": "Starlingbank",
   "documentation": "https://www.home-assistant.io/integrations/starlingbank",
-  "requirements": [
-    "starlingbank==3.1"
-  ],
+  "requirements": ["starlingbank==3.2"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 103
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 6, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1730,7 +1730,7 @@ rfk101py==0.0.1
 rflink==0.0.46
 
 # homeassistant.components.ring
-ring_doorbell==0.2.3
+ring_doorbell==0.2.5
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1868,7 +1868,7 @@ sqlalchemy==1.3.11
 starline==0.1.3
 
 # homeassistant.components.starlingbank
-starlingbank==3.1
+starlingbank==3.2
 
 # homeassistant.components.statsd
 statsd==3.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -549,7 +549,7 @@ restrictedpython==5.0
 rflink==0.0.46
 
 # homeassistant.components.ring
-ring_doorbell==0.2.3
+ring_doorbell==0.2.5
 
 # homeassistant.components.yamaha
 rxv==0.6.0

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -323,32 +323,53 @@ async def test_hassio_update_instance(hass):
     """Test we can update an existing config entry."""
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
-        data={config_flow.CONF_BRIDGEID: "id", config_flow.CONF_HOST: "1.2.3.4"},
+        data={
+            config_flow.CONF_BRIDGEID: "id",
+            config_flow.CONF_HOST: "1.2.3.4",
+            config_flow.CONF_PORT: 40850,
+            config_flow.CONF_API_KEY: "secret",
+        },
     )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        data={config_flow.CONF_HOST: "mock-deconz", config_flow.CONF_SERIAL: "id"},
+        data={
+            config_flow.CONF_HOST: "mock-deconz",
+            config_flow.CONF_PORT: 8080,
+            config_flow.CONF_API_KEY: "updated",
+            config_flow.CONF_SERIAL: "id",
+        },
         context={"source": "hassio"},
     )
 
     assert result["type"] == "abort"
     assert result["reason"] == "updated_instance"
     assert entry.data[config_flow.CONF_HOST] == "mock-deconz"
+    assert entry.data[config_flow.CONF_PORT] == 8080
+    assert entry.data[config_flow.CONF_API_KEY] == "updated"
 
 
 async def test_hassio_dont_update_instance(hass):
     """Test we can update an existing config entry."""
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
-        data={config_flow.CONF_BRIDGEID: "id", config_flow.CONF_HOST: "1.2.3.4"},
+        data={
+            config_flow.CONF_BRIDGEID: "id",
+            config_flow.CONF_HOST: "1.2.3.4",
+            config_flow.CONF_PORT: 8080,
+            config_flow.CONF_API_KEY: "secret",
+        },
     )
     entry.add_to_hass(hass)
-
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        data={config_flow.CONF_HOST: "1.2.3.4", config_flow.CONF_SERIAL: "id"},
+        data={
+            config_flow.CONF_HOST: "1.2.3.4",
+            config_flow.CONF_PORT: 8080,
+            config_flow.CONF_API_KEY: "secret",
+            config_flow.CONF_SERIAL: "id",
+        },
         context={"source": "hassio"},
     )
 

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -197,7 +197,10 @@ async def test_fan_speed(hass, hk_driver, cls, events):
     )
     await hass.async_block_till_done()
     acc = cls.fan(hass, hk_driver, "Fan", entity_id, 2, None)
-    assert acc.char_speed.value == 0
+
+    # Initial value can be anything but 0. If it is 0, it might cause HomeKit to set the
+    # speed to 100 when turning on a fan on a freshly booted up server.
+    assert acc.char_speed.value != 0
 
     await hass.async_add_job(acc.run)
     assert (

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -101,7 +101,9 @@ async def test_light_brightness(hass, hk_driver, cls, events):
     await hass.async_block_till_done()
     acc = cls.light(hass, hk_driver, "Light", entity_id, 2, None)
 
-    assert acc.char_brightness.value == 0
+    # Initial value can be anything but 0. If it is 0, it might cause HomeKit to set the
+    # brightness to 100 when turning on a light on a freshly booted up server.
+    assert acc.char_brightness.value != 0
 
     await hass.async_add_job(acc.run)
     await hass.async_block_till_done()


### PR DESCRIPTION
- Fix update port and api key on deconz discovery config entry u… ([@frenck] - [#30088]) ([deconz docs])
- Patch rachio ([@omriasta] - [#30031]) ([rachio docs])
- Fix failure in transform method ([@depl0y] - [#30023]) ([dsmr_reader docs])
- Fix homekit handling of 0 light brightness and fan speed ([@fuzzie360] - [#29962]) ([homekit docs])
- Bump starlingbank to 3.2 ([@springstan] - [#30098]) ([starlingbank docs])
- Bump ring to 0.2.5 ([@balloob] - [#30103]) ([ring docs])

[#29962]: https://github.com/home-assistant/home-assistant/pull/29962
[#30023]: https://github.com/home-assistant/home-assistant/pull/30023
[#30031]: https://github.com/home-assistant/home-assistant/pull/30031
[#30088]: https://github.com/home-assistant/home-assistant/pull/30088
[#30098]: https://github.com/home-assistant/home-assistant/pull/30098
[#30103]: https://github.com/home-assistant/home-assistant/pull/30103
[@balloob]: https://github.com/balloob
[@depl0y]: https://github.com/depl0y
[@frenck]: https://github.com/frenck
[@fuzzie360]: https://github.com/fuzzie360
[@omriasta]: https://github.com/omriasta
[@springstan]: https://github.com/springstan
[deconz docs]: https://www.home-assistant.io/integrations/deconz/
[dsmr_reader docs]: https://www.home-assistant.io/integrations/dsmr_reader/
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[rachio docs]: https://www.home-assistant.io/integrations/rachio/
[ring docs]: https://www.home-assistant.io/integrations/ring/
[starlingbank docs]: https://www.home-assistant.io/integrations/starlingbank/