### PR TITLE
Bump pyps4-2ndscreen to 1.0.4

### DIFF
--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -3,11 +3,7 @@
   "name": "Ps4",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ps4",
-  "requirements": [
-    "pyps4-2ndscreen==1.0.3"
-  ],
+  "requirements": ["pyps4-2ndscreen==1.0.4"],
   "dependencies": [],
-  "codeowners": [
-    "@ktnrg45"
-  ]
+  "codeowners": ["@ktnrg45"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1448,7 +1448,7 @@ pypjlink2==1.2.0
 pypoint==1.1.2
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.0.3
+pyps4-2ndscreen==1.0.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -487,7 +487,7 @@ pyotp==2.3.0
 pypoint==1.1.2
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.0.3
+pyps4-2ndscreen==1.0.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93


### PR DESCRIPTION
## Description:

Bumps `pyps4-2ndscreen` to 1.0.4

Changelog: <https://github.com/ktnrg45/pyps4-2ndscreen/releases/tag/1.0.4>

Addresses issue with tests on newer Python versions:

```
ERROR:homeassistant.setup:Error during setup of component ps4
Traceback (most recent call last):
  File "/home/frenck/code/home-assistant/home-assistant/homeassistant/setup.py", line 170, in _async_setup_component
    hass, processed_config
  File "/home/frenck/code/home-assistant/home-assistant/homeassistant/components/ps4/__init__.py", line 56, in async_setup
    transport, protocol = await async_create_ddp_endpoint()
  File "/home/frenck/code/home-assistant/home-assistant/venv/lib/python3.7/site-packages/pyps4_2ndscreen/ddp.py", line 130, in async_create_ddp_endpoint
    transport, protocol = await loop.create_task(connect)
  File "/home/frenck/.pyenv/versions/3.7.6/lib/python3.7/asyncio/base_events.py", line 1211, in create_datagram_endpoint
    raise ValueError("Passing `reuse_address=True` is no "
ValueError: Passing `reuse_address=True` is no longer supported, as the usage of SO_REUSEPORT in UDP poses a significant security concern.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
