### PR TITLE
Migrate api tests from coroutine to async/await

### DIFF
--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the Home Assistant API component."""
 # pylint: disable=protected-access
-import asyncio
 import json
 from unittest.mock import patch
 
@@ -23,27 +22,23 @@ def mock_api_client(hass, hass_client):
     return hass.loop.run_until_complete(hass_client())
 
 
-@asyncio.coroutine
-def test_api_list_state_entities(hass, mock_api_client):
+async def test_api_list_state_entities(hass, mock_api_client):
     """Test if the debug interface allows us to list state entities."""
     hass.states.async_set("test.entity", "hello")
-    resp = yield from mock_api_client.get(const.URL_API_STATES)
+    resp = await mock_api_client.get(const.URL_API_STATES)
     assert resp.status == 200
-    json = yield from resp.json()
+    json = await resp.json()
 
     remote_data = [ha.State.from_dict(item) for item in json]
     assert remote_data == hass.states.async_all()
 
 
-@asyncio.coroutine
-def test_api_get_state(hass, mock_api_client):
+async def test_api_get_state(hass, mock_api_client):
     """Test if the debug interface allows us to get a state."""
     hass.states.async_set("hello.world", "nice", {"attr": 1})
-    resp = yield from mock_api_client.get(
-        const.URL_API_STATES_ENTITY.format("hello.world")
-    )
+    resp = await mock_api_client.get(const.URL_API_STATES_ENTITY.format("hello.world"))
     assert resp.status == 200
-    json = yield from resp.json()
+    json = await resp.json()
 
     data = ha.State.from_dict(json)
 
@@ -54,21 +49,19 @@ def test_api_get_state(hass, mock_api_client):
     assert data.attributes == state.attributes
 
 
-@asyncio.coroutine
-def test_api_get_non_existing_state(hass, mock_api_client):
+async def test_api_get_non_existing_state(hass, mock_api_client):
     """Test if the debug interface allows us to get a state."""
-    resp = yield from mock_api_client.get(
+    resp = await mock_api_client.get(
         const.URL_API_STATES_ENTITY.format("does_not_exist")
     )
     assert resp.status == 404
 
 
-@asyncio.coroutine
-def test_api_state_change(hass, mock_api_client):
+async def test_api_state_change(hass, mock_api_client):
     """Test if we can change the state of an entity that exists."""
     hass.states.async_set("test.test", "not_to_be_set")
 
-    yield from mock_api_client.post(
+    await mock_api_client.post(
         const.URL_API_STATES_ENTITY.format("test.test"),
         json={"state": "debug_state_change2"},
     )
@@ -77,12 +70,11 @@ def test_api_state_change(hass, mock_api_client):
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_api_state_change_of_non_existing_entity(hass, mock_api_client):
+async def test_api_state_change_of_non_existing_entity(hass, mock_api_client):
     """Test if changing a state of a non existing entity is possible."""
     new_state = "debug_state_change"
 
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_STATES_ENTITY.format("test_entity.that_does_not_exist"),
         json={"state": new_state},
     )
@@ -93,10 +85,9 @@ def test_api_state_change_of_non_existing_entity(hass, mock_api_client):
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_api_state_change_with_bad_data(hass, mock_api_client):
+async def test_api_state_change_with_bad_data(hass, mock_api_client):
     """Test if API sends appropriate error if we omit state."""
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_STATES_ENTITY.format("test_entity.that_does_not_exist"), json={}
     )
 
@@ -104,17 +95,16 @@ def test_api_state_change_with_bad_data(hass, mock_api_client):
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_api_state_change_to_zero_value(hass, mock_api_client):
+async def test_api_state_change_to_zero_value(hass, mock_api_client):
     """Test if changing a state to a zero value is possible."""
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_STATES_ENTITY.format("test_entity.with_zero_state"),
         json={"state": 0},
     )
 
     assert resp.status == 201
 
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_STATES_ENTITY.format("test_entity.with_zero_state"),
         json={"state": 0.0},
     )
@@ -123,8 +113,7 @@ def test_api_state_change_to_zero_value(hass, mock_api_client):
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_api_state_change_push(hass, mock_api_client):
+async def test_api_state_change_push(hass, mock_api_client):
     """Test if we can push a change the state of an entity."""
     hass.states.async_set("test.test", "not_to_be_set")
 
@@ -137,23 +126,22 @@ def test_api_state_change_push(hass, mock_api_client):
 
     hass.bus.async_listen(const.EVENT_STATE_CHANGED, event_listener)
 
-    yield from mock_api_client.post(
+    await mock_api_client.post(
         const.URL_API_STATES_ENTITY.format("test.test"), json={"state": "not_to_be_set"}
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(events) == 0
 
-    yield from mock_api_client.post(
+    await mock_api_client.post(
         const.URL_API_STATES_ENTITY.format("test.test"),
         json={"state": "not_to_be_set", "force_update": True},
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(events) == 1
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_api_fire_event_with_no_data(hass, mock_api_client):
+async def test_api_fire_event_with_no_data(hass, mock_api_client):
     """Test if the API allows us to fire an event."""
     test_value = []
 
@@ -164,17 +152,14 @@ def test_api_fire_event_with_no_data(hass, mock_api_client):
 
     hass.bus.async_listen_once("test.event_no_data", listener)
 
-    yield from mock_api_client.post(
-        const.URL_API_EVENTS_EVENT.format("test.event_no_data")
-    )
-    yield from hass.async_block_till_done()
+    await mock_api_client.post(const.URL_API_EVENTS_EVENT.format("test.event_no_data"))
+    await hass.async_block_till_done()
 
     assert len(test_value) == 1
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_api_fire_event_with_data(hass, mock_api_client):
+async def test_api_fire_event_with_data(hass, mock_api_client):
     """Test if the API allows us to fire an event."""
     test_value = []
 
@@ -189,18 +174,17 @@ def test_api_fire_event_with_data(hass, mock_api_client):
 
     hass.bus.async_listen_once("test_event_with_data", listener)
 
-    yield from mock_api_client.post(
+    await mock_api_client.post(
         const.URL_API_EVENTS_EVENT.format("test_event_with_data"), json={"test": 1}
     )
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(test_value) == 1
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_api_fire_event_with_invalid_json(hass, mock_api_client):
+async def test_api_fire_event_with_invalid_json(hass, mock_api_client):
     """Test if the API allows us to fire an event."""
     test_value = []
 
@@ -211,33 +195,32 @@ def test_api_fire_event_with_invalid_json(hass, mock_api_client):
 
     hass.bus.async_listen_once("test_event_bad_data", listener)
 
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_EVENTS_EVENT.format("test_event_bad_data"),
         data=json.dumps("not an object"),
     )
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert resp.status == 400
     assert len(test_value) == 0
 
     # Try now with valid but unusable JSON
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_EVENTS_EVENT.format("test_event_bad_data"),
         data=json.dumps([1, 2, 3]),
     )
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert resp.status == 400
     assert len(test_value) == 0
 
 
-@asyncio.coroutine
-def test_api_get_config(hass, mock_api_client):
+async def test_api_get_config(hass, mock_api_client):
     """Test the return of the configuration."""
-    resp = yield from mock_api_client.get(const.URL_API_CONFIG)
-    result = yield from resp.json()
+    resp = await mock_api_client.get(const.URL_API_CONFIG)
+    result = await resp.json()
     if "components" in result:
         result["components"] = set(result["components"])
     if "whitelist_external_dirs" in result:
@@ -246,19 +229,17 @@ def test_api_get_config(hass, mock_api_client):
     assert hass.config.as_dict() == result
 
 
-@asyncio.coroutine
-def test_api_get_components(hass, mock_api_client):
+async def test_api_get_components(hass, mock_api_client):
     """Test the return of the components."""
-    resp = yield from mock_api_client.get(const.URL_API_COMPONENTS)
-    result = yield from resp.json()
+    resp = await mock_api_client.get(const.URL_API_COMPONENTS)
+    result = await resp.json()
     assert set(result) == hass.config.components
 
 
-@asyncio.coroutine
-def test_api_get_event_listeners(hass, mock_api_client):
+async def test_api_get_event_listeners(hass, mock_api_client):
     """Test if we can get the list of events being listened for."""
-    resp = yield from mock_api_client.get(const.URL_API_EVENTS)
-    data = yield from resp.json()
+    resp = await mock_api_client.get(const.URL_API_EVENTS)
+    data = await resp.json()
 
     local = hass.bus.async_listeners()
 
@@ -268,11 +249,10 @@ def test_api_get_event_listeners(hass, mock_api_client):
     assert len(local) == 0
 
 
-@asyncio.coroutine
-def test_api_get_services(hass, mock_api_client):
+async def test_api_get_services(hass, mock_api_client):
     """Test if we can get a dict describing current services."""
-    resp = yield from mock_api_client.get(const.URL_API_SERVICES)
-    data = yield from resp.json()
+    resp = await mock_api_client.get(const.URL_API_SERVICES)
+    data = await resp.json()
     local_services = hass.services.async_services()
 
     for serv_domain in data:
@@ -281,8 +261,7 @@ def test_api_get_services(hass, mock_api_client):
         assert serv_domain["services"] == local
 
 
-@asyncio.coroutine
-def test_api_call_service_no_data(hass, mock_api_client):
+async def test_api_call_service_no_data(hass, mock_api_client):
     """Test if the API allows us to call a service."""
     test_value = []
 
@@ -293,15 +272,14 @@ def test_api_call_service_no_data(hass, mock_api_client):
 
     hass.services.async_register("test_domain", "test_service", listener)
 
-    yield from mock_api_client.post(
+    await mock_api_client.post(
         const.URL_API_SERVICES_SERVICE.format("test_domain", "test_service")
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(test_value) == 1
 
 
-@asyncio.coroutine
-def test_api_call_service_with_data(hass, mock_api_client):
+async def test_api_call_service_with_data(hass, mock_api_client):
     """Test if the API allows us to call a service."""
     test_value = []
 
@@ -316,88 +294,83 @@ def test_api_call_service_with_data(hass, mock_api_client):
 
     hass.services.async_register("test_domain", "test_service", listener)
 
-    yield from mock_api_client.post(
+    await mock_api_client.post(
         const.URL_API_SERVICES_SERVICE.format("test_domain", "test_service"),
         json={"test": 1},
     )
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(test_value) == 1
 
 
-@asyncio.coroutine
-def test_api_template(hass, mock_api_client):
+async def test_api_template(hass, mock_api_client):
     """Test the template API."""
     hass.states.async_set("sensor.temperature", 10)
 
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_TEMPLATE,
         json={"template": "{{ states.sensor.temperature.state }}"},
     )
 
-    body = yield from resp.text()
+    body = await resp.text()
 
     assert body == "10"
 
 
-@asyncio.coroutine
-def test_api_template_error(hass, mock_api_client):
+async def test_api_template_error(hass, mock_api_client):
     """Test the template API."""
     hass.states.async_set("sensor.temperature", 10)
 
-    resp = yield from mock_api_client.post(
+    resp = await mock_api_client.post(
         const.URL_API_TEMPLATE, json={"template": "{{ states.sensor.temperature.state"}
     )
 
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_stream(hass, mock_api_client):
+async def test_stream(hass, mock_api_client):
     """Test the stream."""
     listen_count = _listen_count(hass)
 
-    resp = yield from mock_api_client.get(const.URL_API_STREAM)
+    resp = await mock_api_client.get(const.URL_API_STREAM)
     assert resp.status == 200
     assert listen_count + 1 == _listen_count(hass)
 
     hass.bus.async_fire("test_event")
 
-    data = yield from _stream_next_event(resp.content)
+    data = await _stream_next_event(resp.content)
 
     assert data["event_type"] == "test_event"
 
 
-@asyncio.coroutine
-def test_stream_with_restricted(hass, mock_api_client):
+async def test_stream_with_restricted(hass, mock_api_client):
     """Test the stream with restrictions."""
     listen_count = _listen_count(hass)
 
-    resp = yield from mock_api_client.get(
+    resp = await mock_api_client.get(
         "{}?restrict=test_event1,test_event3".format(const.URL_API_STREAM)
     )
     assert resp.status == 200
     assert listen_count + 1 == _listen_count(hass)
 
     hass.bus.async_fire("test_event1")
-    data = yield from _stream_next_event(resp.content)
+    data = await _stream_next_event(resp.content)
     assert data["event_type"] == "test_event1"
 
     hass.bus.async_fire("test_event2")
     hass.bus.async_fire("test_event3")
-    data = yield from _stream_next_event(resp.content)
+    data = await _stream_next_event(resp.content)
     assert data["event_type"] == "test_event3"
 
 
-@asyncio.coroutine
-def _stream_next_event(stream):
+async def _stream_next_event(stream):
     """Read the stream for next event while ignoring ping."""
     while True:
         last_new_line = False
         data = b""
 
         while True:
-            dat = yield from stream.read(1)
+            dat = await stream.read(1)
             if dat == b"\n" and last_new_line:
                 break
             data += dat


### PR DESCRIPTION
## Description:

Migrate api tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
