### PR TITLE
Improve Withings tests in different time zone

### DIFF
--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -29,7 +29,7 @@ def withings_api_fixture() -> WithingsApi:
 
 @pytest.fixture
 def mock_time_zone():
-    """Provide a alternative time zone."""
+    """Provide an alternative time zone."""
     patch_time_zone = patch(
         "homeassistant.util.dt.DEFAULT_TIME_ZONE",
         new=dt.get_time_zone("America/Los_Angeles"),


### PR DESCRIPTION
## Description:

Addresses review comment by @MartinHjelmare in #30320: <https://github.com/home-assistant/home-assistant/pull/30320#discussion_r362215622>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
