### PR TITLE
Add attributes to fritz device_tracker

### DIFF
--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -80,7 +80,7 @@ class FritzBoxScanner(DeviceScanner):
         return ret
 
     def get_extra_attributes(self, device):
-        """Return the name of the given device or None if is not known."""
+        """Return the attributes (ip, mac) of the given device or None if is not known."""
         ip_device = self.fritz_box.get_specific_host_entry(device).get("NewIPAddress")
 
         if not ip_device:

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -79,6 +79,14 @@ class FritzBoxScanner(DeviceScanner):
             return None
         return ret
 
+    def get_extra_attributes(self, device):
+        """Return the name of the given device or None if is not known."""
+        ip = self.fritz_box.get_specific_host_entry(device).get("NewIPAddress")
+
+        if ip == {}:
+            return None
+        return {"IP": ip, "MAC": device}
+
     def _update_info(self):
         """Retrieve latest information from the FRITZ!Box."""
         if not self.success_init:

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -83,7 +83,7 @@ class FritzBoxScanner(DeviceScanner):
         """Return the name of the given device or None if is not known."""
         ip_device = self.fritz_box.get_specific_host_entry(device).get("NewIPAddress")
 
-        if ip_device == {}:
+        if not ip_device:
             return None
         return {"ip": ip_device, "mac": device}
 

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -81,11 +81,11 @@ class FritzBoxScanner(DeviceScanner):
 
     def get_extra_attributes(self, device):
         """Return the name of the given device or None if is not known."""
-        ip = self.fritz_box.get_specific_host_entry(device).get("NewIPAddress")
+        ip_device = self.fritz_box.get_specific_host_entry(device).get("NewIPAddress")
 
-        if ip == {}:
+        if ip_device == {}:
             return None
-        return {"IP": ip, "MAC": device}
+        return {"ip": ip_device, "mac": device}
 
     def _update_info(self):
         """Retrieve latest information from the FRITZ!Box."""


### PR DESCRIPTION
## Breaking Change:
Ip and mac addresses added to the device attributes

## Description:
It would be nice to monitor not only the state of your network devices, but also the ip and mac address. This can be easily implemented into the existing fritz integration which has been done in this pull request.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/mammuth/ha-fritzbox-tools/issues/48

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
