### PR TITLE
Add last_online and level attribute to steam online

### DIFF
--- a/homeassistant/components/steam_online/sensor.py
+++ b/homeassistant/components/steam_online/sensor.py
@@ -167,11 +167,14 @@ class SteamSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            "game": self._game if self._game else None,
-            "last_online": self._last_online if self._last_online else None,
-            "level": self._level if self._level else None,
-        }
+        attr = {}
+        if self._game is not None:
+            attr["game"] = self._game
+        if self._last_online is not None:
+            attr["last_online"] = self._last_online
+        if self._level is not None:
+            attr["level"] = self._level
+        return attr
 
     @property
     def entity_picture(self):


### PR DESCRIPTION
## Description:
Added 2 new attributed to the steam_online component: last_online and level

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html

