### PR TITLE
Bump envoy_reader to 0.11.0

### DIFF
--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -3,7 +3,7 @@
   "name": "Enphase envoy",
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "requirements": [
-    "envoy_reader==0.10.0"
+    "envoy_reader==0.11.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -483,7 +483,7 @@ env_canada==0.0.30
 # envirophat==0.0.6
 
 # homeassistant.components.enphase_envoy
-envoy_reader==0.10.0
+envoy_reader==0.11.0
 
 # homeassistant.components.season
 ephem==3.7.7.0


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Upgrade envoy_reader library to 0.11.0.  This updated library is to support PR #28837, so that a message is logged when authentication fails. 

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** None

## Example entry for `configuration.yaml` (if applicable):
```yaml
None
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
