### PR TITLE
Implement EqualizerController in Alexa for media_player

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -120,7 +120,20 @@ class AlexaCapability:
 
     @staticmethod
     def configuration():
-        """Return the configuration object."""
+        """Return the configuration object.
+
+        Applicable to the ThermostatController, SecurityControlPanel, ModeController, RangeController,
+        and EventDetectionSensor.
+        """
+        return []
+
+    @staticmethod
+    def configurations():
+        """Return the configurations object.
+
+        The plural configurations object is different that the singular configuration object.
+        Applicable to EqualizerController interface.
+        """
         return []
 
     @staticmethod
@@ -176,6 +189,11 @@ class AlexaCapability:
         configuration = self.configuration()
         if configuration:
             result["configuration"] = configuration
+
+        # The plural configurations object is different than the singular configuration object above.
+        configurations = self.configurations()
+        if configurations:
+            result["configurations"] = configurations
 
         semantics = self.semantics()
         if semantics:
@@ -1356,3 +1374,55 @@ class AlexaEventDetectionSensor(AlexaCapability):
                 }
             },
         }
+
+
+class AlexaEqualizerController(AlexaCapability):
+    """Implements Alexa.EqualizerController.
+
+    https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-equalizercontroller.html
+    """
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa.EqualizerController"
+
+    def properties_supported(self):
+        """Return what properties this entity supports.
+
+        Either bands, mode or both can be specified. Only mode is supported at this time.
+        """
+        return [{"name": "mode"}]
+
+    def get_property(self, name):
+        """Read and return a property."""
+        if name != "mode":
+            raise UnsupportedProperty(name)
+
+        sound_mode = self.entity.attributes.get(media_player.ATTR_SOUND_MODE)
+        if sound_mode and sound_mode.upper() in (
+            "MOVIE",
+            "MUSIC",
+            "NIGHT",
+            "SPORT",
+            "TV",
+        ):
+            return sound_mode.upper()
+
+        return None
+
+    def configurations(self):
+        """Return the sound modes supported in the configurations object.
+
+        Valid Values for modes are: MOVIE, MUSIC, NIGHT, SPORT, TV.
+        """
+        configurations = None
+        sound_mode_list = self.entity.attributes.get(media_player.ATTR_SOUND_MODE_LIST)
+        if sound_mode_list:
+            supported_sound_modes = []
+            for sound_mode in sound_mode_list:
+                if sound_mode.upper() in ("MOVIE", "MUSIC", "NIGHT", "SPORT", "TV"):
+                    supported_sound_modes.append({"name": sound_mode.upper()})
+
+            configurations = {"modes": {"supported": supported_sound_modes}}
+
+        return configurations

--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -196,3 +196,11 @@ class Inputs:
         "video3": "VIDEO 3",
         "xbox": "XBOX",
     }
+
+    VALID_SOUND_MODE_MAP = {
+        "movie": "MOVIE",
+        "music": "MUSIC",
+        "night": "NIGHT",
+        "sport": "SPORT",
+        "tv": "TV",
+    }

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -42,6 +42,7 @@ from .capabilities import (
     AlexaContactSensor,
     AlexaDoorbellEventSource,
     AlexaEndpointHealth,
+    AlexaEqualizerController,
     AlexaEventDetectionSensor,
     AlexaInputController,
     AlexaLockController,
@@ -521,6 +522,9 @@ class MediaPlayerCapabilities(AlexaEntity):
 
         if supported & media_player.const.SUPPORT_PLAY_MEDIA:
             yield AlexaChannelController(self.entity)
+
+        if supported & media_player.const.SUPPORT_SELECT_SOUND_MODE:
+            yield AlexaEqualizerController(self.entity)
 
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.hass)

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1352,3 +1352,43 @@ async def async_api_seek(hass, config, directive, context):
     return directive.response(
         name="StateReport", namespace="Alexa.SeekController", payload=payload
     )
+
+
+@HANDLERS.register(("Alexa.EqualizerController", "SetMode"))
+async def async_api_set_eq_mode(hass, config, directive, context):
+    """Process a SetMode request for EqualizerController."""
+    mode = directive.payload["mode"]
+    entity = directive.entity
+    data = {ATTR_ENTITY_ID: entity.entity_id}
+
+    sound_mode_list = entity.attributes.get(media_player.const.ATTR_SOUND_MODE_LIST)
+    if sound_mode_list and mode.lower() in sound_mode_list:
+        data[media_player.const.ATTR_SOUND_MODE] = mode.lower()
+    else:
+        msg = "failed to map sound mode {} to a mode on {}".format(
+            mode, entity.entity_id
+        )
+        raise AlexaInvalidValueError(msg)
+
+    await hass.services.async_call(
+        entity.domain,
+        media_player.SERVICE_SELECT_SOUND_MODE,
+        data,
+        blocking=False,
+        context=context,
+    )
+
+    return directive.response()
+
+
+@HANDLERS.register(("Alexa.EqualizerController", "AdjustBands"))
+@HANDLERS.register(("Alexa.EqualizerController", "ResetBands"))
+@HANDLERS.register(("Alexa.EqualizerController", "SetBands"))
+async def async_api_bands_directive(hass, config, directive, context):
+    """Handle an AdjustBands, ResetBands, SetBands request.
+
+    Only mode directives are currently supported for the EqualizerController.
+    """
+    # Currently bands directives are not supported.
+    msg = "Entity does not support directive"
+    raise AlexaInvalidDirectiveError(msg)


### PR DESCRIPTION
## Description:
Implements the `Alexa.EqualizerController` for `media_player` entities that `SUPPORT_SET_SOUND_MODE`.

> Alexa, set mode to movie on the TV.

This controller is implemented similar to the `InputController`. Uses the `SOUND_MODE_LIST` attribute to generate a list of supported presets, and exposes them to Alexa. 



**bands and mode**
The `EqualizerController` can be configured with `bands`, `mode` or both. This implementation configures the controller with `mode` from the available `SOUND_MODE_LIST` attribute.

With `bands` the `EqualizerController` also has the ability to change bands, `BASS`, `MIDRANGE`, `TREBLE`. But there currently isn't support for this in HA. Bands are not configured during discovery, and the `SetBands`, `AdjustBands` and `ResetBands` directives will raise `INVALID_DIRECTIVE`.

**`configuration()` vs `configurations()`**
The `EqualizerController` uses a plural object name: `configurations` instead of the already implemented object: `configuration` to configure this controller.  Therefore the Base class `AlexaCapability` now has `configuration()` and `configurations()` that are overridden depending on the controller capability subclass. 

I considered just checking for an instance of `EqualizerController` and setting the correct object name in the serialize discovery, but decided against that to keep the current structure consistent and in case `configurations` is used again with a future controller. 

**Related issue (if applicable):** check box in #24579

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
