### PR TITLE
Upgrade zeroconf to 0.24.2

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -1,5 +1,4 @@
 """Support for exposing Home Assistant via Zeroconf."""
-
 import ipaddress
 import logging
 import socket
@@ -15,6 +14,7 @@ from zeroconf import (
 
 from homeassistant import util
 from homeassistant.const import (
+    ATTR_NAME,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
     __version__,
@@ -29,7 +29,6 @@ ATTR_HOST = "host"
 ATTR_PORT = "port"
 ATTR_HOSTNAME = "hostname"
 ATTR_TYPE = "type"
-ATTR_NAME = "name"
 ATTR_PROPERTIES = "properties"
 
 ZEROCONF_TYPE = "_home-assistant._tcp.local."

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zeroconf",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
   "requirements": [
-    "zeroconf==0.24.1"
+    "zeroconf==0.24.2"
   ],
   "dependencies": [
     "api"

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,7 +24,7 @@ ruamel.yaml==0.15.100
 sqlalchemy==1.3.11
 voluptuous-serialize==2.3.0
 voluptuous==0.11.7
-zeroconf==0.24.1
+zeroconf==0.24.2
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2086,7 +2086,7 @@ youtube_dl==2019.11.28
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.24.1
+zeroconf==0.24.2
 
 # homeassistant.components.zha
 zha-quirks==0.0.28

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -658,7 +658,7 @@ ya_ma==0.3.8
 yahooweather==0.10
 
 # homeassistant.components.zeroconf
-zeroconf==0.24.1
+zeroconf==0.24.2
 
 # homeassistant.components.zha
 zha-quirks==0.0.28


### PR DESCRIPTION
## Description:
Changelog: https://github.com/jstasiak/python-zeroconf/#0242

## Example entry for `configuration.yaml` (if applicable):
```yaml
default_config:
```

```bash
$ avahi-browse -alr
+ wlp4s0 IPv4 Home1                                         _home-assistant._tcp local
+     lo IPv4 Home1                                         _home-assistant._tcp local
= wlp4s0 IPv4 Home1                                         _home-assistant._tcp local
   hostname = [Home1._home-assistant._tcp.local]
   address = [192.168.1.2]
   port = [8123]
   txt = ["requires_api_password=true" "base_url=http://192.168.1.2:8123" "version=0.104.0.dev0"]
[...]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
