### PR TITLE
Implement supported locales for Alexa capabilities

### DIFF
--- a/homeassistant/components/alexa/__init__.py
+++ b/homeassistant/components/alexa/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_ENTITY_CONFIG,
     CONF_FILTER,
     CONF_LOCALE,
+    CONF_SUPPORTED_LOCALES,
     CONF_TEXT,
     CONF_TITLE,
     CONF_UID,
@@ -43,7 +44,9 @@ SMART_HOME_SCHEMA = vol.Schema(
         vol.Optional(CONF_ENDPOINT): cv.string,
         vol.Optional(CONF_CLIENT_ID): cv.string,
         vol.Optional(CONF_CLIENT_SECRET): cv.string,
-        vol.Optional(CONF_LOCALE, default=DEFAULT_LOCALE): cv.string,
+        vol.Optional(CONF_LOCALE, default=DEFAULT_LOCALE): vol.In(
+            CONF_SUPPORTED_LOCALES
+        ),
         vol.Optional(CONF_FILTER, default={}): entityfilter.FILTER_SCHEMA,
         vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ALEXA_ENTITY_SCHEMA},
     }

--- a/homeassistant/components/alexa/__init__.py
+++ b/homeassistant/components/alexa/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_ENDPOINT,
     CONF_ENTITY_CONFIG,
     CONF_FILTER,
+    CONF_LOCALE,
     CONF_TEXT,
     CONF_TITLE,
     CONF_UID,
@@ -27,6 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_FLASH_BRIEFINGS = "flash_briefings"
 CONF_SMART_HOME = "smart_home"
+DEFAULT_LOCALE = "en-US"
 
 ALEXA_ENTITY_SCHEMA = vol.Schema(
     {
@@ -41,6 +43,7 @@ SMART_HOME_SCHEMA = vol.Schema(
         vol.Optional(CONF_ENDPOINT): cv.string,
         vol.Optional(CONF_CLIENT_ID): cv.string,
         vol.Optional(CONF_CLIENT_SECRET): cv.string,
+        vol.Optional(CONF_LOCALE, default=DEFAULT_LOCALE): cv.string,
         vol.Optional(CONF_FILTER, default={}): entityfilter.FILTER_SCHEMA,
         vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ALEXA_ENTITY_SCHEMA},
     }

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -56,6 +56,8 @@ class AlexaCapability:
     https://developer.amazon.com/docs/device-apis/message-guide.html
     """
 
+    SUPPORTED_LOCALES = "en-US"
+
     def __init__(self, entity, instance=None):
         """Initialize an Alexa capability."""
         self.entity = entity
@@ -239,6 +241,21 @@ class Alexa(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-interface.html
     """
 
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "es-MX",
+        "fr-CA",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa"
@@ -249,6 +266,19 @@ class AlexaEndpointHealth(AlexaCapability):
 
     https://developer.amazon.com/docs/smarthome/state-reporting-for-a-smart-home-skill.html#report-state-when-alexa-requests-it
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -287,6 +317,19 @@ class AlexaPowerController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-powercontroller.html
     """
 
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.PowerController"
@@ -323,6 +366,17 @@ class AlexaLockController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-lockcontroller.html
     """
 
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-US",
+        "es-ES",
+        "it-IT",
+        "ja-JP",
+    )
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.LockController"
@@ -357,6 +411,17 @@ class AlexaSceneController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-scenecontroller.html
     """
 
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+    )
+
     def __init__(self, entity, supports_deactivation):
         """Initialize the entity."""
         super().__init__(entity)
@@ -372,6 +437,19 @@ class AlexaBrightnessController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-brightnesscontroller.html
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -403,6 +481,19 @@ class AlexaColorController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-colorcontroller.html
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -436,6 +527,19 @@ class AlexaColorTemperatureController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-colortemperaturecontroller.html
     """
 
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.ColorTemperatureController"
@@ -464,6 +568,19 @@ class AlexaPercentageController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-percentagecontroller.html
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -499,6 +616,8 @@ class AlexaSpeaker(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-speaker.html
     """
 
+    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.Speaker"
@@ -510,6 +629,8 @@ class AlexaStepSpeaker(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-stepspeaker.html
     """
 
+    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.StepSpeaker"
@@ -520,6 +641,8 @@ class AlexaPlaybackController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-playbackcontroller.html
     """
+
+    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US", "fr-FR")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -554,6 +677,8 @@ class AlexaInputController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-inputcontroller.html
     """
 
+    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.InputController"
@@ -581,6 +706,19 @@ class AlexaTemperatureSensor(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-temperaturesensor.html
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -637,6 +775,8 @@ class AlexaContactSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-contactsensor.html
     """
 
+    SUPPORTED_LOCALES = ("en-CA", "en-US")
+
     def __init__(self, hass, entity):
         """Initialize the entity."""
         super().__init__(entity)
@@ -674,6 +814,8 @@ class AlexaMotionSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-motionsensor.html
     """
 
+    SUPPORTED_LOCALES = ("en-CA", "en-US")
+
     def __init__(self, hass, entity):
         """Initialize the entity."""
         super().__init__(entity)
@@ -710,6 +852,19 @@ class AlexaThermostatController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-thermostatcontroller.html
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -819,6 +974,19 @@ class AlexaPowerLevelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-powerlevelcontroller.html
     """
 
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.PowerLevelController"
@@ -853,6 +1021,8 @@ class AlexaSecurityPanelController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-securitypanelcontroller.html
     """
+
+    SUPPORTED_LOCALES = ("en-AU", "en-CA", "en-IN", "en-US")
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -905,6 +1075,21 @@ class AlexaModeController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-modecontroller.html
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "es-MX",
+        "fr-CA",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def __init__(self, entity, instance, non_controllable=False):
         """Initialize the entity."""
@@ -1030,6 +1215,21 @@ class AlexaRangeController(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-rangecontroller.html
     """
+
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "es-MX",
+        "fr-CA",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
 
     def __init__(self, entity, instance, non_controllable=False):
         """Initialize the entity."""
@@ -1198,6 +1398,21 @@ class AlexaToggleController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-togglecontroller.html
     """
 
+    SUPPORTED_LOCALES = (
+        "de-DE",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "es-MX",
+        "fr-CA",
+        "fr-FR",
+        "it-IT",
+        "ja-JP",
+    )
+
     def __init__(self, entity, instance, non_controllable=False):
         """Initialize the entity."""
         super().__init__(entity, instance)
@@ -1252,6 +1467,8 @@ class AlexaChannelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-channelcontroller.html
     """
 
+    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.ChannelController"
@@ -1262,6 +1479,8 @@ class AlexaDoorbellEventSource(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-doorbelleventsource.html
     """
+
+    SUPPORTED_LOCALES = "en-US"
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1277,6 +1496,8 @@ class AlexaPlaybackStateReporter(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-playbackstatereporter.html
     """
+
+    SUPPORTED_LOCALES = ("de-DE", "en-GB", "en-US", "fr-FR")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1314,6 +1535,8 @@ class AlexaSeekController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-seekcontroller.html
     """
 
+    SUPPORTED_LOCALES = ("de-DE", "en-GB", "en-US")
+
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.SeekController"
@@ -1324,6 +1547,8 @@ class AlexaEventDetectionSensor(AlexaCapability):
 
     https://developer.amazon.com/docs/device-apis/alexa-eventdetectionsensor.html
     """
+
+    SUPPORTED_LOCALES = "en-US"
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -1381,6 +1606,8 @@ class AlexaEqualizerController(AlexaCapability):
 
     https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-equalizercontroller.html
     """
+
+    SUPPORTED_LOCALES = "en-US"
 
     def name(self):
         """Return the Alexa API name of this interface."""

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -56,7 +56,7 @@ class AlexaCapability:
     https://developer.amazon.com/docs/device-apis/message-guide.html
     """
 
-    SUPPORTED_LOCALES = "en-US"
+    supported_locales = "en-US"
 
     def __init__(self, entity, instance=None):
         """Initialize an Alexa capability."""
@@ -241,7 +241,7 @@ class Alexa(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-interface.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -267,7 +267,7 @@ class AlexaEndpointHealth(AlexaCapability):
     https://developer.amazon.com/docs/smarthome/state-reporting-for-a-smart-home-skill.html#report-state-when-alexa-requests-it
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -317,7 +317,7 @@ class AlexaPowerController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-powercontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -366,7 +366,7 @@ class AlexaLockController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-lockcontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -411,7 +411,7 @@ class AlexaSceneController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-scenecontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-CA",
         "en-GB",
@@ -438,7 +438,7 @@ class AlexaBrightnessController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-brightnesscontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -482,7 +482,7 @@ class AlexaColorController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-colorcontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -527,7 +527,7 @@ class AlexaColorTemperatureController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-colortemperaturecontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -569,7 +569,7 @@ class AlexaPercentageController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-percentagecontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -616,7 +616,7 @@ class AlexaSpeaker(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-speaker.html
     """
 
-    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -629,7 +629,7 @@ class AlexaStepSpeaker(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-stepspeaker.html
     """
 
-    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -642,7 +642,7 @@ class AlexaPlaybackController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-playbackcontroller.html
     """
 
-    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US", "fr-FR")
+    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US", "fr-FR")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -677,7 +677,7 @@ class AlexaInputController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-inputcontroller.html
     """
 
-    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -707,7 +707,7 @@ class AlexaTemperatureSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-temperaturesensor.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -775,7 +775,7 @@ class AlexaContactSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-contactsensor.html
     """
 
-    SUPPORTED_LOCALES = ("en-CA", "en-US")
+    supported_locales = ("en-CA", "en-US")
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -814,7 +814,7 @@ class AlexaMotionSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-motionsensor.html
     """
 
-    SUPPORTED_LOCALES = ("en-CA", "en-US")
+    supported_locales = ("en-CA", "en-US")
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -853,7 +853,7 @@ class AlexaThermostatController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-thermostatcontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -974,7 +974,7 @@ class AlexaPowerLevelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-powerlevelcontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -1022,7 +1022,7 @@ class AlexaSecurityPanelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-securitypanelcontroller.html
     """
 
-    SUPPORTED_LOCALES = ("en-AU", "en-CA", "en-IN", "en-US")
+    supported_locales = ("en-AU", "en-CA", "en-IN", "en-US")
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -1076,7 +1076,7 @@ class AlexaModeController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-modecontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -1216,7 +1216,7 @@ class AlexaRangeController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-rangecontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -1398,7 +1398,7 @@ class AlexaToggleController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-togglecontroller.html
     """
 
-    SUPPORTED_LOCALES = (
+    supported_locales = (
         "de-DE",
         "en-AU",
         "en-CA",
@@ -1467,7 +1467,7 @@ class AlexaChannelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-channelcontroller.html
     """
 
-    SUPPORTED_LOCALES = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1480,7 +1480,7 @@ class AlexaDoorbellEventSource(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-doorbelleventsource.html
     """
 
-    SUPPORTED_LOCALES = "en-US"
+    supported_locales = "en-US"
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1497,7 +1497,7 @@ class AlexaPlaybackStateReporter(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-playbackstatereporter.html
     """
 
-    SUPPORTED_LOCALES = ("de-DE", "en-GB", "en-US", "fr-FR")
+    supported_locales = ("de-DE", "en-GB", "en-US", "fr-FR")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1535,7 +1535,7 @@ class AlexaSeekController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-seekcontroller.html
     """
 
-    SUPPORTED_LOCALES = ("de-DE", "en-GB", "en-US")
+    supported_locales = ("de-DE", "en-GB", "en-US")
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1548,7 +1548,7 @@ class AlexaEventDetectionSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-eventdetectionsensor.html
     """
 
-    SUPPORTED_LOCALES = "en-US"
+    supported_locales = "en-US"
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -1607,7 +1607,7 @@ class AlexaEqualizerController(AlexaCapability):
     https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-equalizercontroller.html
     """
 
-    SUPPORTED_LOCALES = "en-US"
+    supported_locales = "en-US"
 
     def name(self):
         """Return the Alexa API name of this interface."""

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -56,7 +56,7 @@ class AlexaCapability:
     https://developer.amazon.com/docs/device-apis/message-guide.html
     """
 
-    supported_locales = "en-US"
+    supported_locales = {"en-US"}
 
     def __init__(self, entity, instance=None):
         """Initialize an Alexa capability."""
@@ -241,7 +241,7 @@ class Alexa(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-interface.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -254,7 +254,7 @@ class Alexa(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -267,7 +267,7 @@ class AlexaEndpointHealth(AlexaCapability):
     https://developer.amazon.com/docs/smarthome/state-reporting-for-a-smart-home-skill.html#report-state-when-alexa-requests-it
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -278,7 +278,7 @@ class AlexaEndpointHealth(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -317,7 +317,7 @@ class AlexaPowerController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-powercontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -328,7 +328,7 @@ class AlexaPowerController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -366,7 +366,7 @@ class AlexaLockController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-lockcontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -375,7 +375,7 @@ class AlexaLockController(AlexaCapability):
         "es-ES",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -411,7 +411,7 @@ class AlexaSceneController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-scenecontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-CA",
         "en-GB",
@@ -420,7 +420,7 @@ class AlexaSceneController(AlexaCapability):
         "es-ES",
         "fr-FR",
         "it-IT",
-    )
+    }
 
     def __init__(self, entity, supports_deactivation):
         """Initialize the entity."""
@@ -438,7 +438,7 @@ class AlexaBrightnessController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-brightnesscontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -449,7 +449,7 @@ class AlexaBrightnessController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -482,7 +482,7 @@ class AlexaColorController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-colorcontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -493,7 +493,7 @@ class AlexaColorController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -527,7 +527,7 @@ class AlexaColorTemperatureController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-colortemperaturecontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -538,7 +538,7 @@ class AlexaColorTemperatureController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -569,7 +569,7 @@ class AlexaPercentageController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-percentagecontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -580,7 +580,7 @@ class AlexaPercentageController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -616,7 +616,7 @@ class AlexaSpeaker(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-speaker.html
     """
 
-    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = {"de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -629,7 +629,7 @@ class AlexaStepSpeaker(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-stepspeaker.html
     """
 
-    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = {"de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -642,7 +642,7 @@ class AlexaPlaybackController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-playbackcontroller.html
     """
 
-    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US", "fr-FR")
+    supported_locales = {"de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US", "fr-FR"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -677,7 +677,7 @@ class AlexaInputController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-inputcontroller.html
     """
 
-    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = {"de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -707,7 +707,7 @@ class AlexaTemperatureSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-temperaturesensor.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -718,7 +718,7 @@ class AlexaTemperatureSensor(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -775,7 +775,7 @@ class AlexaContactSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-contactsensor.html
     """
 
-    supported_locales = ("en-CA", "en-US")
+    supported_locales = {"en-CA", "en-US"}
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -814,7 +814,7 @@ class AlexaMotionSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-motionsensor.html
     """
 
-    supported_locales = ("en-CA", "en-US")
+    supported_locales = {"en-CA", "en-US"}
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -853,7 +853,7 @@ class AlexaThermostatController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-thermostatcontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -864,7 +864,7 @@ class AlexaThermostatController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -974,7 +974,7 @@ class AlexaPowerLevelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-powerlevelcontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -985,7 +985,7 @@ class AlexaPowerLevelController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1022,7 +1022,7 @@ class AlexaSecurityPanelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-securitypanelcontroller.html
     """
 
-    supported_locales = ("en-AU", "en-CA", "en-IN", "en-US")
+    supported_locales = {"en-AU", "en-CA", "en-IN", "en-US"}
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -1076,7 +1076,7 @@ class AlexaModeController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-modecontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -1089,7 +1089,7 @@ class AlexaModeController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def __init__(self, entity, instance, non_controllable=False):
         """Initialize the entity."""
@@ -1216,7 +1216,7 @@ class AlexaRangeController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-rangecontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -1229,7 +1229,7 @@ class AlexaRangeController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def __init__(self, entity, instance, non_controllable=False):
         """Initialize the entity."""
@@ -1398,7 +1398,7 @@ class AlexaToggleController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-togglecontroller.html
     """
 
-    supported_locales = (
+    supported_locales = {
         "de-DE",
         "en-AU",
         "en-CA",
@@ -1411,7 +1411,7 @@ class AlexaToggleController(AlexaCapability):
         "fr-FR",
         "it-IT",
         "ja-JP",
-    )
+    }
 
     def __init__(self, entity, instance, non_controllable=False):
         """Initialize the entity."""
@@ -1467,7 +1467,7 @@ class AlexaChannelController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-channelcontroller.html
     """
 
-    supported_locales = ("de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US")
+    supported_locales = {"de-DE", "en-AU", "en-CA", "en-GB", "en-IN", "en-US"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1480,7 +1480,7 @@ class AlexaDoorbellEventSource(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-doorbelleventsource.html
     """
 
-    supported_locales = "en-US"
+    supported_locales = {"en-US"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1497,7 +1497,7 @@ class AlexaPlaybackStateReporter(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-playbackstatereporter.html
     """
 
-    supported_locales = ("de-DE", "en-GB", "en-US", "fr-FR")
+    supported_locales = {"de-DE", "en-GB", "en-US", "fr-FR"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1535,7 +1535,7 @@ class AlexaSeekController(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-seekcontroller.html
     """
 
-    supported_locales = ("de-DE", "en-GB", "en-US")
+    supported_locales = {"de-DE", "en-GB", "en-US"}
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1548,7 +1548,7 @@ class AlexaEventDetectionSensor(AlexaCapability):
     https://developer.amazon.com/docs/device-apis/alexa-eventdetectionsensor.html
     """
 
-    supported_locales = "en-US"
+    supported_locales = {"en-US"}
 
     def __init__(self, hass, entity):
         """Initialize the entity."""
@@ -1607,7 +1607,7 @@ class AlexaEqualizerController(AlexaCapability):
     https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-equalizercontroller.html
     """
 
-    supported_locales = "en-US"
+    supported_locales = {"en-US"}
 
     def name(self):
         """Return the Alexa API name of this interface."""

--- a/homeassistant/components/alexa/config.py
+++ b/homeassistant/components/alexa/config.py
@@ -29,6 +29,11 @@ class AbstractConfig:
         return None
 
     @property
+    def locale(self):
+        """Return config locale."""
+        return None
+
+    @property
     def entity_config(self):
         """Return entity config."""
         return {}

--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -19,6 +19,7 @@ CONF_ENTITY_CONFIG = "entity_config"
 CONF_ENDPOINT = "endpoint"
 CONF_CLIENT_ID = "client_id"
 CONF_CLIENT_SECRET = "client_secret"
+CONF_LOCALE = "locale"
 
 ATTR_UID = "uid"
 ATTR_UPDATE_DATE = "updateDate"

--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -43,6 +43,20 @@ API_CHANGE = "change"
 
 CONF_DESCRIPTION = "description"
 CONF_DISPLAY_CATEGORIES = "display_categories"
+CONF_SUPPORTED_LOCALES = (
+    "de-DE",
+    "en-AU",
+    "en-CA",
+    "en-GB",
+    "en-IN",
+    "en-US",
+    "es-ES",
+    "es-MX",
+    "fr-CA",
+    "fr-FR",
+    "it-IT",
+    "ja-JP",
+)
 
 API_TEMP_UNITS = {TEMP_FAHRENHEIT: "FAHRENHEIT", TEMP_CELSIUS: "CELSIUS"}
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -63,7 +63,7 @@ from .capabilities import (
     AlexaThermostatController,
     AlexaToggleController,
 )
-from .const import CONF_DESCRIPTION, CONF_DISPLAY_CATEGORIES, CONF_LOCALE
+from .const import CONF_DESCRIPTION, CONF_DISPLAY_CATEGORIES
 
 ENTITY_ADAPTERS = Registry()
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -63,7 +63,7 @@ from .capabilities import (
     AlexaThermostatController,
     AlexaToggleController,
 )
-from .const import CONF_DESCRIPTION, CONF_DISPLAY_CATEGORIES
+from .const import CONF_DESCRIPTION, CONF_DISPLAY_CATEGORIES, CONF_LOCALE
 
 ENTITY_ADAPTERS = Registry()
 
@@ -260,15 +260,23 @@ class AlexaEntity:
 
     def serialize_discovery(self):
         """Serialize the entity for discovery."""
-        return {
+        result = {
             "displayCategories": self.display_categories(),
             "cookie": {},
             "endpointId": self.alexa_id(),
             "friendlyName": self.friendly_name(),
             "description": self.description(),
             "manufacturerName": "Home Assistant",
-            "capabilities": [i.serialize_discovery() for i in self.interfaces()],
         }
+
+        locale = self.config.locale
+        capabilities = []
+        for i in self.interfaces():
+            if locale in i.SUPPORTED_LOCALES:
+                capabilities.append(i.serialize_discovery())
+        result["capabilities"] = capabilities
+
+        return result
 
 
 @callback

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -272,7 +272,7 @@ class AlexaEntity:
         locale = self.config.locale
         capabilities = []
         for i in self.interfaces():
-            if locale in i.SUPPORTED_LOCALES:
+            if locale in i.supported_locales:
                 capabilities.append(i.serialize_discovery())
         result["capabilities"] = capabilities
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -412,7 +412,7 @@ async def async_api_lock(hass, config, directive, context):
 @HANDLERS.register(("Alexa.LockController", "Unlock"))
 async def async_api_unlock(hass, config, directive, context):
     """Process an unlock request."""
-    if config.locale not in ("de-DE", "en-US", "ja-JP"):
+    if config.locale not in {"de-DE", "en-US", "ja-JP"}:
         msg = f"The unlock directive is not supported for the following locales: {config.locale}"
         raise AlexaInvalidDirectiveError(msg)
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -412,6 +412,10 @@ async def async_api_lock(hass, config, directive, context):
 @HANDLERS.register(("Alexa.LockController", "Unlock"))
 async def async_api_unlock(hass, config, directive, context):
     """Process an unlock request."""
+    if config.locale not in ("de-DE", "en-US", "ja-JP"):
+        msg = f"The unlock directive is not supported for the following locales: {config.locale}"
+        raise AlexaInvalidDirectiveError(msg)
+
     entity = directive.entity
     await hass.services.async_call(
         entity.domain,

--- a/homeassistant/components/alexa/smart_home_http.py
+++ b/homeassistant/components/alexa/smart_home_http.py
@@ -12,6 +12,7 @@ from .const import (
     CONF_ENDPOINT,
     CONF_ENTITY_CONFIG,
     CONF_FILTER,
+    CONF_LOCALE,
 )
 from .smart_home import async_handle_message
 from .state_report import async_enable_proactive_mode
@@ -52,6 +53,11 @@ class AlexaConfig(AbstractConfig):
     def entity_config(self):
         """Return entity config."""
         return self._config.get(CONF_ENTITY_CONFIG) or {}
+
+    @property
+    def locale(self):
+        """Return config locale."""
+        return self._config.get(CONF_LOCALE)
 
     def should_expose(self, entity_id):
         """If an entity should be exposed."""

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -8,6 +8,7 @@ from tests.common import async_mock_service
 
 TEST_URL = "https://api.amazonalexa.com/v3/events"
 TEST_TOKEN_URL = "https://api.amazon.com/auth/o2/token"
+TEST_LOCALE = "en-US"
 
 
 class MockConfig(config.AbstractConfig):
@@ -29,6 +30,11 @@ class MockConfig(config.AbstractConfig):
     def endpoint(self):
         """Endpoint for report state."""
         return TEST_URL
+
+    @property
+    def locale(self):
+        """Return config locale."""
+        return TEST_LOCALE
 
     def should_expose(self, entity_id):
         """If an entity should be exposed."""


### PR DESCRIPTION
## Description:
Implements the [supported locales for each Alexa Capability Interface](https://developer.amazon.com/en-US/docs/alexa/device-apis/list-of-interfaces.html). This PR is the first step toward supporting additional languages for custom Toggle/Range/Mode Controller utterances. 

Sets a variable `supported_locales` in the Base `AlexaCapability` class; each capability sub class overrides the variable with the supported locales for that capability. 

The `AlexaLockController` restricts the `Unlock` directive to a smaller subset of support locales, this is handled directly in the handlers for the `Unlock` directive. 

Adds a new configuration parameter `locale:` to the `smart_home` configuration section. Setting the locale will filter entity capabilities to only those capabilities supported for the configured locale. The default is `en-US` to maintain existing capabilities; as every capability supports `en-US`.  If there is a more preferred way to obtain the a users HA locale let me know. I could only find options referencing the front-end. 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11566

## Example entry for `configuration.yaml` (if applicable):
```yaml
smart_home:
  locale: en-US
  endpoint: https://api.amazonalexa.com/v3/events
  client_id: !secret alexa_client_id
  client_secret: !secret alexa_client_secret
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
