### PR TITLE
Bump starlingbank to 3.2

### DIFF
--- a/homeassistant/components/starlingbank/manifest.json
+++ b/homeassistant/components/starlingbank/manifest.json
@@ -2,9 +2,7 @@
   "domain": "starlingbank",
   "name": "Starlingbank",
   "documentation": "https://www.home-assistant.io/integrations/starlingbank",
-  "requirements": [
-    "starlingbank==3.1"
-  ],
+  "requirements": ["starlingbank==3.2"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1876,7 +1876,7 @@ sqlalchemy==1.3.11
 starline==0.1.3
 
 # homeassistant.components.starlingbank
-starlingbank==3.1
+starlingbank==3.2
 
 # homeassistant.components.statsd
 statsd==3.2.1


### PR DESCRIPTION
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This PR bumps `starlingbank` to 3.2.
Changelog: https://github.com/Dullage/starlingbank#change-log


**Related issue (if applicable):** fixes #30092<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally. (see https://github.com/home-assistant/home-assistant/issues/30092#issue-540959900)
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
