### PR TITLE
Revert state standby back to state off

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -5,13 +5,7 @@ import logging
 from pyps4_2ndscreen.errors import NotReady, PSDataIncomplete
 import pyps4_2ndscreen.ps4 as pyps4
 
-from homeassistant.components.media_player import (
-    ENTITY_IMAGE_URL,
-    STATE_IDLE,
-    STATE_OFF,
-    STATE_PLAYING,
-    MediaPlayerDevice,
-)
+from homeassistant.components.media_player import ENTITY_IMAGE_URL, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_TITLE,
@@ -30,6 +24,9 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_REGION,
     CONF_TOKEN,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_PLAYING,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry, entity_registry

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -5,7 +5,13 @@ import logging
 from pyps4_2ndscreen.errors import NotReady, PSDataIncomplete
 import pyps4_2ndscreen.ps4 as pyps4
 
-from homeassistant.components.media_player import ENTITY_IMAGE_URL, MediaPlayerDevice
+from homeassistant.components.media_player import (
+    ENTITY_IMAGE_URL,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_PLAYING,
+    MediaPlayerDevice,
+)
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_TITLE,
@@ -24,9 +30,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_REGION,
     CONF_TOKEN,
-    STATE_IDLE,
-    STATE_PLAYING,
-    STATE_STANDBY,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry, entity_registry
@@ -201,8 +204,8 @@ class PS4Device(MediaPlayerDevice):
                     if self._state != STATE_IDLE:
                         self.idle()
             else:
-                if self._state != STATE_STANDBY:
-                    self.state_standby()
+                if self._state != STATE_OFF:
+                    self.state_off()
 
         elif self._retry > DEFAULT_RETRIES:
             self.state_unknown()
@@ -230,10 +233,10 @@ class PS4Device(MediaPlayerDevice):
         self._state = STATE_IDLE
         self.schedule_update()
 
-    def state_standby(self):
-        """Set states for state standby."""
+    def state_off(self):
+        """Set states for state off."""
         self.reset_title()
-        self._state = STATE_STANDBY
+        self._state = STATE_OFF
         self.schedule_update()
 
     def state_unknown(self):

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from pyps4_2ndscreen.credential import get_ddp_message
 
 from homeassistant.components import ps4
+from homeassistant.components.media_player import STATE_IDLE, STATE_OFF, STATE_PLAYING
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
@@ -28,9 +29,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_REGION,
     CONF_TOKEN,
-    STATE_IDLE,
-    STATE_PLAYING,
-    STATE_STANDBY,
     STATE_UNKNOWN,
 )
 from homeassistant.setup import async_setup_component
@@ -183,14 +181,14 @@ async def test_media_player_is_setup_correctly_with_entry(hass):
     assert mock_state == STATE_UNKNOWN
 
 
-async def test_state_standby_is_set(hass):
+async def test_state_off_is_set(hass):
     """Test that state is set to standby."""
     mock_entity_id = await setup_mock_component(hass)
 
     with patch(MOCK_SAVE, side_effect=MagicMock()):
         await mock_ddp_response(hass, MOCK_STATUS_STANDBY)
 
-    assert hass.states.get(mock_entity_id).state == STATE_STANDBY
+    assert hass.states.get(mock_entity_id).state == STATE_OFF
 
 
 async def test_state_playing_is_set(hass):
@@ -306,7 +304,7 @@ async def test_device_info_is_set_from_status_correctly(hass):
     mock_entry = mock_d_registry.async_get_device(
         identifiers={(DOMAIN, MOCK_HOST_ID)}, connections={()}
     )
-    assert mock_state == STATE_STANDBY
+    assert mock_state == STATE_OFF
 
     assert len(mock_d_entries) == 1
     assert mock_entry.name == MOCK_HOST_NAME

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 from pyps4_2ndscreen.credential import get_ddp_message
 
 from homeassistant.components import ps4
-from homeassistant.components.media_player import STATE_IDLE, STATE_OFF, STATE_PLAYING
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
@@ -29,6 +28,9 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_REGION,
     CONF_TOKEN,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_PLAYING,
     STATE_UNKNOWN,
 )
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
## Breaking Change:
State Standby is reverted back to State Off. User defined scripts, automations, etc., will need to be updated.

## Description:
Fixes unforeseen front end card issue with change to state_standby from #28261. Service turn_off called when state is standby instead of turn_on when power button is clicked.

**Related issue (if applicable):** fixes #28891

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
