### PR TITLE
Updated formatting of total_blocks value

### DIFF
--- a/homeassistant/components/bitcoin/sensor.py
+++ b/homeassistant/components/bitcoin/sensor.py
@@ -148,7 +148,7 @@ class BitcoinSensor(Entity):
         elif self.type == "total_btc":
             self._state = "{0:.2f}".format(stats.total_btc * 0.00000001)
         elif self.type == "total_blocks":
-            self._state = "{0:.2f}".format(stats.total_blocks)
+            self._state = "{0:.0f}".format(stats.total_blocks)
         elif self.type == "next_retarget":
             self._state = "{0:.2f}".format(stats.next_retarget)
         elif self.type == "estimated_transaction_volume_usd":


### PR DESCRIPTION
The number of total blocks is always a round number. There can't be .1 or .11 blocks for example. The output is now always formatted with two decimals that are always 00.

## Breaking Change:
None

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
The Bitcoin blockchain aka number of blocks is always a round number. The value is now formatted with two decimals, which is unnecessary, as there can never be a partial block.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
