### PR TITLE
Migrate startca tests from coroutine to async/await

### DIFF
--- a/tests/components/startca/test_sensor.py
+++ b/tests/components/startca/test_sensor.py
@@ -1,13 +1,10 @@
 """Tests for the Start.ca sensor platform."""
-import asyncio
-
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.startca.sensor import StartcaData
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 
-@asyncio.coroutine
-def test_capped_setup(hass, aioclient_mock):
+async def test_capped_setup(hass, aioclient_mock):
     """Test the default setup."""
     config = {
         "platform": "startca",
@@ -51,7 +48,7 @@ def test_capped_setup(hass, aioclient_mock):
         "https://www.start.ca/support/usage/api?key=" "NOTAKEY", text=result
     )
 
-    yield from async_setup_component(hass, "sensor", {"sensor": config})
+    await async_setup_component(hass, "sensor", {"sensor": config})
 
     state = hass.states.get("sensor.start_ca_usage_ratio")
     assert state.attributes.get("unit_of_measurement") == "%"
@@ -102,8 +99,7 @@ def test_capped_setup(hass, aioclient_mock):
     assert state.state == "95.05"
 
 
-@asyncio.coroutine
-def test_unlimited_setup(hass, aioclient_mock):
+async def test_unlimited_setup(hass, aioclient_mock):
     """Test the default setup."""
     config = {
         "platform": "startca",
@@ -147,7 +143,7 @@ def test_unlimited_setup(hass, aioclient_mock):
         "https://www.start.ca/support/usage/api?key=" "NOTAKEY", text=result
     )
 
-    yield from async_setup_component(hass, "sensor", {"sensor": config})
+    await async_setup_component(hass, "sensor", {"sensor": config})
 
     state = hass.states.get("sensor.start_ca_usage_ratio")
     assert state.attributes.get("unit_of_measurement") == "%"
@@ -198,8 +194,7 @@ def test_unlimited_setup(hass, aioclient_mock):
     assert state.state == "inf"
 
 
-@asyncio.coroutine
-def test_bad_return_code(hass, aioclient_mock):
+async def test_bad_return_code(hass, aioclient_mock):
     """Test handling a return code that isn't HTTP OK."""
     aioclient_mock.get(
         "https://www.start.ca/support/usage/api?key=" "NOTAKEY", status=404
@@ -207,12 +202,11 @@ def test_bad_return_code(hass, aioclient_mock):
 
     scd = StartcaData(hass.loop, async_get_clientsession(hass), "NOTAKEY", 400)
 
-    result = yield from scd.async_update()
+    result = await scd.async_update()
     assert result is False
 
 
-@asyncio.coroutine
-def test_bad_json_decode(hass, aioclient_mock):
+async def test_bad_json_decode(hass, aioclient_mock):
     """Test decoding invalid json result."""
     aioclient_mock.get(
         "https://www.start.ca/support/usage/api?key=" "NOTAKEY", text="this is not xml"
@@ -220,5 +214,5 @@ def test_bad_json_decode(hass, aioclient_mock):
 
     scd = StartcaData(hass.loop, async_get_clientsession(hass), "NOTAKEY", 400)
 
-    result = yield from scd.async_update()
+    result = await scd.async_update()
     assert result is False


### PR DESCRIPTION
## Description:

Migrate startca tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
