### PR TITLE
Migrate discovery tests from coroutine to async/await

### DIFF
--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the discovery component."""
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -55,29 +54,27 @@ async def mock_discovery(hass, discoveries, config=BASE_CONFIG):
     return mock_discover, mock_platform
 
 
-@asyncio.coroutine
-def test_unknown_service(hass):
+async def test_unknown_service(hass):
     """Test that unknown service is ignored."""
 
     def discover(netdisco):
         """Fake discovery."""
         return [("this_service_will_never_be_supported", {"info": "some"})]
 
-    mock_discover, mock_platform = yield from mock_discovery(hass, discover)
+    mock_discover, mock_platform = await mock_discovery(hass, discover)
 
     assert not mock_discover.called
     assert not mock_platform.called
 
 
-@asyncio.coroutine
-def test_load_platform(hass):
+async def test_load_platform(hass):
     """Test load a platform."""
 
     def discover(netdisco):
         """Fake discovery."""
         return [(SERVICE, SERVICE_INFO)]
 
-    mock_discover, mock_platform = yield from mock_discovery(hass, discover)
+    mock_discover, mock_platform = await mock_discovery(hass, discover)
 
     assert not mock_discover.called
     assert mock_platform.called
@@ -86,15 +83,14 @@ def test_load_platform(hass):
     )
 
 
-@asyncio.coroutine
-def test_load_component(hass):
+async def test_load_component(hass):
     """Test load a component."""
 
     def discover(netdisco):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
-    mock_discover, mock_platform = yield from mock_discovery(hass, discover)
+    mock_discover, mock_platform = await mock_discovery(hass, discover)
 
     assert mock_discover.called
     assert not mock_platform.called
@@ -107,24 +103,20 @@ def test_load_component(hass):
     )
 
 
-@asyncio.coroutine
-def test_ignore_service(hass):
+async def test_ignore_service(hass):
     """Test ignore service."""
 
     def discover(netdisco):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
-    mock_discover, mock_platform = yield from mock_discovery(
-        hass, discover, IGNORE_CONFIG
-    )
+    mock_discover, mock_platform = await mock_discovery(hass, discover, IGNORE_CONFIG)
 
     assert not mock_discover.called
     assert not mock_platform.called
 
 
-@asyncio.coroutine
-def test_discover_duplicates(hass):
+async def test_discover_duplicates(hass):
     """Test load a component."""
 
     def discover(netdisco):
@@ -134,7 +126,7 @@ def test_discover_duplicates(hass):
             (SERVICE_NO_PLATFORM, SERVICE_INFO),
         ]
 
-    mock_discover, mock_platform = yield from mock_discovery(hass, discover)
+    mock_discover, mock_platform = await mock_discovery(hass, discover)
 
     assert mock_discover.called
     assert mock_discover.call_count == 1


### PR DESCRIPTION
## Description:

Migrate discovery tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
