### PR TITLE
Fix creating smappee sensors when remote is not active

### DIFF
--- a/homeassistant/components/smappee/sensor.py
+++ b/homeassistant/components/smappee/sensor.py
@@ -97,19 +97,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                         )
 
     if smappee.is_local_active:
-        for location_id in smappee.locations.keys():
+        if smappee.is_remote_active:
+            location_keys = smappee.locations.keys()
+        else:
+            location_keys = [None]
+        for location_id in location_keys:
             for sensor in SENSOR_TYPES:
                 if "local" in SENSOR_TYPES[sensor]:
-                    if smappee.is_remote_active:
-                        dev.append(
-                            SmappeeSensor(
-                                smappee, location_id, sensor, SENSOR_TYPES[sensor]
-                            )
+                    dev.append(
+                        SmappeeSensor(
+                            smappee, location_id, sensor, SENSOR_TYPES[sensor]
                         )
-                    else:
-                        dev.append(
-                            SmappeeSensor(smappee, None, sensor, SENSOR_TYPES[sensor])
-                        )
+                    )
 
     add_entities(dev, True)
 


### PR DESCRIPTION
## Description:

For [Smappee integration](https://www.home-assistant.io/integrations/smappee/), the sensors were not created when using only the local API.
This is because in this case, there are no locations, as they are set from the remote api to distinguish between several Smappee devices. This fixes the issue by setting a default location when only local is enabled for adding the sensors.

## Example entry for `configuration.yaml`:
```yaml
# Minimal example configuration.yaml entry
smappee:
  host: 10.0.0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
