### PR TITLE
Update discovery_schemas.py for Aeotec Smart Switches

### DIFF
--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -293,10 +293,12 @@ DISCOVERY_SCHEMAS = [
         const.DISC_COMPONENT: "light",
         const.DISC_GENERIC_DEVICE_CLASS: [
             const.GENERIC_TYPE_SWITCH_MULTILEVEL,
+            const.GENERIC_TYPE_SWITCH_BINARY,
             const.GENERIC_TYPE_SWITCH_REMOTE,
         ],
         const.DISC_SPECIFIC_DEVICE_CLASS: [
             const.SPECIFIC_TYPE_POWER_SWITCH_MULTILEVEL,
+            const.SPECIFIC_TYPE_POWER_SWITCH_BINARY,
             const.SPECIFIC_TYPE_SCENE_SWITCH_MULTILEVEL,
             const.SPECIFIC_TYPE_NOT_USED,
         ],


### PR DESCRIPTION
Aeotec's Smart Switch 6 and 7 has a light on the switch itself,
which can be controlled via COLOR_SWITCH_CC and MULTILEVEL_SWITCH_CC
as usual with other light entities.

Since the proper generic/specific types were missing HomeAssistant
did not create a light entity for these devices.