### PR TITLE
Add light support to Velbus integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -758,6 +758,7 @@ omit =
     homeassistant/components/velbus/climate.py
     homeassistant/components/velbus/const.py
     homeassistant/components/velbus/cover.py
+    homeassistant/components/velbus/light.py
     homeassistant/components/velbus/sensor.py
     homeassistant/components/velbus/switch.py
     homeassistant/components/velux/*

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -22,7 +22,7 @@ CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: vol.Schema({vol.Required(CONF_PORT): cv.string})}, extra=vol.ALLOW_EXTRA
 )
 
-COMPONENT_TYPES = ["switch", "sensor", "binary_sensor", "cover", "climate"]
+COMPONENT_TYPES = ["switch", "sensor", "binary_sensor", "cover", "climate", "light"]
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -56,7 +56,8 @@ class VelbusLight(VelbusEntity, Light):
         try:
             if ATTR_BRIGHTNESS in kwargs:
                 self._module.set_dimmer_state(
-                    self._channel, kwargs[ATTR_BRIGHTNESS],
+                    self._channel,
+                    kwargs[ATTR_BRIGHTNESS],
                     kwargs.get(ATTR_TRANSITION, 0),
                 )
             else:

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -1,0 +1,76 @@
+"""Support for Velbus light."""
+import logging
+
+from velbus.util import VelbusException
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_TRANSITION,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_TRANSITION,
+    Light,
+)
+
+from . import VelbusEntity
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Old way."""
+    pass
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Velbus light based on config_entry."""
+    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
+    modules_data = hass.data[DOMAIN][entry.entry_id]["light"]
+    entities = []
+    for address, channel in modules_data:
+        module = cntrl.get_module(address)
+        entities.append(VelbusLight(module, channel))
+    async_add_entities(entities)
+
+
+class VelbusLight(VelbusEntity, Light):
+    """Representation of a Velbus light."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+
+    @property
+    def is_on(self):
+        """Return true if the light is on."""
+        return self._module.is_on(self._channel)
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        return self._module.get_dimmer_state(self._channel)
+
+    def turn_on(self, **kwargs):
+        """Instruct the Velbus light to turn on."""
+        try:
+            if ATTR_BRIGHTNESS in kwargs:
+                self._module.set_dimmer_state(
+                    self._channel, kwargs[ATTR_BRIGHTNESS],
+                    kwargs.get(ATTR_TRANSITION, 0),
+                )
+            else:
+                self._module.restore_dimmer_state(
+                    self._channel, kwargs.get(ATTR_TRANSITION, 0),
+                )
+        except VelbusException as err:
+            _LOGGER.error("A Velbus error occurred: %s", err)
+
+    def turn_off(self, **kwargs):
+        """Instruct the velbus light to turn off."""
+        try:
+            self._module.set_dimmer_state(
+                self._channel, 0, kwargs.get(ATTR_TRANSITION, 0),
+            )
+        except VelbusException as err:
+            _LOGGER.error("A Velbus error occurred: %s", err)


### PR DESCRIPTION
## Breaking Change:

No breaking changes

## Description:
Add Light Entity control for Velbus modules that have a dimming feature and supported bij [Python-Velbus](https://pypi.org/project/python-velbus) library

**Related issue (if applicable):** none

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11581

## Example entry for `configuration.yaml` (if applicable):
not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
