### PR TITLE
Bump alarmdecoder to 1.13.9

### DIFF
--- a/homeassistant/components/alarmdecoder/manifest.json
+++ b/homeassistant/components/alarmdecoder/manifest.json
@@ -2,9 +2,7 @@
   "domain": "alarmdecoder",
   "name": "Alarmdecoder",
   "documentation": "https://www.home-assistant.io/integrations/alarmdecoder",
-  "requirements": [
-    "alarmdecoder==1.13.2"
-  ],
+  "requirements": ["alarmdecoder==1.13.9"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -202,7 +202,7 @@ airly==0.0.2
 aladdin_connect==0.3
 
 # homeassistant.components.alarmdecoder
-alarmdecoder==1.13.2
+alarmdecoder==1.13.9
 
 # homeassistant.components.alpha_vantage
 alpha_vantage==2.1.2


### PR DESCRIPTION
## Description:
- bump alarmdecoder to 1.13.9 to fix requirements incompatibility

**Related issue (if applicable):** fixes #29875<home-assistant issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.


If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
