### PR TITLE
Bump importlib-metadata to 1.3.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -12,7 +12,7 @@ defusedxml==0.6.0
 distro==1.4.0
 hass-nabucasa==0.30
 home-assistant-frontend==20191204.1
-importlib-metadata==0.23
+importlib-metadata==1.3.0
 jinja2>=2.10.3
 netdisco==2.6.0
 pip>=8.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@ async_timeout==3.0.1
 attrs==19.3.0
 bcrypt==3.1.7
 certifi>=2019.11.28
-importlib-metadata==0.23
+importlib-metadata==1.3.0
 jinja2>=2.10.3
 PyJWT==1.7.1
 cryptography==2.8

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ REQUIRES = [
     "attrs==19.3.0",
     "bcrypt==3.1.7",
     "certifi>=2019.11.28",
-    "importlib-metadata==0.23",
+    "importlib-metadata==1.3.0",
     "jinja2>=2.10.3",
     "PyJWT==1.7.1",
     # PyJWT has loose dependency. We want the latest one.


### PR DESCRIPTION
## Description:
- bump importlib-metadata to the newest version to fix incompatibility issue

**Related issue (if applicable):** fixes #30046<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
