### PR TITLE
Fix AdGuard Home safe search sensor name

### DIFF
--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -178,7 +178,7 @@ class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
         """Initialize AdGuard Home sensor."""
         super().__init__(
             adguard,
-            "Searches Safe Search Enforced",
+            "AdGuard Safe Search Enforced",
             "mdi:shield-search",
             "enforced_safesearch",
             "requests",

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -178,7 +178,7 @@ class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
         """Initialize AdGuard Home sensor."""
         super().__init__(
             adguard,
-            "AdGuard Safe Search Enforced",
+            "AdGuard Safe Searches Enforced",
             "mdi:shield-search",
             "enforced_safesearch",
             "requests",


### PR DESCRIPTION
## Breaking Change:

None

## Description:

The "Searches Safe Search Enforced" is the only one without the AdGuard name, and "search" twice in name, so I renamed it to "AdGuard Safe Searches Enforced".

See an example here :  
<img width="364" alt="Capture d’écran 2019-12-23 à 15 16 54" src="https://user-images.githubusercontent.com/14821482/71362998-fd689380-2597-11ea-84d4-1a7aa78a83ad.png">

No need to fix the documentation: https://www.home-assistant.io/integrations/adguard/

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html