### PR TITLE
Bump python-velbus version

### DIFF
--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -3,7 +3,7 @@
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
   "requirements": [
-    "python-velbus==2.0.30"
+    "python-velbus==2.0.32"
   ],
   "config_flow": true,
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1628,7 +1628,7 @@ python-telnet-vlc==1.0.4
 python-twitch-client==0.6.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.30
+python-velbus==2.0.32
 
 # homeassistant.components.vlc
 python-vlc==1.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -523,7 +523,7 @@ python-miio==0.4.8
 python-nest==4.1.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.30
+python-velbus==2.0.32
 
 # homeassistant.components.awair
 python_awair==0.0.4


### PR DESCRIPTION
## Description:

bump the python-velbus version to 2.0.32 this will allow us to use all channels of the glaspanels (non-edge-lit)
in previous versions this could cause the velbus integretion to not find these components

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
