### PR TITLE
Migrate emulated_hue tests from coroutine to async/await

### DIFF
--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1,5 +1,4 @@
 """The tests for the emulated Hue component."""
-import asyncio
 from datetime import timedelta
 from ipaddress import ip_address
 import json
@@ -194,15 +193,14 @@ def hue_client(loop, hass_hue, aiohttp_client):
     return loop.run_until_complete(aiohttp_client(web_app))
 
 
-@asyncio.coroutine
-def test_discover_lights(hue_client):
+async def test_discover_lights(hue_client):
     """Test the discovery of lights."""
-    result = yield from hue_client.get("/api/username/lights")
+    result = await hue_client.get("/api/username/lights")
 
     assert result.status == 200
     assert "application/json" in result.headers["content-type"]
 
-    result_json = yield from result.json()
+    result_json = await result.json()
 
     devices = set(val["uniqueid"] for val in result_json.values())
 
@@ -223,10 +221,9 @@ def test_discover_lights(hue_client):
     assert "00:57:77:a1:6a:8e:ef:b3-6c" not in devices  # climate.ecobee
 
 
-@asyncio.coroutine
-def test_light_without_brightness_supported(hass_hue, hue_client):
+async def test_light_without_brightness_supported(hass_hue, hue_client):
     """Test that light without brightness is supported."""
-    light_without_brightness_json = yield from perform_get_light_state(
+    light_without_brightness_json = await perform_get_light_state(
         hue_client, "light.no_brightness", 200
     )
 
@@ -234,7 +231,6 @@ def test_light_without_brightness_supported(hass_hue, hue_client):
     assert light_without_brightness_json["type"] == "On/off light"
 
 
-@asyncio.coroutine
 @pytest.mark.parametrize(
     "state,is_reachable",
     [
@@ -243,26 +239,25 @@ def test_light_without_brightness_supported(hass_hue, hue_client):
         (const.STATE_UNKNOWN, True),
     ],
 )
-def test_reachable_for_state(hass_hue, hue_client, state, is_reachable):
+async def test_reachable_for_state(hass_hue, hue_client, state, is_reachable):
     """Test that an entity is reported as unreachable if in unavailable state."""
     entity_id = "light.ceiling_lights"
 
     hass_hue.states.async_set(entity_id, state)
 
-    state_json = yield from perform_get_light_state(hue_client, entity_id, 200)
+    state_json = await perform_get_light_state(hue_client, entity_id, 200)
 
     assert state_json["state"]["reachable"] == is_reachable, state_json
 
 
-@asyncio.coroutine
-def test_discover_full_state(hue_client):
+async def test_discover_full_state(hue_client):
     """Test the discovery of full state."""
-    result = yield from hue_client.get("/api/" + HUE_API_USERNAME)
+    result = await hue_client.get("/api/" + HUE_API_USERNAME)
 
     assert result.status == 200
     assert "application/json" in result.headers["content-type"]
 
-    result_json = yield from result.json()
+    result_json = await result.json()
 
     # Make sure array has correct content
     assert "lights" in result_json
@@ -297,11 +292,10 @@ def test_discover_full_state(hue_client):
     assert "127.0.0.1:8300" in config_json["ipaddress"]
 
 
-@asyncio.coroutine
-def test_get_light_state(hass_hue, hue_client):
+async def test_get_light_state(hass_hue, hue_client):
     """Test the getting of light state."""
     # Turn office light on and set to 127 brightness, and set light color
-    yield from hass_hue.services.async_call(
+    await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_ON,
         {
@@ -312,9 +306,7 @@ def test_get_light_state(hass_hue, hue_client):
         blocking=True,
     )
 
-    office_json = yield from perform_get_light_state(
-        hue_client, "light.ceiling_lights", 200
-    )
+    office_json = await perform_get_light_state(hue_client, "light.ceiling_lights", 200)
 
     assert office_json["state"][HUE_API_STATE_ON] is True
     assert office_json["state"][HUE_API_STATE_BRI] == 127
@@ -322,27 +314,25 @@ def test_get_light_state(hass_hue, hue_client):
     assert office_json["state"][HUE_API_STATE_SAT] == 217
 
     # Check all lights view
-    result = yield from hue_client.get("/api/username/lights")
+    result = await hue_client.get("/api/username/lights")
 
     assert result.status == 200
     assert "application/json" in result.headers["content-type"]
 
-    result_json = yield from result.json()
+    result_json = await result.json()
 
     assert "light.ceiling_lights" in result_json
     assert result_json["light.ceiling_lights"]["state"][HUE_API_STATE_BRI] == 127
 
     # Turn office light off
-    yield from hass_hue.services.async_call(
+    await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_OFF,
         {const.ATTR_ENTITY_ID: "light.ceiling_lights"},
         blocking=True,
     )
 
-    office_json = yield from perform_get_light_state(
-        hue_client, "light.ceiling_lights", 200
-    )
+    office_json = await perform_get_light_state(hue_client, "light.ceiling_lights", 200)
 
     assert office_json["state"][HUE_API_STATE_ON] is False
     # Removed assert HUE_API_STATE_BRI == 0 as Hue API states bri must be 1..254
@@ -350,19 +340,18 @@ def test_get_light_state(hass_hue, hue_client):
     assert office_json["state"][HUE_API_STATE_SAT] == 0
 
     # Make sure bedroom light isn't accessible
-    yield from perform_get_light_state(hue_client, "light.bed_light", 401)
+    await perform_get_light_state(hue_client, "light.bed_light", 401)
 
     # Make sure kitchen light isn't accessible
-    yield from perform_get_light_state(hue_client, "light.kitchen_lights", 401)
+    await perform_get_light_state(hue_client, "light.kitchen_lights", 401)
 
 
-@asyncio.coroutine
-def test_put_light_state(hass_hue, hue_client):
+async def test_put_light_state(hass_hue, hue_client):
     """Test the setting of light states."""
-    yield from perform_put_test_on_ceiling_lights(hass_hue, hue_client)
+    await perform_put_test_on_ceiling_lights(hass_hue, hue_client)
 
     # Turn the bedroom light on first
-    yield from hass_hue.services.async_call(
+    await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_ON,
         {const.ATTR_ENTITY_ID: "light.ceiling_lights", light.ATTR_BRIGHTNESS: 153},
@@ -374,7 +363,7 @@ def test_put_light_state(hass_hue, hue_client):
     assert ceiling_lights.attributes[light.ATTR_BRIGHTNESS] == 153
 
     # update light state through api
-    yield from perform_put_light_state(
+    await perform_put_light_state(
         hass_hue,
         hue_client,
         "light.ceiling_lights",
@@ -385,7 +374,7 @@ def test_put_light_state(hass_hue, hue_client):
     )
 
     # go through api to get the state back
-    ceiling_json = yield from perform_get_light_state(
+    ceiling_json = await perform_get_light_state(
         hue_client, "light.ceiling_lights", 200
     )
     assert ceiling_json["state"][HUE_API_STATE_BRI] == 123
@@ -393,11 +382,11 @@ def test_put_light_state(hass_hue, hue_client):
     assert ceiling_json["state"][HUE_API_STATE_SAT] == 127
 
     # Go through the API to turn it off
-    ceiling_result = yield from perform_put_light_state(
+    ceiling_result = await perform_put_light_state(
         hass_hue, hue_client, "light.ceiling_lights", False
     )
 
-    ceiling_result_json = yield from ceiling_result.json()
+    ceiling_result_json = await ceiling_result.json()
 
     assert ceiling_result.status == 200
     assert "application/json" in ceiling_result.headers["content-type"]
@@ -407,7 +396,7 @@ def test_put_light_state(hass_hue, hue_client):
     # Check to make sure the state changed
     ceiling_lights = hass_hue.states.get("light.ceiling_lights")
     assert ceiling_lights.state == STATE_OFF
-    ceiling_json = yield from perform_get_light_state(
+    ceiling_json = await perform_get_light_state(
         hue_client, "light.ceiling_lights", 200
     )
     # Removed assert HUE_API_STATE_BRI == 0 as Hue API states bri must be 1..254
@@ -415,23 +404,22 @@ def test_put_light_state(hass_hue, hue_client):
     assert ceiling_json["state"][HUE_API_STATE_SAT] == 0
 
     # Make sure we can't change the bedroom light state
-    bedroom_result = yield from perform_put_light_state(
+    bedroom_result = await perform_put_light_state(
         hass_hue, hue_client, "light.bed_light", True
     )
     assert bedroom_result.status == 401
 
     # Make sure we can't change the kitchen light state
-    kitchen_result = yield from perform_put_light_state(
+    kitchen_result = await perform_put_light_state(
         hass_hue, hue_client, "light.kitchen_light", True
     )
     assert kitchen_result.status == 404
 
 
-@asyncio.coroutine
-def test_put_light_state_script(hass_hue, hue_client):
+async def test_put_light_state_script(hass_hue, hue_client):
     """Test the setting of script variables."""
     # Turn the kitchen light off first
-    yield from hass_hue.services.async_call(
+    await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_OFF,
         {const.ATTR_ENTITY_ID: "light.kitchen_lights"},
@@ -442,11 +430,11 @@ def test_put_light_state_script(hass_hue, hue_client):
     level = 23
     brightness = round(level * 255 / 100)
 
-    script_result = yield from perform_put_light_state(
+    script_result = await perform_put_light_state(
         hass_hue, hue_client, "script.set_kitchen_light", True, brightness
     )
 
-    script_result_json = yield from script_result.json()
+    script_result_json = await script_result.json()
 
     assert script_result.status == 200
     assert len(script_result_json) == 2
@@ -456,17 +444,16 @@ def test_put_light_state_script(hass_hue, hue_client):
     assert kitchen_light.attributes[light.ATTR_BRIGHTNESS] == level
 
 
-@asyncio.coroutine
-def test_put_light_state_climate_set_temperature(hass_hue, hue_client):
+async def test_put_light_state_climate_set_temperature(hass_hue, hue_client):
     """Test setting climate temperature."""
     brightness = 19
     temperature = round(brightness / 255 * 100)
 
-    hvac_result = yield from perform_put_light_state(
+    hvac_result = await perform_put_light_state(
         hass_hue, hue_client, "climate.hvac", True, brightness
     )
 
-    hvac_result_json = yield from hvac_result.json()
+    hvac_result_json = await hvac_result.json()
 
     assert hvac_result.status == 200
     assert len(hvac_result_json) == 2
@@ -476,17 +463,16 @@ def test_put_light_state_climate_set_temperature(hass_hue, hue_client):
     assert hvac.attributes[climate.ATTR_TEMPERATURE] == temperature
 
     # Make sure we can't change the ecobee temperature since it's not exposed
-    ecobee_result = yield from perform_put_light_state(
+    ecobee_result = await perform_put_light_state(
         hass_hue, hue_client, "climate.ecobee", True
     )
     assert ecobee_result.status == 401
 
 
-@asyncio.coroutine
-def test_put_light_state_media_player(hass_hue, hue_client):
+async def test_put_light_state_media_player(hass_hue, hue_client):
     """Test turning on media player and setting volume."""
     # Turn the music player off first
-    yield from hass_hue.services.async_call(
+    await hass_hue.services.async_call(
         media_player.DOMAIN,
         const.SERVICE_TURN_OFF,
         {const.ATTR_ENTITY_ID: "media_player.walkman"},
@@ -497,11 +483,11 @@ def test_put_light_state_media_player(hass_hue, hue_client):
     level = 0.25
     brightness = round(level * 255)
 
-    mp_result = yield from perform_put_light_state(
+    mp_result = await perform_put_light_state(
         hass_hue, hue_client, "media_player.walkman", True, brightness
     )
 
-    mp_result_json = yield from mp_result.json()
+    mp_result_json = await mp_result.json()
 
     assert mp_result.status == 200
     assert len(mp_result_json) == 2
@@ -610,11 +596,10 @@ async def test_set_position_cover(hass_hue, hue_client):
     assert cover_test_2.attributes.get("current_position") == level
 
 
-@asyncio.coroutine
-def test_put_light_state_fan(hass_hue, hue_client):
+async def test_put_light_state_fan(hass_hue, hue_client):
     """Test turning on fan and setting speed."""
     # Turn the fan off first
-    yield from hass_hue.services.async_call(
+    await hass_hue.services.async_call(
         fan.DOMAIN,
         const.SERVICE_TURN_OFF,
         {const.ATTR_ENTITY_ID: "fan.living_room_fan"},
@@ -625,11 +610,11 @@ def test_put_light_state_fan(hass_hue, hue_client):
     level = 43
     brightness = round(level * 255 / 100)
 
-    fan_result = yield from perform_put_light_state(
+    fan_result = await perform_put_light_state(
         hass_hue, hue_client, "fan.living_room_fan", True, brightness
     )
 
-    fan_result_json = yield from fan_result.json()
+    fan_result_json = await fan_result.json()
 
     assert fan_result.status == 200
     assert len(fan_result_json) == 2
@@ -640,17 +625,16 @@ def test_put_light_state_fan(hass_hue, hue_client):
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_put_with_form_urlencoded_content_type(hass_hue, hue_client):
+async def test_put_with_form_urlencoded_content_type(hass_hue, hue_client):
     """Test the form with urlencoded content."""
     # Needed for Alexa
-    yield from perform_put_test_on_ceiling_lights(
+    await perform_put_test_on_ceiling_lights(
         hass_hue, hue_client, "application/x-www-form-urlencoded"
     )
 
     # Make sure we fail gracefully when we can't parse the data
     data = {"key1": "value1", "key2": "value2"}
-    result = yield from hue_client.put(
+    result = await hue_client.put(
         "/api/username/lights/light.ceiling_lights/state",
         headers={"content-type": "application/x-www-form-urlencoded"},
         data=data,
@@ -659,41 +643,36 @@ def test_put_with_form_urlencoded_content_type(hass_hue, hue_client):
     assert result.status == 400
 
 
-@asyncio.coroutine
-def test_entity_not_found(hue_client):
+async def test_entity_not_found(hue_client):
     """Test for entity which are not found."""
-    result = yield from hue_client.get("/api/username/lights/not.existant_entity")
+    result = await hue_client.get("/api/username/lights/not.existant_entity")
 
     assert result.status == 404
 
-    result = yield from hue_client.put("/api/username/lights/not.existant_entity/state")
+    result = await hue_client.put("/api/username/lights/not.existant_entity/state")
 
     assert result.status == 404
 
 
-@asyncio.coroutine
-def test_allowed_methods(hue_client):
+async def test_allowed_methods(hue_client):
     """Test the allowed methods."""
-    result = yield from hue_client.get(
-        "/api/username/lights/light.ceiling_lights/state"
-    )
+    result = await hue_client.get("/api/username/lights/light.ceiling_lights/state")
 
     assert result.status == 405
 
-    result = yield from hue_client.put("/api/username/lights/light.ceiling_lights")
+    result = await hue_client.put("/api/username/lights/light.ceiling_lights")
 
     assert result.status == 405
 
-    result = yield from hue_client.put("/api/username/lights")
+    result = await hue_client.put("/api/username/lights")
 
     assert result.status == 405
 
 
-@asyncio.coroutine
-def test_proper_put_state_request(hue_client):
+async def test_proper_put_state_request(hue_client):
     """Test the request to set the state."""
     # Test proper on value parsing
-    result = yield from hue_client.put(
+    result = await hue_client.put(
         "/api/username/lights/{}/state".format("light.ceiling_lights"),
         data=json.dumps({HUE_API_STATE_ON: 1234}),
     )
@@ -701,7 +680,7 @@ def test_proper_put_state_request(hue_client):
     assert result.status == 400
 
     # Test proper brightness value parsing
-    result = yield from hue_client.put(
+    result = await hue_client.put(
         "/api/username/lights/{}/state".format("light.ceiling_lights"),
         data=json.dumps({HUE_API_STATE_ON: True, HUE_API_STATE_BRI: "Hello world!"}),
     )
@@ -709,15 +688,14 @@ def test_proper_put_state_request(hue_client):
     assert result.status == 400
 
 
-@asyncio.coroutine
-def test_get_empty_groups_state(hue_client):
+async def test_get_empty_groups_state(hue_client):
     """Test the request to get groups endpoint."""
     # Test proper on value parsing
-    result = yield from hue_client.get("/api/username/groups")
+    result = await hue_client.get("/api/username/groups")
 
     assert result.status == 200
 
-    result_json = yield from result.json()
+    result_json = await result.json()
 
     assert result_json == {}
 
@@ -756,23 +734,21 @@ async def perform_put_test_on_ceiling_lights(
     assert ceiling_lights.attributes[light.ATTR_BRIGHTNESS] == 56
 
 
-@asyncio.coroutine
-def perform_get_light_state(client, entity_id, expected_status):
+async def perform_get_light_state(client, entity_id, expected_status):
     """Test the getting of a light state."""
-    result = yield from client.get("/api/username/lights/{}".format(entity_id))
+    result = await client.get("/api/username/lights/{}".format(entity_id))
 
     assert result.status == expected_status
 
     if expected_status == 200:
         assert "application/json" in result.headers["content-type"]
 
-        return (yield from result.json())
+        return await result.json()
 
     return None
 
 
-@asyncio.coroutine
-def perform_put_light_state(
+async def perform_put_light_state(
     hass_hue,
     client,
     entity_id,
@@ -794,14 +770,14 @@ def perform_put_light_state(
     if saturation is not None:
         data[HUE_API_STATE_SAT] = saturation
 
-    result = yield from client.put(
+    result = await client.put(
         "/api/username/lights/{}/state".format(entity_id),
         headers=req_headers,
         data=json.dumps(data).encode(),
     )
 
     # Wait until state change is complete before continuing
-    yield from hass_hue.async_block_till_done()
+    await hass_hue.async_block_till_done()
 
     return result
 


### PR DESCRIPTION
## Description:

Migrate emulated_hue tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
