### PR TITLE
Upgrade python_opendata_transport to 0.2.1

### DIFF
--- a/homeassistant/components/swiss_public_transport/manifest.json
+++ b/homeassistant/components/swiss_public_transport/manifest.json
@@ -3,7 +3,7 @@
   "name": "Swiss public transport",
   "documentation": "https://www.home-assistant.io/integrations/swiss_public_transport",
   "requirements": [
-    "python_opendata_transport==0.1.4"
+    "python_opendata_transport==0.2.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1646,7 +1646,7 @@ python-wink==1.10.5
 python_awair==0.0.4
 
 # homeassistant.components.swiss_public_transport
-python_opendata_transport==0.1.4
+python_opendata_transport==0.2.1
 
 # homeassistant.components.egardia
 pythonegardia==1.0.40


### PR DESCRIPTION
## Description:
Changelog: https://github.com/fabaff/python-opendata-transport/blob/master/CHANGES.rst#changes

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: swiss_public_transport
    name: Train
    from: Bern
    to: Biel
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
