### PR TITLE
Contributing: Add note about feature suggestions and bug tracking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Everybody is invited and welcome to contribute to Home Assistant. There is a lot
 
 The process is straight-forward.
 
- - Read [How to get faster PR reviews](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews) by Kubernetes (but skip step 0)
+ - Read [How to get faster PR reviews](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews) by Kubernetes (but skip step 0 and 1)
  - Fork the Home Assistant [git repository](https://github.com/home-assistant/home-assistant).
  - Write the code for your device, notification service, sensor, or IoT thing.
  - Ensure tests work.
@@ -12,3 +12,7 @@ The process is straight-forward.
 
 Still interested? Then you should take a peek at the [developer documentation](https://developers.home-assistant.io/) to get more details.
 
+## Feature suggestions
+
+If you want to suggest a new feature for Home Assistant (e.g., new integrations), please open a thread in our [Community Forum: Feature Requests](https://community.home-assistant.io/c/feature-requests).
+We use [GitHub for tracking issues](https://github.com/home-assistant/home-assistant/issues), not for tracking feature requests.


### PR DESCRIPTION
## Description:

Adding a note to `CONTRIBUTING.md` about Feature suggestions.

In #30195 I wrote down details about an implementation of a new integration.
#30195 was meant to be like a Home Assistant Enhancement Proposal like described in https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews (linked from the `CONTRIBUTING.md`).

For me, as a potential new contributor, this was not clear.
I thought it would be useful to write down details, gather community feedback and requirements, before starting with the implementations. More meant to be a design discussion.

This additional note should make it more clear.

**Related issue (if applicable):** fixes #30195

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
