### PR TITLE
Add xiaomi miio sensors cgllc.airmonitor.s1 & cgllc.airmonitor.b1

### DIFF
--- a/homeassistant/components/xiaomi_miio/air_quality.py
+++ b/homeassistant/components/xiaomi_miio/air_quality.py
@@ -1,20 +1,47 @@
 """Support for Xiaomi Mi Air Quality Monitor (PM2.5)."""
 from miio import AirQualityMonitor, Device, DeviceException
 import voluptuous as vol
+import logging
 
-from homeassistant.components.air_quality import (
-    _LOGGER,
-    PLATFORM_SCHEMA,
-    AirQualityEntity,
+from homeassistant.components.air_quality import PLATFORM_SCHEMA, AirQualityEntity
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_TOKEN,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
+    TEMP_CELSIUS,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
-from homeassistant.exceptions import PlatformNotReady
+from homeassistant.exceptions import PlatformNotReady, NoEntitySpecifiedError
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Xiaomi Miio Air Quality Monitor"
 
+MODEL_XIAOMI_AIRQUALITYMONITOR_S1 = "cgllc.airmonitor.s1"
+MODEL_XIAOMI_AIRQUALITYMONITOR_B1 = "cgllc.airmonitor.b1"
+
 ATTR_CO2E = "carbon_dioxide_equivalent"
 ATTR_TVOC = "total_volatile_organic_compounds"
+ATTR_TEMPERATURE = "temperature"
+ATTR_HUMIDITY = "humidity"
+
+SENSOR_TYPES = {
+    "TEMPERATURE": {
+        "device_class": DEVICE_CLASS_TEMPERATURE,
+        "unit_of_measurement": TEMP_CELSIUS,
+        "icon": "mdi:thermometer",
+        "state_attr": ATTR_TEMPERATURE,
+    },
+    "HUMIDITY": {
+        "device_class": DEVICE_CLASS_HUMIDITY,
+        "unit_of_measurement": "%",
+        "icon": "mdi:water-percent",
+        "state_attr": ATTR_HUMIDITY,
+    },
+}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -54,21 +81,38 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         device_info.firmware_version,
         device_info.hardware_version,
     )
-    device = AirMonitorB1(name, AirQualityMonitor(host, token, model=model), unique_id)
 
-    async_add_entities([device], update_before_add=True)
+    device = AirQualityMonitor(host, token, model=model)
+    temperature_sensor = XiaomiCgllcSensor(name, SENSOR_TYPES["TEMPERATURE"], unique_id)
+    humidity_sensor = XiaomiCgllcSensor(name, SENSOR_TYPES["HUMIDITY"], unique_id)
+    if model == MODEL_XIAOMI_AIRQUALITYMONITOR_S1:
+        entity = AirMonitorS1(
+            name, device, unique_id, temperature_sensor, humidity_sensor
+        )
+    elif model == MODEL_XIAOMI_AIRQUALITYMONITOR_B1:
+        entity = AirMonitorB1(
+            name, device, unique_id, temperature_sensor, humidity_sensor
+        )
+    else:
+        raise NoEntitySpecifiedError(f"Not support for entity {unique_id}")
+
+    async_add_entities([entity, temperature_sensor, humidity_sensor], update_before_add=True)
 
 
 class AirMonitorB1(AirQualityEntity):
     """Air Quality class for Xiaomi cgllc.airmonitor.b1 device."""
 
-    def __init__(self, name, device, unique_id):
+    def __init__(self, name, device, unique_id, temperature_sensor, humidity_sensor):
         """Initialize the entity."""
         self._name = name
         self._device = device
         self._unique_id = unique_id
+        self._temperature_sensor = temperature_sensor
+        self._humidity_sensor = humidity_sensor
         self._icon = "mdi:cloud"
         self._unit_of_measurement = "μg/m3"
+        self._available = None
+        self._carbon_dioxide = None
         self._carbon_dioxide_equivalent = None
         self._particulate_matter_2_5 = None
         self._total_volatile_organic_compounds = None
@@ -83,8 +127,11 @@ class AirMonitorB1(AirQualityEntity):
             self._carbon_dioxide_equivalent = state.co2e
             self._particulate_matter_2_5 = round(state.pm25, 1)
             self._total_volatile_organic_compounds = round(state.tvoc, 3)
-
+            self._available = True
+            self._temperature_sensor.set_state(state.temperature)
+            self._humidity_sensor.set_state(state.humidity)
         except DeviceException as ex:
+            self._available = False
             _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @property
@@ -98,9 +145,19 @@ class AirMonitorB1(AirQualityEntity):
         return self._icon
 
     @property
+    def available(self):
+        """Return true when state is known."""
+        return self._available
+
+    @property
     def unique_id(self):
         """Return the unique ID."""
         return self._unique_id
+
+    @property
+    def carbon_dioxide(self):
+        """Return the CO2 (carbon dioxide) level."""
+        return self._carbon_dioxide
 
     @property
     def carbon_dioxide_equivalent(self):
@@ -132,4 +189,76 @@ class AirMonitorB1(AirQualityEntity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
+        return self._unit_of_measurement
+
+
+class AirMonitorS1(AirMonitorB1):
+    """Air Quality class for Xiaomi cgllc.airmonitor.s1 device."""
+
+    async def async_update(self):
+        """Fetch state from the miio device."""
+
+        try:
+            state = await self.hass.async_add_executor_job(self._device.status)
+            _LOGGER.debug("Got new state: %s", state)
+            self._carbon_dioxide = state.co2
+            self._particulate_matter_2_5 = state.pm25
+            self._total_volatile_organic_compounds = state.tvoc
+            self._available = True
+            self._temperature_sensor.set_state(state.temperature)
+            self._humidity_sensor.set_state(state.humidity)
+        except DeviceException as ex:
+            self._available = False
+            _LOGGER.error("Got exception while fetching the state: %s", ex)
+
+
+class XiaomiCgllcSensor(Entity):
+    """Implementation of an XiaomiCgllcSensor device."""
+
+    def __init__(self, name, sensor_type, unique_id):
+        """Initialize the sensor."""
+        self._type = sensor_type
+        self._unit_of_measurement = self._type["unit_of_measurement"]
+        self._name = name + " " + sensor_type["device_class"]
+        self._unique_id = unique_id + "_" + sensor_type["device_class"]
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._type["device_class"]
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return self._type["icon"]
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    def set_state(self, state):
+        """Update the sensor state."""
+        self._state = state
+        self.async_schedule_update_ha_state()
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def unique_id(self):
+        """Return the unique id of this entity."""
+        return self._unique_id
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
         return self._unit_of_measurement

--- a/homeassistant/components/xiaomi_miio/air_quality.py
+++ b/homeassistant/components/xiaomi_miio/air_quality.py
@@ -1,13 +1,14 @@
 """Support for Xiaomi Mi Air Quality Monitor (PM2.5)."""
 import logging
 
-import voluptuous as vol
 from miio import AirQualityMonitor, Device, DeviceException
+import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.air_quality import PLATFORM_SCHEMA, AirQualityEntity
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
-from homeassistant.exceptions import PlatformNotReady, NoEntitySpecifiedError
+from homeassistant.exceptions import NoEntitySpecifiedError, PlatformNotReady
+import homeassistant.helpers.config_validation as cv
+
 from .const import (
     MODEL_AIRQUALITYMONITOR_B1,
     MODEL_AIRQUALITYMONITOR_S1,

--- a/homeassistant/components/xiaomi_miio/air_quality.py
+++ b/homeassistant/components/xiaomi_miio/air_quality.py
@@ -199,11 +199,6 @@ class AirMonitorV1(AirMonitorB1):
             _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @property
-    def state(self):
-        """Return the current state."""
-        return self._air_quality_index
-
-    @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         return "AQI"

--- a/homeassistant/components/xiaomi_miio/air_quality.py
+++ b/homeassistant/components/xiaomi_miio/air_quality.py
@@ -1,47 +1,25 @@
 """Support for Xiaomi Mi Air Quality Monitor (PM2.5)."""
-from miio import AirQualityMonitor, Device, DeviceException
-import voluptuous as vol
 import logging
 
-from homeassistant.components.air_quality import PLATFORM_SCHEMA, AirQualityEntity
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_TOKEN,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_TEMPERATURE,
-    TEMP_CELSIUS,
-)
-from homeassistant.exceptions import PlatformNotReady, NoEntitySpecifiedError
+import voluptuous as vol
+from miio import AirQualityMonitor, Device, DeviceException
+
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import Entity
+from homeassistant.components.air_quality import PLATFORM_SCHEMA, AirQualityEntity
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
+from homeassistant.exceptions import PlatformNotReady, NoEntitySpecifiedError
+from .const import (
+    MODEL_AIRQUALITYMONITOR_B1,
+    MODEL_AIRQUALITYMONITOR_S1,
+    MODEL_AIRQUALITYMONITOR_V1,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Xiaomi Miio Air Quality Monitor"
 
-MODEL_XIAOMI_AIRQUALITYMONITOR_S1 = "cgllc.airmonitor.s1"
-MODEL_XIAOMI_AIRQUALITYMONITOR_B1 = "cgllc.airmonitor.b1"
-
 ATTR_CO2E = "carbon_dioxide_equivalent"
 ATTR_TVOC = "total_volatile_organic_compounds"
-ATTR_TEMPERATURE = "temperature"
-ATTR_HUMIDITY = "humidity"
-
-SENSOR_TYPES = {
-    "TEMPERATURE": {
-        "device_class": DEVICE_CLASS_TEMPERATURE,
-        "unit_of_measurement": TEMP_CELSIUS,
-        "icon": "mdi:thermometer",
-        "state_attr": ATTR_TEMPERATURE,
-    },
-    "HUMIDITY": {
-        "device_class": DEVICE_CLASS_HUMIDITY,
-        "unit_of_measurement": "%",
-        "icon": "mdi:water-percent",
-        "state_attr": ATTR_HUMIDITY,
-    },
-}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -83,35 +61,31 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
 
     device = AirQualityMonitor(host, token, model=model)
-    temperature_sensor = XiaomiCgllcSensor(name, SENSOR_TYPES["TEMPERATURE"], unique_id)
-    humidity_sensor = XiaomiCgllcSensor(name, SENSOR_TYPES["HUMIDITY"], unique_id)
-    if model == MODEL_XIAOMI_AIRQUALITYMONITOR_S1:
-        entity = AirMonitorS1(
-            name, device, unique_id, temperature_sensor, humidity_sensor
-        )
-    elif model == MODEL_XIAOMI_AIRQUALITYMONITOR_B1:
-        entity = AirMonitorB1(
-            name, device, unique_id, temperature_sensor, humidity_sensor
-        )
+
+    if model == MODEL_AIRQUALITYMONITOR_S1:
+        entity = AirMonitorS1(name, device, unique_id)
+    elif model == MODEL_AIRQUALITYMONITOR_B1:
+        entity = AirMonitorB1(name, device, unique_id)
+    elif model == MODEL_AIRQUALITYMONITOR_V1:
+        entity = AirMonitorV1(name, device, unique_id)
     else:
         raise NoEntitySpecifiedError(f"Not support for entity {unique_id}")
 
-    async_add_entities([entity, temperature_sensor, humidity_sensor], update_before_add=True)
+    async_add_entities([entity], update_before_add=True)
 
 
 class AirMonitorB1(AirQualityEntity):
     """Air Quality class for Xiaomi cgllc.airmonitor.b1 device."""
 
-    def __init__(self, name, device, unique_id, temperature_sensor, humidity_sensor):
+    def __init__(self, name, device, unique_id):
         """Initialize the entity."""
         self._name = name
         self._device = device
         self._unique_id = unique_id
-        self._temperature_sensor = temperature_sensor
-        self._humidity_sensor = humidity_sensor
         self._icon = "mdi:cloud"
         self._unit_of_measurement = "μg/m3"
         self._available = None
+        self._air_quality_index = None
         self._carbon_dioxide = None
         self._carbon_dioxide_equivalent = None
         self._particulate_matter_2_5 = None
@@ -119,17 +93,13 @@ class AirMonitorB1(AirQualityEntity):
 
     async def async_update(self):
         """Fetch state from the miio device."""
-
         try:
             state = await self.hass.async_add_executor_job(self._device.status)
             _LOGGER.debug("Got new state: %s", state)
-
             self._carbon_dioxide_equivalent = state.co2e
             self._particulate_matter_2_5 = round(state.pm25, 1)
             self._total_volatile_organic_compounds = round(state.tvoc, 3)
             self._available = True
-            self._temperature_sensor.set_state(state.temperature)
-            self._humidity_sensor.set_state(state.humidity)
         except DeviceException as ex:
             self._available = False
             _LOGGER.error("Got exception while fetching the state: %s", ex)
@@ -153,6 +123,11 @@ class AirMonitorB1(AirQualityEntity):
     def unique_id(self):
         """Return the unique ID."""
         return self._unique_id
+
+    @property
+    def air_quality_index(self):
+        """Return the Air Quality Index (AQI)."""
+        return self._air_quality_index
 
     @property
     def carbon_dioxide(self):
@@ -197,7 +172,6 @@ class AirMonitorS1(AirMonitorB1):
 
     async def async_update(self):
         """Fetch state from the miio device."""
-
         try:
             state = await self.hass.async_add_executor_job(self._device.status)
             _LOGGER.debug("Got new state: %s", state)
@@ -205,60 +179,31 @@ class AirMonitorS1(AirMonitorB1):
             self._particulate_matter_2_5 = state.pm25
             self._total_volatile_organic_compounds = state.tvoc
             self._available = True
-            self._temperature_sensor.set_state(state.temperature)
-            self._humidity_sensor.set_state(state.humidity)
         except DeviceException as ex:
             self._available = False
             _LOGGER.error("Got exception while fetching the state: %s", ex)
 
 
-class XiaomiCgllcSensor(Entity):
-    """Implementation of an XiaomiCgllcSensor device."""
+class AirMonitorV1(AirMonitorB1):
+    """Air Quality class for Xiaomi cgllc.airmonitor.s1 device."""
 
-    def __init__(self, name, sensor_type, unique_id):
-        """Initialize the sensor."""
-        self._type = sensor_type
-        self._unit_of_measurement = self._type["unit_of_measurement"]
-        self._name = name + " " + sensor_type["device_class"]
-        self._unique_id = unique_id + "_" + sensor_type["device_class"]
-        self._state = None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def device_class(self):
-        """Return the device class."""
-        return self._type["device_class"]
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend."""
-        return self._type["icon"]
+    async def async_update(self):
+        """Fetch state from the miio device."""
+        try:
+            state = await self.hass.async_add_executor_job(self._device.status)
+            _LOGGER.debug("Got new state: %s", state)
+            self._air_quality_index = state.aqi
+            self._available = True
+        except DeviceException as ex:
+            self._available = False
+            _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @property
     def state(self):
-        """Return the state of the device."""
-        return self._state
-
-    def set_state(self, state):
-        """Update the sensor state."""
-        self._state = state
-        self.async_schedule_update_ha_state()
-
-    @property
-    def should_poll(self):
-        """Return the polling state."""
-        return False
-
-    @property
-    def unique_id(self):
-        """Return the unique id of this entity."""
-        return self._unique_id
+        """Return the current state."""
+        return self._air_quality_index
 
     @property
     def unit_of_measurement(self):
-        """Return the unit of measurement of this entity."""
-        return self._unit_of_measurement
+        """Return the unit of measurement."""
+        return "AQI"

--- a/homeassistant/components/xiaomi_miio/air_quality.py
+++ b/homeassistant/components/xiaomi_miio/air_quality.py
@@ -201,4 +201,4 @@ class AirMonitorV1(AirMonitorB1):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return "AQI"
+        return None

--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -46,3 +46,8 @@ SERVICE_MOVE_REMOTE_CONTROL_STEP = "vacuum_remote_control_move_step"
 SERVICE_START_REMOTE_CONTROL = "vacuum_remote_control_start"
 SERVICE_STOP_REMOTE_CONTROL = "vacuum_remote_control_stop"
 SERVICE_CLEAN_ZONE = "vacuum_clean_zone"
+
+# AirQuality Model
+MODEL_AIRQUALITYMONITOR_V1 = "zhimi.airmonitor.v1"
+MODEL_AIRQUALITYMONITOR_B1 = "cgllc.airmonitor.b1"
+MODEL_AIRQUALITYMONITOR_S1 = "cgllc.airmonitor.s1"


### PR DESCRIPTION
## Description:
support xiaomi miio sensor: cgllc.airmonitor.s1 & cgllc.airmonitor.b1

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
air_quality:
  - platform: xiaomi_miio
    name: QinPingAirSensor
    host: 192.168.100.184
    token: XXXXXXXXXXXXXXXXXXXXXX
```

## Checklist:
  - [x] The code change is tested and works locally.

![image](https://user-images.githubusercontent.com/40521367/72666145-4d792f80-3a4a-11ea-8e15-a7de2e79a219.png)


