### PR TITLE
Migrate input_* tests from coroutine to async/await

### DIFF
--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the input_boolean component."""
 # pylint: disable=protected-access
-import asyncio
 import logging
 from unittest.mock import patch
 
@@ -96,8 +95,7 @@ async def test_config_options(hass):
     assert "mdi:work" == state_2.attributes.get(ATTR_ICON)
 
 
-@asyncio.coroutine
-def test_restore_state(hass):
+async def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -111,7 +109,7 @@ def test_restore_state(hass):
     hass.state = CoreState.starting
     mock_component(hass, "recorder")
 
-    yield from async_setup_component(hass, DOMAIN, {DOMAIN: {"b1": None, "b2": None}})
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"b1": None, "b2": None}})
 
     state = hass.states.get("input_boolean.b1")
     assert state
@@ -122,8 +120,7 @@ def test_restore_state(hass):
     assert state.state == "off"
 
 
-@asyncio.coroutine
-def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State("input_boolean.b1", "on"), State("input_boolean.b2", "off"))
@@ -131,7 +128,7 @@ def test_initial_state_overrules_restore_state(hass):
 
     hass.state = CoreState.starting
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {DOMAIN: {"b1": {CONF_INITIAL: False}, "b2": {CONF_INITIAL: True}}},

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -1,6 +1,5 @@
 """Tests for the Input slider component."""
 # pylint: disable=protected-access
-import asyncio
 import datetime
 from unittest.mock import patch
 
@@ -192,10 +191,9 @@ async def test_set_invalid_2(hass):
     assert state.state == initial
 
 
-@asyncio.coroutine
-def test_set_datetime_date(hass):
+async def test_set_datetime_date(hass):
     """Test set_datetime method with only date."""
-    yield from async_setup_component(
+    await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_date": {"has_time": False, "has_date": True}}}
     )
 
@@ -204,7 +202,7 @@ def test_set_datetime_date(hass):
     dt_obj = datetime.datetime(2017, 9, 7, 19, 46)
     date_portion = dt_obj.date()
 
-    yield from async_set_date_and_time(hass, entity_id, dt_obj)
+    await async_set_date_and_time(hass, entity_id, dt_obj)
 
     state = hass.states.get(entity_id)
     assert state.state == str(date_portion)
@@ -215,8 +213,7 @@ def test_set_datetime_date(hass):
     assert state.attributes["timestamp"] == date_dt_obj.timestamp()
 
 
-@asyncio.coroutine
-def test_restore_state(hass):
+async def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -232,7 +229,7 @@ def test_restore_state(hass):
 
     initial = datetime.datetime(2017, 1, 1, 23, 42)
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {
@@ -263,10 +260,9 @@ def test_restore_state(hass):
     assert state_bogus.state == str(initial)
 
 
-@asyncio.coroutine
-def test_default_value(hass):
+async def test_default_value(hass):
     """Test default value if none has been set via inital or restore state."""
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the Input number component."""
 # pylint: disable=protected-access
-import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -171,8 +170,7 @@ async def test_mode(hass):
     assert "slider" == state.attributes["mode"]
 
 
-@asyncio.coroutine
-def test_restore_state(hass):
+async def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State("input_number.b1", "70"), State("input_number.b2", "200"))
@@ -180,7 +178,7 @@ def test_restore_state(hass):
 
     hass.state = CoreState.starting
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {DOMAIN: {"b1": {"min": 0, "max": 100}, "b2": {"min": 10, "max": 100}}},
@@ -195,8 +193,7 @@ def test_restore_state(hass):
     assert float(state.state) == 10
 
 
-@asyncio.coroutine
-def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State("input_number.b1", "70"), State("input_number.b2", "200"))
@@ -204,7 +201,7 @@ def test_initial_state_overrules_restore_state(hass):
 
     hass.state = CoreState.starting
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {
@@ -224,14 +221,11 @@ def test_initial_state_overrules_restore_state(hass):
     assert float(state.state) == 60
 
 
-@asyncio.coroutine
-def test_no_initial_state_and_no_restore_state(hass):
+async def test_no_initial_state_and_no_restore_state(hass):
     """Ensure that entity is create without initial and restore feature."""
     hass.state = CoreState.starting
 
-    yield from async_setup_component(
-        hass, DOMAIN, {DOMAIN: {"b1": {"min": 0, "max": 100}}}
-    )
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"b1": {"min": 0, "max": 100}}})
 
     state = hass.states.get("input_number.b1")
     assert state

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the Input select component."""
 # pylint: disable=protected-access
-import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -249,8 +248,7 @@ async def test_set_options_service(hass):
     assert "test2" == state.state
 
 
-@asyncio.coroutine
-def test_restore_state(hass):
+async def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -262,9 +260,7 @@ def test_restore_state(hass):
 
     options = {"options": ["first option", "middle option", "last option"]}
 
-    yield from async_setup_component(
-        hass, DOMAIN, {DOMAIN: {"s1": options, "s2": options}}
-    )
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"s1": options, "s2": options}})
 
     state = hass.states.get("input_select.s1")
     assert state
@@ -275,8 +271,7 @@ def test_restore_state(hass):
     assert state.state == "first option"
 
 
-@asyncio.coroutine
-def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -291,9 +286,7 @@ def test_initial_state_overrules_restore_state(hass):
         "initial": "middle option",
     }
 
-    yield from async_setup_component(
-        hass, DOMAIN, {DOMAIN: {"s1": options, "s2": options}}
-    )
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"s1": options, "s2": options}})
 
     state = hass.states.get("input_select.s1")
     assert state

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the Input text component."""
 # pylint: disable=protected-access
-import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -122,8 +121,7 @@ async def test_restore_state(hass):
     assert str(state.state) == "unknown"
 
 
-@asyncio.coroutine
-def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -132,7 +130,7 @@ def test_initial_state_overrules_restore_state(hass):
 
     hass.state = CoreState.starting
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         DOMAIN,
         {
@@ -152,14 +150,11 @@ def test_initial_state_overrules_restore_state(hass):
     assert str(state.state) == "test"
 
 
-@asyncio.coroutine
-def test_no_initial_state_and_no_restore_state(hass):
+async def test_no_initial_state_and_no_restore_state(hass):
     """Ensure that entity is create without initial and restore feature."""
     hass.state = CoreState.starting
 
-    yield from async_setup_component(
-        hass, DOMAIN, {DOMAIN: {"b1": {"min": 0, "max": 100}}}
-    )
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"b1": {"min": 0, "max": 100}}})
 
     state = hass.states.get("input_text.b1")
     assert state


### PR DESCRIPTION
## Description:

Migrate input_* tests from coroutine to async/await:

- input_boolean
- input_datetime
- input_number
- input_select
- input_text

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
