### PR TITLE
Fix deconz SSDP updating Hassio config entry

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -161,7 +161,11 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _update_entry(self, entry, host, port, api_key=None):
         """Update existing entry."""
-        if entry.data[CONF_HOST] == host:
+        if (
+            entry.data[CONF_HOST] == host
+            and entry.data[CONF_PORT] == port
+            and (api_key is None or entry.data[CONF_API_KEY] == api_key)
+        ):
             return self.async_abort(reason="already_configured")
 
         entry.data[CONF_HOST] = host
@@ -186,6 +190,8 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if uuid == entry.data.get(CONF_UUID):
+                if entry.source == "hassio":
+                    return self.async_abort(reason="already_configured")
                 return self._update_entry(entry, parsed_url.hostname, parsed_url.port)
 
         bridgeid = discovery_info[ssdp.ATTR_UPNP_SERIAL]


### PR DESCRIPTION
## Description:

Fixes an issue where SSDP is capable of updating a configuration entry that originally was created by a Hass.io discovery.

Furthermore, it addresses a small issue in the logic that updates the entry, so that it actually updates the entry when a port or API key is changed, while the host stayed the same.

**Related issue (if applicable):** fixes home-assistant/hassio-addons#942

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
