### PR TITLE
Add belgian meter and rename some dsmr sensors

### DIFF
--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dsmr",
   "name": "DSMR Slimme Meter",
   "documentation": "https://www.home-assistant.io/integrations/dsmr",
-  "requirements": ["dsmr_parser==0.16"],
+  "requirements": ["dsmr_parser==0.18"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dsmr",
   "name": "DSMR Slimme Meter",
   "documentation": "https://www.home-assistant.io/integrations/dsmr",
-  "requirements": ["dsmr_parser==0.12"],
+  "requirements": ["dsmr_parser==0.16"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -32,8 +32,8 @@ ICON_POWER = "mdi:flash"
 ICON_POWER_FAILURE = "mdi:flash-off"
 ICON_SWELL_SAG = "mdi:pulse"
 
-# Smart meter sends telegram every 10 seconds
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+# Smart meter sends telegram every 10 seconds or every second for DSMR 5
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
 
 RECONNECT_INTERVAL = 5
 
@@ -42,7 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
         vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_DSMR_VERSION, default=DEFAULT_DSMR_VERSION): vol.All(
-            cv.string, vol.In(["5", "4", "2.2"])
+            cv.string, vol.In(["5B", "5", "4", "2.2"])
         ),
         vol.Optional(CONF_RECONNECT_INTERVAL, default=30): int,
         vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): vol.Coerce(int),
@@ -62,17 +62,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         ["Power Consumption", obis_ref.CURRENT_ELECTRICITY_USAGE],
         ["Power Production", obis_ref.CURRENT_ELECTRICITY_DELIVERY],
         ["Power Tariff", obis_ref.ELECTRICITY_ACTIVE_TARIFF],
-        ["Power Consumption (total)", obis_ref.ELECTRICITY_IMPORTED_TOTAL],
-        ["Power Consumption (low)", obis_ref.ELECTRICITY_USED_TARIFF_1],
-        ["Power Consumption (normal)", obis_ref.ELECTRICITY_USED_TARIFF_2],
-        ["Power Production (low)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_1],
-        ["Power Production (normal)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_2],
+        ["Energy Consumption (total)", obis_ref.ELECTRICITY_IMPORTED_TOTAL],
+        ["Energy Consumption (tarif 1)", obis_ref.ELECTRICITY_USED_TARIFF_1],
+        ["Energy Consumption (tarif 2)", obis_ref.ELECTRICITY_USED_TARIFF_2],
+        ["Energy Production (tarif 1)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_1],
+        ["Energy Production (tarif 2)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_2],
         ["Power Consumption Phase L1", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE],
         ["Power Consumption Phase L2", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE],
         ["Power Consumption Phase L3", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE],
         ["Power Production Phase L1", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE],
         ["Power Production Phase L2", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE],
         ["Power Production Phase L3", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE],
+        ["Short Power Failure Count", obis_ref.SHORT_POWER_FAILURE_COUNT],
         ["Long Power Failure Count", obis_ref.LONG_POWER_FAILURE_COUNT],
         ["Voltage Sags Phase L1", obis_ref.VOLTAGE_SAG_L1_COUNT],
         ["Voltage Sags Phase L2", obis_ref.VOLTAGE_SAG_L2_COUNT],
@@ -83,6 +84,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         ["Voltage Phase L1", obis_ref.INSTANTANEOUS_VOLTAGE_L1],
         ["Voltage Phase L2", obis_ref.INSTANTANEOUS_VOLTAGE_L2],
         ["Voltage Phase L3", obis_ref.INSTANTANEOUS_VOLTAGE_L3],
+        ["Current Phase L1", obis_ref.INSTANTANEOUS_CURRENT_L1],
+        ["Current Phase L2", obis_ref.INSTANTANEOUS_CURRENT_L2],
+        ["Current Phase L3", obis_ref.INSTANTANEOUS_CURRENT_L3],
     ]
 
     # Generate device entities
@@ -91,6 +95,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Protocol version specific obis
     if dsmr_version in ("4", "5"):
         gas_obis = obis_ref.HOURLY_GAS_METER_READING
+    elif dsmr_version in ("5B"):
+        gas_obis = obis_ref.BELGIUM_HOURLY_GAS_METER_READING
     else:
         gas_obis = obis_ref.GAS_METER_READING
 
@@ -214,7 +220,7 @@ class DSMREntity(Entity):
         value = self.get_dsmr_object_attr("value")
 
         if self._obis == obis_ref.ELECTRICITY_ACTIVE_TARIFF:
-            return self.translate_tariff(value)
+            return self.translate_tariff(value, self._config[CONF_DSMR_VERSION])
 
         try:
             value = round(float(value), self._config[CONF_PRECISION])
@@ -232,8 +238,14 @@ class DSMREntity(Entity):
         return self.get_dsmr_object_attr("unit")
 
     @staticmethod
-    def translate_tariff(value):
-        """Convert 2/1 to normal/low."""
+    def translate_tariff(value, dsmr_version):
+        """Convert 2/1 to normal/low depening on DSMR version."""
+        # In Belgium 0001 is normal, 0002 is low
+        if dsmr_version in ("5B"):
+            if value == "0001":
+                return "normal"
+            if value == "0002":
+                return "low"
         # DSMR V2.2: Note: Rate code 1 is used for low rate and rate code 2 is
         # used for normal rate.
         if value == "0002":

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -1,6 +1,5 @@
 """Support for Dutch Smart Meter (also known as Smartmeter or P1 port)."""
 import asyncio
-from datetime import timedelta
 from functools import partial
 import logging
 
@@ -46,19 +45,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-# Smart meter sends telegram every 10 seconds or every second for DSMR 5
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the DSMR sensor."""
     # Suppress logging
     logging.getLogger("dsmr_parser").setLevel(logging.ERROR)
 
-    global MIN_TIME_BETWEEN_UPDATES
     dsmr_version = config[CONF_DSMR_VERSION]
-    if dsmr_version != "5B" or dsmr_version != "5":
-        MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
     # Define list of name,obis mappings to generate entities
     obis_mapping = [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -447,7 +447,7 @@ doorbirdpy==2.0.8
 dovado==0.4.1
 
 # homeassistant.components.dsmr
-dsmr_parser==0.12
+dsmr_parser==0.16
 
 # homeassistant.components.dweet
 dweepy==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -447,7 +447,7 @@ doorbirdpy==2.0.8
 dovado==0.4.1
 
 # homeassistant.components.dsmr
-dsmr_parser==0.16
+dsmr_parser==0.18
 
 # homeassistant.components.dweet
 dweepy==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -162,7 +162,7 @@ directpy==0.5
 distro==1.4.0
 
 # homeassistant.components.dsmr
-dsmr_parser==0.16
+dsmr_parser==0.18
 
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -162,7 +162,7 @@ directpy==0.5
 distro==1.4.0
 
 # homeassistant.components.dsmr
-dsmr_parser==0.12
+dsmr_parser==0.16
 
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -226,7 +226,7 @@ async def test_belgian_meter(hass, mock_connection_factory):
     telegram_callback(telegram)
 
     # after receiving telegram entities need to have the chance to update
-    yield from asyncio.sleep(0)
+    await asyncio.sleep(0)
 
     # tariff should be translated in human readable and have no unit
     power_tariff = hass.states.get("sensor.power_tariff")

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -58,8 +58,9 @@ async def test_default_setup(hass, mock_connection_factory):
     from dsmr_parser.obis_references import (
         CURRENT_ELECTRICITY_USAGE,
         ELECTRICITY_ACTIVE_TARIFF,
+        GAS_METER_READING,
     )
-    from dsmr_parser.objects import CosemObject
+    from dsmr_parser.objects import CosemObject, MBusObject
 
     config = {"platform": "dsmr"}
 
@@ -68,6 +69,12 @@ async def test_default_setup(hass, mock_connection_factory):
             [{"value": Decimal("0.0"), "unit": "kWh"}]
         ),
         ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
+        GAS_METER_READING: MBusObject(
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ]
+        ),
     }
 
     with assert_setup_component(1):
@@ -95,6 +102,11 @@ async def test_default_setup(hass, mock_connection_factory):
     power_tariff = hass.states.get("sensor.power_tariff")
     assert power_tariff.state == "low"
     assert power_tariff.attributes.get("unit_of_measurement") == ""
+
+    # check if gas consumption is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_consumption")
+    assert gas_consumption.state == "745.695"
+    assert gas_consumption.attributes.get("unit_of_measurement") == "m3"
 
 
 async def test_derivative():
@@ -137,6 +149,94 @@ async def test_derivative():
     ), "state should be hourly usage calculated from first and second update"
 
     assert entity.unit_of_measurement == "m3/h"
+
+
+async def test_v4_meter(hass, mock_connection_factory):
+    """Test if v4 meter is correctly parsed."""
+    (connection_factory, transport, protocol) = mock_connection_factory
+
+    from dsmr_parser.obis_references import (
+        HOURLY_GAS_METER_READING,
+        ELECTRICITY_ACTIVE_TARIFF,
+    )
+    from dsmr_parser.objects import CosemObject, MBusObject
+
+    config = {"platform": "dsmr", "dsmr_version": "4"}
+
+    telegram = {
+        HOURLY_GAS_METER_READING: MBusObject(
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ]
+        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
+    }
+
+    with assert_setup_component(1):
+        await async_setup_component(hass, "sensor", {"sensor": config})
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to update
+    await asyncio.sleep(0)
+
+    # tariff should be translated in human readable and have no unit
+    power_tariff = hass.states.get("sensor.power_tariff")
+    assert power_tariff.state == "low"
+    assert power_tariff.attributes.get("unit_of_measurement") == ""
+
+    # check if gas consumption is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_consumption")
+    assert gas_consumption.state == "745.695"
+    assert gas_consumption.attributes.get("unit_of_measurement") == "m3"
+
+
+async def test_belgian_meter(hass, mock_connection_factory):
+    """Test if Belgian meter is correctly parsed."""
+    (connection_factory, transport, protocol) = mock_connection_factory
+
+    from dsmr_parser.obis_references import (
+        BELGIUM_HOURLY_GAS_METER_READING,
+        ELECTRICITY_ACTIVE_TARIFF,
+    )
+    from dsmr_parser.objects import CosemObject, MBusObject
+
+    config = {"platform": "dsmr", "dsmr_version": "5B"}
+
+    telegram = {
+        BELGIUM_HOURLY_GAS_METER_READING: MBusObject(
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ]
+        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
+    }
+
+    with assert_setup_component(1):
+        await async_setup_component(hass, "sensor", {"sensor": config})
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to update
+    yield from asyncio.sleep(0)
+
+    # tariff should be translated in human readable and have no unit
+    power_tariff = hass.states.get("sensor.power_tariff")
+    assert power_tariff.state == "normal"
+    assert power_tariff.attributes.get("unit_of_measurement") == ""
+
+    # check if gas consumption is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_consumption")
+    assert gas_consumption.state == "745.695"
+    assert gas_consumption.attributes.get("unit_of_measurement") == "m3"
 
 
 async def test_tcp(hass, mock_connection_factory):


### PR DESCRIPTION
## Breaking Change:

Some sensors were renamed. This because the suffix _low/_normal isn't valid in all cases.
Also DMSR Specs use Tarif 1 and Tarif 2.
Also fix Bug #24075

## Description:

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11509

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io): 

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
