### PR TITLE
Migrate ffmpeg tests from coroutine to async/await

### DIFF
--- a/tests/components/ffmpeg/test_init.py
+++ b/tests/components/ffmpeg/test_init.py
@@ -1,5 +1,4 @@
 """The tests for Home Assistant ffmpeg."""
-import asyncio
 from unittest.mock import MagicMock
 
 import homeassistant.components.ffmpeg as ffmpeg
@@ -61,14 +60,12 @@ class MockFFmpegDev(ffmpeg.FFmpegBase):
         self.called_restart = False
         self.called_entities = None
 
-    @asyncio.coroutine
-    def _async_start_ffmpeg(self, entity_ids):
+    async def _async_start_ffmpeg(self, entity_ids):
         """Mock start."""
         self.called_start = True
         self.called_entities = entity_ids
 
-    @asyncio.coroutine
-    def _async_stop_ffmpeg(self, entity_ids):
+    async def _async_stop_ffmpeg(self, entity_ids):
         """Mock stop."""
         self.called_stop = True
         self.called_entities = entity_ids
@@ -102,91 +99,85 @@ class TestFFmpegSetup:
         assert self.hass.services.has_service(ffmpeg.DOMAIN, "restart")
 
 
-@asyncio.coroutine
-def test_setup_component_test_register(hass):
+async def test_setup_component_test_register(hass):
     """Set up ffmpeg component test register."""
     with assert_setup_component(1):
-        yield from async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
+        await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
     hass.bus.async_listen_once = MagicMock()
     ffmpeg_dev = MockFFmpegDev(hass)
-    yield from ffmpeg_dev.async_added_to_hass()
+    await ffmpeg_dev.async_added_to_hass()
 
     assert hass.bus.async_listen_once.called
     assert hass.bus.async_listen_once.call_count == 2
 
 
-@asyncio.coroutine
-def test_setup_component_test_register_no_startup(hass):
+async def test_setup_component_test_register_no_startup(hass):
     """Set up ffmpeg component test register without startup."""
     with assert_setup_component(1):
-        yield from async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
+        await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
     hass.bus.async_listen_once = MagicMock()
     ffmpeg_dev = MockFFmpegDev(hass, False)
-    yield from ffmpeg_dev.async_added_to_hass()
+    await ffmpeg_dev.async_added_to_hass()
 
     assert hass.bus.async_listen_once.called
     assert hass.bus.async_listen_once.call_count == 1
 
 
-@asyncio.coroutine
-def test_setup_component_test_service_start(hass):
+async def test_setup_component_test_service_start(hass):
     """Set up ffmpeg component test service start."""
     with assert_setup_component(1):
-        yield from async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
+        await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
     ffmpeg_dev = MockFFmpegDev(hass, False)
-    yield from ffmpeg_dev.async_added_to_hass()
+    await ffmpeg_dev.async_added_to_hass()
 
     async_start(hass)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert ffmpeg_dev.called_start
 
 
-@asyncio.coroutine
-def test_setup_component_test_service_stop(hass):
+async def test_setup_component_test_service_stop(hass):
     """Set up ffmpeg component test service stop."""
     with assert_setup_component(1):
-        yield from async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
+        await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
     ffmpeg_dev = MockFFmpegDev(hass, False)
-    yield from ffmpeg_dev.async_added_to_hass()
+    await ffmpeg_dev.async_added_to_hass()
 
     async_stop(hass)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert ffmpeg_dev.called_stop
 
 
-@asyncio.coroutine
-def test_setup_component_test_service_restart(hass):
+async def test_setup_component_test_service_restart(hass):
     """Set up ffmpeg component test service restart."""
     with assert_setup_component(1):
-        yield from async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
+        await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
     ffmpeg_dev = MockFFmpegDev(hass, False)
-    yield from ffmpeg_dev.async_added_to_hass()
+    await ffmpeg_dev.async_added_to_hass()
 
     async_restart(hass)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert ffmpeg_dev.called_stop
     assert ffmpeg_dev.called_start
 
 
-@asyncio.coroutine
-def test_setup_component_test_service_start_with_entity(hass):
+async def test_setup_component_test_service_start_with_entity(hass):
     """Set up ffmpeg component test service start."""
     with assert_setup_component(1):
-        yield from async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
+        await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
     ffmpeg_dev = MockFFmpegDev(hass, False)
-    yield from ffmpeg_dev.async_added_to_hass()
+    await ffmpeg_dev.async_added_to_hass()
 
     async_start(hass, "test.ffmpeg_device")
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert ffmpeg_dev.called_start
     assert ffmpeg_dev.called_entities == ["test.ffmpeg_device"]


### PR DESCRIPTION
## Description:

Migrate ffmpeg tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
