### PR TITLE
Fix handling of symlinked device descriptors in keyboard_remote and move remaining sync io to executor thread pool

### DIFF
--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -2,6 +2,7 @@
 # pylint: disable=import-error
 import asyncio
 import logging
+import os
 
 import aionotify
 from evdev import InputDevice, categorize, ecodes, list_devices
@@ -165,6 +166,11 @@ class KeyboardRemote:
             handler = self.handlers_by_descriptor[descriptor]
         elif dev.name in self.handlers_by_name:
             handler = self.handlers_by_name[dev.name]
+        else:
+            # check for symlinked paths matching descriptor
+            for d, h in self.handlers_by_descriptor.items():
+                if os.path.realpath(d) == descriptor:
+                    handler = h
 
         return (dev, handler)
 

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -120,12 +120,10 @@ class KeyboardRemote:
         # add initial devices (do this AFTER starting watcher in order to
         # avoid race conditions leading to missing device connections)
         initial_start_monitoring = set()
-        descriptors = await self.hass.async_add_executor_job(
-            lambda: list_devices(DEVINPUT)
-        )
+        descriptors = await self.hass.async_add_executor_job(list_devices, DEVINPUT)
         for descriptor in descriptors:
             dev, handler = await self.hass.async_add_executor_job(
-                lambda: self.get_device_handler(descriptor)
+                self.get_device_handler, descriptor
             )
 
             if handler is None:
@@ -201,7 +199,7 @@ class KeyboardRemote:
                     or (event.flags & aionotify.Flags.ATTRIB)
                 ) and not descriptor_active:
                     dev, handler = await self.hass.async_add_executor_job(
-                        lambda: self.get_device_handler(descriptor)
+                        self.get_device_handler, descriptor
                     )
                     if handler is None:
                         continue

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -120,7 +120,9 @@ class KeyboardRemote:
         # add initial devices (do this AFTER starting watcher in order to
         # avoid race conditions leading to missing device connections)
         initial_start_monitoring = set()
-        descriptors = list_devices(DEVINPUT)
+        descriptors = await self.hass.async_add_executor_job(
+            lambda: list_devices(DEVINPUT)
+        )
         for descriptor in descriptors:
             dev, handler = await self.hass.async_add_executor_job(
                 lambda: self.get_device_handler(descriptor)

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -169,7 +169,11 @@ class KeyboardRemote:
         else:
             # check for symlinked paths matching descriptor
             for d, h in self.handlers_by_descriptor.items():
-                if os.path.realpath(d) == descriptor:
+                if h.dev is not None:
+                    fullpath = h.dev.path
+                else:
+                    fullpath = os.path.realpath(d)
+                if fullpath == descriptor:
                     handler = h
 
         return (dev, handler)

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -168,13 +168,13 @@ class KeyboardRemote:
             handler = self.handlers_by_name[dev.name]
         else:
             # check for symlinked paths matching descriptor
-            for d, h in self.handlers_by_descriptor.items():
-                if h.dev is not None:
-                    fullpath = h.dev.path
+            for test_descriptor, test_handler in self.handlers_by_descriptor.items():
+                if test_handler.dev is not None:
+                    fullpath = test_handler.dev.path
                 else:
-                    fullpath = os.path.realpath(d)
+                    fullpath = os.path.realpath(test_descriptor)
                 if fullpath == descriptor:
-                    handler = h
+                    handler = test_handler
 
         return (dev, handler)
 


### PR DESCRIPTION
Fixes #28982 (regression introduced by https://github.com/home-assistant/home-assistant/pull/27761 where symlinked paths were not handled properly by the new asynchronous device detection)

