### PR TITLE
Add Alexa message payload info logging

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -38,6 +38,12 @@ async def async_handle_message(hass, config, request, context=None, enabled=True
 
         funct_ref = HANDLERS.get((directive.namespace, directive.name))
         if funct_ref:
+            _LOGGER.info(
+                "Processing %s.%s Payload: %s",
+                directive.namespace,
+                directive.name,
+                directive.payload,
+            )
             response = await funct_ref(hass, config, directive, context)
             if directive.has_endpoint:
                 response.merge_context_properties(directive.endpoint)


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Alexa component logs full received message and full requesta at debug level.
Full messages are too verbose. The message data is the payload. This PR adds logging of directive name and payload at info level.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
