### PR TITLE
Add pilight dimmer as light component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -247,6 +247,7 @@ homeassistant/components/pcal9535a/* @Shulyaka
 homeassistant/components/persistent_notification/* @home-assistant/core
 homeassistant/components/philips_js/* @elupus
 homeassistant/components/pi_hole/* @fabaff @johnluetke
+homeassistant/components/pilight/* @trekky12
 homeassistant/components/plaato/* @JohNan
 homeassistant/components/plant/* @ChristianKuehnel
 homeassistant/components/plex/* @jjlawren

--- a/homeassistant/components/pilight/base_class.py
+++ b/homeassistant/components/pilight/base_class.py
@@ -85,6 +85,8 @@ class PilightBaseDevice(RestoreEntity):
         if any(self._code_on_receive) or any(self._code_off_receive):
             hass.bus.listen(pilight.EVENT, self._handle_code)
 
+        self._brightness = 255
+
     async def async_added_to_hass(self):
         """Call when entity about to be added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/pilight/base_class.py
+++ b/homeassistant/components/pilight/base_class.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import pilight
+from homeassistant.components.pilight import DOMAIN, EVENT, SERVICE_NAME
 from homeassistant.const import (
     CONF_ID,
     CONF_NAME,
@@ -83,7 +83,7 @@ class PilightBaseDevice(RestoreEntity):
                 code_list.append(_ReceiveHandle(code, echo))
 
         if any(self._code_on_receive) or any(self._code_off_receive):
-            hass.bus.listen(pilight.EVENT, self._handle_code)
+            hass.bus.listen(EVENT, self._handle_code)
 
         self._brightness = 255
 
@@ -149,12 +149,10 @@ class PilightBaseDevice(RestoreEntity):
                 if dimlevel is not None:
                     code.update({"dimlevel": dimlevel})
 
-                self._hass.services.call(
-                    pilight.DOMAIN, pilight.SERVICE_NAME, code, blocking=True
-                )
+                self._hass.services.call(DOMAIN, SERVICE_NAME, code, blocking=True)
             else:
                 self._hass.services.call(
-                    pilight.DOMAIN, pilight.SERVICE_NAME, self._code_off, blocking=True
+                    DOMAIN, SERVICE_NAME, self._code_off, blocking=True
                 )
 
         self._is_on = turn_on

--- a/homeassistant/components/pilight/base_class.py
+++ b/homeassistant/components/pilight/base_class.py
@@ -1,0 +1,185 @@
+"""Base class for pilight."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import pilight
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.const import (
+    CONF_ID,
+    CONF_NAME,
+    CONF_PROTOCOL,
+    CONF_STATE,
+    STATE_ON
+)
+
+from .const import (
+    CONF_OFF_CODE,
+    CONF_OFF_CODE_RECEIVE,
+    CONF_ON_CODE,
+    CONF_ON_CODE_RECEIVE,
+    CONF_SYSTEMCODE,
+    CONF_UNIT,
+    CONF_UNITCODE,
+    CONF_ECHO
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+COMMAND_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_PROTOCOL): cv.string,
+        vol.Optional("on"): cv.positive_int,
+        vol.Optional("off"): cv.positive_int,
+        vol.Optional(CONF_UNIT): cv.positive_int,
+        vol.Optional(CONF_UNITCODE): cv.positive_int,
+        vol.Optional(CONF_ID): vol.Any(cv.positive_int, cv.string),
+        vol.Optional(CONF_STATE): cv.string,
+        vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+RECEIVE_SCHEMA = COMMAND_SCHEMA.extend({vol.Optional(CONF_ECHO): cv.boolean})
+
+SWITCHES_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ON_CODE): COMMAND_SCHEMA,
+        vol.Required(CONF_OFF_CODE): COMMAND_SCHEMA,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_OFF_CODE_RECEIVE, default=[]): vol.All(
+            cv.ensure_list, [COMMAND_SCHEMA]
+        ),
+        vol.Optional(CONF_ON_CODE_RECEIVE, default=[]): vol.All(
+            cv.ensure_list, [COMMAND_SCHEMA]
+        )
+    }
+)
+
+class PilightBaseDevice(RestoreEntity):
+    """Base class for pilight switches and lights."""
+
+    def __init__(self, hass, name, properties):
+        """Initialize a device."""
+        self._hass = hass
+        self._name = properties.get(CONF_NAME, name)
+        self._state = False
+        self._code_on = properties.get(CONF_ON_CODE)
+        self._code_off = properties.get(CONF_OFF_CODE)
+        
+        code_on_receive = properties.get(CONF_ON_CODE_RECEIVE)
+        code_off_receive = properties.get(CONF_OFF_CODE_RECEIVE)
+
+        self._code_on_receive = []
+        self._code_off_receive = []
+
+        for code_list, conf in (
+            (self._code_on_receive, code_on_receive),
+            (self._code_off_receive, code_off_receive),
+        ):
+            for code in conf:
+                echo = code.pop(CONF_ECHO, True)
+                code_list.append(_ReceiveHandle(code, echo))
+
+        if any(self._code_on_receive) or any(self._code_off_receive):
+            hass.bus.listen(pilight.EVENT, self._handle_code)
+
+    async def async_added_to_hass(self):
+        """Call when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state:
+            self._state = state.state == STATE_ON
+
+    @property
+    def name(self):
+        """Get the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed, state set when correct code is received."""
+        return False
+
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of the entity."""
+        return True
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state
+
+    def _handle_code(self, call):
+        """Check if received code by the pilight-daemon.
+
+        If the code matches the receive on/off codes of this switch the switch
+        state is changed accordingly.
+        """
+        # - True if off_code/on_code is contained in received code dict, not
+        #   all items have to match.
+        # - Call turn on/off only once, even if more than one code is received
+        if any(self._code_on_receive):
+            for on_code in self._code_on_receive:
+                if on_code.match(call.data):
+                    on_code.run(switch=self, turn_on=True)
+                    break
+
+        if any(self._code_off_receive):
+            for off_code in self._code_off_receive:
+                if off_code.match(call.data):
+                    off_code.run(switch=self, turn_on=False)
+                    break
+
+    def set_state(self, turn_on, send_code=True, dimlevel = None):
+        """Set the state of the switch.
+
+        This sets the state of the switch. If send_code is set to True, then
+        it will call the pilight.send service to actually send the codes
+        to the pilight daemon.
+        """
+        if send_code:
+            if turn_on:
+                code = self._code_on
+                if dimlevel is not None:
+                    code.update({'dimlevel': dimlevel})
+                
+                self._hass.services.call(
+                    pilight.DOMAIN, pilight.SERVICE_NAME, code, blocking=True
+                )
+            else:
+                self._hass.services.call(
+                    pilight.DOMAIN, pilight.SERVICE_NAME, self._code_off, blocking=True
+                )
+
+        self._state = turn_on
+        self.schedule_update_ha_state()
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on by calling pilight.send service with on code."""
+        self.set_state(turn_on=True)
+
+    def turn_off(self, **kwargs):
+        """Turn the switch on by calling pilight.send service with off code."""
+        self.set_state(turn_on=False)
+
+
+class _ReceiveHandle:
+    def __init__(self, config, echo):
+        """Initialize the handle."""
+        self.config_items = config.items()
+        self.echo = echo
+
+    def match(self, code):
+        """Test if the received code matches the configured values.
+
+        The received values have to be a subset of the configured options.
+        """
+        return self.config_items <= code.items()
+
+    def run(self, switch, turn_on):
+        """Change the state of the switch."""
+        switch.set_state(turn_on=turn_on, send_code=self.echo)

--- a/homeassistant/components/pilight/base_class.py
+++ b/homeassistant/components/pilight/base_class.py
@@ -58,6 +58,7 @@ SWITCHES_SCHEMA = vol.Schema(
     }
 )
 
+
 class PilightBaseDevice(RestoreEntity):
     """Base class for pilight switches and lights."""
 
@@ -68,7 +69,7 @@ class PilightBaseDevice(RestoreEntity):
         self._state = False
         self._code_on = properties.get(CONF_ON_CODE)
         self._code_off = properties.get(CONF_OFF_CODE)
-        
+
         code_on_receive = properties.get(CONF_ON_CODE_RECEIVE)
         code_off_receive = properties.get(CONF_OFF_CODE_RECEIVE)
 
@@ -134,7 +135,7 @@ class PilightBaseDevice(RestoreEntity):
                     off_code.run(switch=self, turn_on=False)
                     break
 
-    def set_state(self, turn_on, send_code=True, dimlevel = None):
+    def set_state(self, turn_on, send_code=True, dimlevel=None):
         """Set the state of the switch.
 
         This sets the state of the switch. If send_code is set to True, then
@@ -146,7 +147,7 @@ class PilightBaseDevice(RestoreEntity):
                 code = self._code_on
                 if dimlevel is not None:
                     code.update({'dimlevel': dimlevel})
-                
+
                 self._hass.services.call(
                     pilight.DOMAIN, pilight.SERVICE_NAME, code, blocking=True
                 )

--- a/homeassistant/components/pilight/const.py
+++ b/homeassistant/components/pilight/const.py
@@ -1,12 +1,14 @@
 """Consts used by pilight."""
 
+CONF_DIMLEVEL_MAX = "dimlevel_max"
+CONF_DIMLEVEL_MIN = "dimlevel_min"
+CONF_ECHO = "echo"
+CONF_OFF = "off"
 CONF_OFF_CODE = "off_code"
 CONF_OFF_CODE_RECEIVE = "off_code_receive"
+CONF_ON = "on"
 CONF_ON_CODE = "on_code"
 CONF_ON_CODE_RECEIVE = "on_code_receive"
 CONF_SYSTEMCODE = "systemcode"
 CONF_UNIT = "unit"
 CONF_UNITCODE = "unitcode"
-CONF_ECHO = "echo"
-CONF_DIMLEVEL_MIN = 'dimlevel_min'
-CONF_DIMLEVEL_MAX = 'dimlevel_max'

--- a/homeassistant/components/pilight/const.py
+++ b/homeassistant/components/pilight/const.py
@@ -1,0 +1,13 @@
+"""Consts used by pilight."""
+from homeassistant.components.light import SUPPORT_BRIGHTNESS
+
+CONF_OFF_CODE = "off_code"
+CONF_OFF_CODE_RECEIVE = "off_code_receive"
+CONF_ON_CODE = "on_code"
+CONF_ON_CODE_RECEIVE = "on_code_receive"
+CONF_SYSTEMCODE = "systemcode"
+CONF_UNIT = "unit"
+CONF_UNITCODE = "unitcode"
+CONF_ECHO = "echo"
+CONF_DIMLEVEL_MIN = 'dimlevel_min'
+CONF_DIMLEVEL_MAX = 'dimlevel_max'

--- a/homeassistant/components/pilight/const.py
+++ b/homeassistant/components/pilight/const.py
@@ -1,5 +1,4 @@
 """Consts used by pilight."""
-from homeassistant.components.light import SUPPORT_BRIGHTNESS
 
 CONF_OFF_CODE = "off_code"
 CONF_OFF_CODE_RECEIVE = "off_code_receive"

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -3,16 +3,17 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.light import PLATFORM_SCHEMA, Light, ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS,
+    Light,
+)
 from homeassistant.const import CONF_LIGHTS
 import homeassistant.helpers.config_validation as cv
 
 from .base_class import SWITCHES_SCHEMA, PilightBaseDevice
-
-from .const import (
-    CONF_DIMLEVEL_MIN,
-    CONF_DIMLEVEL_MAX
-)
+from .const import CONF_DIMLEVEL_MAX, CONF_DIMLEVEL_MIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,14 +34,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     switches = config.get(CONF_LIGHTS)
     devices = []
 
-    for dev_name, properties in switches.items():
-        devices.append(
-            PilightLight(
-                hass,
-                dev_name,
-                properties
-            )
-        )
+    for dev_name, config in switches.items():
+        devices.append(PilightLight(hass, dev_name, config))
 
     add_entities(devices)
 
@@ -48,12 +43,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class PilightLight(PilightBaseDevice, Light):
     """Representation of a Pilight switch."""
 
-    def __init__(self, hass, name, properties):
+    def __init__(self, hass, name, config):
         """Initialize a switch."""
-        super().__init__(hass, name, properties)
+        super().__init__(hass, name, config)
         self._brightness = 255
-        self._dimlevel_min = properties.get(CONF_DIMLEVEL_MIN)
-        self._dimlevel_max = properties.get(CONF_DIMLEVEL_MAX)
+        self._dimlevel_min = config.get(CONF_DIMLEVEL_MIN)
+        self._dimlevel_max = config.get(CONF_DIMLEVEL_MAX)
 
     @property
     def brightness(self):

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -34,8 +34,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     switches = config.get(CONF_LIGHTS)
     devices = []
 
-    for dev_name, config in switches.items():
-        devices.append(PilightLight(hass, dev_name, config))
+    for dev_name, dev_config in switches.items():
+        devices.append(PilightLight(hass, dev_name, dev_config))
 
     add_entities(devices)
 
@@ -46,7 +46,6 @@ class PilightLight(PilightBaseDevice, Light):
     def __init__(self, hass, name, config):
         """Initialize a switch."""
         super().__init__(hass, name, config)
-        self._brightness = 255
         self._dimlevel_min = config.get(CONF_DIMLEVEL_MIN)
         self._dimlevel_max = config.get(CONF_DIMLEVEL_MAX)
 

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -1,0 +1,73 @@
+"""Support for switching devices via Pilight to on and off."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.light import PLATFORM_SCHEMA, Light, ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS
+from homeassistant.const import CONF_LIGHTS
+import homeassistant.helpers.config_validation as cv
+
+from .base_class import SWITCHES_SCHEMA, PilightBaseDevice
+
+from .const import (
+    CONF_DIMLEVEL_MIN,
+    CONF_DIMLEVEL_MAX
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+LIGHTS_SCHEMA = SWITCHES_SCHEMA.extend(
+    {
+        vol.Optional(CONF_DIMLEVEL_MIN, default=0): cv.positive_int,
+        vol.Optional(CONF_DIMLEVEL_MAX, default=15): cv.positive_int,
+    }
+)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {vol.Required(CONF_LIGHTS): vol.Schema({cv.string: LIGHTS_SCHEMA})}
+)
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Pilight platform."""
+    switches = config.get(CONF_LIGHTS)
+    devices = []
+
+    for dev_name, properties in switches.items():
+        devices.append(
+            PilightLight(
+                hass,
+                dev_name,
+                properties
+            )
+        )
+
+    add_entities(devices)
+
+
+
+class PilightLight(PilightBaseDevice, Light):
+    """Representation of a Pilight switch."""
+
+    def __init__(self, hass, name, properties):
+        """Initialize a switch."""
+        super().__init__(hass, name, properties)
+        self._brightness = 255
+        self._dimlevel_min = properties.get(CONF_DIMLEVEL_MIN)
+        self._dimlevel_max = properties.get(CONF_DIMLEVEL_MAX)
+
+    @property
+    def brightness(self):
+        """Return the brightness"""
+        return self._brightness
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS
+        
+    def turn_on(self, **kwargs):
+        """Turn the switch on by calling pilight.send service with on code."""
+        self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        dimlevel = int(self._brightness / (255/self._dimlevel_max))
+
+        self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -27,6 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_LIGHTS): vol.Schema({cv.string: LIGHTS_SCHEMA})}
 )
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Pilight platform."""
     switches = config.get(CONF_LIGHTS)
@@ -43,8 +44,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(devices)
 
-
-
 class PilightLight(PilightBaseDevice, Light):
     """Representation of a Pilight switch."""
 
@@ -57,17 +56,17 @@ class PilightLight(PilightBaseDevice, Light):
 
     @property
     def brightness(self):
-        """Return the brightness"""
+        """Return the brightness."""
         return self._brightness
 
     @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS
-        
+
     def turn_on(self, **kwargs):
         """Turn the switch on by calling pilight.send service with on code."""
         self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-        dimlevel = int(self._brightness / (255/self._dimlevel_max))
+        dimlevel = int(self._brightness / (255 / self._dimlevel_max))
 
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -44,6 +44,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(devices)
 
+
 class PilightLight(PilightBaseDevice, Light):
     """Representation of a Pilight switch."""
 

--- a/homeassistant/components/pilight/manifest.json
+++ b/homeassistant/components/pilight/manifest.json
@@ -6,5 +6,5 @@
     "pilight==0.1.1"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@trekky12"]
 }

--- a/homeassistant/components/pilight/switch.py
+++ b/homeassistant/components/pilight/switch.py
@@ -21,15 +21,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     switches = config.get(CONF_SWITCHES)
     devices = []
 
-    for dev_name, config in switches.items():
-        devices.append(PilightSwitch(hass, dev_name, config))
+    for dev_name, dev_config in switches.items():
+        devices.append(PilightSwitch(hass, dev_name, dev_config))
 
     add_entities(devices)
 
 
 class PilightSwitch(PilightBaseDevice, SwitchDevice):
     """Representation of a Pilight switch."""
-
-    def __init__(self, hass, name, config):
-        """Initialize a switch."""
-        super().__init__(hass, name, config)

--- a/homeassistant/components/pilight/switch.py
+++ b/homeassistant/components/pilight/switch.py
@@ -21,14 +21,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     switches = config.get(CONF_SWITCHES)
     devices = []
 
-    for dev_name, properties in switches.items():
-        devices.append(
-            PilightSwitch(
-                hass,
-                dev_name,
-                properties
-            )
-        )
+    for dev_name, config in switches.items():
+        devices.append(PilightSwitch(hass, dev_name, config))
 
     add_entities(devices)
 
@@ -36,6 +30,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class PilightSwitch(PilightBaseDevice, SwitchDevice):
     """Representation of a Pilight switch."""
 
-    def __init__(self, hass, name, properties):
+    def __init__(self, hass, name, config):
         """Initialize a switch."""
-        super().__init__(hass, name, properties)
+        super().__init__(hass, name, config)

--- a/homeassistant/components/pilight/switch.py
+++ b/homeassistant/components/pilight/switch.py
@@ -15,6 +15,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_SWITCHES): vol.Schema({cv.string: SWITCHES_SCHEMA})}
 )
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Pilight platform."""
     switches = config.get(CONF_SWITCHES)
@@ -31,12 +32,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(devices)
 
-
-
 class PilightSwitch(PilightBaseDevice, SwitchDevice):
     """Representation of a Pilight switch."""
 
     def __init__(self, hass, name, properties):
         """Initialize a switch."""
         super().__init__(hass, name, properties)
-

--- a/homeassistant/components/pilight/switch.py
+++ b/homeassistant/components/pilight/switch.py
@@ -3,64 +3,17 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import pilight
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
-from homeassistant.const import (
-    CONF_ID,
-    CONF_NAME,
-    CONF_PROTOCOL,
-    CONF_STATE,
-    CONF_SWITCHES,
-    STATE_ON,
-)
+from homeassistant.const import CONF_SWITCHES
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.restore_state import RestoreEntity
+
+from .base_class import SWITCHES_SCHEMA, PilightBaseDevice
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_OFF_CODE = "off_code"
-CONF_OFF_CODE_RECEIVE = "off_code_receive"
-CONF_ON_CODE = "on_code"
-CONF_ON_CODE_RECEIVE = "on_code_receive"
-CONF_SYSTEMCODE = "systemcode"
-CONF_UNIT = "unit"
-CONF_UNITCODE = "unitcode"
-CONF_ECHO = "echo"
-
-COMMAND_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_PROTOCOL): cv.string,
-        vol.Optional("on"): cv.positive_int,
-        vol.Optional("off"): cv.positive_int,
-        vol.Optional(CONF_UNIT): cv.positive_int,
-        vol.Optional(CONF_UNITCODE): cv.positive_int,
-        vol.Optional(CONF_ID): vol.Any(cv.positive_int, cv.string),
-        vol.Optional(CONF_STATE): cv.string,
-        vol.Optional(CONF_SYSTEMCODE): cv.positive_int,
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
-RECEIVE_SCHEMA = COMMAND_SCHEMA.extend({vol.Optional(CONF_ECHO): cv.boolean})
-
-SWITCHES_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_ON_CODE): COMMAND_SCHEMA,
-        vol.Required(CONF_OFF_CODE): COMMAND_SCHEMA,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_OFF_CODE_RECEIVE, default=[]): vol.All(
-            cv.ensure_list, [COMMAND_SCHEMA]
-        ),
-        vol.Optional(CONF_ON_CODE_RECEIVE, default=[]): vol.All(
-            cv.ensure_list, [COMMAND_SCHEMA]
-        ),
-    }
-)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_SWITCHES): vol.Schema({cv.string: SWITCHES_SCHEMA})}
 )
-
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Pilight platform."""
@@ -71,134 +24,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         devices.append(
             PilightSwitch(
                 hass,
-                properties.get(CONF_NAME, dev_name),
-                properties.get(CONF_ON_CODE),
-                properties.get(CONF_OFF_CODE),
-                properties.get(CONF_ON_CODE_RECEIVE),
-                properties.get(CONF_OFF_CODE_RECEIVE),
+                dev_name,
+                properties
             )
         )
 
     add_entities(devices)
 
 
-class _ReceiveHandle:
-    def __init__(self, config, echo):
-        """Initialize the handle."""
-        self.config_items = config.items()
-        self.echo = echo
 
-    def match(self, code):
-        """Test if the received code matches the configured values.
-
-        The received values have to be a subset of the configured options.
-        """
-        return self.config_items <= code.items()
-
-    def run(self, switch, turn_on):
-        """Change the state of the switch."""
-        switch.set_state(turn_on=turn_on, send_code=self.echo)
-
-
-class PilightSwitch(SwitchDevice, RestoreEntity):
+class PilightSwitch(PilightBaseDevice, SwitchDevice):
     """Representation of a Pilight switch."""
 
-    def __init__(
-        self, hass, name, code_on, code_off, code_on_receive, code_off_receive
-    ):
-        """Initialize the switch."""
-        self._hass = hass
-        self._name = name
-        self._state = False
-        self._code_on = code_on
-        self._code_off = code_off
+    def __init__(self, hass, name, properties):
+        """Initialize a switch."""
+        super().__init__(hass, name, properties)
 
-        self._code_on_receive = []
-        self._code_off_receive = []
-
-        for code_list, conf in (
-            (self._code_on_receive, code_on_receive),
-            (self._code_off_receive, code_off_receive),
-        ):
-            for code in conf:
-                echo = code.pop(CONF_ECHO, True)
-                code_list.append(_ReceiveHandle(code, echo))
-
-        if any(self._code_on_receive) or any(self._code_off_receive):
-            hass.bus.listen(pilight.EVENT, self._handle_code)
-
-    async def async_added_to_hass(self):
-        """Call when entity about to be added to hass."""
-        await super().async_added_to_hass()
-        state = await self.async_get_last_state()
-        if state:
-            self._state = state.state == STATE_ON
-
-    @property
-    def name(self):
-        """Get the name of the switch."""
-        return self._name
-
-    @property
-    def should_poll(self):
-        """No polling needed, state set when correct code is received."""
-        return False
-
-    @property
-    def assumed_state(self):
-        """Return True if unable to access real state of the entity."""
-        return True
-
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        return self._state
-
-    def _handle_code(self, call):
-        """Check if received code by the pilight-daemon.
-
-        If the code matches the receive on/off codes of this switch the switch
-        state is changed accordingly.
-        """
-        # - True if off_code/on_code is contained in received code dict, not
-        #   all items have to match.
-        # - Call turn on/off only once, even if more than one code is received
-        if any(self._code_on_receive):
-            for on_code in self._code_on_receive:
-                if on_code.match(call.data):
-                    on_code.run(switch=self, turn_on=True)
-                    break
-
-        if any(self._code_off_receive):
-            for off_code in self._code_off_receive:
-                if off_code.match(call.data):
-                    off_code.run(switch=self, turn_on=False)
-                    break
-
-    def set_state(self, turn_on, send_code=True):
-        """Set the state of the switch.
-
-        This sets the state of the switch. If send_code is set to True, then
-        it will call the pilight.send service to actually send the codes
-        to the pilight daemon.
-        """
-        if send_code:
-            if turn_on:
-                self._hass.services.call(
-                    pilight.DOMAIN, pilight.SERVICE_NAME, self._code_on, blocking=True
-                )
-            else:
-                self._hass.services.call(
-                    pilight.DOMAIN, pilight.SERVICE_NAME, self._code_off, blocking=True
-                )
-
-        self._state = turn_on
-        self.schedule_update_ha_state()
-
-    def turn_on(self, **kwargs):
-        """Turn the switch on by calling pilight.send service with on code."""
-        self.set_state(turn_on=True)
-
-    def turn_off(self, **kwargs):
-        """Turn the switch on by calling pilight.send service with off code."""
-        self.set_state(turn_on=False)

--- a/homeassistant/components/pilight/switch.py
+++ b/homeassistant/components/pilight/switch.py
@@ -32,6 +32,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(devices)
 
+
 class PilightSwitch(PilightBaseDevice, SwitchDevice):
     """Representation of a Pilight switch."""
 


### PR DESCRIPTION
## Description:
I would like to make a new attempt to add the pilight dimmer as light component.
I refactored the pilight switch so that there should no duplicated code.

The event bus is still used for device communication to not break an existing feature (see #7344 and #7372).

**Related PR:** https://github.com/home-assistant/home-assistant/pull/9114

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: pilight
    lights:
      test2:
        on_code:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          'on': 1
        off_code:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          'off': 1
        on_code_receive:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          state: 'on'
        off_code_receive:
          protocol: kaku_dimmer
          id: 23298822
          unit: 10
          state: 'off'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
