### PR TITLE
Migrate owntracks tests from coroutine to async/await

### DIFF
--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -1,6 +1,4 @@
 """Test the owntracks_http platform."""
-import asyncio
-
 import pytest
 
 from homeassistant.components import owntracks
@@ -55,10 +53,9 @@ def mock_client(hass, aiohttp_client):
     return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
 
 
-@asyncio.coroutine
-def test_handle_valid_message(mock_client):
+async def test_handle_valid_message(mock_client):
     """Test that we forward messages correctly to OwnTracks."""
-    resp = yield from mock_client.post(
+    resp = await mock_client.post(
         "/api/webhook/owntracks_test",
         json=LOCATION_MESSAGE,
         headers={"X-Limit-u": "Paulus", "X-Limit-d": "Pixel"},
@@ -66,14 +63,13 @@ def test_handle_valid_message(mock_client):
 
     assert resp.status == 200
 
-    json = yield from resp.json()
+    json = await resp.json()
     assert json == []
 
 
-@asyncio.coroutine
-def test_handle_valid_minimal_message(mock_client):
+async def test_handle_valid_minimal_message(mock_client):
     """Test that we forward messages correctly to OwnTracks."""
-    resp = yield from mock_client.post(
+    resp = await mock_client.post(
         "/api/webhook/owntracks_test",
         json=MINIMAL_LOCATION_MESSAGE,
         headers={"X-Limit-u": "Paulus", "X-Limit-d": "Pixel"},
@@ -81,14 +77,13 @@ def test_handle_valid_minimal_message(mock_client):
 
     assert resp.status == 200
 
-    json = yield from resp.json()
+    json = await resp.json()
     assert json == []
 
 
-@asyncio.coroutine
-def test_handle_value_error(mock_client):
+async def test_handle_value_error(mock_client):
     """Test we don't disclose that this is a valid webhook."""
-    resp = yield from mock_client.post(
+    resp = await mock_client.post(
         "/api/webhook/owntracks_test",
         json="",
         headers={"X-Limit-u": "Paulus", "X-Limit-d": "Pixel"},
@@ -96,14 +91,13 @@ def test_handle_value_error(mock_client):
 
     assert resp.status == 200
 
-    json = yield from resp.text()
+    json = await resp.text()
     assert json == ""
 
 
-@asyncio.coroutine
-def test_returns_error_missing_username(mock_client, caplog):
+async def test_returns_error_missing_username(mock_client, caplog):
     """Test that an error is returned when username is missing."""
-    resp = yield from mock_client.post(
+    resp = await mock_client.post(
         "/api/webhook/owntracks_test",
         json=LOCATION_MESSAGE,
         headers={"X-Limit-d": "Pixel"},
@@ -111,29 +105,27 @@ def test_returns_error_missing_username(mock_client, caplog):
 
     # Needs to be 200 or OwnTracks keeps retrying bad packet.
     assert resp.status == 200
-    json = yield from resp.json()
+    json = await resp.json()
     assert json == []
     assert "No topic or user found" in caplog.text
 
 
-@asyncio.coroutine
-def test_returns_error_incorrect_json(mock_client, caplog):
+async def test_returns_error_incorrect_json(mock_client, caplog):
     """Test that an error is returned when username is missing."""
-    resp = yield from mock_client.post(
+    resp = await mock_client.post(
         "/api/webhook/owntracks_test", data="not json", headers={"X-Limit-d": "Pixel"}
     )
 
     # Needs to be 200 or OwnTracks keeps retrying bad packet.
     assert resp.status == 200
-    json = yield from resp.json()
+    json = await resp.json()
     assert json == []
     assert "invalid JSON" in caplog.text
 
 
-@asyncio.coroutine
-def test_returns_error_missing_device(mock_client):
+async def test_returns_error_missing_device(mock_client):
     """Test that an error is returned when device name is missing."""
-    resp = yield from mock_client.post(
+    resp = await mock_client.post(
         "/api/webhook/owntracks_test",
         json=LOCATION_MESSAGE,
         headers={"X-Limit-u": "Paulus"},
@@ -141,7 +133,7 @@ def test_returns_error_missing_device(mock_client):
 
     assert resp.status == 200
 
-    json = yield from resp.json()
+    json = await resp.json()
     assert json == []
 
 


### PR DESCRIPTION
## Description:

Migrate owntracks tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
