### PR TITLE
Bump libpurecool to 0.6.0

### DIFF
--- a/homeassistant/components/dyson/manifest.json
+++ b/homeassistant/components/dyson/manifest.json
@@ -3,7 +3,7 @@
   "name": "Dyson",
   "documentation": "https://www.home-assistant.io/integrations/dyson",
   "requirements": [
-    "libpurecool==0.5.0"
+    "libpurecool==0.6.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -756,7 +756,7 @@ konnected==0.1.5
 lakeside==0.12
 
 # homeassistant.components.dyson
-libpurecool==0.5.0
+libpurecool==0.6.0
 
 # homeassistant.components.foscam
 libpyfoscam==1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -265,7 +265,7 @@ keyring==20.0.0
 keyrings.alt==3.4.0
 
 # homeassistant.components.dyson
-libpurecool==0.5.0
+libpurecool==0.6.0
 
 # homeassistant.components.soundtouch
 libsoundtouch==0.7.2


### PR DESCRIPTION
## Description:

fixes home-assistant/home-assistant#26367 by bumping libpurecool to 0.6.0 which added support for HP04 dyson devices

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]