### PR TITLE
Fix luftdaten integration by adding a sensor for pressure at sealevel 

### DIFF
--- a/homeassistant/components/luftdaten/__init__.py
+++ b/homeassistant/components/luftdaten/__init__.py
@@ -34,6 +34,7 @@ SENSOR_HUMIDITY = "humidity"
 SENSOR_PM10 = "P1"
 SENSOR_PM2_5 = "P2"
 SENSOR_PRESSURE = "pressure"
+SENSOR_PRESSURE_AT_SEALEVEL = "pressure_at_sealevel"
 SENSOR_TEMPERATURE = "temperature"
 
 TOPIC_UPDATE = f"{DOMAIN}_data_update"
@@ -44,6 +45,7 @@ SENSORS = {
     SENSOR_TEMPERATURE: ["Temperature", "mdi:thermometer", TEMP_CELSIUS],
     SENSOR_HUMIDITY: ["Humidity", "mdi:water-percent", "%"],
     SENSOR_PRESSURE: ["Pressure", "mdi:arrow-down-bold", "Pa"],
+    SENSOR_PRESSURE_AT_SEALEVEL: ["Pressure at sealevel", "mdi:mdi-download", "Pa"],
     SENSOR_PM10: ["PM10", "mdi:thought-bubble", VOLUME_MICROGRAMS_PER_CUBIC_METER],
     SENSOR_PM2_5: [
         "PM2.5",


### PR DESCRIPTION
## Description:
Due to changes in the python-luftdaten library, there was an exception while parsing the results of the webservice. It was triggerd by trying to add a sensor for "pressure at sealevel" which was unknown. Added this sensor to the source code.

**Related issue (if applicable):** fixes #27493

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
