### PR TITLE
Change default icons for Tesla components

### DIFF
--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -26,7 +26,7 @@ from .config_flow import (
     configured_instances,
     validate_input,
 )
-from .const import DATA_LISTENER, DOMAIN, TESLA_COMPONENTS
+from .const import DATA_LISTENER, DOMAIN, SENSOR_ICONS, TESLA_COMPONENTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -186,6 +186,11 @@ class TeslaDevice(Entity):
         self._name = self.tesla_device.name
         self.tesla_id = slugify(self.tesla_device.uniq_name)
         self._attributes = {}
+        self._icon = (
+            SENSOR_ICONS[self.tesla_device.type]
+            if self.tesla_device.type and self.tesla_device.type in SENSOR_ICONS.keys()
+            else None
+        )
 
     @property
     def name(self):
@@ -196,6 +201,11 @@ class TeslaDevice(Entity):
     def unique_id(self) -> str:
         """Return a unique ID."""
         return self.tesla_id
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
 
     @property
     def should_poll(self):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Update icons to align better with sensor type.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
