### PR TITLE
Config Flow and Entity registry support for Monoprice

### DIFF
--- a/homeassistant/components/monoprice/__init__.py
+++ b/homeassistant/components/monoprice/__init__.py
@@ -1,1 +1,45 @@
-"""The monoprice component."""
+"""The Monoprice 6-Zone Amplifier integration."""
+import asyncio
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+# TODO List the platforms that you want to support.
+# For your initial PR, limit it to 1 platform.
+PLATFORMS = ["media_player"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Monoprice 6-Zone Amplifier component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Monoprice 6-Zone Amplifier from a config entry."""
+    # TODO Store an API object for your platforms to access
+    # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/monoprice/__init__.py
+++ b/homeassistant/components/monoprice/__init__.py
@@ -4,10 +4,6 @@ import asyncio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-
-# TODO List the platforms that you want to support.
-# For your initial PR, limit it to 1 platform.
 PLATFORMS = ["media_player"]
 
 
@@ -18,9 +14,6 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Monoprice 6-Zone Amplifier from a config entry."""
-    # TODO Store an API object for your platforms to access
-    # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
-
     for component in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
@@ -39,7 +32,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             ]
         )
     )
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/monoprice/config_flow.py
+++ b/homeassistant/components/monoprice/config_flow.py
@@ -66,7 +66,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Monoprice 6-Zone Amplifier."""
 
     VERSION = 1
-    # TODO pick one of the available connection classes in homeassistant/config_entries.py
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/monoprice/config_flow.py
+++ b/homeassistant/components/monoprice/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Monoprice 6-Zone Amplifier integration."""
 import logging
 
-from pymonoprice import get_monoprice
+from pymonoprice import get_async_monoprice
 from serial import SerialException
 import voluptuous as vol
 
@@ -40,7 +40,7 @@ async def validate_input(hass: core.HomeAssistant, data):
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
     try:
-        await hass.async_add_executor_job(get_monoprice, data[CONF_PORT])
+        await get_async_monoprice(data[CONF_PORT], hass.loop)
     except SerialException:
         _LOGGER.error("Error connecting to Monoprice controller")
         raise CannotConnect

--- a/homeassistant/components/monoprice/config_flow.py
+++ b/homeassistant/components/monoprice/config_flow.py
@@ -1,0 +1,96 @@
+"""Config flow for Monoprice 6-Zone Amplifier integration."""
+import logging
+
+from pymonoprice import get_monoprice
+from serial import SerialException
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_PORT
+
+from .const import (
+    CONF_SOURCE_1,
+    CONF_SOURCE_2,
+    CONF_SOURCE_3,
+    CONF_SOURCE_4,
+    CONF_SOURCE_5,
+    CONF_SOURCE_6,
+    CONF_SOURCES,
+)
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PORT): str,
+        vol.Optional(CONF_SOURCE_1): str,
+        vol.Optional(CONF_SOURCE_2): str,
+        vol.Optional(CONF_SOURCE_3): str,
+        vol.Optional(CONF_SOURCE_4): str,
+        vol.Optional(CONF_SOURCE_5): str,
+        vol.Optional(CONF_SOURCE_6): str,
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    try:
+        await hass.async_add_executor_job(get_monoprice, data[CONF_PORT])
+    except SerialException:
+        _LOGGER.error("Error connecting to Monoprice controller")
+        raise CannotConnect
+
+    sources_config = {
+        1: data.get(CONF_SOURCE_1),
+        2: data.get(CONF_SOURCE_2),
+        3: data.get(CONF_SOURCE_3),
+        4: data.get(CONF_SOURCE_4),
+        5: data.get(CONF_SOURCE_5),
+        6: data.get(CONF_SOURCE_6),
+    }
+    sources = {
+        index: name.strip()
+        for index, name in sources_config.items()
+        if (name is not None and name.strip() != "")
+    }
+    # Return info that you want to store in the config entry.
+    return {CONF_PORT: data[CONF_PORT], CONF_SOURCES: sources}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Monoprice 6-Zone Amplifier."""
+
+    VERSION = 1
+    # TODO pick one of the available connection classes in homeassistant/config_entries.py
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+
+                return self.async_create_entry(title=user_input[CONF_PORT], data=info)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/monoprice/const.py
+++ b/homeassistant/components/monoprice/const.py
@@ -1,5 +1,15 @@
 """Constants for the Monoprice 6-Zone Amplifier Media Player component."""
 
 DOMAIN = "monoprice"
+
+CONF_SOURCES = "sources"
+
+CONF_SOURCE_1 = "source_1"
+CONF_SOURCE_2 = "source_2"
+CONF_SOURCE_3 = "source_3"
+CONF_SOURCE_4 = "source_4"
+CONF_SOURCE_5 = "source_5"
+CONF_SOURCE_6 = "source_6"
+
 SERVICE_SNAPSHOT = "snapshot"
 SERVICE_RESTORE = "restore"

--- a/homeassistant/components/monoprice/manifest.json
+++ b/homeassistant/components/monoprice/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/monoprice",
   "requirements": ["pymonoprice==0.3"],
   "dependencies": [],
-  "codeowners": ["@etsinko"]
+  "codeowners": ["@etsinko"],
+  "config_flow": true
 }

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -52,16 +52,16 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     sources = _get_sources(config_entry.data.get(CONF_SOURCES))
 
-    hass.data[DOMAIN] = []
+    devices = []
     for i in range(1, 4):
         for j in range(1, 7):
             zone_id = (i * 10) + j
             _LOGGER.info("Adding zone %d for port %s", zone_id, port)
-            hass.data[DOMAIN].append(
+            devices.append(
                 MonopriceZone(monoprice, sources, config_entry.entry_id, zone_id)
             )
 
-    async_add_devices(hass.data[DOMAIN], True)
+    async_add_devices(devices, True)
 
     platform = entity_platform.current_platform.get()
 
@@ -133,10 +133,6 @@ class MonopriceZone(MediaPlayerDevice):
         else:
             self._source = None
         return True
-
-    async def async_will_remove_from_hass(self):
-        """Remove zone from list."""
-        self.hass.data[DOMAIN].remove(self)
 
     @property
     def entity_registry_enabled_default(self):

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -31,9 +31,6 @@ SUPPORT_MONOPRICE = (
 )
 
 
-DATA_MONOPRICE = "monoprice"
-
-
 MEDIA_PLAYER_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.comp_entity_ids})
 
 
@@ -59,16 +56,16 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     sources = _get_sources(config_entry.data.get(CONF_SOURCES))
 
-    hass.data[DATA_MONOPRICE] = []
+    hass.data[DOMAIN] = []
     for i in range(1, 4):
         for j in range(1, 7):
             zone_id = (i * 10) + j
             _LOGGER.info("Adding zone %d for port %s", zone_id, port)
-            hass.data[DATA_MONOPRICE].append(
+            hass.data[DOMAIN].append(
                 MonopriceZone(monoprice, sources, config_entry.entry_id, zone_id)
             )
 
-    async_add_devices(hass.data[DATA_MONOPRICE], True)
+    async_add_devices(hass.data[DOMAIN], True)
 
     def service_handle(service):
         """Handle for services."""
@@ -76,12 +73,10 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
         if entity_ids:
             devices = [
-                device
-                for device in hass.data[DATA_MONOPRICE]
-                if device.entity_id in entity_ids
+                device for device in hass.data[DOMAIN] if device.entity_id in entity_ids
             ]
         else:
-            devices = hass.data[DATA_MONOPRICE]
+            devices = hass.data[DOMAIN]
 
         for device in devices:
             if service.service == SERVICE_SNAPSHOT:
@@ -134,6 +129,10 @@ class MonopriceZone(MediaPlayerDevice):
         else:
             self._source = None
         return True
+
+    async def async_will_remove_from_hass(self):
+        """Remove zone from list."""
+        self.hass.data[DOMAIN].remove(self)
 
     @property
     def entity_registry_enabled_default(self):

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -157,6 +157,11 @@ class MonopriceZone(MediaPlayerDevice):
         return True
 
     @property
+    def unique_id(self):
+        """Return unique ID for this device."""
+        return self._zone_id
+
+    @property
     def name(self):
         """Return the name of the zone."""
         return self._name

--- a/homeassistant/components/monoprice/strings.json
+++ b/homeassistant/components/monoprice/strings.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "title": "Monoprice 6-Zone Amplifier",
+    "step": {
+      "user": {
+        "title": "Connect to the device",
+        "data": {
+          "port": "Serial port",
+          "source_1": "Name of source #1",
+          "source_2": "Name of source #2",
+          "source_3": "Name of source #3",
+          "source_4": "Name of source #4",
+          "source_5": "Name of source #5",
+          "source_6": "Name of source #6"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -63,6 +63,7 @@ FLOWS = [
     "mikrotik",
     "minecraft_server",
     "mobile_app",
+    "monoprice",
     "mqtt",
     "neato",
     "nest",

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -1,0 +1,90 @@
+"""Test the Monoprice 6-Zone Amplifier config flow."""
+from asynctest import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.monoprice.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.monoprice.const import DOMAIN
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.monoprice.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.monoprice.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.monoprice.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.monoprice.config_flow.PlaceholderHub.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.monoprice.config_flow.PlaceholderHub.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -68,3 +68,21 @@ async def test_form_cannot_connect(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_generic_exception(hass):
+    """Test we handle cannot generic exception."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.monoprice.config_flow.get_monoprice",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], CONFIG
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "unknown"}

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.monoprice.config_flow.get_monoprice",
+        "homeassistant.components.monoprice.config_flow.get_async_monoprice",
         return_value=True,
     ), patch(
         "homeassistant.components.monoprice.async_setup", return_value=True
@@ -59,7 +59,7 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.monoprice.config_flow.get_monoprice",
+        "homeassistant.components.monoprice.config_flow.get_async_monoprice",
         side_effect=SerialException,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -77,7 +77,7 @@ async def test_generic_exception(hass):
     )
 
     with patch(
-        "homeassistant.components.monoprice.config_flow.get_monoprice",
+        "homeassistant.components.monoprice.config_flow.get_async_monoprice",
         side_effect=Exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -339,6 +339,10 @@ class TestMonopriceMediaPlayer(unittest.TestCase):
         """Test name property."""
         assert "Zone name" == self.media_player.name
 
+    def test_unique_id(self):
+        """Test unique_id property."""
+        assert 12 == self.media_player.unique_id
+
     def test_state(self):
         """Test state property."""
         assert self.media_player.state is None

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -1,12 +1,14 @@
 """The tests for Monoprice Media player platform."""
 from collections import defaultdict
-import unittest
-from unittest import mock
 
-import pytest
-import voluptuous as vol
+from asynctest import patch
 
 from homeassistant.components.media_player.const import (
+    ATTR_INPUT_SOURCE,
+    ATTR_INPUT_SOURCE_LIST,
+    ATTR_MEDIA_VOLUME_LEVEL,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOURCE,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
@@ -15,18 +17,27 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.components.monoprice.const import (
+    CONF_SOURCES,
     DOMAIN,
     SERVICE_RESTORE,
     SERVICE_SNAPSHOT,
 )
-from homeassistant.components.monoprice.media_player import (
-    DATA_MONOPRICE,
-    PLATFORM_SCHEMA,
-    setup_platform,
+from homeassistant.const import (
+    CONF_PORT,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
 )
-from homeassistant.const import STATE_OFF, STATE_ON
 
-import tests.common
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG = {CONF_PORT: "fake port", CONF_SOURCES: {"1": "one", "3": "three"}}
+
+ZONE_1_ID = "media_player.zone_11"
+ZONE_2_ID = "media_player.zone_12"
 
 
 class AttrDict(dict):
@@ -77,444 +88,255 @@ class MockMonoprice:
         self.zones[zone.zone] = AttrDict(zone)
 
 
-class TestMonopriceSchema(unittest.TestCase):
-    """Test Monoprice schema."""
-
-    def test_valid_schema(self):
-        """Test valid schema."""
-        valid_schema = {
-            "platform": "monoprice",
-            "port": "/dev/ttyUSB0",
-            "entity_namespace": "namespace",
-            "zones": {
-                11: {"name": "a"},
-                12: {"name": "a"},
-                13: {"name": "a"},
-                14: {"name": "a"},
-                15: {"name": "a"},
-                16: {"name": "a"},
-                21: {"name": "a"},
-                22: {"name": "a"},
-                23: {"name": "a"},
-                24: {"name": "a"},
-                25: {"name": "a"},
-                26: {"name": "a"},
-                31: {"name": "a"},
-                32: {"name": "a"},
-                33: {"name": "a"},
-                34: {"name": "a"},
-                35: {"name": "a"},
-                36: {"name": "a"},
-            },
-            "sources": {
-                1: {"name": "a"},
-                2: {"name": "a"},
-                3: {"name": "a"},
-                4: {"name": "a"},
-                5: {"name": "a"},
-                6: {"name": "a"},
-            },
-        }
-        PLATFORM_SCHEMA(valid_schema)
-
-    def test_invalid_schemas(self):
-        """Test invalid schemas."""
-        schemas = (
-            {},  # Empty
-            None,  # None
-            # Missing port
-            {
-                "platform": "monoprice",
-                "entity_namespace": "namespace",
-                "name": "Name",
-                "zones": {11: {"name": "a"}},
-                "sources": {1: {"name": "b"}},
-            },
-            # Missing namespace
-            {
-                "platform": "monoprice",
-                "name": "Name",
-                "zones": {11: {"name": "a"}},
-                "sources": {1: {"name": "b"}},
-            },
-            # Invalid zone number
-            {
-                "platform": "monoprice",
-                "port": "aaa",
-                "entity_namespace": "namespace",
-                "name": "Name",
-                "zones": {10: {"name": "a"}},
-                "sources": {1: {"name": "b"}},
-            },
-            # Invalid source number
-            {
-                "platform": "monoprice",
-                "port": "aaa",
-                "entity_namespace": "namespace",
-                "name": "Name",
-                "zones": {11: {"name": "a"}},
-                "sources": {0: {"name": "b"}},
-            },
-            # Zone missing name
-            {
-                "platform": "monoprice",
-                "port": "aaa",
-                "entity_namespace": "namespace",
-                "name": "Name",
-                "zones": {11: {}},
-                "sources": {1: {"name": "b"}},
-            },
-            # Source missing name
-            {
-                "platform": "monoprice",
-                "port": "aaa",
-                "entity_namespace": "namespace",
-                "name": "Name",
-                "zones": {11: {"name": "a"}},
-                "sources": {1: {}},
-            },
-        )
-        for value in schemas:
-            with pytest.raises(vol.MultipleInvalid):
-                PLATFORM_SCHEMA(value)
+async def _setup_monoprice(hass, monoprice):
+    with patch(
+        "homeassistant.components.monoprice.media_player.get_monoprice",
+        new=lambda *a: monoprice,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        # setup_component(self.hass, DOMAIN, MOCK_CONFIG)
+        # self.hass.async_block_till_done()
+        await hass.async_block_till_done()
 
 
-class TestMonopriceMediaPlayer(unittest.TestCase):
-    """Test the media_player module."""
+async def _call_media_player_service(hass, name, data):
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN, name, service_data=data, blocking=True
+    )
 
-    def setUp(self):
-        """Set up the test case."""
-        self.monoprice = MockMonoprice()
-        self.hass = tests.common.get_test_home_assistant()
-        self.hass.start()
-        # Note, source dictionary is unsorted!
-        with mock.patch(
-            "homeassistant.components.monoprice.media_player.get_monoprice",
-            new=lambda *a: self.monoprice,
-        ):
-            setup_platform(
-                self.hass,
-                {
-                    "platform": "monoprice",
-                    "port": "/dev/ttyS0",
-                    "entity_namespace": "namespace",
-                    "name": "Name",
-                    "zones": {12: {"name": "Zone name"}},
-                    "sources": {
-                        1: {"name": "one"},
-                        3: {"name": "three"},
-                        2: {"name": "two"},
-                    },
-                },
-                lambda *args, **kwargs: None,
-                {},
-            )
-            self.hass.block_till_done()
-        self.media_player = self.hass.data[DATA_MONOPRICE][0]
-        self.media_player.hass = self.hass
-        self.media_player.entity_id = "media_player.zone_1"
 
-    def tearDown(self):
-        """Tear down the test case."""
-        self.hass.stop()
+async def _call_homeassistant_service(hass, name, data):
+    await hass.services.async_call(
+        "homeassistant", name, service_data=data, blocking=True
+    )
 
-    def test_setup_platform(self, *args):
-        """Test setting up platform."""
-        # Two services must be registered
-        assert self.hass.services.has_service(DOMAIN, SERVICE_RESTORE)
-        assert self.hass.services.has_service(DOMAIN, SERVICE_SNAPSHOT)
-        assert len(self.hass.data[DATA_MONOPRICE]) == 1
-        assert self.hass.data[DATA_MONOPRICE][0].name == "Zone name"
 
-    def test_service_calls_with_entity_id(self):
-        """Test snapshot save/restore service calls."""
-        self.media_player.update()
-        assert "Zone name" == self.media_player.name
-        assert STATE_ON == self.media_player.state
-        assert 0.0 == self.media_player.volume_level, 0.0001
-        assert self.media_player.is_volume_muted
-        assert "one" == self.media_player.source
+async def _call_monoprice_service(hass, name, data):
+    await hass.services.async_call(DOMAIN, name, service_data=data, blocking=True)
 
-        # Saving default values
-        self.hass.services.call(
-            DOMAIN,
-            SERVICE_SNAPSHOT,
-            {"entity_id": "media_player.zone_1"},
-            blocking=True,
-        )
-        # self.hass.block_till_done()
 
-        # Changing media player to new state
-        self.media_player.set_volume_level(1)
-        self.media_player.select_source("two")
-        self.media_player.mute_volume(False)
-        self.media_player.turn_off()
+async def test_service_calls_with_entity_id(hass):
+    """Test snapshot save/restore service calls."""
+    await _setup_monoprice(hass, MockMonoprice())
 
-        # Checking that values were indeed changed
-        self.media_player.update()
-        assert "Zone name" == self.media_player.name
-        assert STATE_OFF == self.media_player.state
-        assert 1.0 == self.media_player.volume_level, 0.0001
-        assert not self.media_player.is_volume_muted
-        assert "two" == self.media_player.source
+    # Changing media player to new state
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 0.0}
+    )
+    await _call_media_player_service(
+        hass, SERVICE_SELECT_SOURCE, {"entity_id": ZONE_1_ID, "source": "one"}
+    )
 
-        # Restoring wrong media player to its previous state
-        # Nothing should be done
-        self.hass.services.call(
-            DOMAIN, SERVICE_RESTORE, {"entity_id": "media.not_existing"}, blocking=True
-        )
-        # self.hass.block_till_done()
+    # Saving existing values
+    await _call_monoprice_service(hass, SERVICE_SNAPSHOT, {"entity_id": ZONE_1_ID})
 
-        # Checking that values were not (!) restored
-        self.media_player.update()
-        assert "Zone name" == self.media_player.name
-        assert STATE_OFF == self.media_player.state
-        assert 1.0 == self.media_player.volume_level, 0.0001
-        assert not self.media_player.is_volume_muted
-        assert "two" == self.media_player.source
+    # Changing media player to new state
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 1.0}
+    )
+    await _call_media_player_service(
+        hass, SERVICE_SELECT_SOURCE, {"entity_id": ZONE_1_ID, "source": "three"}
+    )
 
-        # Restoring media player to its previous state
-        self.hass.services.call(
-            DOMAIN, SERVICE_RESTORE, {"entity_id": "media_player.zone_1"}, blocking=True
-        )
-        self.hass.block_till_done()
+    # Restoring other media player to its previous state
+    # The zone should not be restored
+    await _call_monoprice_service(hass, SERVICE_RESTORE, {"entity_id": ZONE_2_ID})
+    await hass.async_block_till_done()
 
-        # Checking that values were restored
-        assert "Zone name" == self.media_player.name
-        assert STATE_ON == self.media_player.state
-        assert 0.0 == self.media_player.volume_level, 0.0001
-        assert self.media_player.is_volume_muted
-        assert "one" == self.media_player.source
+    # Checking that values were not (!) restored
+    state = hass.states.get(ZONE_1_ID)
 
-    def test_service_calls_without_entity_id(self):
-        """Test snapshot save/restore service calls."""
-        self.media_player.update()
-        assert "Zone name" == self.media_player.name
-        assert STATE_ON == self.media_player.state
-        assert 0.0 == self.media_player.volume_level, 0.0001
-        assert self.media_player.is_volume_muted
-        assert "one" == self.media_player.source
+    assert 1.0 == state.attributes[ATTR_MEDIA_VOLUME_LEVEL]
+    assert "three" == state.attributes[ATTR_INPUT_SOURCE]
 
-        # Restoring media player
-        # since there is no snapshot, nothing should be done
-        self.hass.services.call(DOMAIN, SERVICE_RESTORE, blocking=True)
-        self.hass.block_till_done()
-        self.media_player.update()
-        assert "Zone name" == self.media_player.name
-        assert STATE_ON == self.media_player.state
-        assert 0.0 == self.media_player.volume_level, 0.0001
-        assert self.media_player.is_volume_muted
-        assert "one" == self.media_player.source
+    # Restoring media player to its previous state
+    await _call_monoprice_service(hass, SERVICE_RESTORE, {"entity_id": ZONE_1_ID})
+    await hass.async_block_till_done()
 
-        # Saving default values
-        self.hass.services.call(DOMAIN, SERVICE_SNAPSHOT, blocking=True)
-        self.hass.block_till_done()
+    state = hass.states.get(ZONE_1_ID)
 
-        # Changing media player to new state
-        self.media_player.set_volume_level(1)
-        self.media_player.select_source("two")
-        self.media_player.mute_volume(False)
-        self.media_player.turn_off()
+    assert 0.0 == state.attributes[ATTR_MEDIA_VOLUME_LEVEL]
+    assert "one" == state.attributes[ATTR_INPUT_SOURCE]
 
-        # Checking that values were indeed changed
-        self.media_player.update()
-        assert "Zone name" == self.media_player.name
-        assert STATE_OFF == self.media_player.state
-        assert 1.0 == self.media_player.volume_level, 0.0001
-        assert not self.media_player.is_volume_muted
-        assert "two" == self.media_player.source
 
-        # Restoring media player to its previous state
-        self.hass.services.call(DOMAIN, SERVICE_RESTORE, blocking=True)
-        self.hass.block_till_done()
+async def test_service_calls_without_entity_id(hass):
+    """Test snapshot save/restore service calls."""
+    await _setup_monoprice(hass, MockMonoprice())
 
-        # Checking that values were restored
-        assert "Zone name" == self.media_player.name
-        assert STATE_ON == self.media_player.state
-        assert 0.0 == self.media_player.volume_level, 0.0001
-        assert self.media_player.is_volume_muted
-        assert "one" == self.media_player.source
+    # Changing media player to new state
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 0.0}
+    )
+    await _call_media_player_service(
+        hass, SERVICE_SELECT_SOURCE, {"entity_id": ZONE_1_ID, "source": "one"}
+    )
 
-    def test_update(self):
-        """Test updating values from monoprice."""
-        assert self.media_player.state is None
-        assert self.media_player.volume_level is None
-        assert self.media_player.is_volume_muted is None
-        assert self.media_player.source is None
+    # Saving existing values
+    await _call_monoprice_service(hass, SERVICE_SNAPSHOT, {})
 
-        self.media_player.update()
+    # Changing media player to new state
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 1.0}
+    )
+    await _call_media_player_service(
+        hass, SERVICE_SELECT_SOURCE, {"entity_id": ZONE_1_ID, "source": "three"}
+    )
 
-        assert STATE_ON == self.media_player.state
-        assert 0.0 == self.media_player.volume_level, 0.0001
-        assert self.media_player.is_volume_muted
-        assert "one" == self.media_player.source
+    # Restoring media player to its previous state
+    await _call_monoprice_service(hass, SERVICE_RESTORE, {})
+    await hass.async_block_till_done()
 
-    def test_name(self):
-        """Test name property."""
-        assert "Zone name" == self.media_player.name
+    state = hass.states.get(ZONE_1_ID)
 
-    def test_unique_id(self):
-        """Test unique_id property."""
-        assert "namespace_12" == self.media_player.unique_id
+    assert 0.0 == state.attributes[ATTR_MEDIA_VOLUME_LEVEL]
+    assert "one" == state.attributes[ATTR_INPUT_SOURCE]
 
-    def test_state(self):
-        """Test state property."""
-        assert self.media_player.state is None
 
-        self.media_player.update()
-        assert STATE_ON == self.media_player.state
+async def test_restore_without_snapshort(hass):
+    """Test restore when snapshot wasn't called."""
+    await _setup_monoprice(hass, MockMonoprice())
 
-        self.monoprice.zones[12].power = False
-        self.media_player.update()
-        assert STATE_OFF == self.media_player.state
+    with patch.object(MockMonoprice, "restore_zone") as method_call:
+        await _call_monoprice_service(hass, SERVICE_RESTORE, {"entity_id": ZONE_1_ID})
+        await hass.async_block_till_done()
 
-    def test_volume_level(self):
-        """Test volume level property."""
-        assert self.media_player.volume_level is None
-        self.media_player.update()
-        assert 0.0 == self.media_player.volume_level, 0.0001
+        assert not method_call.called
 
-        self.monoprice.zones[12].volume = 38
-        self.media_player.update()
-        assert 1.0 == self.media_player.volume_level, 0.0001
 
-        self.monoprice.zones[12].volume = 19
-        self.media_player.update()
-        assert 0.5 == self.media_player.volume_level, 0.0001
+async def test_update(hass):
+    """Test updating values from monoprice."""
+    """Test snapshot save/restore service calls."""
+    monoprice = MockMonoprice()
+    await _setup_monoprice(hass, monoprice)
 
-    def test_is_volume_muted(self):
-        """Test volume muted property."""
-        assert self.media_player.is_volume_muted is None
+    # Changing media player to new state
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 0.0}
+    )
+    await _call_media_player_service(
+        hass, SERVICE_SELECT_SOURCE, {"entity_id": ZONE_1_ID, "source": "one"}
+    )
 
-        self.media_player.update()
-        assert self.media_player.is_volume_muted
+    monoprice.set_source(11, 3)
+    monoprice.set_volume(11, 38)
 
-        self.monoprice.zones[12].mute = False
-        self.media_player.update()
-        assert not self.media_player.is_volume_muted
+    await _call_homeassistant_service(hass, "update_entity", {"entity_id": ZONE_1_ID})
+    await hass.async_block_till_done()
 
-    def test_supported_features(self):
-        """Test supported features property."""
-        assert (
-            SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET
-            | SUPPORT_VOLUME_STEP
-            | SUPPORT_TURN_ON
-            | SUPPORT_TURN_OFF
-            | SUPPORT_SELECT_SOURCE
-            == self.media_player.supported_features
-        )
+    state = hass.states.get(ZONE_1_ID)
 
-    def test_source(self):
-        """Test source property."""
-        assert self.media_player.source is None
-        self.media_player.update()
-        assert "one" == self.media_player.source
+    assert 1.0 == state.attributes[ATTR_MEDIA_VOLUME_LEVEL]
+    assert "three" == state.attributes[ATTR_INPUT_SOURCE]
 
-    def test_media_title(self):
-        """Test media title property."""
-        assert self.media_player.media_title is None
-        self.media_player.update()
-        assert "one" == self.media_player.media_title
 
-    def test_source_list(self):
-        """Test source list property."""
-        # Note, the list is sorted!
-        assert ["one", "two", "three"] == self.media_player.source_list
+async def test_supported_features(hass):
+    """Test supported features property."""
+    await _setup_monoprice(hass, MockMonoprice())
 
-    def test_select_source(self):
-        """Test source selection methods."""
-        self.media_player.update()
+    state = hass.states.get(ZONE_1_ID)
+    assert (
+        SUPPORT_VOLUME_MUTE
+        | SUPPORT_VOLUME_SET
+        | SUPPORT_VOLUME_STEP
+        | SUPPORT_TURN_ON
+        | SUPPORT_TURN_OFF
+        | SUPPORT_SELECT_SOURCE
+        == state.attributes["supported_features"]
+    )
 
-        assert "one" == self.media_player.source
 
-        self.media_player.select_source("two")
-        assert 2 == self.monoprice.zones[12].source
-        self.media_player.update()
-        assert "two" == self.media_player.source
+async def test_source_list(hass):
+    """Test source list property."""
+    await _setup_monoprice(hass, MockMonoprice())
 
-        # Trying to set unknown source
-        self.media_player.select_source("no name")
-        assert 2 == self.monoprice.zones[12].source
-        self.media_player.update()
-        assert "two" == self.media_player.source
+    state = hass.states.get(ZONE_1_ID)
+    # Note, the list is sorted!
+    assert ["one", "three"] == state.attributes[ATTR_INPUT_SOURCE_LIST]
 
-    def test_turn_on(self):
-        """Test turning on the zone."""
-        self.monoprice.zones[12].power = False
-        self.media_player.update()
-        assert STATE_OFF == self.media_player.state
 
-        self.media_player.turn_on()
-        assert self.monoprice.zones[12].power
-        self.media_player.update()
-        assert STATE_ON == self.media_player.state
+async def test_select_source(hass):
+    """Test source selection methods."""
+    monoprice = MockMonoprice()
+    await _setup_monoprice(hass, monoprice)
 
-    def test_turn_off(self):
-        """Test turning off the zone."""
-        self.monoprice.zones[12].power = True
-        self.media_player.update()
-        assert STATE_ON == self.media_player.state
+    await _call_media_player_service(
+        hass,
+        SERVICE_SELECT_SOURCE,
+        {"entity_id": ZONE_1_ID, ATTR_INPUT_SOURCE: "three"},
+    )
+    assert 3 == monoprice.zones[11].source
 
-        self.media_player.turn_off()
-        assert not self.monoprice.zones[12].power
-        self.media_player.update()
-        assert STATE_OFF == self.media_player.state
+    # Trying to set unknown source
+    await _call_media_player_service(
+        hass,
+        SERVICE_SELECT_SOURCE,
+        {"entity_id": ZONE_1_ID, ATTR_INPUT_SOURCE: "no name"},
+    )
+    assert 3 == monoprice.zones[11].source
 
-    def test_mute_volume(self):
-        """Test mute functionality."""
-        self.monoprice.zones[12].mute = True
-        self.media_player.update()
-        assert self.media_player.is_volume_muted
 
-        self.media_player.mute_volume(False)
-        assert not self.monoprice.zones[12].mute
-        self.media_player.update()
-        assert not self.media_player.is_volume_muted
+async def test_turn_on_off(hass):
+    """Test turning on the zone."""
+    monoprice = MockMonoprice()
+    await _setup_monoprice(hass, monoprice)
 
-        self.media_player.mute_volume(True)
-        assert self.monoprice.zones[12].mute
-        self.media_player.update()
-        assert self.media_player.is_volume_muted
+    await _call_media_player_service(hass, SERVICE_TURN_OFF, {"entity_id": ZONE_1_ID})
+    assert not monoprice.zones[11].power
 
-    def test_set_volume_level(self):
-        """Test set volume level."""
-        self.media_player.set_volume_level(1.0)
-        assert 38 == self.monoprice.zones[12].volume
-        assert isinstance(self.monoprice.zones[12].volume, int)
+    await _call_media_player_service(hass, SERVICE_TURN_ON, {"entity_id": ZONE_1_ID})
+    assert monoprice.zones[11].power
 
-        self.media_player.set_volume_level(0.0)
-        assert 0 == self.monoprice.zones[12].volume
-        assert isinstance(self.monoprice.zones[12].volume, int)
 
-        self.media_player.set_volume_level(0.5)
-        assert 19 == self.monoprice.zones[12].volume
-        assert isinstance(self.monoprice.zones[12].volume, int)
+async def test_mute_volume(hass):
+    """Test mute functionality."""
+    monoprice = MockMonoprice()
+    await _setup_monoprice(hass, monoprice)
 
-    def test_volume_up(self):
-        """Test increasing volume by one."""
-        self.monoprice.zones[12].volume = 37
-        self.media_player.update()
-        self.media_player.volume_up()
-        assert 38 == self.monoprice.zones[12].volume
-        assert isinstance(self.monoprice.zones[12].volume, int)
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 0.5}
+    )
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_MUTE, {"entity_id": ZONE_1_ID, "is_volume_muted": False}
+    )
+    assert not monoprice.zones[11].mute
 
-        # Try to raise value beyond max
-        self.media_player.update()
-        self.media_player.volume_up()
-        assert 38 == self.monoprice.zones[12].volume
-        assert isinstance(self.monoprice.zones[12].volume, int)
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_MUTE, {"entity_id": ZONE_1_ID, "is_volume_muted": True}
+    )
+    assert monoprice.zones[11].mute
 
-    def test_volume_down(self):
-        """Test decreasing volume by one."""
-        self.monoprice.zones[12].volume = 1
-        self.media_player.update()
-        self.media_player.volume_down()
-        assert 0 == self.monoprice.zones[12].volume
-        assert isinstance(self.monoprice.zones[12].volume, int)
 
-        # Try to lower value beyond minimum
-        self.media_player.update()
-        self.media_player.volume_down()
-        assert 0 == self.monoprice.zones[12].volume
-        assert isinstance(self.monoprice.zones[12].volume, int)
+async def test_volume_up_down(hass):
+    """Test increasing volume by one."""
+    monoprice = MockMonoprice()
+    await _setup_monoprice(hass, monoprice)
+
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 0.0}
+    )
+    assert 0 == monoprice.zones[11].volume
+
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_DOWN, {"entity_id": ZONE_1_ID}
+    )
+    # should not go below zero
+    assert 0 == monoprice.zones[11].volume
+
+    await _call_media_player_service(hass, SERVICE_VOLUME_UP, {"entity_id": ZONE_1_ID})
+    assert 1 == monoprice.zones[11].volume
+
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_SET, {"entity_id": ZONE_1_ID, "volume_level": 1.0}
+    )
+    assert 38 == monoprice.zones[11].volume
+
+    await _call_media_player_service(hass, SERVICE_VOLUME_UP, {"entity_id": ZONE_1_ID})
+    # should not go above 38
+    assert 38 == monoprice.zones[11].volume
+
+    await _call_media_player_service(
+        hass, SERVICE_VOLUME_DOWN, {"entity_id": ZONE_1_ID}
+    )
+    assert 37 == monoprice.zones[11].volume

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -85,6 +85,7 @@ class TestMonopriceSchema(unittest.TestCase):
         valid_schema = {
             "platform": "monoprice",
             "port": "/dev/ttyUSB0",
+            "entity_namespace": "namespace",
             "zones": {
                 11: {"name": "a"},
                 12: {"name": "a"},
@@ -124,6 +125,14 @@ class TestMonopriceSchema(unittest.TestCase):
             # Missing port
             {
                 "platform": "monoprice",
+                "entity_namespace": "namespace",
+                "name": "Name",
+                "zones": {11: {"name": "a"}},
+                "sources": {1: {"name": "b"}},
+            },
+            # Missing namespace
+            {
+                "platform": "monoprice",
                 "name": "Name",
                 "zones": {11: {"name": "a"}},
                 "sources": {1: {"name": "b"}},
@@ -132,6 +141,7 @@ class TestMonopriceSchema(unittest.TestCase):
             {
                 "platform": "monoprice",
                 "port": "aaa",
+                "entity_namespace": "namespace",
                 "name": "Name",
                 "zones": {10: {"name": "a"}},
                 "sources": {1: {"name": "b"}},
@@ -140,6 +150,7 @@ class TestMonopriceSchema(unittest.TestCase):
             {
                 "platform": "monoprice",
                 "port": "aaa",
+                "entity_namespace": "namespace",
                 "name": "Name",
                 "zones": {11: {"name": "a"}},
                 "sources": {0: {"name": "b"}},
@@ -148,6 +159,7 @@ class TestMonopriceSchema(unittest.TestCase):
             {
                 "platform": "monoprice",
                 "port": "aaa",
+                "entity_namespace": "namespace",
                 "name": "Name",
                 "zones": {11: {}},
                 "sources": {1: {"name": "b"}},
@@ -156,6 +168,7 @@ class TestMonopriceSchema(unittest.TestCase):
             {
                 "platform": "monoprice",
                 "port": "aaa",
+                "entity_namespace": "namespace",
                 "name": "Name",
                 "zones": {11: {"name": "a"}},
                 "sources": {1: {}},
@@ -184,6 +197,7 @@ class TestMonopriceMediaPlayer(unittest.TestCase):
                 {
                     "platform": "monoprice",
                     "port": "/dev/ttyS0",
+                    "entity_namespace": "namespace",
                     "name": "Name",
                     "zones": {12: {"name": "Zone name"}},
                     "sources": {
@@ -341,7 +355,7 @@ class TestMonopriceMediaPlayer(unittest.TestCase):
 
     def test_unique_id(self):
         """Test unique_id property."""
-        assert 12 == self.media_player.unique_id
+        assert "namespace_12" == self.media_player.unique_id
 
     def test_state(self):
         """Test state property."""

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -175,7 +175,7 @@ async def test_service_calls_without_entity_id(hass):
     )
 
     # Saving existing values
-    await _call_monoprice_service(hass, SERVICE_SNAPSHOT, {})
+    await _call_monoprice_service(hass, SERVICE_SNAPSHOT, {"entity_id": "all"})
 
     # Changing media player to new state
     await _call_media_player_service(
@@ -186,7 +186,7 @@ async def test_service_calls_without_entity_id(hass):
     )
 
     # Restoring media player to its previous state
-    await _call_monoprice_service(hass, SERVICE_RESTORE, {})
+    await _call_monoprice_service(hass, SERVICE_RESTORE, {"entity_id": "all"})
     await hass.async_block_till_done()
 
     state = hass.states.get(ZONE_1_ID)

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
 )
+from homeassistant.helpers.entity_component import async_update_entity
 
 from tests.common import MockConfigEntry
 
@@ -222,7 +223,7 @@ async def test_update(hass):
     monoprice.set_source(11, 3)
     monoprice.set_volume(11, 38)
 
-    await _call_homeassistant_service(hass, "update_entity", {"entity_id": ZONE_1_ID})
+    await async_update_entity(hass, ZONE_1_ID)
     await hass.async_block_till_done()
 
     state = hass.states.get(ZONE_1_ID)


### PR DESCRIPTION
## Breaking Change:

Monoprice is now configured through the UI. Please remove the configuration from YAML, and add the Monoprice integration via the Integrations page.

## Description:
Monoprice is now configured through the UI, with device and entity registry support.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#12480

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html