### PR TITLE
Bump ring to 0.2.6 to fix Oauth issues

### DIFF
--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ring",
   "name": "Ring",
   "documentation": "https://www.home-assistant.io/integrations/ring",
-  "requirements": ["ring_doorbell==0.2.5"],
+  "requirements": ["ring_doorbell==0.2.6"],
   "dependencies": ["ffmpeg"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1743,7 +1743,7 @@ rfk101py==0.0.1
 rflink==0.0.46
 
 # homeassistant.components.ring
-ring_doorbell==0.2.5
+ring_doorbell==0.2.6
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -553,7 +553,7 @@ restrictedpython==5.0
 rflink==0.0.46
 
 # homeassistant.components.ring
-ring_doorbell==0.2.5
+ring_doorbell==0.2.6
 
 # homeassistant.components.yamaha
 rxv==0.6.0


### PR DESCRIPTION
Breaking Change:
Bump Ring to 0.2.6 version

Description:
Upgraded Ring component to address oauth issues.
