### PR TITLE
Small ZHA channel logging refactoring

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -89,18 +89,18 @@ class ZigbeeChannel(LogMixin):
         self._generic_id = f"channel_0x{cluster.cluster_id:04x}"
         self._cluster = cluster
         self._zha_device = device
-        self._unique_id = "{}:{}:0x{:04x}".format(
-            str(device.ieee), cluster.endpoint.endpoint_id, cluster.cluster_id
-        )
-        # this keeps logs consistent with zigpy logging
-        self._log_id = "0x{:04x}:{}:0x{:04x}".format(
-            device.nwk, cluster.endpoint.endpoint_id, cluster.cluster_id
-        )
+        self._id = f"{cluster.endpoint.endpoint_id}:0x{cluster.cluster_id:04x}"
+        self._unique_id = f"{str(device.ieee)}:{self._id}"
         self._report_config = CLUSTER_REPORT_CONFIGS.get(
             self._cluster.cluster_id, self.REPORT_CONFIG
         )
         self._status = ChannelStatus.CREATED
         self._cluster.add_listener(self)
+
+    @property
+    def id(self) -> str:
+        """Return channel id unique for this device only."""
+        return self._id
 
     @property
     def generic_id(self):
@@ -263,8 +263,8 @@ class ZigbeeChannel(LogMixin):
 
     def log(self, level, msg, *args):
         """Log a message."""
-        msg = "[%s]: " + msg
-        args = (self._log_id,) + args
+        msg = "[%s:%s]: " + msg
+        args = (self.device.nwk, self._id,) + args
         _LOGGER.log(level, msg, *args)
 
     def __getattr__(self, name):


### PR DESCRIPTION
## Description:
Zigbee devices may change their network address occasionally on rejoins. Make sure we log messages with the updated NWK. No changes for users. 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
