### PR TITLE
Add a config entry mechanism to rediscover a discovery that was ignored

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -108,7 +108,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             ),
         )
 
-    async def async_step_rediscover(self, user_input):
+    async def async_step_unignore(self, user_input):
         """Rediscover a previously ignored discover."""
         unique_id = user_input["unique_id"]
         await self.async_set_unique_id(unique_id)

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -108,6 +108,38 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             ),
         )
 
+    async def async_step_rediscover(self, user_input):
+        """Rediscover a previously ignored discover."""
+        unique_id = user_input["unique_id"]
+        await self.async_set_unique_id(unique_id)
+
+        records = await self.hass.async_add_executor_job(self.controller.discover, 5)
+        for record in records:
+            if normalize_hkid(record["id"]) != unique_id:
+                continue
+            return await self.async_step_zeroconf(
+                {
+                    "host": record["address"],
+                    "port": record["port"],
+                    "hostname": record["name"],
+                    "type": "_hap._tcp.local.",
+                    "name": record["name"],
+                    "properties": {
+                        "md": record["md"],
+                        "pv": record["pv"],
+                        "id": unique_id,
+                        "c#": record["c#"],
+                        "s#": record["s#"],
+                        "ff": record["ff"],
+                        "ci": record["ci"],
+                        "sf": record["sf"],
+                        "sh": "",
+                    },
+                }
+            )
+
+        return self.async_abort(reason="no_devices")
+
     async def async_step_zeroconf(self, discovery_info):
         """Handle a discovered HomeKit accessory.
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -25,7 +25,7 @@ SOURCE_SSDP = "ssdp"
 SOURCE_USER = "user"
 SOURCE_ZEROCONF = "zeroconf"
 SOURCE_IGNORE = "ignore"
-SOURCE_REDISCOVER = "rediscover"
+SOURCE_UNIGNORE = "unignore"
 
 HANDLERS = Registry()
 
@@ -466,7 +466,7 @@ class ConfigEntries:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
                     entry.domain,
-                    context={"source": SOURCE_REDISCOVER},
+                    context={"source": SOURCE_UNIGNORE},
                     data={"unique_id": entry.unique_id},
                 )
             )
@@ -837,7 +837,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         await self.async_set_unique_id(user_input["unique_id"], raise_on_progress=False)
         return self.async_create_entry(title="Ignored", data={})
 
-    async def async_step_rediscover(self, user_input: Dict[str, Any]) -> Dict[str, Any]:
+    async def async_step_unignore(self, user_input: Dict[str, Any]) -> Dict[str, Any]:
         """Rediscover a config entry by it's unique_id."""
         return self.async_abort(reason="not_implemented")
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -839,7 +839,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     async def async_step_rediscover(self, user_input: Dict[str, Any]) -> Dict[str, Any]:
         """Rediscover a config entry by it's unique_id."""
-        pass
+        return self.async_abort(reason="not_implemented")
 
 
 class OptionsFlowManager:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -25,6 +25,7 @@ SOURCE_SSDP = "ssdp"
 SOURCE_USER = "user"
 SOURCE_ZEROCONF = "zeroconf"
 SOURCE_IGNORE = "ignore"
+SOURCE_REDISCOVER = "rediscover"
 
 HANDLERS = Registry()
 
@@ -461,6 +462,15 @@ class ConfigEntries:
         dev_reg.async_clear_config_entry(entry_id)
         ent_reg.async_clear_config_entry(entry_id)
 
+        if entry.source == SOURCE_IGNORE:
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    entry.domain,
+                    context={"source": SOURCE_REDISCOVER},
+                    data={"unique_id": entry.unique_id},
+                )
+            )
+
         return {"require_restart": not unload_success}
 
     async def async_initialize(self) -> None:
@@ -826,6 +836,10 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         """Ignore this config flow."""
         await self.async_set_unique_id(user_input["unique_id"], raise_on_progress=False)
         return self.async_create_entry(title="Ignored", data={})
+
+    async def async_step_rediscover(self, user_input: Dict[str, Any]) -> Dict[str, Any]:
+        """Rediscover a config entry by it's unique_id."""
+        pass
 
 
 class OptionsFlowManager:

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -836,3 +836,85 @@ async def test_parse_overlapping_homekit_json(hass):
         "title_placeholders": {"name": "TestDevice"},
         "unique_id": "00:00:00:00:00:00",
     }
+
+
+async def test_rediscover_works(hass):
+    """Test rediscovery triggered disovers work."""
+    discovery_info = {
+        "name": "TestDevice",
+        "address": "127.0.0.1",
+        "port": 8080,
+        "md": "TestDevice",
+        "pv": "1.0",
+        "id": "00:00:00:00:00:00",
+        "c#": 1,
+        "s#": 1,
+        "ff": 0,
+        "ci": 0,
+        "sf": 1,
+    }
+
+    pairing = mock.Mock(pairing_data={"AccessoryPairingID": "00:00:00:00:00:00"})
+    pairing.list_accessories_and_characteristics.return_value = [
+        {
+            "aid": 1,
+            "services": [
+                {
+                    "characteristics": [{"type": "23", "value": "Koogeek-LS1-20833F"}],
+                    "type": "3e",
+                }
+            ],
+        }
+    ]
+
+    flow = _setup_flow_handler(hass)
+
+    flow.controller.pairings = {"00:00:00:00:00:00": pairing}
+    flow.controller.discover.return_value = [discovery_info]
+
+    result = await flow.async_step_rediscover({"unique_id": "00:00:00:00:00:00"})
+    assert result["type"] == "form"
+    assert result["step_id"] == "pair"
+    assert flow.context == {
+        "hkid": "00:00:00:00:00:00",
+        "title_placeholders": {"name": "TestDevice"},
+        "unique_id": "00:00:00:00:00:00",
+    }
+
+    # User initiates pairing by clicking on 'configure' - device enters pairing mode and displays code
+    result = await flow.async_step_pair({})
+    assert result["type"] == "form"
+    assert result["step_id"] == "pair"
+    assert flow.controller.start_pairing.call_count == 1
+
+    # Pairing finalized
+    result = await flow.async_step_pair({"pairing_code": "111-22-33"})
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Koogeek-LS1-20833F"
+    assert result["data"] == pairing.pairing_data
+
+
+async def test_rediscover_ignores_missing_devices(hass):
+    """Test rediscovery triggered disovers handle devices that have gone away."""
+    discovery_info = {
+        "name": "TestDevice",
+        "address": "127.0.0.1",
+        "port": 8080,
+        "md": "TestDevice",
+        "pv": "1.0",
+        "id": "00:00:00:00:00:00",
+        "c#": 1,
+        "s#": 1,
+        "ff": 0,
+        "ci": 0,
+        "sf": 1,
+    }
+
+    flow = _setup_flow_handler(hass)
+    flow.controller.discover.return_value = [discovery_info]
+
+    result = await flow.async_step_rediscover({"unique_id": "00:00:00:00:00:01"})
+    assert result["type"] == "abort"
+    assert flow.context == {
+        "unique_id": "00:00:00:00:00:01",
+    }

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -838,7 +838,7 @@ async def test_parse_overlapping_homekit_json(hass):
     }
 
 
-async def test_rediscover_works(hass):
+async def test_unignore_works(hass):
     """Test rediscovery triggered disovers work."""
     discovery_info = {
         "name": "TestDevice",
@@ -872,7 +872,7 @@ async def test_rediscover_works(hass):
     flow.controller.pairings = {"00:00:00:00:00:00": pairing}
     flow.controller.discover.return_value = [discovery_info]
 
-    result = await flow.async_step_rediscover({"unique_id": "00:00:00:00:00:00"})
+    result = await flow.async_step_unignore({"unique_id": "00:00:00:00:00:00"})
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
     assert flow.context == {
@@ -894,7 +894,7 @@ async def test_rediscover_works(hass):
     assert result["data"] == pairing.pairing_data
 
 
-async def test_rediscover_ignores_missing_devices(hass):
+async def test_unignore_ignores_missing_devices(hass):
     """Test rediscovery triggered disovers handle devices that have gone away."""
     discovery_info = {
         "name": "TestDevice",
@@ -913,7 +913,7 @@ async def test_rediscover_ignores_missing_devices(hass):
     flow = _setup_flow_handler(hass)
     flow.controller.discover.return_value = [discovery_info]
 
-    result = await flow.async_step_rediscover({"unique_id": "00:00:00:00:00:01"})
+    result = await flow.async_step_unignore({"unique_id": "00:00:00:00:00:01"})
     assert result["type"] == "abort"
     assert flow.context == {
         "unique_id": "00:00:00:00:00:01",

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1186,3 +1186,120 @@ async def test_unique_id_ignore(hass, manager):
 
     assert entry.source == "ignore"
     assert entry.unique_id == "mock-unique-id"
+
+
+async def test_rediscovery_step_form(hass, manager):
+    """Test that we can ignore flows that are in progress and have a unique ID, then rediscover them."""
+    async_setup_entry = MagicMock(return_value=mock_coro(True))
+    mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+
+        VERSION = 1
+
+        async def async_step_rediscover(self, user_input):
+            unique_id = user_input["unique_id"]
+            await self.async_set_unique_id(unique_id)
+            return self.async_show_form(step_id="discovery")
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        result = await manager.flow.async_init(
+            "comp",
+            context={"source": config_entries.SOURCE_IGNORE},
+            data={"unique_id": "mock-unique-id"},
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+        entry = hass.config_entries.async_entries("comp")[0]
+        assert entry.source == "ignore"
+        assert entry.unique_id == "mock-unique-id"
+        assert entry.domain == "comp"
+
+        await manager.async_remove(entry.entry_id)
+
+        # Right after removal there shouldn't be an entry or active flows
+        assert len(hass.config_entries.async_entries("comp")) == 0
+        assert len(hass.config_entries.flow.async_progress()) == 0
+
+        # But after a 'tick' the rediscover step has run and we can see an active flow again.
+        await hass.async_block_till_done()
+        assert len(hass.config_entries.flow.async_progress()) == 1
+
+        # and still not config entries
+        assert len(hass.config_entries.async_entries("comp")) == 0
+
+
+async def test_rediscovery_create_entry(hass, manager):
+    """Test that we can ignore flows that are in progress and have a unique ID, then rediscover them."""
+    async_setup_entry = MagicMock(return_value=mock_coro(True))
+    mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+
+        VERSION = 1
+
+        async def async_step_rediscover(self, user_input):
+            unique_id = user_input["unique_id"]
+            await self.async_set_unique_id(unique_id)
+            return self.async_create_entry(title="yo", data={})
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        result = await manager.flow.async_init(
+            "comp",
+            context={"source": config_entries.SOURCE_IGNORE},
+            data={"unique_id": "mock-unique-id"},
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+        entry = hass.config_entries.async_entries("comp")[0]
+        assert entry.source == "ignore"
+        assert entry.unique_id == "mock-unique-id"
+        assert entry.domain == "comp"
+
+        await manager.async_remove(entry.entry_id)
+
+        # Right after removal there shouldn't be an entry or flow
+        assert len(hass.config_entries.flow.async_progress()) == 0
+        assert len(hass.config_entries.async_entries("comp")) == 0
+
+        # But after a 'tick' the rediscover step has run and we can see a config entry.
+        await hass.async_block_till_done()
+        entry = hass.config_entries.async_entries("comp")[0]
+        assert entry.source == "rediscover"
+        assert entry.unique_id == "mock-unique-id"
+        assert entry.title == "yo"
+
+        # And still no active flow
+        assert len(hass.config_entries.flow.async_progress()) == 0
+
+
+async def test_rediscovery_default_impl(hass, manager):
+    """Test that resdicovery is a no-op by default."""
+    async_setup_entry = MagicMock(return_value=mock_coro(True))
+    mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+
+        VERSION = 1
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        result = await manager.flow.async_init(
+            "comp",
+            context={"source": config_entries.SOURCE_IGNORE},
+            data={"unique_id": "mock-unique-id"},
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+        entry = hass.config_entries.async_entries("comp")[0]
+        assert entry.source == "ignore"
+        assert entry.unique_id == "mock-unique-id"
+        assert entry.domain == "comp"
+
+        await manager.async_remove(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert len(hass.config_entries.async_entries("comp")) == 0
+        assert len(hass.config_entries.flow.async_progress()) == 0

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1188,7 +1188,7 @@ async def test_unique_id_ignore(hass, manager):
     assert entry.unique_id == "mock-unique-id"
 
 
-async def test_rediscovery_step_form(hass, manager):
+async def test_unignore_step_form(hass, manager):
     """Test that we can ignore flows that are in progress and have a unique ID, then rediscover them."""
     async_setup_entry = MagicMock(return_value=mock_coro(True))
     mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))
@@ -1198,7 +1198,7 @@ async def test_rediscovery_step_form(hass, manager):
 
         VERSION = 1
 
-        async def async_step_rediscover(self, user_input):
+        async def async_step_unignore(self, user_input):
             unique_id = user_input["unique_id"]
             await self.async_set_unique_id(unique_id)
             return self.async_show_form(step_id="discovery")
@@ -1222,7 +1222,7 @@ async def test_rediscovery_step_form(hass, manager):
         assert len(hass.config_entries.async_entries("comp")) == 0
         assert len(hass.config_entries.flow.async_progress()) == 0
 
-        # But after a 'tick' the rediscover step has run and we can see an active flow again.
+        # But after a 'tick' the unignore step has run and we can see an active flow again.
         await hass.async_block_till_done()
         assert len(hass.config_entries.flow.async_progress()) == 1
 
@@ -1230,7 +1230,7 @@ async def test_rediscovery_step_form(hass, manager):
         assert len(hass.config_entries.async_entries("comp")) == 0
 
 
-async def test_rediscovery_create_entry(hass, manager):
+async def test_unignore_create_entry(hass, manager):
     """Test that we can ignore flows that are in progress and have a unique ID, then rediscover them."""
     async_setup_entry = MagicMock(return_value=mock_coro(True))
     mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))
@@ -1240,7 +1240,7 @@ async def test_rediscovery_create_entry(hass, manager):
 
         VERSION = 1
 
-        async def async_step_rediscover(self, user_input):
+        async def async_step_unignore(self, user_input):
             unique_id = user_input["unique_id"]
             await self.async_set_unique_id(unique_id)
             return self.async_create_entry(title="yo", data={})
@@ -1264,10 +1264,10 @@ async def test_rediscovery_create_entry(hass, manager):
         assert len(hass.config_entries.flow.async_progress()) == 0
         assert len(hass.config_entries.async_entries("comp")) == 0
 
-        # But after a 'tick' the rediscover step has run and we can see a config entry.
+        # But after a 'tick' the unignore step has run and we can see a config entry.
         await hass.async_block_till_done()
         entry = hass.config_entries.async_entries("comp")[0]
-        assert entry.source == "rediscover"
+        assert entry.source == "unignore"
         assert entry.unique_id == "mock-unique-id"
         assert entry.title == "yo"
 
@@ -1275,7 +1275,7 @@ async def test_rediscovery_create_entry(hass, manager):
         assert len(hass.config_entries.flow.async_progress()) == 0
 
 
-async def test_rediscovery_default_impl(hass, manager):
+async def test_unignore_default_impl(hass, manager):
     """Test that resdicovery is a no-op by default."""
     async_setup_entry = MagicMock(return_value=mock_coro(True))
     mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))


### PR DESCRIPTION
## Description:

Here is a quick PR implementing the ideas we discussed in #30083. It's still marked as WIP because I need to figure out how to test it, but it did pass manual tests - I was able to "ignore" a homekit device and then "stop ignoring" it, and after a few seconds i was able to pair it.

@balloob what do you think so far?

RE: #29806 #30035 #30083

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]