### PR TITLE
Migrate xiaomi_miio tests from coroutine to async/await

### DIFF
--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -1,5 +1,4 @@
 """The tests for the Xiaomi vacuum platform."""
-import asyncio
 from datetime import time, timedelta
 from unittest import mock
 
@@ -149,11 +148,10 @@ def mirobo_errors_fixture():
         yield mock_vacuum
 
 
-@asyncio.coroutine
-def test_xiaomi_exceptions(hass, caplog, mock_mirobo_errors):
+async def test_xiaomi_exceptions(hass, caplog, mock_mirobo_errors):
     """Test vacuum supported features."""
     entity_name = "test_vacuum_cleaner_error"
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {
@@ -165,7 +163,7 @@ def test_xiaomi_exceptions(hass, caplog, mock_mirobo_errors):
             }
         },
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Initializing with host 127.0.0.1 (token 12345...)" in caplog.text
     assert mock_mirobo_errors.status.call_count == 1
@@ -173,13 +171,12 @@ def test_xiaomi_exceptions(hass, caplog, mock_mirobo_errors):
     assert "Got OSError while fetching the state" in caplog.text
 
 
-@asyncio.coroutine
-def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
+async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     """Test vacuum supported features."""
     entity_name = "test_vacuum_cleaner_1"
     entity_id = "{}.{}".format(DOMAIN, entity_name)
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {
@@ -191,7 +188,7 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
             }
         },
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Initializing with host 127.0.0.1 (token 12345...)" in caplog.text
 
@@ -223,7 +220,7 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 695
 
     # Call services
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN, SERVICE_START, {"entity_id": entity_id}, blocking=True
     )
     mock_mirobo_is_got_error.assert_has_calls(
@@ -232,28 +229,28 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     mock_mirobo_is_got_error.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_got_error.reset_mock()
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN, SERVICE_STOP, {"entity_id": entity_id}, blocking=True
     )
     mock_mirobo_is_got_error.assert_has_calls([mock.call.stop()], any_order=True)
     mock_mirobo_is_got_error.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_got_error.reset_mock()
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN, SERVICE_RETURN_TO_BASE, {"entity_id": entity_id}, blocking=True
     )
     mock_mirobo_is_got_error.assert_has_calls([mock.call.home()], any_order=True)
     mock_mirobo_is_got_error.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_got_error.reset_mock()
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN, SERVICE_LOCATE, {"entity_id": entity_id}, blocking=True
     )
     mock_mirobo_is_got_error.assert_has_calls([mock.call.find()], any_order=True)
     mock_mirobo_is_got_error.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_got_error.reset_mock()
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN, SERVICE_CLEAN_SPOT, {"entity_id": entity_id}, blocking=True
     )
     mock_mirobo_is_got_error.assert_has_calls([mock.call.spot()], any_order=True)
@@ -261,7 +258,7 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     mock_mirobo_is_got_error.reset_mock()
 
     # Set speed service:
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_FAN_SPEED,
         {"entity_id": entity_id, "fan_speed": 60},
@@ -273,7 +270,7 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     mock_mirobo_is_got_error.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_got_error.reset_mock()
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_FAN_SPEED,
         {"entity_id": entity_id, "fan_speed": "turbo"},
@@ -286,7 +283,7 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     mock_mirobo_is_got_error.reset_mock()
 
     assert "ERROR" not in caplog.text
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_FAN_SPEED,
         {"entity_id": entity_id, "fan_speed": "invent"},
@@ -294,7 +291,7 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     )
     assert "ERROR" in caplog.text
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN,
         SERVICE_SEND_COMMAND,
         {"entity_id": entity_id, "command": "raw"},
@@ -306,7 +303,7 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     mock_mirobo_is_got_error.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_got_error.reset_mock()
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         DOMAIN,
         SERVICE_SEND_COMMAND,
         {"entity_id": entity_id, "command": "raw", "params": {"k1": 2}},
@@ -319,13 +316,12 @@ def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     mock_mirobo_is_got_error.reset_mock()
 
 
-@asyncio.coroutine
-def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
+async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     """Test vacuum supported features."""
     entity_name = "test_vacuum_cleaner_2"
     entity_id = "{}.{}".format(DOMAIN, entity_name)
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {
@@ -337,7 +333,7 @@ def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
             }
         },
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Initializing with host 192.168.1.100 (token 12345" in caplog.text
 
@@ -366,7 +362,7 @@ def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 675
 
     # Xiaomi vacuum specific services:
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         XIAOMI_DOMAIN,
         SERVICE_START_REMOTE_CONTROL,
         {ATTR_ENTITY_ID: entity_id},
@@ -378,7 +374,7 @@ def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.reset_mock()
 
     control = {"duration": 1000, "rotation": -40, "velocity": -0.1}
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         XIAOMI_DOMAIN, SERVICE_MOVE_REMOTE_CONTROL, control, blocking=True
     )
     mock_mirobo_is_on.manual_control.assert_has_calls(
@@ -387,7 +383,7 @@ def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_on.reset_mock()
 
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         XIAOMI_DOMAIN, SERVICE_STOP_REMOTE_CONTROL, {}, blocking=True
     )
     mock_mirobo_is_on.assert_has_calls([mock.call.manual_stop()], any_order=True)
@@ -395,7 +391,7 @@ def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.reset_mock()
 
     control_once = {"duration": 2000, "rotation": 120, "velocity": 0.1}
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         XIAOMI_DOMAIN, SERVICE_MOVE_REMOTE_CONTROL_STEP, control_once, blocking=True
     )
     mock_mirobo_is_on.manual_control_once.assert_has_calls(
@@ -405,7 +401,7 @@ def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.reset_mock()
 
     control = {"zone": [[123, 123, 123, 123]], "repeats": 2}
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         XIAOMI_DOMAIN, SERVICE_CLEAN_ZONE, control, blocking=True
     )
     mock_mirobo_is_on.zoned_clean.assert_has_calls(


### PR DESCRIPTION
## Description:

Migrate xiaomi_miio tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
