### PR TITLE
Add mqtt cover support for IS_CLOSING and IS_OPENING

### DIFF
--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -3,18 +3,23 @@ import logging
 
 import voluptuous as vol
 
+"""ADD SUPPORT FOR IS_CLOSING IS_OPENING & IS_CLOSED maybe? """
+
 from homeassistant.components import cover, mqtt
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DEVICE_CLASSES_SCHEMA,
     SUPPORT_CLOSE,
+    SUPPORT_IS_CLOSING,
     SUPPORT_CLOSE_TILT,
     SUPPORT_OPEN,
+    SUPPORT_IS_OPENING,
     SUPPORT_OPEN_TILT,
     SUPPORT_SET_POSITION,
     SUPPORT_SET_TILT_POSITION,
     SUPPORT_STOP,
+    SUPPORT_IS_CLOSED,
     SUPPORT_STOP_TILT,
     CoverDevice,
 )


### PR DESCRIPTION
Hello,

Sorry Its probably not the way I should do that, but I am very new to Github and HomeAssistant, please forgive me :-)
Also I am not programmer so I would like to ask if someone can do a change for me. 
I'm also not sure if I will phrase that correctly. Sorry about that if its the case. I will try to provide the max info.

Is it possible for someone to add the support of additional states (OPENING and CLOSING and STOPPED) with the usage of an additional MQTT topic. I think this a supported feature of the platform/entity ? with is_opening or is_closing ? (https://developers.home-assistant.io/docs/en/entity_cover.html#supported-features)

There would be 3 different payloads which would define the "direction" of the shutter.

here is an example of my homebridge equivalent with tasmota shutter if it helps to understand : 

shutter2/tele/RESULT this topic from my tasmota provides this JSON message 
{
    "Shutter1": {
        "Position": 100,
        "direction": 0
    }
}

So, with direction being 1, 0 or -1 I can know if it goes up, down or if it is stopped

in Homebridge ( Homebridge can do that with "PostionStateValue" : https://www.npmjs.com/package/homebridge-mqttthing#window-covering ),
 this works :

 "getPositionState": {
                    "topic": "shutter2/tele/RESULT",
                    "apply": "return JSON.parse(message).Shutter1.direction;"
                }
            },
            "positionStateValues": [
                1,
                -1,
                0 "getPositionState": {
                    "topic": "shutter2/tele/RESULT",
                    "apply": "return JSON.parse(message).Shutter1.direction;"
                }
            },
            "positionStateValues": [
                1,
                -1,
                0
            ]

Thank you very much 👍

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
