### PR TITLE
Migrate camera tests from coroutine to async/await

### DIFF
--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -147,8 +147,7 @@ class TestGetImage:
             ).result()
 
 
-@asyncio.coroutine
-def test_snapshot_service(hass, mock_camera):
+async def test_snapshot_service(hass, mock_camera):
     """Test snapshot service."""
     mopen = mock_open()
 
@@ -156,7 +155,7 @@ def test_snapshot_service(hass, mock_camera):
         "homeassistant.components.camera.open", mopen, create=True
     ), patch.object(hass.config, "is_allowed_path", return_value=True):
         common.async_snapshot(hass, "/tmp/bla")
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
         mock_write = mopen().write
 


### PR DESCRIPTION
## Description:

Migrate camera tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
