### PR TITLE
Drop timer component microseconds

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -181,7 +181,7 @@ class Timer(RestoreEntity):
             event = EVENT_TIMER_RESTARTED
 
         self._state = STATUS_ACTIVE
-        start = dt_util.utcnow()
+        start = dt_util.utcnow().replace(microsecond=0)
         if self._remaining and newduration is None:
             self._end = start + self._remaining
         else:
@@ -206,7 +206,7 @@ class Timer(RestoreEntity):
 
         self._listener()
         self._listener = None
-        self._remaining = self._end - dt_util.utcnow()
+        self._remaining = self._end - dt_util.utcnow().replace(microsecond=0)
         self._state = STATUS_PAUSED
         self._end = None
         self._hass.bus.async_fire(EVENT_TIMER_PAUSED, {"entity_id": self.entity_id})

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -155,7 +155,7 @@ class Timer(RestoreEntity):
         """Return the state attributes."""
         return {
             ATTR_DURATION: str(self._duration),
-            ATTR_REMAINING: str(self._remaining)[:7],
+            ATTR_REMAINING: str(self._remaining),
         }
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -155,7 +155,7 @@ class Timer(RestoreEntity):
         """Return the state attributes."""
         return {
             ATTR_DURATION: str(self._duration),
-            ATTR_REMAINING: str(self._remaining),
+            ATTR_REMAINING: str(self._remaining)[:7],
         }
 
     async def async_added_to_hass(self):


### PR DESCRIPTION
## Description:
Removes microseconds from the timer component

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

Closes #27910 (https://github.com/home-assistant/home-assistant/issues/27910). This issue comments that the remaining timer does not update until paused and that the timer displays remaining time microseconds. According to #30062(https://github.com/home-assistant/home-assistant/issues/30062), the remaining attribute does this by design, and may even be removed. 


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
