### PR TITLE
Bump python-qbittorrent to 0.4.1

### DIFF
--- a/homeassistant/components/qbittorrent/manifest.json
+++ b/homeassistant/components/qbittorrent/manifest.json
@@ -2,9 +2,7 @@
   "domain": "qbittorrent",
   "name": "Qbittorrent",
   "documentation": "https://www.home-assistant.io/integrations/qbittorrent",
-  "requirements": [
-    "python-qbittorrent==0.3.1"
-  ],
+  "requirements": ["python-qbittorrent==0.4.1"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/qbittorrent/sensor.py
+++ b/homeassistant/components/qbittorrent/sensor.py
@@ -107,7 +107,7 @@ class QBittorrentSensor(Entity):
     def update(self):
         """Get the latest data from qBittorrent and updates the state."""
         try:
-            data = self.client.sync()
+            data = self.client.sync_main_data()
             self._available = True
         except RequestException:
             _LOGGER.error("Connection lost")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1601,7 +1601,7 @@ python-nmap==0.6.1
 python-pushover==0.4
 
 # homeassistant.components.qbittorrent
-python-qbittorrent==0.3.1
+python-qbittorrent==0.4.1
 
 # homeassistant.components.ripple
 python-ripple-api==0.0.3


### PR DESCRIPTION
## Description:
- bump python-qbittorrent to the latest version to support qBittorrent applications with version higher than 3.1.x
- difference between 0.3.1 and 0.4.1: https://github.com/v1k45/python-qBittorrent/commit/cf0f958262c8fef5c96318edf17f2e0d67bab574
- [python-qbittorrent documentation](https://python-qbittorrent.readthedocs.io/en/latest/modules/api.html#module-qbittorrent.client)

**Related issue (if applicable):** fixes #29843 <home-assistant issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
