### PR TITLE
Remove use of bin_type in Tesla component

### DIFF
--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.helpers.entity import Entity
+from homeassistant.util.distance import convert
 
 from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
@@ -84,8 +85,9 @@ class TeslaSensor(TeslaDevice, Entity):
                 self.units = LENGTH_MILES
             else:
                 self.units = LENGTH_KILOMETERS
-                self.current_value /= 0.621371
-                self.current_value = round(self.current_value, 2)
+                self.current_value = round(
+                    convert(self.current_value, LENGTH_MILES, LENGTH_KILOMETERS), 2
+                )
         else:
             self.current_value = self.tesla_device.get_value()
             self.units = units

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -38,7 +38,7 @@ class TeslaSensor(TeslaDevice, Entity):
     def __init__(self, tesla_device, controller, config_entry, sensor_type=None):
         """Initialize of the sensor."""
         self.current_value = None
-        self._unit = None
+        self.units = None
         self.last_changed_time = None
         self.type = sensor_type
         super().__init__(tesla_device, controller, config_entry)
@@ -61,7 +61,7 @@ class TeslaSensor(TeslaDevice, Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit_of_measurement of the device."""
-        return self._unit
+        return self.units
 
     async def async_update(self):
         """Update the state from the sensor."""
@@ -75,18 +75,18 @@ class TeslaSensor(TeslaDevice, Entity):
             else:
                 self.current_value = self.tesla_device.get_inside_temp()
             if units == "F":
-                self._unit = TEMP_FAHRENHEIT
+                self.units = TEMP_FAHRENHEIT
             else:
-                self._unit = TEMP_CELSIUS
+                self.units = TEMP_CELSIUS
         elif self.tesla_device.type in ["range sensor", "mileage sensor"]:
             self.current_value = self.tesla_device.get_value()
-            tesla_dist_unit = self.tesla_device.measurement
-            if tesla_dist_unit == "LENGTH_MILES":
-                self._unit = LENGTH_MILES
+            tesla_distunits = self.tesla_device.measurement
+            if tesla_distunits == "LENGTH_MILES":
+                self.units = LENGTH_MILES
             else:
-                self._unit = LENGTH_KILOMETERS
+                self.units = LENGTH_KILOMETERS
                 self.current_value /= 0.621371
                 self.current_value = round(self.current_value, 2)
         else:
             self.current_value = self.tesla_device.get_value()
-            self._unit = units
+            self.units = units

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -80,8 +80,7 @@ class TeslaSensor(TeslaDevice, Entity):
                 self.units = TEMP_CELSIUS
         elif self.tesla_device.type in ["range sensor", "mileage sensor"]:
             self.current_value = self.tesla_device.get_value()
-            tesla_distunits = self.tesla_device.measurement
-            if tesla_distunits == "LENGTH_MILES":
+            if units == "LENGTH_MILES":
                 self.units = LENGTH_MILES
             else:
                 self.units = LENGTH_KILOMETERS

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -19,10 +19,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     controller = hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"]
     entities = []
     for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"]["switch"]:
-        if device.bin_type == 0x8:
+        if device.type == "charger switch":
             entities.append(ChargerSwitch(device, controller, config_entry))
             entities.append(UpdateSwitch(device, controller, config_entry))
-        elif device.bin_type == 0x9:
+        elif device.type == "maxrange switch":
             entities.append(RangeSwitch(device, controller, config_entry))
     async_add_entities(entities, True)
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Per request in #30286, this removes the use of bin_type to differentiate sensors and switches.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
