### PR TITLE
Remove requirements from image_processing

### DIFF
--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -14,12 +14,12 @@ from homeassistant.components.image_processing import (
     CONF_SOURCE,
     PLATFORM_SCHEMA,
     ImageProcessingEntity,
-    draw_box,
 )
 from homeassistant.const import CONF_TIMEOUT
 from homeassistant.core import split_entity_id
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.pil import draw_box
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/doods/manifest.json
+++ b/homeassistant/components/doods/manifest.json
@@ -1,10 +1,8 @@
 {
-    "domain": "doods",
-    "name": "DOODS - Distributed Outside Object Detection Service",
-    "documentation": "https://www.home-assistant.io/integrations/doods",
-    "requirements": [
-        "pydoods==1.0.2"
-    ],
-    "dependencies": [],
-    "codeowners": []
+  "domain": "doods",
+  "name": "DOODS - Distributed Outside Object Detection Service",
+  "documentation": "https://www.home-assistant.io/integrations/doods",
+  "requirements": ["pydoods==1.0.2", "pillow==6.2.1"],
+  "dependencies": [],
+  "codeowners": []
 }

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -2,9 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Tuple
 
-from PIL import ImageDraw
 import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, CONF_ENTITY_ID, CONF_NAME
@@ -63,46 +61,6 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
     }
 )
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE.extend(PLATFORM_SCHEMA.schema)
-
-
-def draw_box(
-    draw: ImageDraw,
-    box: Tuple[float, float, float, float],
-    img_width: int,
-    img_height: int,
-    text: str = "",
-    color: Tuple[int, int, int] = (255, 255, 0),
-) -> None:
-    """
-    Draw a bounding box on and image.
-
-    The bounding box is defined by the tuple (y_min, x_min, y_max, x_max)
-    where the coordinates are floats in the range [0.0, 1.0] and
-    relative to the width and height of the image.
-
-    For example, if an image is 100 x 200 pixels (height x width) and the bounding
-    box is `(0.1, 0.2, 0.5, 0.9)`, the upper-left and bottom-right coordinates of
-    the bounding box will be `(40, 10)` to `(180, 50)` (in (x,y) coordinates).
-    """
-
-    line_width = 3
-    font_height = 8
-    y_min, x_min, y_max, x_max = box
-    (left, right, top, bottom) = (
-        x_min * img_width,
-        x_max * img_width,
-        y_min * img_height,
-        y_max * img_height,
-    )
-    draw.line(
-        [(left, top), (left, bottom), (right, bottom), (right, top), (left, top)],
-        width=line_width,
-        fill=color,
-    )
-    if text:
-        draw.text(
-            (left + line_width, abs(top - line_width - font_height)), text, fill=color
-        )
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/image_processing/manifest.json
+++ b/homeassistant/components/image_processing/manifest.json
@@ -2,11 +2,7 @@
   "domain": "image_processing",
   "name": "Image processing",
   "documentation": "https://www.home-assistant.io/integrations/image_processing",
-  "requirements": [
-    "pillow==6.2.1"
-  ],
-  "dependencies": [
-    "camera"
-  ],
+  "requirements": [],
+  "dependencies": ["camera"],
   "codeowners": []
 }

--- a/homeassistant/components/seven_segments/manifest.json
+++ b/homeassistant/components/seven_segments/manifest.json
@@ -2,7 +2,7 @@
   "domain": "seven_segments",
   "name": "Seven segments",
   "documentation": "https://www.home-assistant.io/integrations/seven_segments",
-  "requirements": [],
+  "requirements": ["pillow==6.2.1"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/tensorflow/image_processing.py
+++ b/homeassistant/components/tensorflow/image_processing.py
@@ -15,11 +15,11 @@ from homeassistant.components.image_processing import (
     CONF_SOURCE,
     PLATFORM_SCHEMA,
     ImageProcessingEntity,
-    draw_box,
 )
 from homeassistant.core import split_entity_id
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.pil import draw_box
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tensorflow/manifest.json
+++ b/homeassistant/components/tensorflow/manifest.json
@@ -2,7 +2,12 @@
   "domain": "tensorflow",
   "name": "Tensorflow",
   "documentation": "https://www.home-assistant.io/integrations/tensorflow",
-  "requirements": ["tensorflow==1.13.2", "numpy==1.17.4", "protobuf==3.6.1"],
+  "requirements": [
+    "tensorflow==1.13.2",
+    "numpy==1.17.4",
+    "protobuf==3.6.1",
+    "pillow==6.2.1"
+  ],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/util/pil.py
+++ b/homeassistant/util/pil.py
@@ -1,0 +1,47 @@
+"""PIL utilities.
+
+Can only be used by integrations that have pillow in their requirements.
+"""
+from typing import Tuple
+
+from PIL import ImageDraw
+
+
+def draw_box(
+    draw: ImageDraw,
+    box: Tuple[float, float, float, float],
+    img_width: int,
+    img_height: int,
+    text: str = "",
+    color: Tuple[int, int, int] = (255, 255, 0),
+) -> None:
+    """
+    Draw a bounding box on and image.
+
+    The bounding box is defined by the tuple (y_min, x_min, y_max, x_max)
+    where the coordinates are floats in the range [0.0, 1.0] and
+    relative to the width and height of the image.
+
+    For example, if an image is 100 x 200 pixels (height x width) and the bounding
+    box is `(0.1, 0.2, 0.5, 0.9)`, the upper-left and bottom-right coordinates of
+    the bounding box will be `(40, 10)` to `(180, 50)` (in (x,y) coordinates).
+    """
+
+    line_width = 3
+    font_height = 8
+    y_min, x_min, y_max, x_max = box
+    (left, right, top, bottom) = (
+        x_min * img_width,
+        x_max * img_width,
+        y_min * img_height,
+        y_max * img_height,
+    )
+    draw.line(
+        [(left, top), (left, bottom), (right, bottom), (right, top), (left, top)],
+        width=line_width,
+        fill=color,
+    )
+    if text:
+        draw.text(
+            (left + line_width, abs(top - line_width - font_height)), text, fill=color
+        )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -982,9 +982,11 @@ piglow==1.2.4
 # homeassistant.components.pilight
 pilight==0.1.1
 
-# homeassistant.components.image_processing
+# homeassistant.components.doods
 # homeassistant.components.proxy
 # homeassistant.components.qrcode
+# homeassistant.components.seven_segments
+# homeassistant.components.tensorflow
 pillow==6.2.1
 
 # homeassistant.components.dominos

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -323,11 +323,6 @@ pexpect==4.6.0
 # homeassistant.components.pilight
 pilight==0.1.1
 
-# homeassistant.components.image_processing
-# homeassistant.components.proxy
-# homeassistant.components.qrcode
-pillow==6.2.1
-
 # homeassistant.components.plex
 plexapi==3.3.0
 


### PR DESCRIPTION
## Description:
The image processing integration contained a utility function that caused it to have a requirement. This is not good as image processing is an entity integration and is thus imported by other integrations that expose Home Assistant to other systems. Now all of a system they all had to install this requirement.

I moved the utility function to `util.pil` and updated all integrations that used it.

**Related issue (if applicable):** partial fix for #29845

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

