### PR TITLE
Defer homekit_controller initial poll after all entities are created

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -201,8 +201,6 @@ class HKDevice:
 
         self.hass.async_create_task(self.async_process_entity_map())
 
-        return True
-
     def add_listener(self, add_entities_cb):
         """Add a callback to run when discovering new entities."""
         self.listeners.append(add_entities_cb)


### PR DESCRIPTION
## Description:

Since homekit_controller starting doing it's own polling via its own `async_track_time_interval` call there has been a race where the first poll after starting could happen before `HKDevice.pollable_characteristics` has been populated. This would mean the first set of data might take a minute to arrive, and in the mean time an entity like a climate device might appear in the UI but look broken.

We used to use `self.hass.async_create_task` to defer platform loading till after the current config entry was processed. This was done mostly because  thats what other integrations did. However it's more correct to defer the entire load platforms, add entities, do first poll process, which this PR does.

In my dev env with this PR in place the first poll is successful before the web ui has finished loading, and when it does the data is there and correct.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
