### PR TITLE
Migrate config tests from coroutine to async/await

### DIFF
--- a/tests/components/config/test_customize.py
+++ b/tests/components/config/test_customize.py
@@ -1,5 +1,4 @@
 """Test Customize config panel."""
-import asyncio
 import json
 from unittest.mock import patch
 
@@ -8,13 +7,12 @@ from homeassistant.components import config
 from homeassistant.config import DATA_CUSTOMIZE
 
 
-@asyncio.coroutine
-def test_get_entity(hass, hass_client):
+async def test_get_entity(hass, hass_client):
     """Test getting entity."""
     with patch.object(config, "SECTIONS", ["customize"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     def mock_read(path):
         """Mock reading data."""
@@ -22,21 +20,20 @@ def test_get_entity(hass, hass_client):
 
     hass.data[DATA_CUSTOMIZE] = {"hello.beer": {"cold": "beer"}}
     with patch("homeassistant.components.config._read", mock_read):
-        resp = yield from client.get("/api/config/customize/config/hello.beer")
+        resp = await client.get("/api/config/customize/config/hello.beer")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {"local": {"free": "beer"}, "global": {"cold": "beer"}}
 
 
-@asyncio.coroutine
-def test_update_entity(hass, hass_client):
+async def test_update_entity(hass, hass_client):
     """Test updating entity."""
     with patch.object(config, "SECTIONS", ["customize"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     orig_data = {
         "hello.beer": {"ignored": True},
@@ -57,7 +54,7 @@ def test_update_entity(hass, hass_client):
     with patch("homeassistant.components.config._read", mock_read), patch(
         "homeassistant.components.config._write", mock_write
     ):
-        resp = yield from client.post(
+        resp = await client.post(
             "/api/config/customize/config/hello.world",
             data=json.dumps(
                 {"name": "Beer", "entities": ["light.top", "light.bottom"]}
@@ -65,7 +62,7 @@ def test_update_entity(hass, hass_client):
         )
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert result == {"result": "ok"}
 
     state = hass.states.get("hello.world")
@@ -82,31 +79,27 @@ def test_update_entity(hass, hass_client):
     assert written[0] == orig_data
 
 
-@asyncio.coroutine
-def test_update_entity_invalid_key(hass, hass_client):
+async def test_update_entity_invalid_key(hass, hass_client):
     """Test updating entity."""
     with patch.object(config, "SECTIONS", ["customize"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.post(
+    resp = await client.post(
         "/api/config/customize/config/not_entity", data=json.dumps({"name": "YO"})
     )
 
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_update_entity_invalid_json(hass, hass_client):
+async def test_update_entity_invalid_json(hass, hass_client):
     """Test updating entity."""
     with patch.object(config, "SECTIONS", ["customize"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.post(
-        "/api/config/customize/config/hello.beer", data="not json"
-    )
+    resp = await client.post("/api/config/customize/config/hello.beer", data="not json")
 
     assert resp.status == 400

--- a/tests/components/config/test_group.py
+++ b/tests/components/config/test_group.py
@@ -1,5 +1,4 @@
 """Test Group config panel."""
-import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
@@ -9,34 +8,32 @@ from homeassistant.components import config
 VIEW_NAME = "api:config:group:config"
 
 
-@asyncio.coroutine
-def test_get_device_config(hass, hass_client):
+async def test_get_device_config(hass, hass_client):
     """Test getting device config."""
     with patch.object(config, "SECTIONS", ["group"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     def mock_read(path):
         """Mock reading data."""
         return {"hello.beer": {"free": "beer"}, "other.entity": {"do": "something"}}
 
     with patch("homeassistant.components.config._read", mock_read):
-        resp = yield from client.get("/api/config/group/config/hello.beer")
+        resp = await client.get("/api/config/group/config/hello.beer")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {"free": "beer"}
 
 
-@asyncio.coroutine
-def test_update_device_config(hass, hass_client):
+async def test_update_device_config(hass, hass_client):
     """Test updating device config."""
     with patch.object(config, "SECTIONS", ["group"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     orig_data = {
         "hello.beer": {"ignored": True},
@@ -58,7 +55,7 @@ def test_update_device_config(hass, hass_client):
     with patch("homeassistant.components.config._read", mock_read), patch(
         "homeassistant.components.config._write", mock_write
     ), patch.object(hass.services, "async_call", mock_call):
-        resp = yield from client.post(
+        resp = await client.post(
             "/api/config/group/config/hello_beer",
             data=json.dumps(
                 {"name": "Beer", "entities": ["light.top", "light.bottom"]}
@@ -66,7 +63,7 @@ def test_update_device_config(hass, hass_client):
         )
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert result == {"result": "ok"}
 
     orig_data["hello_beer"]["name"] = "Beer"
@@ -76,46 +73,41 @@ def test_update_device_config(hass, hass_client):
     mock_call.assert_called_once_with("group", "reload")
 
 
-@asyncio.coroutine
-def test_update_device_config_invalid_key(hass, hass_client):
+async def test_update_device_config_invalid_key(hass, hass_client):
     """Test updating device config."""
     with patch.object(config, "SECTIONS", ["group"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.post(
+    resp = await client.post(
         "/api/config/group/config/not a slug", data=json.dumps({"name": "YO"})
     )
 
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_update_device_config_invalid_data(hass, hass_client):
+async def test_update_device_config_invalid_data(hass, hass_client):
     """Test updating device config."""
     with patch.object(config, "SECTIONS", ["group"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.post(
+    resp = await client.post(
         "/api/config/group/config/hello_beer", data=json.dumps({"invalid_option": 2})
     )
 
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_update_device_config_invalid_json(hass, hass_client):
+async def test_update_device_config_invalid_json(hass, hass_client):
     """Test updating device config."""
     with patch.object(config, "SECTIONS", ["group"]):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.post(
-        "/api/config/group/config/hello_beer", data="not json"
-    )
+    resp = await client.post("/api/config/group/config/hello_beer", data="not json")
 
     assert resp.status == 400

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -1,5 +1,4 @@
 """Test config init."""
-import asyncio
 from unittest.mock import patch
 
 from homeassistant.components import config
@@ -9,15 +8,13 @@ from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 from tests.common import mock_component, mock_coro
 
 
-@asyncio.coroutine
-def test_config_setup(hass, loop):
+async def test_config_setup(hass, loop):
     """Test it sets up hassbian."""
-    yield from async_setup_component(hass, "config", {})
+    await async_setup_component(hass, "config", {})
     assert "config" in hass.config.components
 
 
-@asyncio.coroutine
-def test_load_on_demand_already_loaded(hass, aiohttp_client):
+async def test_load_on_demand_already_loaded(hass, aiohttp_client):
     """Test getting suites."""
     mock_component(hass, "zwave")
 
@@ -26,25 +23,24 @@ def test_load_on_demand_already_loaded(hass, aiohttp_client):
     ), patch("homeassistant.components.config.zwave.async_setup") as stp:
         stp.return_value = mock_coro(True)
 
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert stp.called
 
 
-@asyncio.coroutine
-def test_load_on_demand_on_load(hass, aiohttp_client):
+async def test_load_on_demand_on_load(hass, aiohttp_client):
     """Test getting suites."""
     with patch.object(config, "SECTIONS", []), patch.object(
         config, "ON_DEMAND", ["zwave"]
     ):
-        yield from async_setup_component(hass, "config", {})
+        await async_setup_component(hass, "config", {})
 
     assert "config.zwave" not in hass.config.components
 
     with patch("homeassistant.components.config.zwave.async_setup") as stp:
         stp.return_value = mock_coro(True)
         hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: "zwave"})
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert stp.called

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -1,5 +1,4 @@
 """Test Z-Wave config panel."""
-import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
@@ -23,8 +22,7 @@ def client(loop, hass, hass_client):
     return loop.run_until_complete(hass_client())
 
 
-@asyncio.coroutine
-def test_get_device_config(client):
+async def test_get_device_config(client):
     """Test getting device config."""
 
     def mock_read(path):
@@ -32,16 +30,15 @@ def test_get_device_config(client):
         return {"hello.beer": {"free": "beer"}, "other.entity": {"do": "something"}}
 
     with patch("homeassistant.components.config._read", mock_read):
-        resp = yield from client.get("/api/config/zwave/device_config/hello.beer")
+        resp = await client.get("/api/config/zwave/device_config/hello.beer")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {"free": "beer"}
 
 
-@asyncio.coroutine
-def test_update_device_config(client):
+async def test_update_device_config(client):
     """Test updating device config."""
     orig_data = {
         "hello.beer": {"ignored": True},
@@ -61,13 +58,13 @@ def test_update_device_config(client):
     with patch("homeassistant.components.config._read", mock_read), patch(
         "homeassistant.components.config._write", mock_write
     ):
-        resp = yield from client.post(
+        resp = await client.post(
             "/api/config/zwave/device_config/hello.beer",
             data=json.dumps({"polling_intensity": 2}),
         )
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert result == {"result": "ok"}
 
     orig_data["hello.beer"]["polling_intensity"] = 2
@@ -75,10 +72,9 @@ def test_update_device_config(client):
     assert written[0] == orig_data
 
 
-@asyncio.coroutine
-def test_update_device_config_invalid_key(client):
+async def test_update_device_config_invalid_key(client):
     """Test updating device config."""
-    resp = yield from client.post(
+    resp = await client.post(
         "/api/config/zwave/device_config/invalid_entity",
         data=json.dumps({"polling_intensity": 2}),
     )
@@ -86,10 +82,9 @@ def test_update_device_config_invalid_key(client):
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_update_device_config_invalid_data(client):
+async def test_update_device_config_invalid_data(client):
     """Test updating device config."""
-    resp = yield from client.post(
+    resp = await client.post(
         "/api/config/zwave/device_config/hello.beer",
         data=json.dumps({"invalid_option": 2}),
     )
@@ -97,18 +92,16 @@ def test_update_device_config_invalid_data(client):
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_update_device_config_invalid_json(client):
+async def test_update_device_config_invalid_json(client):
     """Test updating device config."""
-    resp = yield from client.post(
+    resp = await client.post(
         "/api/config/zwave/device_config/hello.beer", data="not json"
     )
 
     assert resp.status == 400
 
 
-@asyncio.coroutine
-def test_get_values(hass, client):
+async def test_get_values(hass, client):
     """Test getting values on node."""
     node = MockNode(node_id=1)
     value = MockValue(
@@ -125,10 +118,10 @@ def test_get_values(hass, client):
     values2 = MockEntityValues(primary=value2)
     hass.data[const.DATA_ENTITY_VALUES] = [values, values2]
 
-    resp = yield from client.get("/api/zwave/values/1")
+    resp = await client.get("/api/zwave/values/1")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {
         "123456": {
@@ -140,8 +133,7 @@ def test_get_values(hass, client):
     }
 
 
-@asyncio.coroutine
-def test_get_groups(hass, client):
+async def test_get_groups(hass, client):
     """Test getting groupdata on node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=2)
@@ -152,10 +144,10 @@ def test_get_groups(hass, client):
     node.groups = {1: node.groups}
     network.nodes = {2: node}
 
-    resp = yield from client.get("/api/zwave/groups/2")
+    resp = await client.get("/api/zwave/groups/2")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {
         "1": {
@@ -167,38 +159,35 @@ def test_get_groups(hass, client):
     }
 
 
-@asyncio.coroutine
-def test_get_groups_nogroups(hass, client):
+async def test_get_groups_nogroups(hass, client):
     """Test getting groupdata on node with no groups."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=2)
 
     network.nodes = {2: node}
 
-    resp = yield from client.get("/api/zwave/groups/2")
+    resp = await client.get("/api/zwave/groups/2")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {}
 
 
-@asyncio.coroutine
-def test_get_groups_nonode(hass, client):
+async def test_get_groups_nonode(hass, client):
     """Test getting groupdata on nonexisting node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     network.nodes = {1: 1, 5: 5}
 
-    resp = yield from client.get("/api/zwave/groups/2")
+    resp = await client.get("/api/zwave/groups/2")
 
     assert resp.status == 404
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {"message": "Node not found"}
 
 
-@asyncio.coroutine
-def test_get_config(hass, client):
+async def test_get_config(hass, client):
     """Test getting config on node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=2)
@@ -214,10 +203,10 @@ def test_get_config(hass, client):
     network.nodes = {2: node}
     node.get_values.return_value = node.values
 
-    resp = yield from client.get("/api/zwave/config/2")
+    resp = await client.get("/api/zwave/config/2")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {
         "12": {
@@ -232,8 +221,7 @@ def test_get_config(hass, client):
     }
 
 
-@asyncio.coroutine
-def test_get_config_noconfig_node(hass, client):
+async def test_get_config_noconfig_node(hass, client):
     """Test getting config on node without config."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=2)
@@ -241,44 +229,41 @@ def test_get_config_noconfig_node(hass, client):
     network.nodes = {2: node}
     node.get_values.return_value = node.values
 
-    resp = yield from client.get("/api/zwave/config/2")
+    resp = await client.get("/api/zwave/config/2")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {}
 
 
-@asyncio.coroutine
-def test_get_config_nonode(hass, client):
+async def test_get_config_nonode(hass, client):
     """Test getting config on nonexisting node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     network.nodes = {1: 1, 5: 5}
 
-    resp = yield from client.get("/api/zwave/config/2")
+    resp = await client.get("/api/zwave/config/2")
 
     assert resp.status == 404
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {"message": "Node not found"}
 
 
-@asyncio.coroutine
-def test_get_usercodes_nonode(hass, client):
+async def test_get_usercodes_nonode(hass, client):
     """Test getting usercodes on nonexisting node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     network.nodes = {1: 1, 5: 5}
 
-    resp = yield from client.get("/api/zwave/usercodes/2")
+    resp = await client.get("/api/zwave/usercodes/2")
 
     assert resp.status == 404
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {"message": "Node not found"}
 
 
-@asyncio.coroutine
-def test_get_usercodes(hass, client):
+async def test_get_usercodes(hass, client):
     """Test getting usercodes on node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18, command_classes=[const.COMMAND_CLASS_USER_CODE])
@@ -290,16 +275,15 @@ def test_get_usercodes(hass, client):
     network.nodes = {18: node}
     node.get_values.return_value = node.values
 
-    resp = yield from client.get("/api/zwave/usercodes/18")
+    resp = await client.get("/api/zwave/usercodes/18")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {"0": {"code": "1234", "label": "label", "length": 4}}
 
 
-@asyncio.coroutine
-def test_get_usercode_nousercode_node(hass, client):
+async def test_get_usercode_nousercode_node(hass, client):
     """Test getting usercodes on node without usercodes."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18)
@@ -307,16 +291,15 @@ def test_get_usercode_nousercode_node(hass, client):
     network.nodes = {18: node}
     node.get_values.return_value = node.values
 
-    resp = yield from client.get("/api/zwave/usercodes/18")
+    resp = await client.get("/api/zwave/usercodes/18")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {}
 
 
-@asyncio.coroutine
-def test_get_usercodes_no_genreuser(hass, client):
+async def test_get_usercodes_no_genreuser(hass, client):
     """Test getting usercodes on node missing genre user."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18, command_classes=[const.COMMAND_CLASS_USER_CODE])
@@ -328,33 +311,31 @@ def test_get_usercodes_no_genreuser(hass, client):
     network.nodes = {18: node}
     node.get_values.return_value = node.values
 
-    resp = yield from client.get("/api/zwave/usercodes/18")
+    resp = await client.get("/api/zwave/usercodes/18")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
 
     assert result == {}
 
 
-@asyncio.coroutine
-def test_save_config_no_network(hass, client):
+async def test_save_config_no_network(hass, client):
     """Test saving configuration without network data."""
-    resp = yield from client.post("/api/zwave/saveconfig")
+    resp = await client.post("/api/zwave/saveconfig")
 
     assert resp.status == 404
-    result = yield from resp.json()
+    result = await resp.json()
     assert result == {"message": "No Z-Wave network data found"}
 
 
-@asyncio.coroutine
-def test_save_config(hass, client):
+async def test_save_config(hass, client):
     """Test saving configuration."""
     network = hass.data[DATA_NETWORK] = MagicMock()
 
-    resp = yield from client.post("/api/zwave/saveconfig")
+    resp = await client.post("/api/zwave/saveconfig")
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert network.write_config.called
     assert result == {"message": "Z-Wave configuration saved to file."}
 


### PR DESCRIPTION
## Description:

Migrate config tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
