### PR TITLE
Add reset_energy_counter service to Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional
 from homematicip.aio.group import AsyncHeatingGroup
 from homematicip.aio.home import AsyncHome
 from homematicip.base.helpers import handle_config
+from homematicip.aio.device import AsyncSwitchMeasuring
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -47,6 +48,7 @@ SERVICE_ACTIVATE_VACATION = "activate_vacation"
 SERVICE_DEACTIVATE_ECO_MODE = "deactivate_eco_mode"
 SERVICE_DEACTIVATE_VACATION = "deactivate_vacation"
 SERVICE_DUMP_HAP_CONFIG = "dump_hap_config"
+SERVICE_RESET_ENERGY_COUNTER = "reset_energy_counter"
 SERVICE_SET_ACTIVE_CLIMATE_PROFILE = "set_active_climate_profile"
 
 CONFIG_SCHEMA = vol.Schema(
@@ -114,6 +116,10 @@ SCHEMA_DUMP_HAP_CONFIG = vol.Schema(
         ): cv.string,
         vol.Optional(ATTR_ANONYMIZE, default=True): cv.boolean,
     }
+)
+
+SCHEMA_RESET_ENERGY_COUNTER = vol.Schema(
+    {vol.Required(ATTR_ENTITY_ID): comp_entity_ids}
 )
 
 
@@ -245,7 +251,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
             if entity_id_list != "all":
                 for entity_id in entity_id_list:
                     group = hap.hmip_device_by_entity_id.get(entity_id)
-                    if group:
+                    if group and isinstance(group, AsyncHeatingGroup):
                         await group.set_active_profile(climate_profile_index)
             else:
                 for group in hap.home.groups:
@@ -287,6 +293,28 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         SERVICE_DUMP_HAP_CONFIG,
         _async_dump_hap_config,
         schema=SCHEMA_DUMP_HAP_CONFIG,
+    )
+
+    async def _async_reset_energy_counter(service):
+        """Service to reset the energy counter."""
+        entity_id_list = service.data[ATTR_ENTITY_ID]
+
+        for hap in hass.data[DOMAIN].values():
+            if entity_id_list != "all":
+                for entity_id in entity_id_list:
+                    device = hap.hmip_device_by_entity_id.get(entity_id)
+                    if device and isinstance(device, AsyncSwitchMeasuring):
+                        await device.reset_energy_counter()
+            else:
+                for device in hap.home.devices:
+                    if isinstance(device, AsyncSwitchMeasuring):
+                        await device.reset_energy_counter()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RESET_ENERGY_COUNTER,
+        _async_reset_energy_counter,
+        schema=SCHEMA_RESET_ENERGY_COUNTER,
     )
 
     def _get_home(hapid: str) -> Optional[AsyncHome]:

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -310,7 +310,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
                     if isinstance(device, AsyncSwitchMeasuring):
                         await device.reset_energy_counter()
 
-    hass.services.async_register(
+    hass.helpers.service.async_register_admin_service(
         DOMAIN,
         SERVICE_RESET_ENERGY_COUNTER,
         _async_reset_energy_counter,

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -3,10 +3,10 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from homematicip.aio.device import AsyncSwitchMeasuring
 from homematicip.aio.group import AsyncHeatingGroup
 from homematicip.aio.home import AsyncHome
 from homematicip.base.helpers import handle_config
-from homematicip.aio.device import AsyncSwitchMeasuring
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -69,3 +69,10 @@ dump_hap_config:
     anonymize:
       description: (Default is True) Should the Configuration be anonymized?
       example: True
+
+reset_energy_counter:
+  description: Reset the energy counter of a measuring entity.
+  fields:
+    entity_id:
+      description: The ID of the measuring entity. Use 'all' keyword to reset all energy counters.
+      example: switch.livingroom

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -130,3 +130,30 @@ async def test_hap_with_name(hass, mock_connection, hmip_config_entry):
     assert hmip_device
     assert ha_state.state == STATE_ON
     assert ha_state.attributes["friendly_name"] == entity_name
+
+
+async def test_hmip_reset_energy_counter_services(hass, mock_hap_with_service):
+    """Test reset_energy_counter service."""
+    entity_id = "switch.pc"
+    entity_name = "Pc"
+    device_model = "HMIP-PSM"
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap_with_service, entity_id, entity_name, device_model
+    )
+    assert ha_state
+
+    await hass.services.async_call(
+        "homematicip_cloud",
+        "reset_energy_counter",
+        {"entity_id": "switch.pc"},
+        blocking=True,
+    )
+    assert hmip_device.mock_calls[-1][0] == "reset_energy_counter"
+    assert len(hmip_device._connection.mock_calls) == 2  # pylint: disable=W0212
+
+    await hass.services.async_call(
+        "homematicip_cloud", "reset_energy_counter", {"entity_id": "all"}, blocking=True
+    )
+    assert hmip_device.mock_calls[-1][0] == "reset_energy_counter"
+    assert len(hmip_device._connection.mock_calls) == 12  # pylint: disable=W0212


### PR DESCRIPTION
## Description:
Add reset_energy_counter service to Homematic IP Cloud

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11553

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
