### PR TITLE
Add support for input_number entities in Alexa integration

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1117,11 +1117,9 @@ class AlexaRangeController(AlexaCapability):
         # Input Number Value
         if self.instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
             min_value = float(self.entity.attributes[input_number.ATTR_MIN])
-            max_value = float(self.entity.attributes.get(input_number.ATTR_MAX))
+            max_value = float(self.entity.attributes[input_number.ATTR_MAX])
             precision = float(self.entity.attributes.get(input_number.ATTR_STEP, 1))
-            unit = self.entity.attributes.get(
-                input_number.ATTR_UNIT_OF_MEASUREMENT, None
-            )
+            unit = self.entity.attributes.get(input_number.ATTR_UNIT_OF_MEASUREMENT)
 
             self._resource = AlexaPresetResource(
                 ["Value"],

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1116,7 +1116,7 @@ class AlexaRangeController(AlexaCapability):
 
         # Input Number Value
         if self.instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
-            min_value = float(self.entity.attributes.get(input_number.ATTR_MIN))
+            min_value = float(self.entity.attributes[input_number.ATTR_MIN])
             max_value = float(self.entity.attributes.get(input_number.ATTR_MAX))
             precision = float(self.entity.attributes.get(input_number.ATTR_STEP, 1))
             unit = self.entity.attributes.get(

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1,7 +1,7 @@
 """Alexa capabilities."""
 import logging
 
-from homeassistant.components import cover, fan, image_processing, light
+from homeassistant.components import cover, fan, image_processing, input_number, light
 from homeassistant.components.alarm_control_panel import ATTR_CODE_FORMAT, FORMAT_NUMBER
 import homeassistant.components.climate.const as climate
 import homeassistant.components.media_player.const as media_player
@@ -1054,6 +1054,10 @@ class AlexaRangeController(AlexaCapability):
         if self.instance == f"{cover.DOMAIN}.{cover.ATTR_TILT_POSITION}":
             return self.entity.attributes.get(cover.ATTR_CURRENT_TILT_POSITION)
 
+        # Input Number Value
+        if self.instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
+            return float(self.entity.state)
+
         return None
 
     def configuration(self):
@@ -1107,6 +1111,30 @@ class AlexaRangeController(AlexaCapability):
                 max_value=100,
                 precision=1,
                 unit=AlexaGlobalCatalog.UNIT_PERCENT,
+            )
+            return self._resource.serialize_capability_resources()
+
+        # Input Number Value
+        if self.instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
+            min_value = float(self.entity.attributes.get(input_number.ATTR_MIN))
+            max_value = float(self.entity.attributes.get(input_number.ATTR_MAX))
+            precision = float(self.entity.attributes.get(input_number.ATTR_STEP, 1))
+            unit = self.entity.attributes.get(
+                input_number.ATTR_UNIT_OF_MEASUREMENT, None
+            )
+
+            self._resource = AlexaPresetResource(
+                ["Value"],
+                min_value=min_value,
+                max_value=max_value,
+                precision=precision,
+                unit=unit,
+            )
+            self._resource.add_preset(
+                value=min_value, labels=[AlexaGlobalCatalog.VALUE_MINIMUM]
+            )
+            self._resource.add_preset(
+                value=max_value, labels=[AlexaGlobalCatalog.VALUE_MAXIMUM]
             )
             return self._resource.serialize_capability_resources()
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -11,6 +11,7 @@ from homeassistant.components import (
     group,
     image_processing,
     input_boolean,
+    input_number,
     light,
     lock,
     media_player,
@@ -672,5 +673,23 @@ class ImageProcessingCapabilities(AlexaEntity):
     def interfaces(self):
         """Yield the supported interfaces."""
         yield AlexaEventDetectionSensor(self.hass, self.entity)
+        yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)
+
+
+@ENTITY_ADAPTERS.register(input_number.DOMAIN)
+class InputNumberCapabilities(AlexaEntity):
+    """Class to represent input_number capabilities."""
+
+    def default_display_categories(self):
+        """Return the display categories for this entity."""
+        return [DisplayCategory.OTHER]
+
+    def interfaces(self):
+        """Yield the supported interfaces."""
+
+        yield AlexaRangeController(
+            self.entity, instance=f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}"
+        )
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.hass)

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1092,7 +1092,7 @@ async def async_api_set_range(hass, config, directive, context):
     # Fan Speed
     if instance == f"{fan.DOMAIN}.{fan.ATTR_SPEED}":
         service = fan.SERVICE_SET_SPEED
-        speed = SPEED_FAN_MAP.get(int(range_value), None)
+        speed = SPEED_FAN_MAP.get(int(range_value))
 
         if not speed:
             msg = "Entity does not support value"
@@ -1129,8 +1129,8 @@ async def async_api_set_range(hass, config, directive, context):
     elif instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
         range_value = float(range_value)
         service = input_number.SERVICE_SET_VALUE
-        min_value = float(entity.attributes.get(input_number.ATTR_MIN))
-        max_value = float(entity.attributes.get(input_number.ATTR_MAX))
+        min_value = float(entity.attributes[input_number.ATTR_MIN])
+        max_value = float(entity.attributes[input_number.ATTR_MAX])
         data[input_number.ATTR_VALUE] = min(max_value, max(min_value, range_value))
 
     else:
@@ -1201,8 +1201,8 @@ async def async_api_adjust_range(hass, config, directive, context):
     elif instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
         range_delta = float(range_delta)
         service = input_number.SERVICE_SET_VALUE
-        min_value = float(entity.attributes.get(input_number.ATTR_MIN))
-        max_value = float(entity.attributes.get(input_number.ATTR_MAX))
+        min_value = float(entity.attributes[input_number.ATTR_MIN])
+        max_value = float(entity.attributes[input_number.ATTR_MAX])
         current = float(entity.state)
         data[input_number.ATTR_VALUE] = response_value = min(
             max_value, max(min_value, range_delta + current)

--- a/homeassistant/components/alexa/resources.py
+++ b/homeassistant/components/alexa/resources.py
@@ -266,9 +266,9 @@ class AlexaPresetResource(AlexaCapabilityResource):
         """Initialize an Alexa presetResource."""
         super().__init__(labels)
         self._presets = []
-        self._minimum_value = int(min_value)
-        self._maximum_value = int(max_value)
-        self._precision = int(precision)
+        self._minimum_value = min_value
+        self._maximum_value = max_value
+        self._precision = precision
         self._unit_of_measure = None
         if unit in AlexaGlobalCatalog.__dict__.values():
             self._unit_of_measure = unit

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2740,3 +2740,175 @@ async def test_cover_semantics(hass):
             "states": ["Alexa.States.Open"],
             "range": {"minimumValue": 1, "maximumValue": 100},
         } in state_mappings
+
+
+async def test_input_number(hass):
+    """Test input_number discovery."""
+    device = (
+        "input_number.test_slider",
+        30,
+        {
+            "initial": 30,
+            "min": -20,
+            "max": 35,
+            "step": 1,
+            "mode": "slider",
+            "friendly_name": "Test Slider",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "input_number#test_slider"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test Slider"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance, "Alexa.RangeController", "Alexa.EndpointHealth", "Alexa"
+    )
+
+    range_capability = get_capability(
+        capabilities, "Alexa.RangeController", "input_number.value"
+    )
+
+    capability_resources = range_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "text",
+        "value": {"text": "Value", "locale": "en-US"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = range_capability["configuration"]
+    assert configuration is not None
+
+    supported_range = configuration["supportedRange"]
+    assert supported_range["minimumValue"] == -20
+    assert supported_range["maximumValue"] == 35
+    assert supported_range["precision"] == 1
+
+    presets = configuration["presets"]
+    assert {
+        "rangeValue": 35,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "asset", "value": {"assetId": "Alexa.Value.Maximum"}}
+            ]
+        },
+    } in presets
+
+    assert {
+        "rangeValue": -20,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "asset", "value": {"assetId": "Alexa.Value.Minimum"}}
+            ]
+        },
+    } in presets
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "input_number#test_slider",
+        "input_number.set_value",
+        hass,
+        payload={"rangeValue": "10"},
+        instance="input_number.value",
+    )
+    assert call.data["value"] == 10
+
+    await assert_range_changes(
+        hass,
+        [(25, "-5"), (35, "5"), (-20, "-100"), (35, "100")],
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "input_number#test_slider",
+        False,
+        "input_number.set_value",
+        "value",
+        instance="input_number.value",
+    )
+
+
+async def test_input_number_float(hass):
+    """Test input_number discovery."""
+    device = (
+        "input_number.test_slider_float",
+        0.5,
+        {
+            "initial": 0.5,
+            "min": 0,
+            "max": 1,
+            "step": 0.01,
+            "mode": "slider",
+            "friendly_name": "Test Slider Float",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "input_number#test_slider_float"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test Slider Float"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance, "Alexa.RangeController", "Alexa.EndpointHealth", "Alexa"
+    )
+
+    range_capability = get_capability(
+        capabilities, "Alexa.RangeController", "input_number.value"
+    )
+
+    capability_resources = range_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "text",
+        "value": {"text": "Value", "locale": "en-US"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = range_capability["configuration"]
+    assert configuration is not None
+
+    supported_range = configuration["supportedRange"]
+    assert supported_range["minimumValue"] == 0
+    assert supported_range["maximumValue"] == 1
+    assert supported_range["precision"] == 0.01
+
+    presets = configuration["presets"]
+    assert {
+        "rangeValue": 1,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "asset", "value": {"assetId": "Alexa.Value.Maximum"}}
+            ]
+        },
+    } in presets
+
+    assert {
+        "rangeValue": 0,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "asset", "value": {"assetId": "Alexa.Value.Minimum"}}
+            ]
+        },
+    } in presets
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "input_number#test_slider_float",
+        "input_number.set_value",
+        hass,
+        payload={"rangeValue": "0.333"},
+        instance="input_number.value",
+    )
+    assert call.data["value"] == 0.333
+
+    await assert_range_changes(
+        hass,
+        [(0.4, "-0.1"), (0.6, "0.1"), (0, "-100"), (1, "100"), (0.51, "0.01")],
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "input_number#test_slider_float",
+        False,
+        "input_number.set_value",
+        "value",
+        instance="input_number.value",
+    )


### PR DESCRIPTION
## Description:

- Implements `Alexa.RangeController` for `input_number` entities. 
- Uses `capabilityResources` to map "minimum" and "maximum" utterances to `min` and `max` attribute values. 
- Supports "increase" and "decrease" utterances.

> Alexa, set input slider to 10.
> Alexa, increase input slider.
> Alexa, decrease input slider.
> Alexa, decrease the input slider by 3.
> Alexa, what is the value of the input slider?

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
