### PR TITLE
Add support for multiple Fitbit trackers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,7 +102,7 @@ homeassistant/components/evohome/* @zxdavb
 homeassistant/components/fastdotcom/* @rohankapoorcom
 homeassistant/components/file/* @fabaff
 homeassistant/components/filter/* @dgomes
-homeassistant/components/fitbit/* @robbiet480
+homeassistant/components/fitbit/* @robbiet480 @agners
 homeassistant/components/fixer/* @fabaff
 homeassistant/components/flock/* @fabaff
 homeassistant/components/flume/* @ChrisMandich

--- a/homeassistant/components/fitbit/manifest.json
+++ b/homeassistant/components/fitbit/manifest.json
@@ -10,6 +10,7 @@
     "http"
   ],
   "codeowners": [
-    "@robbiet480"
+    "@robbiet480",
+    "@agners"
   ]
 }


### PR DESCRIPTION
## Description:

Add config filename and name attributes to support multiple Fitbit
trackers.

Related:
- https://community.home-assistant.io/t/fitbit-component-to-support-multiple-users/87827

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11593

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: fitbit
  filename: fitbit_a1.conf
  name: account1
  monitored_resources:
  - "activities/steps"
  - "activities/distance"

- platform: fitbit
  filename: fitbit_a2.conf
  name: account2
  monitored_resources:
  - "activities/steps"
  - "activities/distance"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
