### PR TITLE
Convert filter state to integer if rounding precision is zero

### DIFF
--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -324,7 +324,8 @@ class FilterState:
     def set_precision(self, precision):
         """Set precision of Number based states."""
         if isinstance(self.state, Number):
-            self.state = round(float(self.state), precision)
+            value = round(float(self.state), precision)
+            self.state = int(value) if precision == 0 else value
 
     def __str__(self):
         """Return state as the string representation of FilterState."""

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -208,6 +208,13 @@ class TestFilterSensor(unittest.TestCase):
             filtered = filt.filter_state(state)
         assert 21 == filtered.state
 
+    def test_precision_zero(self):
+        """Test if precision of zero returns an integer."""
+        filt = LowPassFilter(window_size=10, precision=0, entity=None, time_constant=10)
+        for state in self.values:
+            filtered = filt.filter_state(state)
+        assert isinstance(filtered.state, int)
+
     def test_lowpass(self):
         """Test if lowpass filter works."""
         filt = LowPassFilter(window_size=10, precision=2, entity=None, time_constant=10)


### PR DESCRIPTION
Convert values to integer if rounding precision is zero. With that a
value which is an integer before filtering can be configured to stay
integer when using precision = 0. This also aligns behavior of filters
to how rounding behaves in tempaltes (homeassistant/helpers/template.py,
function forgiving_round).

## Description:


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: filter
  entity_id: sensor.integer_sensor
  name: integer_sensor_filtered
  filters:
    - filter: lowpass
      time_constant: 10
      precision: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
