### PR TITLE
UniFi - Handle wired bug on restart

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -130,6 +130,9 @@ class UniFiClientTracker(ScannerEntity):
         self.is_wired = self.client.mac not in controller.wireless_clients
         self.wired_bug = None
 
+        if self.is_wired != self.client.is_wired:
+            self.wired_bug = dt_util.utcnow() - self.controller.option_detection_time
+
     @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry."""

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -59,6 +59,7 @@ async def setup_unifi_integration(
     clients_response,
     devices_response,
     clients_all_response,
+    known_wireless_clients=None,
 ):
     """Create the UniFi controller."""
     if UNIFI_CONFIG not in hass.data:
@@ -75,6 +76,11 @@ async def setup_unifi_integration(
         options=options,
         entry_id=1,
     )
+
+    if known_wireless_clients:
+        hass.data[UNIFI_WIRELESS_CLIENTS].update_data(
+            known_wireless_clients, config_entry
+        )
 
     mock_client_responses = deque()
     mock_client_responses.append(clients_response)

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -43,6 +43,14 @@ CLIENT_3 = {
     "last_seen": 1562600145,
     "mac": "00:00:00:00:00:03",
 }
+CLIENT_4 = {
+    "essid": "ssid",
+    "hostname": "client_4",
+    "ip": "10.0.0.4",
+    "is_wired": True,
+    "last_seen": 1562600145,
+    "mac": "00:00:00:00:00:04",
+}
 
 DEVICE_1 = {
     "board_rev": 3,
@@ -102,16 +110,20 @@ async def test_no_clients(hass):
 
 async def test_tracked_devices(hass):
     """Test the update_items function with some clients."""
+    client_4_copy = copy(CLIENT_4)
+    client_4_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
+
     controller = await setup_unifi_integration(
         hass,
         ENTRY_CONFIG,
         options={CONF_SSID_FILTER: ["ssid"]},
         sites=SITES,
-        clients_response=[CLIENT_1, CLIENT_2, CLIENT_3],
+        clients_response=[CLIENT_1, CLIENT_2, CLIENT_3, client_4_copy],
         devices_response=[DEVICE_1, DEVICE_2],
         clients_all_response={},
+        known_wireless_clients=(CLIENT_4["mac"],),
     )
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -123,6 +135,11 @@ async def test_tracked_devices(hass):
 
     client_3 = hass.states.get("device_tracker.client_3")
     assert client_3 is None
+
+    # Wireless client with wired bug, if bug active on restart mark device away
+    client_4 = hass.states.get("device_tracker.client_4")
+    assert client_4 is not None
+    assert client_4.state == "not_home"
 
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1 is not None


### PR DESCRIPTION
## Description:
On restart wired bug timer will be set meaning something being affected by wired bug might erroneously get marked as home.

**Related issue (if applicable):** fixes #30162

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
