### PR TITLE
Add date_time_utc display option to time_date sensor platform

### DIFF
--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -20,7 +20,8 @@ OPTION_TYPES = {
     "time": "Time",
     "date": "Date",
     "date_time": "Date & Time",
-    "date_time_iso": "Date & Time ISO",
+    "date_time_utc": "Date & Time (UTC)",
+    "date_time_iso": "Date & Time (ISO)",
     "time_date": "Time & Date",
     "beat": "Internet Time",
     "time_utc": "Time (UTC)",
@@ -102,6 +103,7 @@ class TimeDateSensor(Entity):
         time = dt_util.as_local(time_date).strftime(TIME_STR_FORMAT)
         time_utc = time_date.strftime(TIME_STR_FORMAT)
         date = dt_util.as_local(time_date).date().isoformat()
+        date_utc = time_date.date().isoformat()
 
         # Calculate Swatch Internet Time.
         time_bmt = time_date + timedelta(hours=1)
@@ -119,6 +121,8 @@ class TimeDateSensor(Entity):
             self._state = date
         elif self.type == "date_time":
             self._state = f"{date}, {time}"
+        elif self.type == "date_time_utc":
+            self._state = f"{date_utc}, {time_utc}"
         elif self.type == "time_date":
             self._state = f"{time}, {date}"
         elif self.type == "time_utc":

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -1,4 +1,4 @@
-"""The tests for Kira sensor platform."""
+"""The tests for time_date sensor platform."""
 import unittest
 from unittest.mock import patch
 
@@ -9,7 +9,7 @@ from tests.common import get_test_home_assistant
 
 
 class TestTimeDateSensor(unittest.TestCase):
-    """Tests the Kira Sensor platform."""
+    """Tests the time_date Sensor platform."""
 
     # pylint: disable=invalid-name
     DEVICES = []
@@ -67,6 +67,14 @@ class TestTimeDateSensor(unittest.TestCase):
         device._update_internal_state(now)
         assert device.state == "00:54"
 
+        device = time_date.TimeDateSensor(self.hass, "date_time")
+        device._update_internal_state(now)
+        assert device.state == "2017-05-18, 00:54"
+
+        device = time_date.TimeDateSensor(self.hass, "date_time_utc")
+        device._update_internal_state(now)
+        assert device.state == "2017-05-18, 00:54"
+
         device = time_date.TimeDateSensor(self.hass, "beat")
         device._update_internal_state(now)
         assert device.state == "@079"
@@ -74,6 +82,41 @@ class TestTimeDateSensor(unittest.TestCase):
         device = time_date.TimeDateSensor(self.hass, "date_time_iso")
         device._update_internal_state(now)
         assert device.state == "2017-05-18T00:54:00"
+
+    def test_states_non_default_timezone(self):
+        """Test states of sensors in a timezone other than UTC."""
+        new_tz = dt_util.get_time_zone("America/New_York")
+        assert new_tz is not None
+        dt_util.set_default_time_zone(new_tz)
+
+        now = dt_util.utc_from_timestamp(1495068856)
+        device = time_date.TimeDateSensor(self.hass, "time")
+        device._update_internal_state(now)
+        assert device.state == "20:54"
+
+        device = time_date.TimeDateSensor(self.hass, "date")
+        device._update_internal_state(now)
+        assert device.state == "2017-05-17"
+
+        device = time_date.TimeDateSensor(self.hass, "time_utc")
+        device._update_internal_state(now)
+        assert device.state == "00:54"
+
+        device = time_date.TimeDateSensor(self.hass, "date_time")
+        device._update_internal_state(now)
+        assert device.state == "2017-05-17, 20:54"
+
+        device = time_date.TimeDateSensor(self.hass, "date_time_utc")
+        device._update_internal_state(now)
+        assert device.state == "2017-05-18, 00:54"
+
+        device = time_date.TimeDateSensor(self.hass, "beat")
+        device._update_internal_state(now)
+        assert device.state == "@079"
+
+        device = time_date.TimeDateSensor(self.hass, "date_time_iso")
+        device._update_internal_state(now)
+        assert device.state == "2017-05-17T20:54:00"
 
     # pylint: disable=no-member
     def test_timezone_intervals(self):
@@ -121,6 +164,8 @@ class TestTimeDateSensor(unittest.TestCase):
         device = time_date.TimeDateSensor(self.hass, "date")
         assert device.icon == "mdi:calendar"
         device = time_date.TimeDateSensor(self.hass, "date_time")
+        assert device.icon == "mdi:calendar-clock"
+        device = time_date.TimeDateSensor(self.hass, "date_time_utc")
         assert device.icon == "mdi:calendar-clock"
         device = time_date.TimeDateSensor(self.hass, "date_time_iso")
         assert device.icon == "mdi:calendar-clock"


### PR DESCRIPTION

## Description:

This PR adds a new display option for showing UTC date and time to the time_date sensor platform.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: time_date
    display_options:
    - "date_time_utc"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io PR 11519](https://github.com/home-assistant/home-assistant.io/pull/11519)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
