### PR TITLE
add --show-diff-on-failure to pre-commit

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -54,7 +54,7 @@ stages:
       displayName: 'Run bandit'
     - script: |
         . venv/bin/activate
-        pre-commit run isort --all-files
+        pre-commit run isort --all-files --show-diff-on-failure
       displayName: 'Run isort'
     - script: |
         . venv/bin/activate
@@ -97,7 +97,7 @@ stages:
           pre-commit install-hooks --config .pre-commit-config-all.yaml
     - script: |
         . venv/bin/activate
-        pre-commit run black --all-files
+        pre-commit run black --all-files --show-diff-on-failure
       displayName: 'Check Black formatting'
 
 - stage: 'Tests'


### PR DESCRIPTION
## Description:

This makes the traceback on a failing CI pipeline much more useful.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
