### PR TITLE
Add zha ZCL AnalogOutput cluster support

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -6,6 +6,7 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.cover import DOMAIN as COVER
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
 from homeassistant.components.fan import DOMAIN as FAN
+from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER
 from homeassistant.components.light import DOMAIN as LIGHT
 from homeassistant.components.lock import DOMAIN as LOCK
 from homeassistant.components.sensor import DOMAIN as SENSOR
@@ -46,6 +47,7 @@ BAUD_RATES = [2400, 4800, 9600, 14400, 19200, 38400, 57600, 115200, 128000, 2560
 BINDINGS = "bindings"
 
 CHANNEL_ACCELEROMETER = "accelerometer"
+CHANNEL_ANALOG_OUTPUT = "analog_output"
 CHANNEL_ATTRIBUTE = "attribute"
 CHANNEL_BASIC = "basic"
 CHANNEL_COLOR = "light_color"
@@ -73,7 +75,17 @@ CLUSTER_COMMANDS_SERVER = "server_commands"
 CLUSTER_TYPE_IN = "in"
 CLUSTER_TYPE_OUT = "out"
 
-COMPONENTS = (BINARY_SENSOR, COVER, DEVICE_TRACKER, FAN, LIGHT, LOCK, SENSOR, SWITCH)
+COMPONENTS = (
+    BINARY_SENSOR,
+    COVER,
+    DEVICE_TRACKER,
+    FAN,
+    INPUT_NUMBER,
+    LIGHT,
+    LOCK,
+    SENSOR,
+    SWITCH,
+)
 
 CONF_BAUDRATE = "baudrate"
 CONF_DATABASE = "database_path"

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -24,6 +24,7 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.cover import DOMAIN as COVER
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
 from homeassistant.components.fan import DOMAIN as FAN
+from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER
 from homeassistant.components.light import DOMAIN as LIGHT
 from homeassistant.components.lock import DOMAIN as LOCK
 from homeassistant.components.sensor import DOMAIN as SENSOR
@@ -66,6 +67,7 @@ SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     zcl.clusters.closures.DoorLock: LOCK,
     zcl.clusters.closures.WindowCovering: COVER,
     zcl.clusters.general.AnalogInput.cluster_id: SENSOR,
+    zcl.clusters.general.AnalogOutput.cluster_id: INPUT_NUMBER,
     zcl.clusters.general.MultistateInput.cluster_id: SENSOR,
     zcl.clusters.general.OnOff: SWITCH,
     zcl.clusters.general.PowerConfiguration: SENSOR,

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -48,6 +48,7 @@ class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
         self._unsubs = []
         self.remove_future = None
         for channel in channels:
+            _LOGGER.debug(channel.name)
             self.cluster_channels[channel.name] = channel
 
     @property

--- a/homeassistant/components/zha/input_number.py
+++ b/homeassistant/components/zha/input_number.py
@@ -1,0 +1,393 @@
+"""Analog Output on Zigbee Home Automation networks."""
+from collections import OrderedDict
+import logging
+
+from homeassistant.components.input_number import (
+    ATTR_INITIAL,
+    ATTR_MAX,
+    ATTR_MIN,
+    ATTR_MODE,
+    ATTR_STEP,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_ICON,
+    CONF_INITIAL,
+    CONF_MAX,
+    CONF_MIN,
+    CONF_MODE,
+    CONF_STEP,
+    DOMAIN,
+    MODE_SLIDER,
+    InputNumber,
+)
+from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .core.const import (
+    CHANNEL_ANALOG_OUTPUT,
+    DATA_ZHA,
+    DATA_ZHA_DISPATCHERS,
+    SIGNAL_ATTR_UPDATED,
+    ZHA_DISCOVERY_NEW,
+)
+from .entity import ZhaEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+UNITS = {
+    0: "Square-meters",
+    1: "Square-feet",
+    2: "Milliamperes",
+    3: "Amperes",
+    4: "Ohms",
+    5: "Volts",
+    6: "Kilo-volts",
+    7: "Mega-volts",
+    8: "Volt-amperes",
+    9: "Kilo-volt-amperes",
+    10: "Mega-volt-amperes",
+    11: "Volt-amperes-reactive",
+    12: "Kilo-volt-amperes-reactive",
+    13: "Mega-volt-amperes-reactive",
+    14: "Degrees-phase",
+    15: "Power-factor",
+    16: "Joules",
+    17: "Kilojoules",
+    18: "Watt-hours",
+    19: "Kilowatt-hours",
+    20: "BTUs",
+    21: "Therms",
+    22: "Ton-hours",
+    23: "Joules-per-kilogram-dry-air",
+    24: "BTUs-per-pound-dry-air",
+    25: "Cycles-per-hour",
+    26: "Cycles-per-minute",
+    27: "Hertz",
+    28: "Grams-of-water-per-kilogram-dry-air",
+    29: "Percent-relative-humidity",
+    30: "Millimeters",
+    31: "Meters",
+    32: "Inches",
+    33: "Feet",
+    34: "Watts-per-square-foot",
+    35: "Watts-per-square-meter",
+    36: "Lumens",
+    37: "Luxes",
+    38: "Foot-candles",
+    39: "Kilograms",
+    40: "Pounds-mass",
+    41: "Tons",
+    42: "Kilograms-per-second",
+    43: "Kilograms-per-minute",
+    44: "Kilograms-per-hour",
+    45: "Pounds-mass-per-minute",
+    46: "Pounds-mass-per-hour",
+    47: "Watts",
+    48: "Kilowatts",
+    49: "Megawatts",
+    50: "BTUs-per-hour",
+    51: "Horsepower",
+    52: "Tons-refrigeration",
+    53: "Pascals",
+    54: "Kilopascals",
+    55: "Bars",
+    56: "Pounds-force-per-square-inch",
+    57: "Centimeters-of-water",
+    58: "Inches-of-water",
+    59: "Millimeters-of-mercury",
+    60: "Centimeters-of-mercury",
+    61: "Inches-of-mercury",
+    62: "°C",
+    63: "°K",
+    64: "°F",
+    65: "Degree-days-Celsius",
+    66: "Degree-days-Fahrenheit",
+    67: "Years",
+    68: "Months",
+    69: "Weeks",
+    70: "Days",
+    71: "Hours",
+    72: "Minutes",
+    73: "Seconds",
+    74: "Meters-per-second",
+    75: "Kilometers-per-hour",
+    76: "Feet-per-second",
+    77: "Feet-per-minute",
+    78: "Miles-per-hour",
+    79: "Cubic-feet",
+    80: "Cubic-meters",
+    81: "Imperial-gallons",
+    82: "Liters",
+    83: "Us-gallons",
+    84: "Cubic-feet-per-minute",
+    85: "Cubic-meters-per-second",
+    86: "Imperial-gallons-per-minute",
+    87: "Liters-per-second",
+    88: "Liters-per-minute",
+    89: "Us-gallons-per-minute",
+    90: "Degrees-angular",
+    91: "Degrees-Celsius-per-hour",
+    92: "Degrees-Celsius-per-minute",
+    93: "Degrees-Fahrenheit-per-hour",
+    94: "Degrees-Fahrenheit-per-minute",
+    95: None,
+    96: "Parts-per-million",
+    97: "Parts-per-billion",
+    98: "%",
+    99: "Percent-per-second",
+    100: "Per-minute",
+    101: "Per-second",
+    102: "Psi-per-Degree-Fahrenheit",
+    103: "Radians",
+    104: "Revolutions-per-minute",
+    105: "Currency1",
+    106: "Currency2",
+    107: "Currency3",
+    108: "Currency4",
+    109: "Currency5",
+    110: "Currency6",
+    111: "Currency7",
+    112: "Currency8",
+    113: "Currency9",
+    114: "Currency10",
+    115: "Square-inches",
+    116: "Square-centimeters",
+    117: "BTUs-per-pound",
+    118: "Centimeters",
+    119: "Pounds-mass-per-second",
+    120: "Delta-Degrees-Fahrenheit",
+    121: "Delta-Degrees-Kelvin",
+    122: "Kilohms",
+    123: "Megohms",
+    124: "Millivolts",
+    125: "Kilojoules-per-kilogram",
+    126: "Megajoules",
+    127: "Joules-per-degree-Kelvin",
+    128: "Joules-per-kilogram-degree-Kelvin",
+    129: "Kilohertz",
+    130: "Megahertz",
+    131: "Per-hour",
+    132: "Milliwatts",
+    133: "Hectopascals",
+    134: "Millibars",
+    135: "Cubic-meters-per-hour",
+    136: "Liters-per-hour",
+    137: "Kilowatt-hours-per-square-meter",
+    138: "Kilowatt-hours-per-square-foot",
+    139: "Megajoules-per-square-meter",
+    140: "Megajoules-per-square-foot",
+    141: "Watts-per-square-meter-Degree-Kelvin",
+    142: "Cubic-feet-per-second",
+    143: "Percent-obscuration-per-foot",
+    144: "Percent-obscuration-per-meter",
+    145: "Milliohms",
+    146: "Megawatt-hours",
+    147: "Kilo-BTUs",
+    148: "Mega-BTUs",
+    149: "Kilojoules-per-kilogram-dry-air",
+    150: "Megajoules-per-kilogram-dry-air",
+    151: "Kilojoules-per-degree-Kelvin",
+    152: "Megajoules-per-degree-Kelvin",
+    153: "Newton",
+    154: "Grams-per-second",
+    155: "Grams-per-minute",
+    156: "Tons-per-hour",
+    157: "Kilo-BTUs-per-hour",
+    158: "Hundredths-seconds",
+    159: "Milliseconds",
+    160: "Newton-meters",
+    161: "Millimeters-per-second",
+    162: "Millimeters-per-minute",
+    163: "Meters-per-minute",
+    164: "Meters-per-hour",
+    165: "Cubic-meters-per-minute",
+    166: "Meters-per-second-per-second",
+    167: "Amperes-per-meter",
+    168: "Amperes-per-square-meter",
+    169: "Ampere-square-meters",
+    170: "Farads",
+    171: "Henrys",
+    172: "Ohm-meters",
+    173: "Siemens",
+    174: "Siemens-per-meter",
+    175: "Teslas",
+    176: "Volts-per-degree-Kelvin",
+    177: "Volts-per-meter",
+    178: "Webers",
+    179: "Candelas",
+    180: "Candelas-per-square-meter",
+    181: "Kelvins-per-hour",
+    182: "Kelvins-per-minute",
+    183: "Joule-seconds",
+    185: "Square-meters-per-Newton",
+    186: "Kilogram-per-cubic-meter",
+    187: "Newton-seconds",
+    188: "Newtons-per-meter",
+    189: "Watts-per-meter-per-degree-Kelvin",
+}
+
+ICONS = {
+    0: "mdi:temperature-celsius",
+    1: "mdi:water-percent",
+    2: "mdi:gauge",
+    3: "mdi:speedometer",
+    4: "mdi:percent",
+    5: "mdi:air-filter",
+    6: "mdi:fan",
+    7: "mdi:flash",
+    8: "mdi:current-ac",
+    9: "mdi:flash",
+    10: "mdi:flash",
+    11: "mdi:flash",
+    12: "mdi:counter",
+    13: "mdi:thermometer-lines",
+    14: "mdi:timer",
+}
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Old way of setting up Zigbee Home Automation analog outputs."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Zigbee Home Automation analog output from config entry."""
+
+    async def async_discover(discovery_info):
+        await _async_setup_entities(
+            hass, config_entry, async_add_entities, [discovery_info]
+        )
+
+    unsub = async_dispatcher_connect(
+        hass, ZHA_DISCOVERY_NEW.format(DOMAIN), async_discover
+    )
+    hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
+
+    analog_outputs = hass.data.get(DATA_ZHA, {}).get(DOMAIN)
+    if analog_outputs is not None:
+        await _async_setup_entities(
+            hass, config_entry, async_add_entities, analog_outputs.values()
+        )
+        del hass.data[DATA_ZHA][DOMAIN]
+
+
+async def _async_setup_entities(
+    hass, config_entry, async_add_entities, discovery_infos
+):
+    """Set up the ZHA analog outputs."""
+    entities = []
+    for discovery_info in discovery_infos:
+        entities.append(ZhaInputNumber(**discovery_info))
+
+    async_add_entities(entities, update_before_add=True)
+
+
+class ZhaInputNumber(ZhaEntity, InputNumber):
+    """ZHA analog output."""
+
+    def __init__(self, **kwargs):
+        """Initialize the ZHA analog output."""
+        super().__init__(**kwargs)
+
+        config = OrderedDict()
+        config[CONF_INITIAL] = None
+        config[CONF_MIN] = 0.0
+        config[CONF_MAX] = 100.0
+        config[CONF_STEP] = 1.0
+        config[CONF_MODE] = MODE_SLIDER
+        config[CONF_ICON] = None
+        config[ATTR_UNIT_OF_MEASUREMENT] = None
+        InputNumber.__init__(self, config=config)
+
+        self._channel = self.cluster_channels.get(CHANNEL_ANALOG_OUTPUT)
+
+    async def async_set_value(self, value):
+        """Set new value."""
+        await self._channel.cluster.write_attributes({"present_value": value})
+        await super().async_set_value(value)
+
+    async def async_set_value_from_attr(self, value):
+        """Handle state update from channel."""
+        await super().async_set_value(value)
+
+    async def async_increment(self):
+        """Increment value."""
+        await self.async_set_value(self._current_value + self._step)
+
+    async def async_decrement(self):
+        """Decrement value."""
+        await self.async_set_value(self._current_value - self._step)
+
+    @property
+    def device_state_attributes(self):
+        """Return state attributes."""
+        return self.state_attributes
+
+    async def async_added_to_hass(self):
+        """Run when about to be added to hass."""
+        await super().async_added_to_hass()
+        max_present_value = await self._channel.get_attribute_value("max_present_value")
+        min_present_value = await self._channel.get_attribute_value("min_present_value")
+        relinquish_default = await self._channel.get_attribute_value(
+            "relinquish_default"
+        )
+        step = await self._channel.get_attribute_value("resolution")
+        description = await self._channel.get_attribute_value("description")
+        engineering_units = await self._channel.get_attribute_value("engineering_units")
+        application_type = await self._channel.get_attribute_value("application_type")
+        if max_present_value:
+            self._config[CONF_MAX] = max_present_value
+        if min_present_value:
+            self._config[CONF_MIN] = min_present_value
+        if relinquish_default:
+            self._config[CONF_INITIAL] = relinquish_default
+            if not self._current_value:
+                self._current_value = relinquish_default
+        if step and step > 0:
+            self._config[CONF_STEP] = step
+        if description and len(description) > 0:
+            self._name = description
+        if engineering_units:
+            self._config[ATTR_UNIT_OF_MEASUREMENT] = UNITS.get(engineering_units)
+        if application_type:
+            self._config[CONF_ICON] = ICONS.get(application_type >> 16)
+        await InputNumber.async_added_to_hass(self)
+        await self.async_accept_signal(
+            self._channel, SIGNAL_ATTR_UPDATED, self.async_set_value_from_attr
+        )
+
+    @callback
+    def async_restore_last_state(self, last_state):
+        """Restore previous state."""
+        self._current_value = last_state.state
+        self._name = last_state.attributes.get(ATTR_FRIENDLY_NAME, self._name)
+        self._config[CONF_INITIAL] = last_state.attributes.get(
+            ATTR_INITIAL, self._config[CONF_INITIAL]
+        )
+        self._config[CONF_MIN] = last_state.attributes.get(
+            ATTR_MIN, self._config[CONF_MIN]
+        )
+        self._config[CONF_MAX] = last_state.attributes.get(
+            ATTR_MAX, self._config[CONF_MAX]
+        )
+        self._config[CONF_STEP] = last_state.attributes.get(
+            ATTR_STEP, self._config[CONF_STEP]
+        )
+        self._config[CONF_MODE] = last_state.attributes.get(
+            ATTR_MODE, self._config[CONF_MODE]
+        )
+        self._config[CONF_ICON] = last_state.attributes.get(
+            ATTR_ICON, self._config[CONF_ICON]
+        )
+        self._config[ATTR_UNIT_OF_MEASUREMENT] = last_state.attributes.get(
+            ATTR_UNIT_OF_MEASUREMENT, self._config[ATTR_UNIT_OF_MEASUREMENT]
+        )
+
+    async def async_update(self):
+        """Attempt to retrieve state from the device."""
+        await super().async_update()
+        present_value = self._current_value = await self._channel.get_attribute_value(
+            "present_value"
+        )
+        if present_value:
+            self._current_value = present_value

--- a/tests/components/zha/test_input_number.py
+++ b/tests/components/zha/test_input_number.py
@@ -1,0 +1,112 @@
+"""Test zha analog output."""
+from unittest.mock import MagicMock, call, patch
+
+import zigpy.zcl.clusters.general as general
+import zigpy.zcl.foundation as zcl_f
+
+from homeassistant.components.input_number import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
+
+from .common import (
+    async_enable_traffic,
+    async_init_zigpy_device,
+    async_test_device_join,
+    find_entity_id,
+    make_attribute,
+    make_zcl_header,
+)
+
+from tests.common import mock_coro
+
+
+async def test_analog_output(hass, config_entry, zha_gateway):
+    """Test zha analog output."""
+
+    # create zigpy device
+    zigpy_device = await async_init_zigpy_device(
+        hass,
+        [general.AnalogOutput.cluster_id, general.Basic.cluster_id],
+        [],
+        None,
+        zha_gateway,
+    )
+
+    async def get_chan_attr(*args, **kwargs):
+        return {
+            "present_value": 15.0,
+            "max_present_value": 100.0,
+            "min_present_value": 0.0,
+            "relinquish_default": 50.0,
+            "resolution": 1.0,
+            "description": "PWM1",
+            "engineering_units": 98,
+            "application_type": 4 * 0x10000,
+        }.get(args[0])
+
+    with patch(
+        "homeassistant.components.zha.core.channels.ZigbeeChannel.get_attribute_value",
+        new=MagicMock(side_effect=get_chan_attr),
+    ) as get_attr_mock:
+        # load up input_number domain
+        await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
+        await hass.async_block_till_done()
+        assert get_attr_mock.call_count == 8
+        assert get_attr_mock.call_args[0][0] == "application_type"
+
+    cluster = zigpy_device.endpoints.get(1).analog_output
+    assert cluster is not None
+
+    zha_device = zha_gateway.get_device(zigpy_device.ieee)
+    assert zha_device is not None
+
+    entity_id = await find_entity_id(DOMAIN, zha_device, hass)
+    assert entity_id is not None
+
+    # test that the input_number was created and that its state is unavailable
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, zha_gateway, [zha_device])
+
+    # test that the state has changed from unavailable to 15.0
+    assert hass.states.get(entity_id).state == "15.0"
+
+    # test attributes
+    assert hass.states.get(entity_id).attributes.get("min") == 0.0
+    assert hass.states.get(entity_id).attributes.get("max") == 100.0
+    assert hass.states.get(entity_id).attributes.get("step") == 1.0
+    assert hass.states.get(entity_id).attributes.get("mode") == "slider"
+    assert hass.states.get(entity_id).attributes.get("initial") == 50.0
+    assert hass.states.get(entity_id).attributes.get("icon") == "mdi:percent"
+    assert hass.states.get(entity_id).attributes.get("unit_of_measurement") == "%"
+    assert hass.states.get(entity_id).attributes.get("friendly_name") == "PWM1"
+
+    # change value from device
+    attr = make_attribute(0x0055, 15.0)
+    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
+    cluster.handle_message(hdr, [[attr]])
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == "15.0"
+
+    # update value from device
+    attr.value.value = 20.0
+    cluster.handle_message(hdr, [[attr]])
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == "20.0"
+
+    # change value from HA
+    with patch(
+        "zigpy.zcl.Cluster.write_attributes",
+        return_value=mock_coro([zcl_f.Status.SUCCESS, zcl_f.Status.SUCCESS]),
+    ):
+        # set value via UI
+        await hass.services.async_call(
+            DOMAIN, "set_value", {"entity_id": entity_id, "value": 30.0}, blocking=True
+        )
+        assert len(cluster.write_attributes.mock_calls) == 1
+        assert cluster.write_attributes.call_args == call({"present_value": 30.0})
+
+    # test joining a new device to the network and HA
+    await async_test_device_join(
+        hass, zha_gateway, general.AnalogOutput.cluster_id, entity_id
+    )


### PR DESCRIPTION
## Breaking Change:

N/A

## Description:

Support controlling of zigbee devices with analog output capability from HA.

The PR includes some changes for `input_number` to be usable as a platform for other integrations. My opinion is that the changes are minimal and should not affect maintainability of the code. However this view might have concerns, so here is an architecture issue for discussion: home-assistant/architecture#328

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11587

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
