### PR TITLE
Fix 'NewIPAddress' error in component fritz

### DIFF
--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for FRITZ!Box routers."""
 import logging
 
-from fritzconnection.lib.fritzhosts import FritzHosts  # pylint: disable=import-error
+from fritzconnection.lib.fritzhosts import FritzHosts
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -68,7 +68,7 @@ class FritzBoxScanner(DeviceScanner):
         self._update_info()
         active_hosts = []
         for known_host in self.last_results:
-            if known_host["status"] == "1" and known_host.get("mac"):
+            if known_host["status"] and known_host.get("mac"):
                 active_hosts.append(known_host["mac"])
         return active_hosts
 

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for FRITZ!Box routers."""
 import logging
 
-from fritzconnection import FritzHosts  # pylint: disable=import-error
+from fritzconnection.lib.fritzhosts import FritzHosts  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (

--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fritz",
   "name": "AVM Fritzbox",
   "documentation": "https://www.home-assistant.io/integrations/fritz",
-  "requirements": ["fritzconnection==0.8.4"],
+  "requirements": ["fritzconnection==1.2.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/fritzbox_callmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_callmonitor/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fritzbox_callmonitor",
   "name": "AVM FRITZ!Box Call Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_callmonitor",
-  "requirements": ["fritzconnection==0.8.4"],
+  "requirements": ["fritzconnection==1.2.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -6,7 +6,7 @@ import socket
 import threading
 import time
 
-import fritzconnection as fc  # pylint: disable=import-error
+from fritzconnection.lib.fritzphonebook import FritzPhonebook
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -256,7 +256,7 @@ class FritzBoxPhonebook:
         self.prefixes = prefixes or []
 
         # Establish a connection to the FRITZ!Box.
-        self.fph = fc.FritzPhonebook(
+        self.fph = FritzPhonebook(
             address=self.host, user=self.username, password=self.password
         )
 

--- a/homeassistant/components/fritzbox_netmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_netmonitor/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fritzbox_netmonitor",
   "name": "AVM FRITZ!Box Net Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_netmonitor",
-  "requirements": ["fritzconnection==0.8.4"],
+  "requiremegnts": ["fritzconnection==1.0.1"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/fritzbox_netmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_netmonitor/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fritzbox_netmonitor",
   "name": "AVM FRITZ!Box Net Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_netmonitor",
-  "requiremegnts": ["fritzconnection==1.0.1"],
+  "requirements": ["fritzconnection==1.2.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/fritzbox_netmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_netmonitor/sensor.py
@@ -2,8 +2,8 @@
 from datetime import timedelta
 import logging
 
-from fritzconnection import FritzStatus  # pylint: disable=import-error
-from fritzconnection.fritzconnection import (  # pylint: disable=import-error
+from fritzconnection.lib.fritzstatus import FritzStatus  # pylint: disable=import-error
+from fritzconnection.core.exceptions import (  # pylint: disable=import-error
     FritzConnectionException,
 )
 from requests.exceptions import RequestException

--- a/homeassistant/components/fritzbox_netmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_netmonitor/sensor.py
@@ -2,10 +2,8 @@
 from datetime import timedelta
 import logging
 
-from fritzconnection.lib.fritzstatus import FritzStatus  # pylint: disable=import-error
-from fritzconnection.core.exceptions import (  # pylint: disable=import-error
-    FritzConnectionException,
-)
+from fritzconnection.core.exceptions import FritzConnectionException
+from fritzconnection.lib.fritzstatus import FritzStatus
 from requests.exceptions import RequestException
 import voluptuous as vol
 
@@ -30,7 +28,6 @@ ATTR_IS_LINKED = "is_linked"
 ATTR_MAX_BYTE_RATE_DOWN = "max_byte_rate_down"
 ATTR_MAX_BYTE_RATE_UP = "max_byte_rate_up"
 ATTR_UPTIME = "uptime"
-ATTR_WAN_ACCESS_TYPE = "wan_access_type"
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
@@ -73,7 +70,7 @@ class FritzboxMonitorSensor(Entity):
         self._name = name
         self._fstatus = fstatus
         self._state = STATE_UNAVAILABLE
-        self._is_linked = self._is_connected = self._wan_access_type = None
+        self._is_linked = self._is_connected = None
         self._external_ip = self._uptime = None
         self._bytes_sent = self._bytes_received = None
         self._transmission_rate_up = None
@@ -104,7 +101,6 @@ class FritzboxMonitorSensor(Entity):
         attr = {
             ATTR_IS_LINKED: self._is_linked,
             ATTR_IS_CONNECTED: self._is_connected,
-            ATTR_WAN_ACCESS_TYPE: self._wan_access_type,
             ATTR_EXTERNAL_IP: self._external_ip,
             ATTR_UPTIME: self._uptime,
             ATTR_BYTES_SENT: self._bytes_sent,
@@ -122,7 +118,6 @@ class FritzboxMonitorSensor(Entity):
         try:
             self._is_linked = self._fstatus.is_linked
             self._is_connected = self._fstatus.is_connected
-            self._wan_access_type = self._fstatus.wan_access_type
             self._external_ip = self._fstatus.external_ip
             self._uptime = self._fstatus.uptime
             self._bytes_sent = self._fstatus.bytes_sent

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -546,12 +546,10 @@ fortiosapi==0.10.8
 # homeassistant.components.free_mobile
 freesms==0.1.2
 
-# homeassistant.components.fritzbox_callmonitor
-# fritzconnection==0.8.4
-
 # homeassistant.components.fritz
+# homeassistant.components.fritzbox_callmonitor
 # homeassistant.components.fritzbox_netmonitor
-# fritzconnection==1.0.1
+fritzconnection==1.2.0
 
 # homeassistant.components.fritzdect
 fritzhome==1.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -546,10 +546,12 @@ fortiosapi==0.10.8
 # homeassistant.components.free_mobile
 freesms==0.1.2
 
-# homeassistant.components.fritz
 # homeassistant.components.fritzbox_callmonitor
-# homeassistant.components.fritzbox_netmonitor
 # fritzconnection==0.8.4
+
+# homeassistant.components.fritz
+# homeassistant.components.fritzbox_netmonitor
+# fritzconnection==1.0.1
 
 # homeassistant.components.fritzdect
 fritzhome==1.0.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -25,7 +25,6 @@ COMMENT_REQUIREMENTS = (
     "envirophat",
     "evdev",
     "face_recognition",
-    "fritzconnection",
     "i2csense",
     "opencv-python-headless",
     "py_noaa",


### PR DESCRIPTION
## Breaking Change:

Attribute `wan_access_type` has been removed from `fritzbox_netmonitor` as the new version of the `fritzconnection` component doesn't have this attribute exposed any more. As a result the information will not be available in the HA sensor anymore.

## Description:


**Related issue (if applicable):** fixes #13608, fixes #27257 (duplicates of same issue) and fixes #29994

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11732

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
