### PR TITLE
ZhaEntity class cleanup

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -102,7 +102,6 @@ async def _async_setup_entities(
 class BinarySensor(ZhaEntity, BinarySensorDevice):
     """ZHA BinarySensor."""
 
-    _domain = DOMAIN
     _device_class = None
 
     def __init__(self, **kwargs):

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -30,8 +30,6 @@ RESTART_GRACE_PERIOD = 7200  # 2 hours
 class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
     """A base class for ZHA entities."""
 
-    _domain = None  # Must be overridden by subclasses
-
     def __init__(self, unique_id, zha_device, channels, skip_entity_id=False, **kwargs):
         """Init ZHA entity."""
         self._force_update = False

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -87,8 +87,6 @@ async def _async_setup_entities(
 class ZhaFan(ZhaEntity, FanEntity):
     """Representation of a ZHA fan."""
 
-    _domain = DOMAIN
-
     def __init__(self, unique_id, zha_device, channels, **kwargs):
         """Init this sensor."""
         super().__init__(unique_id, zha_device, channels, **kwargs)

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -80,8 +80,6 @@ async def _async_setup_entities(
 class Light(ZhaEntity, light.Light):
     """Representation of a ZHA or ZLL light."""
 
-    _domain = light.DOMAIN
-
     def __init__(self, unique_id, zha_device, channels, **kwargs):
         """Initialize the ZHA light."""
         super().__init__(unique_id, zha_device, channels, **kwargs)

--- a/homeassistant/components/zha/lock.py
+++ b/homeassistant/components/zha/lock.py
@@ -70,8 +70,6 @@ async def _async_setup_entities(
 class ZhaDoorLock(ZhaEntity, LockDevice):
     """Representation of a ZHA lock."""
 
-    _domain = DOMAIN
-
     def __init__(self, unique_id, zha_device, channels, **kwargs):
         """Init this sensor."""
         super().__init__(unique_id, zha_device, channels, **kwargs)

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -109,7 +109,6 @@ class Sensor(ZhaEntity):
     _decimals = 1
     _device_class = None
     _divisor = 1
-    _domain = DOMAIN
     _multiplier = 1
     _unit = None
 

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -60,8 +60,6 @@ async def _async_setup_entities(
 class Switch(ZhaEntity, SwitchDevice):
     """ZHA switch."""
 
-    _domain = DOMAIN
-
     def __init__(self, **kwargs):
         """Initialize the ZHA switch."""
         super().__init__(**kwargs)


### PR DESCRIPTION
## Description:
Remove `_domain` attribute of the `ZhaEntity` class. We're not using it anymore since https://github.com/home-assistant/home-assistant/pull/28362 This is addresses some of the comments in https://github.com/home-assistant/home-assistant/pull/30108

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
