### PR TITLE
Add venstar PIN to config and client initialization

### DIFF
--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -67,6 +67,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             vol.Coerce(int), vol.Range(min=1)
         ),
         vol.Optional(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PIN): cv.string,
     }
 )
 

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_HOST,
     CONF_PASSWORD,
+    CONF_PIN,
     CONF_SSL,
     CONF_TIMEOUT,
     CONF_USERNAME,
@@ -75,6 +76,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
+    pin = config.get(CONF_PIN)
     host = config.get(CONF_HOST)
     timeout = config.get(CONF_TIMEOUT)
     humidifier = config.get(CONF_HUMIDIFIER)
@@ -85,7 +87,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         proto = "http"
 
     client = VenstarColorTouch(
-        addr=host, timeout=timeout, user=username, password=password, proto=proto
+        addr=host, timeout=timeout, user=username, password=password, pin=pin, proto=proto
     )
 
     add_entities([VenstarThermostat(client, humidifier)], True)

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -87,7 +87,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         proto = "http"
 
     client = VenstarColorTouch(
-        addr=host, timeout=timeout, user=username, password=password, pin=pin, proto=proto
+        addr=host,
+        timeout=timeout,
+        user=username,
+        password=password,
+        pin=pin,
+        proto=proto,
     )
 
     add_entities([VenstarThermostat(client, humidifier)], True)


### PR DESCRIPTION

## Description:

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11571

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
