### PR TITLE
Migrate python_script tests from coroutine to async/await

### DIFF
--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -1,5 +1,4 @@
 """Test the python_script component."""
-import asyncio
 import logging
 from unittest.mock import mock_open, patch
 
@@ -10,8 +9,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import patch_yaml_files
 
 
-@asyncio.coroutine
-def test_setup(hass):
+async def test_setup(hass):
     """Test we can discover scripts."""
     scripts = [
         "/some/config/dir/python_scripts/hello.py",
@@ -20,7 +18,7 @@ def test_setup(hass):
     with patch(
         "homeassistant.components.python_script.os.path.isdir", return_value=True
     ), patch("homeassistant.components.python_script.glob.iglob", return_value=scripts):
-        res = yield from async_setup_component(hass, "python_script", {})
+        res = await async_setup_component(hass, "python_script", {})
 
     assert res
     assert hass.services.has_service("python_script", "hello")
@@ -31,7 +29,7 @@ def test_setup(hass):
         mock_open(read_data="fake source"),
         create=True,
     ), patch("homeassistant.components.python_script.execute") as mock_ex:
-        yield from hass.services.async_call(
+        await hass.services.async_call(
             "python_script", "hello", {"some": "data"}, blocking=True
         )
 
@@ -44,20 +42,18 @@ def test_setup(hass):
     assert data == {"some": "data"}
 
 
-@asyncio.coroutine
-def test_setup_fails_on_no_dir(hass, caplog):
+async def test_setup_fails_on_no_dir(hass, caplog):
     """Test we fail setup when no dir found."""
     with patch(
         "homeassistant.components.python_script.os.path.isdir", return_value=False
     ):
-        res = yield from async_setup_component(hass, "python_script", {})
+        res = await async_setup_component(hass, "python_script", {})
 
     assert not res
     assert "Folder python_scripts not found in configuration folder" in caplog.text
 
 
-@asyncio.coroutine
-def test_execute_with_data(hass, caplog):
+async def test_execute_with_data(hass, caplog):
     """Test executing a script."""
     caplog.set_level(logging.WARNING)
     source = """
@@ -65,7 +61,7 @@ hass.states.set('test.entity', data.get('name', 'not set'))
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {"name": "paulus"})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.is_state("test.entity", "paulus")
 
@@ -73,8 +69,7 @@ hass.states.set('test.entity', data.get('name', 'not set'))
     assert caplog.text == ""
 
 
-@asyncio.coroutine
-def test_execute_warns_print(hass, caplog):
+async def test_execute_warns_print(hass, caplog):
     """Test print triggers warning."""
     caplog.set_level(logging.WARNING)
     source = """
@@ -82,13 +77,12 @@ print("This triggers warning.")
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Don't use print() inside scripts." in caplog.text
 
 
-@asyncio.coroutine
-def test_execute_logging(hass, caplog):
+async def test_execute_logging(hass, caplog):
     """Test logging works."""
     caplog.set_level(logging.INFO)
     source = """
@@ -96,13 +90,12 @@ logger.info('Logging from inside script')
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Logging from inside script" in caplog.text
 
 
-@asyncio.coroutine
-def test_execute_compile_error(hass, caplog):
+async def test_execute_compile_error(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
     source = """
@@ -110,13 +103,12 @@ this is not valid Python
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Error loading script test.py" in caplog.text
 
 
-@asyncio.coroutine
-def test_execute_runtime_error(hass, caplog):
+async def test_execute_runtime_error(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
     source = """
@@ -124,13 +116,12 @@ raise Exception('boom')
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Error executing script: boom" in caplog.text
 
 
-@asyncio.coroutine
-def test_accessing_async_methods(hass, caplog):
+async def test_accessing_async_methods(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
     source = """
@@ -138,13 +129,12 @@ hass.async_stop()
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Not allowed to access async methods" in caplog.text
 
 
-@asyncio.coroutine
-def test_using_complex_structures(hass, caplog):
+async def test_using_complex_structures(hass, caplog):
     """Test that dicts and lists work."""
     caplog.set_level(logging.INFO)
     source = """
@@ -154,13 +144,12 @@ logger.info('Logging from inside script: %s %s' % (mydict["a"], mylist[2]))
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert "Logging from inside script: 1 3" in caplog.text
 
 
-@asyncio.coroutine
-def test_accessing_forbidden_methods(hass, caplog):
+async def test_accessing_forbidden_methods(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
 
@@ -172,12 +161,11 @@ def test_accessing_forbidden_methods(hass, caplog):
     }.items():
         caplog.records.clear()
         hass.async_add_job(execute, hass, "test.py", source, {})
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
         assert "Not allowed to access {}".format(name) in caplog.text
 
 
-@asyncio.coroutine
-def test_iterating(hass):
+async def test_iterating(hass):
     """Test compile error logs error."""
     source = """
 for i in [1, 2]:
@@ -185,14 +173,13 @@ for i in [1, 2]:
     """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.is_state("hello.1", "world")
     assert hass.states.is_state("hello.2", "world")
 
 
-@asyncio.coroutine
-def test_unpacking_sequence(hass, caplog):
+async def test_unpacking_sequence(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
     source = """
@@ -204,7 +191,7 @@ hass.states.set('hello.ab_list', '{}'.format(ab_list))
 """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.is_state("hello.a", "1")
     assert hass.states.is_state("hello.b", "2")
@@ -214,8 +201,7 @@ hass.states.set('hello.ab_list', '{}'.format(ab_list))
     assert caplog.text == ""
 
 
-@asyncio.coroutine
-def test_execute_sorted(hass, caplog):
+async def test_execute_sorted(hass, caplog):
     """Test sorted() function."""
     caplog.set_level(logging.ERROR)
     source = """
@@ -226,7 +212,7 @@ hass.states.set('hello.b', a[1])
 hass.states.set('hello.c', a[2])
 """
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.is_state("hello.a", "1")
     assert hass.states.is_state("hello.b", "2")
@@ -235,8 +221,7 @@ hass.states.set('hello.c', a[2])
     assert caplog.text == ""
 
 
-@asyncio.coroutine
-def test_exposed_modules(hass, caplog):
+async def test_exposed_modules(hass, caplog):
     """Test datetime and time modules exposed."""
     caplog.set_level(logging.ERROR)
     source = """
@@ -248,7 +233,7 @@ hass.states.set('module.datetime',
 """
 
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.is_state("module.time", "1986")
     assert hass.states.is_state("module.time_strptime", "12:34")
@@ -258,8 +243,7 @@ hass.states.set('module.datetime',
     assert caplog.text == ""
 
 
-@asyncio.coroutine
-def test_execute_functions(hass, caplog):
+async def test_execute_functions(hass, caplog):
     """Test functions defined in script can call one another."""
     caplog.set_level(logging.ERROR)
     source = """
@@ -273,7 +257,7 @@ def b():
 b()
 """
     hass.async_add_job(execute, hass, "test.py", source, {})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.is_state("hello.a", "one")
     assert hass.states.is_state("hello.b", "two")
@@ -281,8 +265,7 @@ b()
     assert caplog.text == ""
 
 
-@asyncio.coroutine
-def test_reload(hass):
+async def test_reload(hass):
     """Test we can re-discover scripts."""
     scripts = [
         "/some/config/dir/python_scripts/hello.py",
@@ -291,7 +274,7 @@ def test_reload(hass):
     with patch(
         "homeassistant.components.python_script.os.path.isdir", return_value=True
     ), patch("homeassistant.components.python_script.glob.iglob", return_value=scripts):
-        res = yield from async_setup_component(hass, "python_script", {})
+        res = await async_setup_component(hass, "python_script", {})
 
     assert res
     assert hass.services.has_service("python_script", "hello")
@@ -305,9 +288,7 @@ def test_reload(hass):
     with patch(
         "homeassistant.components.python_script.os.path.isdir", return_value=True
     ), patch("homeassistant.components.python_script.glob.iglob", return_value=scripts):
-        yield from hass.services.async_call(
-            "python_script", "reload", {}, blocking=True
-        )
+        await hass.services.async_call("python_script", "reload", {}, blocking=True)
 
     assert not hass.services.has_service("python_script", "hello")
     assert hass.services.has_service("python_script", "hello2")
@@ -410,8 +391,7 @@ async def test_service_descriptions(hass):
     )
 
 
-@asyncio.coroutine
-def test_sleep_warns_one(hass, caplog):
+async def test_sleep_warns_one(hass, caplog):
     """Test time.sleep warns once."""
     caplog.set_level(logging.WARNING)
     source = """
@@ -421,6 +401,6 @@ time.sleep(5)
 
     with patch("homeassistant.components.python_script.time.sleep"):
         hass.async_add_job(execute, hass, "test.py", source, {})
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert caplog.text.count("time.sleep") == 1


### PR DESCRIPTION
## Description:

Migrate python_script tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
