### PR TITLE
Add HmIP-PMFS and HmIP-WHS2 to HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -10,6 +10,7 @@ from homematicip.aio.device import (
     AsyncMotionDetectorIndoor,
     AsyncMotionDetectorOutdoor,
     AsyncMotionDetectorPushButton,
+    AsyncPluggableMainsFailureSurveillance,
     AsyncPresenceDetectorIndoor,
     AsyncRotaryHandleSensor,
     AsyncShutterContact,
@@ -31,6 +32,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_MOVING,
     DEVICE_CLASS_OPENING,
+    DEVICE_CLASS_POWER,
     DEVICE_CLASS_PRESENCE,
     DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
@@ -105,6 +107,10 @@ async def async_setup_entry(
             ),
         ):
             entities.append(HomematicipMotionDetector(hap, device))
+        if isinstance(device, AsyncPluggableMainsFailureSurveillance):
+            entities.append(
+                HomematicipPluggableMainsFailureSurveillanceSensor(hap, device)
+            )
         if isinstance(device, AsyncPresenceDetectorIndoor):
             entities.append(HomematicipPresenceDetector(hap, device))
         if isinstance(device, AsyncSmokeDetector):
@@ -326,6 +332,26 @@ class HomematicipBatterySensor(HomematicipGenericDevice, BinarySensorDevice):
     def is_on(self) -> bool:
         """Return true if battery is low."""
         return self._device.lowBat
+
+
+class HomematicipPluggableMainsFailureSurveillanceSensor(
+    HomematicipGenericDevice, BinarySensorDevice
+):
+    """Representation of a HomematicIP Cloud pluggable mains failure surveillance sensor."""
+
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize pluggable mains failure surveillance sensor."""
+        super().__init__(hap, device)
+
+    @property
+    def device_class(self) -> str:
+        """Return the class of this sensor."""
+        return DEVICE_CLASS_POWER
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if power mains fails."""
+        return not self._device.powerMainsFailure
 
 
 class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from homematicip.aio.device import (
     AsyncBrandSwitchMeasuring,
     AsyncFullFlushSwitchMeasuring,
+    AsyncHeatingSwitch2,
     AsyncMultiIOBox,
     AsyncOpenCollector8Module,
     AsyncPlugableSwitch,
@@ -54,6 +55,9 @@ async def async_setup_entry(
             entities.append(HomematicipSwitch(hap, device))
         elif isinstance(device, AsyncOpenCollector8Module):
             for channel in range(1, 9):
+                entities.append(HomematicipMultiSwitch(hap, device, channel))
+        elif isinstance(device, AsyncHeatingSwitch2):
+            for channel in range(1, 3):
                 entities.append(HomematicipMultiSwitch(hap, device, channel))
         elif isinstance(device, AsyncMultiIOBox):
             for channel in range(1, 3):

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -161,6 +161,22 @@ async def test_hmip_presence_detector(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_EVENT_DELAY]
 
 
+async def test_hmip_pluggable_mains_failure_surveillance_sensor(hass, default_mock_hap):
+    """Test HomematicipPresenceDetector."""
+    entity_id = "binary_sensor.netzausfall"
+    entity_name = "Netzausfall"
+    device_model = "HmIP-PMFS"
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, default_mock_hap, entity_id, entity_name, device_model
+    )
+
+    assert ha_state.state == STATE_ON
+    await async_manipulate_test_data(hass, hmip_device, "powerMainsFailure", True)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_OFF
+
+
 async def test_hmip_smoke_detector(hass, default_mock_hap):
     """Test HomematicipSmokeDetector."""
     entity_id = "binary_sensor.rauchwarnmelder"

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -14,6 +14,263 @@
         }
     },
     "devices": {
+        "3014F7110000000000ABCD50": {
+            "availableFirmwareVersion": "1.0.12",
+            "firmwareVersion": "1.0.12",
+            "firmwareVersionInteger": 65548,
+            "functionalChannels": {
+                "0": {
+                    "coProFaulty": false,
+                    "coProRestartNeeded": false,
+                    "coProUpdateFailure": false,
+                    "configPending": false,
+                    "deviceId": "3014F7110000000000ABCD50",
+                    "deviceOverheated": false,
+                    "deviceOverloaded": false,
+                    "deviceUndervoltage": false,
+                    "dutyCycle": false,
+                    "functionalChannelType": "DEVICE_BASE",
+                    "groupIndex": 0,
+                    "groups": [
+                    ],
+                    "index": 0,
+                    "label": "",
+                    "lowBat": null,
+                    "routerModuleEnabled": false,
+                    "routerModuleSupported": false,
+                    "rssiDeviceValue": -58,
+                    "rssiPeerValue": null,
+                    "supportedOptionalFeatures": {
+                        "IFeatureDeviceCoProError": false,
+                        "IFeatureDeviceCoProRestart": false,
+                        "IFeatureDeviceCoProUpdate": false,
+                        "IFeatureDeviceOverheated": false,
+                        "IFeatureDeviceOverloaded": false,
+                        "IFeatureDeviceTemperatureOutOfRange": false,
+                        "IFeatureDeviceUndervoltage": false
+                    },
+                    "temperatureOutOfRange": false,
+                    "unreach": false
+                },
+                "1": {
+                    "deviceId": "3014F7110000000000ABCD50",
+                    "functionalChannelType": "MAINS_FAILURE_CHANNEL",
+                    "genericAlarmSignal": "FULL_ALARM",
+                    "groupIndex": 1,
+                    "groups": [
+                    ],
+                    "index": 1,
+                    "label": "",
+                    "powerMainsFailure": false
+                }
+            },
+            "homeId": "00000000-0000-0000-0000-000000000001",
+            "id": "3014F7110000000000ABCD50",
+            "label": "Netzausfall\u00fcberwachung",
+            "lastStatusUpdate": 1577487207542,
+            "liveUpdateState": "LIVE_UPDATE_NOT_SUPPORTED",
+            "manufacturerCode": 1,
+            "modelId": 309,
+            "modelType": "HmIP-PMFS",
+            "oem": "eQ-3",
+            "permanentlyReachable": true,
+            "serializedGlobalTradeItemNumber": "3014F7110000000000ABCD50",
+            "type": "PLUGGABLE_MAINS_FAILURE_SURVEILLANCE",
+            "updateState": "UP_TO_DATE"
+        },
+        "3014F7110000000000000049": {
+            "availableFirmwareVersion": "1.0.8",
+            "firmwareVersion": "1.0.8",
+            "firmwareVersionInteger": 65544,
+            "functionalChannels": {
+                "0": {
+                    "coProFaulty": false,
+                    "coProRestartNeeded": false,
+                    "coProUpdateFailure": false,
+                    "configPending": false,
+                    "coolingEmergencyValue": 0.0,
+                    "deviceId": "3014F7110000000000000049",
+                    "deviceOverheated": false,
+                    "deviceOverloaded": false,
+                    "deviceUndervoltage": false,
+                    "dutyCycle": false,
+                    "frostProtectionTemperature": 8.0,
+                    "functionalChannelType": "DEVICE_BASE_FLOOR_HEATING",
+                    "groupIndex": 0,
+                    "groups": [],
+                    "heatingEmergencyValue": 0.25,
+                    "index": 0,
+                    "label": "",
+                    "lowBat": null,
+                    "minimumFloorHeatingValvePosition": 0.0,
+                    "pulseWidthModulationAtLowFloorHeatingValvePositionEnabled": true,
+                    "routerModuleEnabled": false,
+                    "routerModuleSupported": false,
+                    "rssiDeviceValue": -55,
+                    "rssiPeerValue": null,
+                    "supportedOptionalFeatures": {
+                        "IFeatureDeviceCoProError": false,
+                        "IFeatureDeviceCoProRestart": false,
+                        "IFeatureDeviceCoProUpdate": false,
+                        "IFeatureDeviceOverheated": false,
+                        "IFeatureDeviceOverloaded": false,
+                        "IFeatureDeviceTemperatureOutOfRange": false,
+                        "IFeatureDeviceUndervoltage": false,
+                        "IFeatureMinimumFloorHeatingValvePosition": true,
+                        "IFeaturePulseWidthModulationAtLowFloorHeatingValvePosition": true
+                    },
+                    "temperatureOutOfRange": false,
+                    "unreach": false,
+                    "valveProtectionDuration": 5,
+                    "valveProtectionSwitchingInterval": 14
+                },
+                "1": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 1,
+                    "groups": [],
+                    "index": 1,
+                    "label": "",
+                    "valveState": "ADAPTION_DONE"
+                },
+                "10": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 10,
+                    "groups": [],
+                    "index": 10,
+                    "label": "",
+                    "valveState": "ADJUSTMENT_TOO_SMALL"
+                },
+                "11": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 11,
+                    "groups": [],
+                    "index": 11,
+                    "label": "",
+                    "valveState": "ADJUSTMENT_TOO_SMALL"
+                },
+                "12": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 12,
+                    "groups": [],
+                    "index": 12,
+                    "label": "",
+                    "valveState": "ADJUSTMENT_TOO_SMALL"
+                },
+                "13": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "HEAT_DEMAND_CHANNEL",
+                    "groupIndex": 0,
+                    "groups": [],
+                    "index": 13,
+                    "label": ""
+                },
+                "14": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "DEHUMIDIFIER_DEMAND_CHANNEL",
+                    "groupIndex": 0,
+                    "groups": [],
+                    "index": 14,
+                    "label": ""
+                },
+                "15": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "CHANGE_OVER_CHANNEL",
+                    "groupIndex": 0,
+                    "groups": [],
+                    "index": 15,
+                    "label": ""
+                },
+                "2": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 2,
+                    "groups": [],
+                    "index": 2,
+                    "label": "",
+                    "valveState": "ADAPTION_DONE"
+                },
+                "3": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 3,
+                    "groups": [],
+                    "index": 3,
+                    "label": "",
+                    "valveState": "ADAPTION_DONE"
+                },
+                "4": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 4,
+                    "groups": [],
+                    "index": 4,
+                    "label": "",
+                    "valveState": "ADAPTION_DONE"
+                },
+                "5": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 5,
+                    "groups": [],
+                    "index": 5,
+                    "label": "",
+                    "valveState": "ADAPTION_DONE"
+                },
+                "6": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 6,
+                    "groups": [],
+                    "index": 6,
+                    "label": "",
+                    "valveState": "ADJUSTMENT_TOO_SMALL"
+                },
+                "7": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 7,
+                    "groups": [],
+                    "index": 7,
+                    "label": "",
+                    "valveState": "ADJUSTMENT_TOO_SMALL"
+                },
+                "8": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 8,
+                    "groups": [],
+                    "index": 8,
+                    "label": "",
+                    "valveState": "ADJUSTMENT_TOO_SMALL"
+                },
+                "9": {
+                    "deviceId": "3014F7110000000000000049",
+                    "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
+                    "groupIndex": 9,
+                    "groups": [],
+                    "index": 9,
+                    "label": "",
+                    "valveState": "ADJUSTMENT_TOO_SMALL"
+                }
+            },
+            "homeId": "00000000-0000-0000-0000-000000000001",
+            "id": "3014F7110000000000000049",
+            "label": "Fu\u00dfbodenheizungsaktor OG motorisch",
+            "lastStatusUpdate": 1577486092047,
+            "liveUpdateState": "LIVE_UPDATE_NOT_SUPPORTED",
+            "manufacturerCode": 1,
+            "modelId": 365,
+            "modelType": "HmIP-FALMOT-C12",
+            "oem": "eQ-3",
+            "permanentlyReachable": true,
+            "serializedGlobalTradeItemNumber": "3014F7110000000000000049",
+            "type": "FLOOR_TERMINAL_BLOCK_12",
+            "updateState": "UP_TO_DATE"
+        },
         "3014F7110000ABCDABCD0033": {
             "availableFirmwareVersion": "1.0.6",
             "firmwareVersion": "1.0.6",
@@ -290,7 +547,8 @@
                     "rssiPeerValue": -74,
                     "unreach": false,
                     "valveProtectionDuration": 5,
-                    "valveProtectionSwitchingInterval": 14
+                    "valveProtectionSwitchingInterval": 14,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F71100000000FAL24C10",
@@ -439,7 +697,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -64,
                     "rssiPeerValue": -76,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "blindModeActive": true,
@@ -503,7 +762,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -53,
                     "rssiPeerValue": -56,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000BCBB11",
@@ -566,7 +826,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -79,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711ABCD0ABCD000002",
@@ -654,7 +915,8 @@
                     "rssiDeviceValue": -47,
                     "rssiPeerValue": -50,
                     "sabotage": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F71100000000ABCDEF10",
@@ -706,7 +968,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -51,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F71100000000000TEST1",
@@ -833,7 +1096,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -73,
                     "rssiPeerValue": -78,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "blindModeActive": true,
@@ -899,7 +1163,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -76,
                     "rssiPeerValue": -77,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 21.0,
@@ -969,7 +1234,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": null,
                     "rssiPeerValue": null,
-                    "unreach": null
+                    "unreach": null,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711ABCDEF0000000014",
@@ -1037,7 +1303,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -67,
                     "rssiPeerValue": -70,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711BSL0000000000050",
@@ -1110,7 +1377,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -60,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "averageIllumination": 807.3,
@@ -1161,7 +1429,8 @@
                     "rssiDeviceValue": -76,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000054",
@@ -1217,7 +1486,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -46,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711000000000AAAAA25",
@@ -1290,7 +1560,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -55,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 4.3,
@@ -1361,7 +1632,8 @@
                     "rssiPeerValue": null,
                     "unreach": false,
                     "valveProtectionDuration": 5,
-                    "valveProtectionSwitchingInterval": 14
+                    "valveProtectionSwitchingInterval": 14,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000BBBBB1",
@@ -1480,7 +1752,8 @@
                     "rssiDeviceValue": -59,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000BBBBB8",
@@ -1526,7 +1799,8 @@
                     "rssiDeviceValue": -56,
                     "rssiPeerValue": -52,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "currentIllumination": null,
@@ -1577,7 +1851,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -70,
                     "rssiPeerValue": -67,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "currentIllumination": null,
@@ -1631,7 +1906,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -65,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "acousticAlarmSignal": "FREQUENCY_RISING",
@@ -1689,7 +1965,8 @@
                     "rssiDeviceValue": -85,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000000",
@@ -1739,7 +2016,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -73,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000005551",
@@ -1792,7 +2070,8 @@
                     "rssiDeviceValue": -64,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000001",
@@ -1846,7 +2125,8 @@
                     "rssiDeviceValue": -95,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000002",
@@ -1900,7 +2180,8 @@
                     "rssiDeviceValue": -78,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000003",
@@ -1954,7 +2235,8 @@
                     "rssiDeviceValue": -56,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000004",
@@ -2008,7 +2290,8 @@
                     "rssiDeviceValue": -80,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000005",
@@ -2062,7 +2345,8 @@
                     "rssiDeviceValue": -76,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000006",
@@ -2115,7 +2399,8 @@
                     "rssiDeviceValue": -56,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000007",
@@ -2304,7 +2589,8 @@
                     "routerModuleSupported": true,
                     "rssiDeviceValue": -48,
                     "rssiPeerValue": -49,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "currentPowerConsumption": 195.3,
@@ -2357,7 +2643,8 @@
                     "routerModuleSupported": true,
                     "rssiDeviceValue": -60,
                     "rssiPeerValue": -66,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "currentPowerConsumption": 0.0,
@@ -2410,7 +2697,8 @@
                     "routerModuleSupported": true,
                     "rssiDeviceValue": -47,
                     "rssiPeerValue": -49,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "currentPowerConsumption": 2.04,
@@ -2463,7 +2751,8 @@
                     "routerModuleSupported": true,
                     "rssiDeviceValue": -47,
                     "rssiPeerValue": -49,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000110",
@@ -2516,7 +2805,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -54,
                     "rssiPeerValue": -51,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000011",
@@ -2571,7 +2861,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -46,
                     "rssiPeerValue": -54,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000012",
@@ -2626,7 +2917,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -58,
                     "rssiPeerValue": -58,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000013",
@@ -2681,7 +2973,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -60,
                     "rssiPeerValue": -58,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000014",
@@ -2736,7 +3029,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -65,
                     "rssiPeerValue": -66,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000015",
@@ -2791,7 +3085,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -50,
                     "rssiPeerValue": -51,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000016",
@@ -2846,7 +3141,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -67,
                     "rssiPeerValue": -62,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000017",
@@ -2900,7 +3196,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -67,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000018",
@@ -2951,7 +3248,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -50,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000019",
@@ -3002,7 +3300,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -54,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000020",
@@ -3053,7 +3352,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -80,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F7110000000000000021",
@@ -3104,7 +3404,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -76,
                     "rssiPeerValue": -63,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 24.7,
@@ -3160,7 +3461,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -61,
                     "rssiPeerValue": -58,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 24.5,
@@ -3216,7 +3518,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -75,
                     "rssiPeerValue": -85,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 23.6,
@@ -3272,7 +3575,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -46,
                     "rssiPeerValue": -47,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 23.8,
@@ -3327,7 +3631,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -46,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "binaryBehaviorType": "NORMALLY_CLOSE",
@@ -3378,7 +3683,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -68,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 15.4,
@@ -3445,7 +3751,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -55,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 15.1,
@@ -3494,7 +3801,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -77,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "actualTemperature": 15.2,
@@ -3551,7 +3859,8 @@
                     "rssiDeviceValue": -54,
                     "rssiPeerValue": null,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711AAAA000000000004",
@@ -3599,7 +3908,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -44,
                     "rssiPeerValue": -42,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711AAAA000000000005",
@@ -3649,7 +3959,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -61,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711BBBBBBBBBBBBB017",
@@ -3740,7 +4051,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -42,
                     "rssiPeerValue": null,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711BBBBBBBBBBBBB016",
@@ -3854,7 +4166,8 @@
                     "rssiDeviceValue": -62,
                     "rssiPeerValue": -61,
                     "sabotage": false,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "currentIllumination": null,
@@ -3909,7 +4222,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -78,
                     "rssiPeerValue": -77,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "bottomToTopReferenceTime": 30.080000000000002,
@@ -3972,7 +4286,8 @@
                     "routerModuleSupported": false,
                     "rssiDeviceValue": -35,
                     "rssiPeerValue": -36,
-                    "unreach": false
+                    "unreach": false,
+                    "supportedOptionalFeatures": {}
                 },
                 "1": {
                     "deviceId": "3014F711BBBBBBBBBBBBB18",
@@ -5569,6 +5884,27 @@
             "profileMode": null,
             "type": "HOT_WATER",
             "unreach": null
+        },
+        "00000000-0000-0000-0000-000000000093": {
+            "channels": [],
+            "dutyCycle": false,
+            "homeId": "00000000-0000-0000-0000-000000000001",
+            "id": "00000000-0000-0000-0000-000000000093",
+            "label": "Rollladen Schiebet\u00fcr",
+            "lastStatusUpdate": 1577488124150,
+            "lowBat": null,
+            "metaGroupId": null,
+            "primaryShadingLevel": 0.97,
+            "primaryShadingStateType": "POSITION_USED",
+            "processing": false,
+            "profileId": "00000000-0000-0000-0000-000000000113",
+            "profileMode": "AUTOMATIC",
+            "secondaryShadingLevel": null,
+            "secondaryShadingStateType": "NOT_EXISTENT",
+            "shutterLevel": 0.97,
+            "slatsLevel": null,
+            "type": "SHUTTER_PROFILE",
+            "unreach": false
         }
     },
     "home": {

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -66,7 +66,7 @@
             },
             "homeId": "00000000-0000-0000-0000-000000000001",
             "id": "3014F7110000000000ABCD50",
-            "label": "Netzausfall\u00fcberwachung",
+            "label": "Netzausfall",
             "lastStatusUpdate": 1577487207542,
             "liveUpdateState": "LIVE_UPDATE_NOT_SUPPORTED",
             "manufacturerCode": 1,

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -271,6 +271,88 @@
             "type": "FLOOR_TERMINAL_BLOCK_12",
             "updateState": "UP_TO_DATE"
         },
+        "3014F7110000000000000148": {
+            "availableFirmwareVersion": "1.4.0",
+            "firmwareVersion": "1.4.0",
+            "firmwareVersionInteger": 66560,
+            "functionalChannels": {
+                "0": {
+                    "coProFaulty": false,
+                    "coProRestartNeeded": false,
+                    "coProUpdateFailure": false,
+                    "configPending": false,
+                    "deviceId": "3014F7110000000000000148",
+                    "deviceOverheated": false,
+                    "deviceOverloaded": false,
+                    "deviceUndervoltage": false,
+                    "dutyCycle": false,
+                    "functionalChannelType": "DEVICE_BASE",
+                    "groupIndex": 0,
+                    "groups": [
+                        "00000000-0000-0000-0000-000000000039"
+                    ],
+                    "index": 0,
+                    "label": "",
+                    "lowBat": null,
+                    "routerModuleEnabled": false,
+                    "routerModuleSupported": false,
+                    "rssiDeviceValue": -52,
+                    "rssiPeerValue": null,
+                    "supportedOptionalFeatures": {
+                        "IFeatureDeviceCoProError": false,
+                        "IFeatureDeviceCoProRestart": false,
+                        "IFeatureDeviceCoProUpdate": false,
+                        "IFeatureDeviceOverheated": false,
+                        "IFeatureDeviceOverloaded": false,
+                        "IFeatureDeviceTemperatureOutOfRange": false,
+                        "IFeatureDeviceUndervoltage": false
+                    },
+                    "temperatureOutOfRange": false,
+                    "unreach": false
+                },
+                "1": {
+                    "deviceId": "3014F7110000000000000148",
+                    "functionalChannelType": "SWITCH_CHANNEL",
+                    "groupIndex": 1,
+                    "groups": [
+                        "00000000-0000-0000-0000-000000000043",
+                        "00000000-0000-0000-0000-000000000041"
+                    ],
+                    "index": 1,
+                    "label": "",
+                    "on": true,
+                    "profileMode": "AUTOMATIC",
+                    "userDesiredProfileMode": "AUTOMATIC"
+                },
+                "2": {
+                    "deviceId": "3014F7110000000000000148",
+                    "functionalChannelType": "SWITCH_CHANNEL",
+                    "groupIndex": 2,
+                    "groups": [
+                        "00000000-0000-0000-0000-000000000041",
+                        "00000000-0000-0000-0000-000000000044"
+                    ],
+                    "index": 2,
+                    "label": "",
+                    "on": true,
+                    "profileMode": "AUTOMATIC",
+                    "userDesiredProfileMode": "AUTOMATIC"
+                }
+            },
+            "homeId": "00000000-0000-0000-0000-000000000001",
+            "id": "3014F7110000000000000148",
+            "label": "Heizungsaktor",
+            "lastStatusUpdate": 1577482332693,
+            "liveUpdateState": "LIVE_UPDATE_NOT_SUPPORTED",
+            "manufacturerCode": 1,
+            "modelId": 356,
+            "modelType": "HmIP-WHS2",
+            "oem": "eQ-3",
+            "permanentlyReachable": true,
+            "serializedGlobalTradeItemNumber": "3014F7110000000000000148",
+            "type": "HEATING_SWITCH_2",
+            "updateState": "UP_TO_DATE"
+        },
         "3014F7110000ABCDABCD0033": {
             "availableFirmwareVersion": "1.0.6",
             "firmwareVersion": "1.0.6",


### PR DESCRIPTION
## Description:
Add HmIP-PMFS and HmIP-WHS2 to HomematicIP Cloud

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11582

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
