### PR TITLE
Add device trigger to media_player

### DIFF
--- a/homeassistant/components/media_player/device_trigger.py
+++ b/homeassistant/components/media_player/device_trigger.py
@@ -47,13 +47,13 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
         if entry.domain != DOMAIN:
             continue
 
-        state = hass.states.get(entry.entity_id)
+        entity_state = hass.states.get(entry.entity_id)
 
         # We need a state or else we can't populate the different triggers
-        if state is None:
+        if entity_state is None:
             continue
 
-        supported_features = state.attributes["supported_features"]
+        supported_features = entity_state.attributes["supported_features"]
 
         # Add triggers for each entity that belongs to this integration
         if supported_features & SUPPORT_TURN_ON:

--- a/homeassistant/components/media_player/device_trigger.py
+++ b/homeassistant/components/media_player/device_trigger.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import DOMAIN
 
-TRIGGER_TYPES = {"turned_on", "turned_off", "became_idle", "paused", "played"}
+TRIGGER_TYPES = {"turned_on", "turned_off", "becomes_idle", "paused", "starts_playing"}
 
 TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
@@ -68,7 +68,7 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
                 CONF_DEVICE_ID: device_id,
                 CONF_DOMAIN: DOMAIN,
                 CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "became_idle",
+                CONF_TYPE: "becomes_idle",
             }
         )
         triggers.append(
@@ -86,7 +86,7 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
                 CONF_DEVICE_ID: device_id,
                 CONF_DOMAIN: DOMAIN,
                 CONF_ENTITY_ID: entry.entity_id,
-                CONF_TYPE: "played",
+                CONF_TYPE: "starts_playing",
             }
         )
 
@@ -108,13 +108,13 @@ async def async_attach_trigger(
     elif config[CONF_TYPE] == "turned_off":
         from_state = STATE_ON
         to_state = STATE_OFF
-    elif config[CONF_TYPE] == "played":
+    elif config[CONF_TYPE] == "starts_playing":
         from_state = STATE_PAUSED
         to_state = STATE_PLAYING
     elif config[CONF_TYPE] == "paused":
         from_state = STATE_PLAYING
         to_state = STATE_PAUSED
-    elif config[CONF_TYPE] == "became_idle":
+    elif config[CONF_TYPE] == "becomes_idle":
         from_state = STATE_PAUSED
         to_state = STATE_IDLE
 

--- a/homeassistant/components/media_player/device_trigger.py
+++ b/homeassistant/components/media_player/device_trigger.py
@@ -1,0 +1,130 @@
+"""Provides device automations for Media player."""
+from typing import List
+
+import voluptuous as vol
+
+from homeassistant.components.automation import AutomationActionType, state
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_PAUSED,
+    STATE_PLAYING,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+
+TRIGGER_TYPES = {"turned_on", "turned_off", "became_idle", "paused", "played"}
+
+TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device triggers for Media player devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    triggers = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        # Add triggers for each entity that belongs to this integration
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "turned_on",
+            }
+        )
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "turned_off",
+            }
+        )
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "became_idle",
+            }
+        )
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "paused",
+            }
+        )
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "played",
+            }
+        )
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+
+    if config[CONF_TYPE] == "turned_on":
+        from_state = STATE_OFF
+        to_state = STATE_ON
+    elif config[CONF_TYPE] == "turned_off":
+        from_state = STATE_ON
+        to_state = STATE_OFF
+    elif config[CONF_TYPE] == "played":
+        from_state = STATE_PAUSED
+        to_state = STATE_PLAYING
+    elif config[CONF_TYPE] == "paused":
+        from_state = STATE_PLAYING
+        to_state = STATE_PAUSED
+    elif config[CONF_TYPE] == "became_idle":
+        from_state = STATE_PAUSED
+        to_state = STATE_IDLE
+
+    state_config = {
+        state.CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        state.CONF_FROM: from_state,
+        state.CONF_TO: to_state,
+    }
+    state_config = state.TRIGGER_SCHEMA(state_config)
+    return await state.async_attach_trigger(
+        hass, state_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -10,9 +10,9 @@
     "trigger_type": {
       "turned_on": "{entity_name} turned on",
       "turned_off": "{entity_name} turned off",
-      "became_idle": "{entity_name} became idle",
+      "becomes_idle": "{entity_name} becomes idle",
       "paused": "{entity_name} paused",
-      "played": "{entity_name} played"
+      "starts_playing": "{entity_name} starts playing"
     }
   }
 }

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -6,6 +6,13 @@
       "is_idle": "{entity_name} is idle",
       "is_paused": "{entity_name} is paused",
       "is_playing": "{entity_name} is playing"
+    },
+    "trigger_type": {
+      "turned_on": "{entity_name} turned on",
+      "turned_off": "{entity_name} turned off",
+      "became_idle": "{entity_name} became idle",
+      "paused": "{entity_name} paused",
+      "played": "{entity_name} played"
     }
   }
 }

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -50,6 +50,9 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    hass.states.async_set(
+        "media_player.test_5678", "attributes", {"supported_features": 260}
+    )
     expected_triggers = [
         {
             "platform": "device",

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -68,7 +68,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "became_idle",
+            "type": "becomes_idle",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
         },
@@ -82,7 +82,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         {
             "platform": "device",
             "domain": DOMAIN,
-            "type": "played",
+            "type": "starts_playing",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
         },
@@ -144,7 +144,7 @@ async def test_if_fires_on_state_change(hass, calls):
                         "domain": DOMAIN,
                         "device_id": "",
                         "entity_id": "media_player.entity",
-                        "type": "played",
+                        "type": "starts_playing",
                     },
                     "action": {
                         "service": "test.automation",
@@ -182,7 +182,7 @@ async def test_if_fires_on_state_change(hass, calls):
                         "domain": DOMAIN,
                         "device_id": "",
                         "entity_id": "media_player.entity",
-                        "type": "became_idle",
+                        "type": "becomes_idle",
                     },
                     "action": {
                         "service": "test.automation",

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -51,7 +51,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     hass.states.async_set(
-        "media_player.test_5678", "attributes", {"supported_features": 260}
+        "media_player.test_5678", "attributes", {"supported_features": 384}
     )
     expected_triggers = [
         {

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -216,12 +216,13 @@ async def test_if_fires_on_state_change(hass, calls):
     )
 
     # Fake that the entity is playing.
+    hass.states.async_set("media_player.entity", STATE_PAUSED)
     hass.states.async_set("media_player.entity", STATE_PLAYING)
     await hass.async_block_till_done()
     assert len(calls) == 3
-    assert calls[2].data["some"] == "play - device - {} - off - playing - None".format(
-        "media_player.entity"
-    )
+    assert calls[2].data[
+        "some"
+    ] == "play - device - {} - paused - playing - None".format("media_player.entity")
 
     # Fake that the entity is playing.
     hass.states.async_set("media_player.entity", STATE_PAUSED)

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -1,0 +1,240 @@
+"""The tests for Media player device triggers."""
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.media_player import DOMAIN
+from homeassistant.const import (
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_PAUSED,
+    STATE_PLAYING,
+)
+from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock serivce."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_triggers(hass, device_reg, entity_reg):
+    """Test we get the expected triggers from a media_player."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "turned_on",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "turned_off",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "became_idle",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "paused",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "played",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+    ]
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_if_fires_on_state_change(hass, calls):
+    """Test for turn_on and turn_off triggers firing."""
+    hass.states.async_set("media_player.entity", STATE_OFF)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "media_player.entity",
+                        "type": "turned_on",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "turn_on - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "media_player.entity",
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "turn_off - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "media_player.entity",
+                        "type": "played",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "play - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "media_player.entity",
+                        "type": "paused",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "pause - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "media_player.entity",
+                        "type": "became_idle",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "idle - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is turning on.
+    hass.states.async_set("media_player.entity", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "turn_on - device - {} - off - on - None".format(
+        "media_player.entity"
+    )
+
+    # Fake that the entity is turning off.
+    hass.states.async_set("media_player.entity", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "turn_off - device - {} - on - off - None".format(
+        "media_player.entity"
+    )
+
+    # Fake that the entity is playing.
+    hass.states.async_set("media_player.entity", STATE_PLAYING)
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[2].data["some"] == "play - device - {} - off - playing - None".format(
+        "media_player.entity"
+    )
+
+    # Fake that the entity is playing.
+    hass.states.async_set("media_player.entity", STATE_PAUSED)
+    await hass.async_block_till_done()
+    assert len(calls) == 4
+    assert calls[3].data[
+        "some"
+    ] == "pause - device - {} - playing - paused - None".format("media_player.entity")
+
+    # Fake that the entity is playing.
+    hass.states.async_set("media_player.entity", STATE_IDLE)
+    await hass.async_block_till_done()
+    assert len(calls) == 5
+    assert calls[4].data["some"] == "idle - device - {} - paused - idle - None".format(
+        "media_player.entity"
+    )

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -219,23 +219,23 @@ async def test_if_fires_on_state_change(hass, calls):
     hass.states.async_set("media_player.entity", STATE_PAUSED)
     hass.states.async_set("media_player.entity", STATE_PLAYING)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert calls[3].data[
+    assert len(calls) == 3
+    assert calls[2].data[
         "some"
     ] == "play - device - {} - paused - playing - None".format("media_player.entity")
 
     # Fake that the entity is playing.
     hass.states.async_set("media_player.entity", STATE_PAUSED)
     await hass.async_block_till_done()
-    assert len(calls) == 5
-    assert calls[4].data[
+    assert len(calls) == 4
+    assert calls[3].data[
         "some"
     ] == "pause - device - {} - playing - paused - None".format("media_player.entity")
 
     # Fake that the entity is playing.
     hass.states.async_set("media_player.entity", STATE_IDLE)
     await hass.async_block_till_done()
-    assert len(calls) == 6
-    assert calls[5].data["some"] == "idle - device - {} - paused - idle - None".format(
+    assert len(calls) == 5
+    assert calls[4].data["some"] == "idle - device - {} - paused - idle - None".format(
         "media_player.entity"
     )

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -219,23 +219,23 @@ async def test_if_fires_on_state_change(hass, calls):
     hass.states.async_set("media_player.entity", STATE_PAUSED)
     hass.states.async_set("media_player.entity", STATE_PLAYING)
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data[
+    assert len(calls) == 4
+    assert calls[3].data[
         "some"
     ] == "play - device - {} - paused - playing - None".format("media_player.entity")
 
     # Fake that the entity is playing.
     hass.states.async_set("media_player.entity", STATE_PAUSED)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert calls[3].data[
+    assert len(calls) == 5
+    assert calls[4].data[
         "some"
     ] == "pause - device - {} - playing - paused - None".format("media_player.entity")
 
     # Fake that the entity is playing.
     hass.states.async_set("media_player.entity", STATE_IDLE)
     await hass.async_block_till_done()
-    assert len(calls) == 5
-    assert calls[4].data["some"] == "idle - device - {} - paused - idle - None".format(
+    assert len(calls) == 6
+    assert calls[5].data["some"] == "idle - device - {} - paused - idle - None".format(
         "media_player.entity"
     )


### PR DESCRIPTION
**Description:**
- add basic triggers to the media_player integration

**Related issue (if applicable):** fixes #27020<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
