### PR TITLE
Migrate teksavvy tests from coroutine to async/await

### DIFF
--- a/tests/components/teksavvy/test_sensor.py
+++ b/tests/components/teksavvy/test_sensor.py
@@ -1,13 +1,10 @@
 """Tests for the TekSavvy sensor platform."""
-import asyncio
-
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.teksavvy.sensor import TekSavvyData
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 
-@asyncio.coroutine
-def test_capped_setup(hass, aioclient_mock):
+async def test_capped_setup(hass, aioclient_mock):
     """Test the default setup."""
     config = {
         "platform": "teksavvy",
@@ -45,7 +42,7 @@ def test_capped_setup(hass, aioclient_mock):
         text=result,
     )
 
-    yield from async_setup_component(hass, "sensor", {"sensor": config})
+    await async_setup_component(hass, "sensor", {"sensor": config})
 
     state = hass.states.get("sensor.teksavvy_data_limit")
     assert state.attributes.get("unit_of_measurement") == "GB"
@@ -88,8 +85,7 @@ def test_capped_setup(hass, aioclient_mock):
     assert state.state == "173.25"
 
 
-@asyncio.coroutine
-def test_unlimited_setup(hass, aioclient_mock):
+async def test_unlimited_setup(hass, aioclient_mock):
     """Test the default setup."""
     config = {
         "platform": "teksavvy",
@@ -127,7 +123,7 @@ def test_unlimited_setup(hass, aioclient_mock):
         text=result,
     )
 
-    yield from async_setup_component(hass, "sensor", {"sensor": config})
+    await async_setup_component(hass, "sensor", {"sensor": config})
 
     state = hass.states.get("sensor.teksavvy_data_limit")
     assert state.attributes.get("unit_of_measurement") == "GB"
@@ -170,8 +166,7 @@ def test_unlimited_setup(hass, aioclient_mock):
     assert state.state == "inf"
 
 
-@asyncio.coroutine
-def test_bad_return_code(hass, aioclient_mock):
+async def test_bad_return_code(hass, aioclient_mock):
     """Test handling a return code that isn't HTTP OK."""
     aioclient_mock.get(
         "https://api.teksavvy.com/"
@@ -182,12 +177,11 @@ def test_bad_return_code(hass, aioclient_mock):
 
     tsd = TekSavvyData(hass.loop, async_get_clientsession(hass), "notakey", 400)
 
-    result = yield from tsd.async_update()
+    result = await tsd.async_update()
     assert result is False
 
 
-@asyncio.coroutine
-def test_bad_json_decode(hass, aioclient_mock):
+async def test_bad_json_decode(hass, aioclient_mock):
     """Test decoding invalid json result."""
     aioclient_mock.get(
         "https://api.teksavvy.com/"
@@ -198,5 +192,5 @@ def test_bad_json_decode(hass, aioclient_mock):
 
     tsd = TekSavvyData(hass.loop, async_get_clientsession(hass), "notakey", 400)
 
-    result = yield from tsd.async_update()
+    result = await tsd.async_update()
     assert result is False


### PR DESCRIPTION
## Description:

Migrate teksavvy tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
