### PR TITLE
Explicitly include Alexa interface for image_processing entities.

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -673,3 +673,4 @@ class ImageProcessingCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         yield AlexaEventDetectionSensor(self.hass, self.entity)
         yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2524,7 +2524,7 @@ async def test_image_processing(hass):
     assert appliance["friendlyName"] == "Test face"
 
     assert_endpoint_capabilities(
-        appliance, "Alexa.EventDetectionSensor", "Alexa.EndpointHealth"
+        appliance, "Alexa.EventDetectionSensor", "Alexa.EndpointHealth", "Alexa"
     )
 
 


### PR DESCRIPTION
Description:
Small PR to add `Alexa` capability interface for `image_processing` entities list of capabilities as recommended by the Alexa API Docs. 

The `Alexa.EventDetectionSensor` Interface for `image_processing` entities wasn't implemented yet when PR #28218 was merged and overlooked during Hacktoberfest. 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
