### PR TITLE
Handle telegram event commands with args

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -782,8 +782,7 @@ class BaseTelegramBotEntity:
             if event_data is None:
                 return message_ok
 
-            query_data = data[ATTR_DATA]
-            event_data[ATTR_DATA] = query_data
+            query_data = event_data[ATTR_DATA] = data[ATTR_DATA]
 
             if query_data[0] == "/":
                 pieces = query_data.split(" ")

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -782,8 +782,16 @@ class BaseTelegramBotEntity:
             if event_data is None:
                 return message_ok
 
-            event_data[ATTR_DATA] = data[ATTR_DATA]
-            event_data[ATTR_MSG] = data[ATTR_MSG]
+            query_data = data[ATTR_DATA]
+            event_data[ATTR_DATA] = query_data
+
+            if query_data[0] == "/":
+                pieces = query_data.split(" ")
+                event_data[ATTR_COMMAND] = pieces[0]
+                event_data[ATTR_ARGS] = pieces[1:]
+            else:
+                event_data[ATTR_MSG] = data[ATTR_MSG]
+                
             event_data[ATTR_CHAT_INSTANCE] = data[ATTR_CHAT_INSTANCE]
             event_data[ATTR_MSGID] = data[ATTR_MSGID]
 

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -789,9 +789,8 @@ class BaseTelegramBotEntity:
                 pieces = query_data.split(" ")
                 event_data[ATTR_COMMAND] = pieces[0]
                 event_data[ATTR_ARGS] = pieces[1:]
-            else:
-                event_data[ATTR_MSG] = data[ATTR_MSG]
-                
+   
+            event_data[ATTR_MSG] = data[ATTR_MSG]    
             event_data[ATTR_CHAT_INSTANCE] = data[ATTR_CHAT_INSTANCE]
             event_data[ATTR_MSGID] = data[ATTR_MSGID]
 

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -789,8 +789,8 @@ class BaseTelegramBotEntity:
                 pieces = query_data.split(" ")
                 event_data[ATTR_COMMAND] = pieces[0]
                 event_data[ATTR_ARGS] = pieces[1:]
-   
-            event_data[ATTR_MSG] = data[ATTR_MSG]    
+
+            event_data[ATTR_MSG] = data[ATTR_MSG]
             event_data[ATTR_CHAT_INSTANCE] = data[ATTR_CHAT_INSTANCE]
             event_data[ATTR_MSGID] = data[ATTR_MSGID]
 


### PR DESCRIPTION
## Breaking Change:
Should not have any breaking change

## Description:

Let's take this case:
if we would send a callback with `/switch_heating living_room`
With the current setup the argument would be lost, and we only have access to the raw message

This PR makes the event callback behavior uniform with command message, so we can add triggers by command and use the arguments. It just basically adds a parser for arguments in the event callback

### PR for docs [is here](https://github.com/home-assistant/home-assistant.io/pull/11550)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
