### PR TITLE
0.103.5

### DIFF
--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ring",
   "name": "Ring",
   "documentation": "https://www.home-assistant.io/integrations/ring",
-  "requirements": ["ring_doorbell==0.2.5"],
+  "requirements": ["ring_doorbell==0.2.8"],
   "dependencies": ["ffmpeg"],
   "codeowners": []
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 103
-PATCH_VERSION = "4"
+PATCH_VERSION = "5"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 6, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1732,7 +1732,7 @@ rfk101py==0.0.1
 rflink==0.0.46
 
 # homeassistant.components.ring
-ring_doorbell==0.2.5
+ring_doorbell==0.2.8
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -544,7 +544,7 @@ restrictedpython==5.0
 rflink==0.0.46
 
 # homeassistant.components.ring
-ring_doorbell==0.2.5
+ring_doorbell==0.2.8
 
 # homeassistant.components.yamaha
 rxv==0.6.0


### PR DESCRIPTION
- Bump ring to 0.2.8 to fix Oauth issues ([@tchellomello] - [#30245]) ([ring docs])

[#30245]: https://github.com/home-assistant/home-assistant/pull/30245
[@tchellomello]: https://github.com/tchellomello
[ring docs]: https://www.home-assistant.io/components/ring/