### PR TITLE
Reduce solaredge logging severity

### DIFF
--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -350,7 +350,9 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
         power_to = []
 
         if "connections" not in power_flow:
-            _LOGGER.error("Missing connections in power flow data")
+            _LOGGER.debug(
+                "Missing connections in power flow data; assuming site does not have any"
+            )
             return
 
         for connection in power_flow["connections"]:

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             return
         _LOGGER.debug("Credentials correct and site is active")
     except KeyError:
-        _LOGGER.error("Missing details data in solaredge response")
+        _LOGGER.error("Missing details data in SolarEdge response")
         return
     except (ConnectTimeout, HTTPError):
         _LOGGER.error("Could not retrieve details from SolarEdge API")
@@ -351,7 +351,7 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
 
         if "connections" not in power_flow:
             _LOGGER.debug(
-                "Missing connections in power flow data; assuming site does not have any"
+                "Missing connections in power flow data. Assuming site does not have any"
             )
             return
 


### PR DESCRIPTION
## Description:

This log error happens frequently for some sites, but it shouldn't be an error.
It is expected, per the SolarEdge Monitoring API, that some sites do not
support this information, and the expected result is that this would be
empty (see comments on #27959).

**Related issue (if applicable):** fixes #27959

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  -- `test_timestamp_local` fails, but clearly not related to this change
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
