### PR TITLE
Restore state for Rfxtrx devices

### DIFF
--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -1,6 +1,4 @@
 """Support for RFXtrx covers."""
-import logging
-
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
@@ -21,9 +19,6 @@ from . import (
     get_devices_from_config,
     get_new_device,
 )
-
-
-_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -10,8 +10,9 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS,
     Light,
 )
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, STATE_ON
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (
     CONF_AUTOMATIC_ADD,
@@ -72,13 +73,34 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         RECEIVED_EVT_SUBSCRIBERS.append(light_update)
 
 
-class RfxtrxLight(RfxtrxDevice, Light):
+class RfxtrxLight(RfxtrxDevice, Light, RestoreEntity):
     """Representation of a RFXtrx light."""
+
+    async def async_added_to_hass(self):
+        """Restore RFXtrx device state (ON/OFF)."""
+        await super().async_added_to_hass()
+
+        old_state = await self.async_get_last_state()
+        if old_state is not None:
+            self._state = old_state.state == STATE_ON
+
+        # Restore the brightness of dimmables devices
+        if old_state is not None and \
+                old_state.attributes.get(ATTR_BRIGHTNESS) is not None:
+            self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
 
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         return self._brightness
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        if self._brightness is not None:
+            attr[ATTR_BRIGHTNESS] = self._brightness
+        return attr
 
     @property
     def supported_features(self):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -85,8 +85,10 @@ class RfxtrxLight(RfxtrxDevice, Light, RestoreEntity):
             self._state = old_state.state == STATE_ON
 
         # Restore the brightness of dimmables devices
-        if old_state is not None and \
-                old_state.attributes.get(ATTR_BRIGHTNESS) is not None:
+        if (
+            old_state is not None
+            and old_state.attributes.get(ATTR_BRIGHTNESS) is not None
+        ):
             self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
 
     @property

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -84,7 +84,7 @@ class RfxtrxLight(RfxtrxDevice, Light, RestoreEntity):
         if old_state is not None:
             self._state = old_state.state == STATE_ON
 
-        # Restore the brightness of dimmables devices
+        # Restore the brightness of dimmable devices
         if (
             old_state is not None
             and old_state.attributes.get(ATTR_BRIGHTNESS) is not None

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -5,8 +5,9 @@ import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, STATE_ON
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (
     CONF_AUTOMATIC_ADD,
@@ -20,6 +21,7 @@ from . import (
     get_devices_from_config,
     get_new_device,
 )
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +45,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the RFXtrx platform."""
-    # Add switch from config file
     switches = get_devices_from_config(config, RfxtrxSwitch)
     add_entities_callback(switches)
 
@@ -67,8 +68,16 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         RECEIVED_EVT_SUBSCRIBERS.append(switch_update)
 
 
-class RfxtrxSwitch(RfxtrxDevice, SwitchDevice):
+class RfxtrxSwitch(RfxtrxDevice, SwitchDevice, RestoreEntity):
     """Representation of a RFXtrx switch."""
+
+    async def async_added_to_hass(self):
+        """Restore RFXtrx switch device state (ON/OFF)."""
+        await super().async_added_to_hass()
+
+        old_state = await self.async_get_last_state()
+        if old_state is not None:
+            self._state = old_state.state == STATE_ON
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -22,7 +22,6 @@ from . import (
     get_new_device,
 )
 
-
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -45,6 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the RFXtrx platform."""
+    # Add switch from config file
     switches = get_devices_from_config(config, RfxtrxSwitch)
     add_entities_callback(switches)
 


### PR DESCRIPTION
## Description:
This PR aims to add the ability to recover the previous state to Rrxtrx devices, in the same way as has been done for RFLink devices (see #18816).

Rfxtrx devices do not have the ability to ask for their status, so in the reboots, the previous state is lost. This PR gives these devices the ability to 'remember' the status on the reboots.

The new behavior does not apply to devices of the sensor and binary_sensor type, only for switches and lights. For covers, see note below. 

In my opinion (and similar as the RFLink integration), I do not believe that the previous state should be restored in the case of sensors and binary_sensors, as in the next update the correct state will be restored, regardless of the previous state.

**Note for covers**
For covers, it seems that it is not working (yet), as the state is not being updated/stored when opening or closing a cover (stateless cover) (at least as reported below by one of the testers). The state will always remain unknown. So, it will also restore the same unknown state. However, if in the future saving of the state is being added, the code is already prepared to restore the state for covers as well.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) **n/a**

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`. **n/a**
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`. **n/a**
  - [ ] Untested files have been added to `.coveragerc`. **n/a**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works. **see note**

Note: I haven't added tests as the current test set seems to skip all the tests, see #30272. When #30272 is fixed, I will add tests. Unfortunately, I'm not capable to fix the tests myself.
