### PR TITLE
Preserve new BLE tracker item name if seen before adding discovery

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -84,7 +84,6 @@ omit =
     homeassistant/components/blockchain/sensor.py
     homeassistant/components/bloomsky/*
     homeassistant/components/bluesound/*
-    homeassistant/components/bluetooth_le_tracker/device_tracker.py
     homeassistant/components/bluetooth_tracker/*
     homeassistant/components/bme280/sensor.py
     homeassistant/components/bme680/sensor.py

--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -44,22 +44,26 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     def see_device(address, name, new_device=False):
         """Mark a device as seen."""
+        if name is not None:
+            name = name.strip("\x00")
+
         if new_device:
             if address in new_devices:
-                new_devices[address] += 1
-                _LOGGER.debug("Seen %s %s times", address, new_devices[address])
-                if new_devices[address] >= MIN_SEEN_NEW:
+                new_devices[address]["seen"] += 1
+                if name:
+                    new_devices[address]["name"] = name
+                else:
+                    name = new_devices[address]["name"]
+                _LOGGER.debug("Seen %s %s times", address, new_devices[address]["seen"])
+                if new_devices[address]["seen"] >= MIN_SEEN_NEW:
                     _LOGGER.debug("Adding %s to tracked devices", address)
                     devs_to_track.append(address)
                 else:
                     return
             else:
                 _LOGGER.debug("Seen %s for the first time", address)
-                new_devices[address] = 1
+                new_devices[address] = {"seen": 1, "name": name}
                 return
-
-        if name is not None:
-            name = name.strip("\x00")
 
         see(
             mac=BLE_PREFIX + address,

--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -55,11 +55,10 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 else:
                     name = new_devices[address]["name"]
                 _LOGGER.debug("Seen %s %s times", address, new_devices[address]["seen"])
-                if new_devices[address]["seen"] >= MIN_SEEN_NEW:
-                    _LOGGER.debug("Adding %s to tracked devices", address)
-                    devs_to_track.append(address)
-                else:
+                if new_devices[address]["seen"] < MIN_SEEN_NEW:
                     return
+                _LOGGER.debug("Adding %s to tracked devices", address)
+                devs_to_track.append(address)
             else:
                 _LOGGER.debug("Seen %s for the first time", address)
                 new_devices[address] = {"seen": 1, "name": name}

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -428,6 +428,10 @@ pyfritzhome==0.4.0
 # homeassistant.components.ifttt
 pyfttt==0.3
 
+# homeassistant.components.bluetooth_le_tracker
+# homeassistant.components.skybeacon
+pygatt[GATTTOOL]==4.0.5
+
 # homeassistant.components.version
 pyhaversion==3.1.0
 

--- a/tests/components/bluetooth_le_tracker/__init__.py
+++ b/tests/components/bluetooth_le_tracker/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Bluetooth LE tracker component."""

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -1,0 +1,67 @@
+"""Test Bluetooth LE device tracker."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from homeassistant.components.bluetooth_le_tracker import device_tracker
+from homeassistant.components.device_tracker.const import (
+    CONF_SCAN_INTERVAL,
+    CONF_TRACK_NEW,
+    DOMAIN,
+)
+from homeassistant.components.device_tracker.legacy import YAML_DEVICES
+from homeassistant.const import ATTR_NOW, CONF_PLATFORM, EVENT_TIME_CHANGED
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util, slugify
+
+from tests.common import patch_yaml_files
+
+
+async def test_preserve_new_tracked_device_name(hass):
+    """Test preserving tracked device name across new seens."""
+
+    address = "DE:AD:BE:EF:13:37"
+    name = "Mock device name"
+    entity_id = f"{DOMAIN}.{slugify(name)}"
+
+    with patch(
+        "homeassistant.components."
+        "bluetooth_le_tracker.device_tracker.pygatt.GATTToolBackend"
+    ) as mock_backend, patch.object(
+        device_tracker, "MIN_SEEN_NEW", 3
+    ), patch_yaml_files(  # Ignore possibly existing known_devices.yaml content
+        {hass.config.path(YAML_DEVICES): ""}
+    ), patch(  # Do not write known_devices.yaml
+        "homeassistant.components.device_tracker.legacy.update_config"
+    ):
+
+        # Return with name when seen first time
+        device = {"address": address, "name": name}
+        mock_backend.return_value.scan.return_value = [device]
+
+        config = {
+            CONF_PLATFORM: "bluetooth_le_tracker",
+            CONF_SCAN_INTERVAL: timedelta(minutes=1),
+            CONF_TRACK_NEW: True,
+        }
+        result = await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        assert result
+
+        # Seen once here; return without name when seen subsequent times
+        device["name"] = None
+
+        # Tick until device seen enough times for to be registered for tracking
+        for _ in range(device_tracker.MIN_SEEN_NEW - 1):
+            hass.bus.async_fire(
+                EVENT_TIME_CHANGED,
+                {
+                    ATTR_NOW: dt_util.utcnow()
+                    + config[CONF_SCAN_INTERVAL]
+                    + timedelta(seconds=1)
+                },
+            )
+            await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.name == name


### PR DESCRIPTION
## Description:

Discovered BLE devices may not have their friendly name set on every discovery. This makes new discoveries preserve a name seen for a device still being considered for addition when the discovery that triggers the actual addition doesn't contain the name.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
