### PR TITLE
Fix TOD component incorrectly determining the state between sunrise and sunset

### DIFF
--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -175,7 +175,7 @@ class TodSensor(BinarySensorDevice):
         self._time_before = before_event_date
 
         # We are calculating the _time_after value assuming that it will happen today
-        # But it's not always truth. E.g. after 23:00, before 12:00, and now is 10:00
+        # But that is not always true, e.g. after 23:00, before 12:00 and now is 10:00
         # If _time_before and _time_after are ahead of current_datetime:
         # _time_before is set to 12:00 next day
         # _time_after is set to 23:00 today

--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -184,6 +184,7 @@ class TodSensor(BinarySensorDevice):
             self._time_after > self.current_datetime
             and self._time_before > self.current_datetime + timedelta(days=1)
         ):
+            # remove one day from _time_before and _time_after
             self._time_after -= timedelta(days=1)
             self._time_before -= timedelta(days=1)
 

--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -176,7 +176,10 @@ class TodSensor(BinarySensorDevice):
 
         # We are calculating the _time_after value assuming that it will happen today
         # But it's not always truth. E.g. after 23:00, before 12:00, and now is 10:00
-        # Here we check if _time_after was yesterday and _time_before will be today
+        # If _time_before and _time_after are ahead of current_datetime:
+        # _time_before is set to 12:00 next day
+        # _time_after is set to 23:00 today
+        # current_datetime is set to 10:00 today
         if (
             self._time_after > self.current_datetime
             and self._time_before > self.current_datetime + timedelta(days=1)

--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -174,6 +174,14 @@ class TodSensor(BinarySensorDevice):
 
         self._time_before = before_event_date
 
+        # Check after value is today
+        if (
+            self._time_after > self.current_datetime
+            and self._time_before > self.current_datetime + timedelta(days=1)
+        ):
+            self._time_after -= timedelta(days=1)
+            self._time_before -= timedelta(days=1)
+
         # Add offset to utc boundaries according to the configuration
         self._time_after += self._after_offset
         self._time_before += self._before_offset

--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -174,7 +174,9 @@ class TodSensor(BinarySensorDevice):
 
         self._time_before = before_event_date
 
-        # Check after value is today
+        # We are calculating the _time_after value assuming that it will happen today
+        # But it's not always truth. E.g. after 23:00, before 12:00, and now is 10:00
+        # Here we check if _time_after was yesterday and _time_before will be today
         if (
             self._time_after > self.current_datetime
             and self._time_before > self.current_datetime + timedelta(days=1)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
For example, now is 12:00.
With config below sensor is off. It's because `_time_after` calculates always for current day.
```yaml
binary_sensor:
  - platform: tod
    name: tod_day
    after: '23:00'
    before: '16:00'
```

**Related issue (if applicable):**
fixes #24577 fixes #21974 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
