### PR TITLE
Migrate hassio tests from coroutine to async/await

### DIFF
--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -5,35 +5,32 @@ from unittest.mock import patch
 import pytest
 
 
-@asyncio.coroutine
-def test_forward_request(hassio_client, aioclient_mock):
+async def test_forward_request(hassio_client, aioclient_mock):
     """Test fetching normal path."""
     aioclient_mock.post("http://127.0.0.1/beer", text="response")
 
-    resp = yield from hassio_client.post("/api/hassio/beer")
+    resp = await hassio_client.post("/api/hassio/beer")
 
     # Check we got right response
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "response"
 
     # Check we forwarded command
     assert len(aioclient_mock.mock_calls) == 1
 
 
-@asyncio.coroutine
 @pytest.mark.parametrize(
     "build_type", ["supervisor/info", "homeassistant/update", "host/info"]
 )
-def test_auth_required_forward_request(hassio_noauth_client, build_type):
+async def test_auth_required_forward_request(hassio_noauth_client, build_type):
     """Test auth required for normal request."""
-    resp = yield from hassio_noauth_client.post("/api/hassio/{}".format(build_type))
+    resp = await hassio_noauth_client.post("/api/hassio/{}".format(build_type))
 
     # Check we got right response
     assert resp.status == 401
 
 
-@asyncio.coroutine
 @pytest.mark.parametrize(
     "build_type",
     [
@@ -45,61 +42,60 @@ def test_auth_required_forward_request(hassio_noauth_client, build_type):
         "app/app.js",
     ],
 )
-def test_forward_request_no_auth_for_panel(hassio_client, build_type, aioclient_mock):
+async def test_forward_request_no_auth_for_panel(
+    hassio_client, build_type, aioclient_mock
+):
     """Test no auth needed for ."""
     aioclient_mock.get("http://127.0.0.1/{}".format(build_type), text="response")
 
-    resp = yield from hassio_client.get("/api/hassio/{}".format(build_type))
+    resp = await hassio_client.get("/api/hassio/{}".format(build_type))
 
     # Check we got right response
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "response"
 
     # Check we forwarded command
     assert len(aioclient_mock.mock_calls) == 1
 
 
-@asyncio.coroutine
-def test_forward_request_no_auth_for_logo(hassio_client, aioclient_mock):
+async def test_forward_request_no_auth_for_logo(hassio_client, aioclient_mock):
     """Test no auth needed for ."""
     aioclient_mock.get("http://127.0.0.1/addons/bl_b392/logo", text="response")
 
-    resp = yield from hassio_client.get("/api/hassio/addons/bl_b392/logo")
+    resp = await hassio_client.get("/api/hassio/addons/bl_b392/logo")
 
     # Check we got right response
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "response"
 
     # Check we forwarded command
     assert len(aioclient_mock.mock_calls) == 1
 
 
-@asyncio.coroutine
-def test_forward_log_request(hassio_client, aioclient_mock):
+async def test_forward_log_request(hassio_client, aioclient_mock):
     """Test fetching normal log path doesn't remove ANSI color escape codes."""
     aioclient_mock.get("http://127.0.0.1/beer/logs", text="\033[32mresponse\033[0m")
 
-    resp = yield from hassio_client.get("/api/hassio/beer/logs")
+    resp = await hassio_client.get("/api/hassio/beer/logs")
 
     # Check we got right response
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "\033[32mresponse\033[0m"
 
     # Check we forwarded command
     assert len(aioclient_mock.mock_calls) == 1
 
 
-@asyncio.coroutine
-def test_bad_gateway_when_cannot_find_supervisor(hassio_client):
+async def test_bad_gateway_when_cannot_find_supervisor(hassio_client):
     """Test we get a bad gateway error if we can't find supervisor."""
     with patch(
         "homeassistant.components.hassio.http.async_timeout.timeout",
         side_effect=asyncio.TimeoutError,
     ):
-        resp = yield from hassio_client.get("/api/hassio/addons/test/info")
+        resp = await hassio_client.get("/api/hassio/addons/test/info")
     assert resp.status == 502
 
 


### PR DESCRIPTION
## Description:

Migrate hassio tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
