### PR TITLE
Migrate automatic tests from coroutine to async/await

### DIFF
--- a/tests/components/automatic/test_device_tracker.py
+++ b/tests/components/automatic/test_device_tracker.py
@@ -31,8 +31,7 @@ def test_invalid_credentials(
     hass.loop.run_until_complete(async_setup_component(hass, "http", {}))
     mock_json_load.return_value = {"refresh_token": "bad_token"}
 
-    @asyncio.coroutine
-    def get_session(*args, **kwargs):
+    async def get_session(*args, **kwargs):
         """Return the test session."""
         raise aioautomatic.exceptions.BadRequestError("err_invalid_refresh_token")
 
@@ -87,18 +86,15 @@ def test_valid_credentials(
     trip.end_location.accuracy_m = 5.6
     trip.ended_at = datetime(2017, 8, 13, 1, 2, 4)
 
-    @asyncio.coroutine
-    def get_session(*args, **kwargs):
+    async def get_session(*args, **kwargs):
         """Return the test session."""
         return session
 
-    @asyncio.coroutine
-    def get_vehicles(*args, **kwargs):
+    async def get_vehicles(*args, **kwargs):
         """Return list of test vehicles."""
         return [vehicle]
 
-    @asyncio.coroutine
-    def get_trips(*args, **kwargs):
+    async def get_trips(*args, **kwargs):
         """Return list of test trips."""
         return [trip]
 
@@ -108,8 +104,7 @@ def test_valid_credentials(
     session.get_trips.side_effect = get_trips
     session.refresh_token = "mock_refresh_token"
 
-    @asyncio.coroutine
-    def ws_connect():
+    async def ws_connect():
         return asyncio.Future()
 
     mock_ws_connect.side_effect = ws_connect

--- a/tests/components/automatic/test_device_tracker.py
+++ b/tests/components/automatic/test_device_tracker.py
@@ -1,5 +1,4 @@
 """Test the automatic device tracker platform."""
-import asyncio
 from datetime import datetime
 import logging
 from unittest.mock import MagicMock, patch
@@ -103,11 +102,6 @@ def test_valid_credentials(
     session.get_vehicles.side_effect = get_vehicles
     session.get_trips.side_effect = get_trips
     session.refresh_token = "mock_refresh_token"
-
-    async def ws_connect():
-        return asyncio.Future()
-
-    mock_ws_connect.side_effect = ws_connect
 
     config = {
         "platform": "automatic",

--- a/tests/components/automatic/test_device_tracker.py
+++ b/tests/components/automatic/test_device_tracker.py
@@ -1,9 +1,9 @@
 """Test the automatic device tracker platform."""
 from datetime import datetime
 import logging
-from unittest.mock import MagicMock, patch
 
 import aioautomatic
+from asynctest import MagicMock, patch
 
 from homeassistant.components.automatic.device_tracker import async_setup_scanner
 from homeassistant.setup import async_setup_component
@@ -114,6 +114,9 @@ def test_valid_credentials(
     result = hass.loop.run_until_complete(async_setup_scanner(hass, config, mock_see))
 
     assert result
+
+    assert mock_ws_connect.called
+    assert len(mock_ws_connect.mock_calls) == 2
 
     assert mock_create_session.called
     assert len(mock_create_session.mock_calls) == 1


### PR DESCRIPTION
## Description:

Migrate automatic tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
