### PR TITLE
Bump datapoint to 0.9.5

### DIFF
--- a/homeassistant/components/metoffice/manifest.json
+++ b/homeassistant/components/metoffice/manifest.json
@@ -2,9 +2,7 @@
   "domain": "metoffice",
   "name": "Metoffice",
   "documentation": "https://www.home-assistant.io/integrations/metoffice",
-  "requirements": [
-    "datapoint==0.4.3"
-  ],
+  "requirements": ["datapoint==0.9.5"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -399,7 +399,7 @@ crimereports==1.0.1
 datadog==0.15.0
 
 # homeassistant.components.metoffice
-datapoint==0.4.3
+datapoint==0.9.5
 
 # homeassistant.components.decora
 # decora==0.6


### PR DESCRIPTION
## Description:
- bumps datapoint to the latest version to fix the marked issue
- reported issue in the https://github.com/EJEP/datapoint-python/issues/19

**Related issue (if applicable):** fixes #30114<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
