### PR TITLE
Add RTSP stream support for UVC (Unifi Video Client) integration 

### DIFF
--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -211,7 +211,7 @@ class UnifiVideoCamera(Camera):
         """Disable motion detection in camera."""
         self.set_motion_detection(False)
 
-    def stream_source(self):
+    async def stream_source(self):
         """Return the source of the stream."""
         caminfo = self._nvr.get_camera(self._uuid)
         channels = caminfo["channels"]

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -210,3 +210,13 @@ class UnifiVideoCamera(Camera):
     def disable_motion_detection(self):
         """Disable motion detection in camera."""
         self.set_motion_detection(False)
+
+    def stream_source(self):
+        """Return the source of the stream."""
+        caminfo = self._nvr.get_camera(self._uuid)
+        channels = caminfo["channels"]
+        for channel in channels:
+            if channel["isRtspEnabled"]:
+                return channel["rtspUris"][0]
+
+        return None

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -6,7 +6,7 @@ import requests
 from uvcclient import camera as uvc_camera, nvr
 import voluptuous as vol
 
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
+from homeassistant.components.camera import PLATFORM_SCHEMA, SUPPORT_STREAM, Camera
 from homeassistant.const import CONF_PORT, CONF_SSL
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
@@ -91,6 +91,17 @@ class UnifiVideoCamera(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._name
+
+    @property
+    def supported_features(self):
+        """Return supported features."""
+        caminfo = self._nvr.get_camera(self._uuid)
+        channels = caminfo["channels"]
+        for channel in channels:
+            if channel["isRtspEnabled"]:
+                return SUPPORT_STREAM
+
+        return 0
 
     @property
     def is_recording(self):

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -12,7 +12,7 @@ from homeassistant.components.uvc import camera as uvc
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant
+from tests.common import async_mock_service, get_test_home_assistant
 
 
 class TestUVCSetup(unittest.TestCase):
@@ -221,7 +221,9 @@ class TestUVC(unittest.TestCase):
         assert "Ubiquiti" == self.uvc.brand
         assert "UVC Fake" == self.uvc.model
         assert SUPPORT_STREAM == self.uvc.supported_features
-        assert "rtsp://host-a:7447/uuid_rtspchannel_0" == self.uvc.stream_source()
+
+    async def test_stream(self):
+        assert "rtsp://host-a:7447/uuid_rtspchannel_0" == await self.uvc.stream_source()
 
     @mock.patch("uvcclient.store.get_info_store")
     @mock.patch("uvcclient.camera.UVCCameraClientV320")

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 from uvcclient import camera, nvr
 
+from homeassistant.components.camera import SUPPORT_STREAM
 from homeassistant.components.uvc import camera as uvc
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.setup import setup_component
@@ -190,6 +191,26 @@ class TestUVC(unittest.TestCase):
             "host": "host-a",
             "internalHost": "host-b",
             "username": "admin",
+            "channels": [
+                {
+                    "id": "0",
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": 25,
+                    "bitrate": 6000000,
+                    "isRtspEnabled": True,
+                    "rtspUris": ["rtsp://host-a:7447/uuid_rtspchannel_0"],
+                },
+                {
+                    "id": "1",
+                    "width": 1024,
+                    "height": 576,
+                    "fps": 15,
+                    "bitrate": 1200000,
+                    "isRtspEnabled": False,
+                    "rtspUris": ["rtsp://host-a:7447/uuid_rtspchannel_1"],
+                },
+            ],
         }
         self.nvr.server_version = (3, 2, 0)
 
@@ -199,6 +220,8 @@ class TestUVC(unittest.TestCase):
         assert self.uvc.is_recording
         assert "Ubiquiti" == self.uvc.brand
         assert "UVC Fake" == self.uvc.model
+        assert SUPPORT_STREAM == self.uvc.supported_features
+        assert "rtsp://host-a:7447/uuid_rtspchannel_0" == self.uvc.stream_source()
 
     @mock.patch("uvcclient.store.get_info_store")
     @mock.patch("uvcclient.camera.UVCCameraClientV320")

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -12,7 +12,7 @@ from homeassistant.components.uvc import camera as uvc
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.setup import setup_component
 
-from tests.common import async_mock_service, get_test_home_assistant
+from tests.common import get_test_home_assistant
 
 
 class TestUVCSetup(unittest.TestCase):

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -222,8 +222,10 @@ class TestUVC(unittest.TestCase):
         assert "UVC Fake" == self.uvc.model
         assert SUPPORT_STREAM == self.uvc.supported_features
 
-    async def test_stream(self):
-        assert "rtsp://host-a:7447/uuid_rtspchannel_0" == await self.uvc.stream_source()
+    def test_stream(self):
+        """Test the RTSP stream URI."""
+        stream_source = yield from self.uvc.stream_source()
+        assert stream_source == "rtsp://host-a:7447/uuid_rtspchannel_0"
 
     @mock.patch("uvcclient.store.get_info_store")
     @mock.patch("uvcclient.camera.UVCCameraClientV320")


### PR DESCRIPTION
## Description:
Adds RTSP stream support for UVC (Unifi Video Client) integration. 

Returns 1 of the 3 RTSP URIs that already existed in the camera object; prioritizes highest quality RTSP stream from the available enabled streams.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable): Not needed. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
