### PR TITLE
Fix Withings leaking time zone change into other tests

### DIFF
--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -19,7 +19,7 @@ DEFAULT_TIME_ZONE = dt.DEFAULT_TIME_ZONE
 
 
 def teardown():
-    """Ensure the time zone is revered after tests finish."""
+    """Ensure the time zone is reverted after tests finish."""
     dt.set_default_time_zone(DEFAULT_TIME_ZONE)
 
 

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -15,6 +15,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import dt
 
+DEFAULT_TIME_ZONE = dt.DEFAULT_TIME_ZONE
+
+
+def teardown():
+    """Ensure the time zone is revered after tests finish."""
+    dt.set_default_time_zone(DEFAULT_TIME_ZONE)
+
 
 @pytest.fixture(name="withings_api")
 def withings_api_fixture() -> WithingsApi:


### PR DESCRIPTION
## Description:

Fix our build pipelines by adjusting a Withing test that causes to leak a global timezone change into other tests. (Causing zwave tests to fail at this point).

Introduced in: #30011

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
