### PR TITLE
Upgrade rflink to 0.0.50, ignore_devices now supports * and ? anywhere

### DIFF
--- a/homeassistant/components/rflink/manifest.json
+++ b/homeassistant/components/rflink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Rflink",
   "documentation": "https://www.home-assistant.io/integrations/rflink",
   "requirements": [
-    "rflink==0.0.46"
+    "rflink==0.0.50"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1740,7 +1740,7 @@ restrictedpython==5.0
 rfk101py==0.0.1
 
 # homeassistant.components.rflink
-rflink==0.0.46
+rflink==0.0.50
 
 # homeassistant.components.ring
 ring_doorbell==0.2.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -550,7 +550,7 @@ regenmaschine==1.5.1
 restrictedpython==5.0
 
 # homeassistant.components.rflink
-rflink==0.0.46
+rflink==0.0.50
 
 # homeassistant.components.ring
 ring_doorbell==0.2.8


### PR DESCRIPTION
## Description:

https://github.com/aequitas/python-rflink/releases/tag/0.0.50
https://github.com/aequitas/python-rflink/releases/tag/0.0.49
https://github.com/aequitas/python-rflink/releases/tag/0.0.48
https://github.com/aequitas/python-rflink/releases/tag/0.0.47

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11559

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
