### PR TITLE
Refactor ZHA electrical measurement sensor.

### DIFF
--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/integrations/zha/
 """
 import logging
+from typing import Optional
 
 import zigpy.zcl.clusters.homeautomation as homeautomation
 
@@ -65,6 +66,12 @@ class ElectricalMeasurementChannel(AttributeListeningChannel):
 
     REPORT_CONFIG = ({"attr": "active_power", "config": REPORT_CONFIG_DEFAULT},)
 
+    def __init__(self, cluster, device):
+        """Initialize Metering."""
+        super().__init__(cluster, device)
+        self._divisor = None
+        self._multiplier = None
+
     async def async_update(self):
         """Retrieve latest state."""
         self.debug("async_update")
@@ -78,7 +85,38 @@ class ElectricalMeasurementChannel(AttributeListeningChannel):
     async def async_initialize(self, from_cache):
         """Initialize channel."""
         await self.get_attribute_value("active_power", from_cache=from_cache)
+        await self.fetch_config(from_cache)
         await super().async_initialize(from_cache)
+
+    async def fetch_config(self, from_cache):
+        """Fetch config from device and updates format specifier."""
+        divisor = await self.get_attribute_value(
+            "ac_power_divisor", from_cache=from_cache
+        )
+        if divisor is None:
+            divisor = await self.get_attribute_value(
+                "power_divisor", from_cache=from_cache
+            )
+        self._divisor = divisor
+
+        mult = await self.get_attribute_value(
+            "ac_power_multiplier", from_cache=from_cache
+        )
+        if mult is None:
+            mult = await self.get_attribute_value(
+                "power_multiplier", from_cache=from_cache
+            )
+        self._multiplier = mult
+
+    @property
+    def divisor(self) -> Optional[int]:
+        """Return active power divisor."""
+        return self._divisor or 1
+
+    @property
+    def multiplier(self) -> Optional[int]:
+        """Return active power divisor."""
+        return self._multiplier or 1
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -217,6 +217,10 @@ class ElectricalMeasurement(Sensor):
         """Return True if HA needs to poll for state changes."""
         return True
 
+    def formatter(self, value) -> int:
+        """Return 'normalized' value."""
+        return round(value * self._channel.multiplier / self._channel.divisor)
+
 
 @STRICT_MATCH(MatchRule(generic_ids={CHANNEL_ST_HUMIDITY_CLUSTER}))
 @STRICT_MATCH(MatchRule(channel_names={CHANNEL_HUMIDITY}))

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -166,7 +166,7 @@ async def async_test_metering(hass, device_info):
 async def async_test_electrical_measurement(hass, device_info):
     """Test electrical measurement sensor."""
     await send_attribute_report(hass, device_info["cluster"], 1291, 100)
-    assert_state(hass, device_info, "10.0", "W")
+    assert_state(hass, device_info, "100", "W")
 
 
 async def send_attribute_report(hass, cluster, attrid, value):


### PR DESCRIPTION
## Breaking Change:
Nominally this qualifies as a breaking change, since we're changing the default divisor for `active_power` attribute. Now, `multiplier` and `divisor` both default to `1`, if the device  does not support these attributes or we fail to get those attributes from the device. However I feel this behavior makes more sense instead of blindly applying `10` as a divisor for all devices.

## Description:
Apply `multiplier` and `divisor` attribute values of the `electrical_measurement` ZCL cluster to `active_power` value.

**Related issue (if applicable):** fixes #29879

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
