### PR TITLE
Add icon to Plex sensor

### DIFF
--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -87,6 +87,11 @@ class PlexSensor(Entity):
         return "Watching"
 
     @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return "mdi:plex"
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes."""
         return {content[0]: content[1] for content in self._now_playing}


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Add a Plex icon to the watching sensor.

See an example here (Also renamed the sensor to "Plex watchings" in the customize.yaml): 
<img width="438" alt="Capture d’écran 2019-12-23 à 15 41 15" src="https://user-images.githubusercontent.com/14821482/71364104-71f10180-259b-11ea-99fe-c52d63962c09.png">

No need to update the documentation : https://www.home-assistant.io/integrations/plex/#sensor

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html