### PR TITLE
Migrate google_* tests from coroutine to async/await

### DIFF
--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -1,6 +1,5 @@
 """The tests for the Google Assistant component."""
 # pylint: disable=protected-access
-import asyncio
 import json
 
 from aiohttp.hdrs import AUTHORIZATION
@@ -115,18 +114,17 @@ def hass_fixture(loop, hass):
 # pylint: disable=redefined-outer-name
 
 
-@asyncio.coroutine
-def test_sync_request(hass_fixture, assistant_client, auth_header):
+async def test_sync_request(hass_fixture, assistant_client, auth_header):
     """Test a sync request."""
     reqid = "5711642932632160983"
     data = {"requestId": reqid, "inputs": [{"intent": "action.devices.SYNC"}]}
-    result = yield from assistant_client.post(
+    result = await assistant_client.post(
         ga.const.GOOGLE_ASSISTANT_API_ENDPOINT,
         data=json.dumps(data),
         headers=auth_header,
     )
     assert result.status == 200
-    body = yield from result.json()
+    body = await result.json()
     assert body.get("requestId") == reqid
     devices = body["payload"]["devices"]
     assert sorted([dev["id"] for dev in devices]) == sorted(
@@ -145,8 +143,7 @@ def test_sync_request(hass_fixture, assistant_client, auth_header):
         assert dev["type"] == demo["type"]
 
 
-@asyncio.coroutine
-def test_query_request(hass_fixture, assistant_client, auth_header):
+async def test_query_request(hass_fixture, assistant_client, auth_header):
     """Test a query request."""
     reqid = "5711642932632160984"
     data = {
@@ -165,13 +162,13 @@ def test_query_request(hass_fixture, assistant_client, auth_header):
             }
         ],
     }
-    result = yield from assistant_client.post(
+    result = await assistant_client.post(
         ga.const.GOOGLE_ASSISTANT_API_ENDPOINT,
         data=json.dumps(data),
         headers=auth_header,
     )
     assert result.status == 200
-    body = yield from result.json()
+    body = await result.json()
     assert body.get("requestId") == reqid
     devices = body["payload"]["devices"]
     assert len(devices) == 4
@@ -187,8 +184,7 @@ def test_query_request(hass_fixture, assistant_client, auth_header):
     assert devices["media_player.lounge_room"]["on"] is True
 
 
-@asyncio.coroutine
-def test_query_climate_request(hass_fixture, assistant_client, auth_header):
+async def test_query_climate_request(hass_fixture, assistant_client, auth_header):
     """Test a query request."""
     reqid = "5711642932632160984"
     data = {
@@ -206,13 +202,13 @@ def test_query_climate_request(hass_fixture, assistant_client, auth_header):
             }
         ],
     }
-    result = yield from assistant_client.post(
+    result = await assistant_client.post(
         ga.const.GOOGLE_ASSISTANT_API_ENDPOINT,
         data=json.dumps(data),
         headers=auth_header,
     )
     assert result.status == 200
-    body = yield from result.json()
+    body = await result.json()
     assert body.get("requestId") == reqid
     devices = body["payload"]["devices"]
     assert len(devices) == 3
@@ -238,8 +234,7 @@ def test_query_climate_request(hass_fixture, assistant_client, auth_header):
     }
 
 
-@asyncio.coroutine
-def test_query_climate_request_f(hass_fixture, assistant_client, auth_header):
+async def test_query_climate_request_f(hass_fixture, assistant_client, auth_header):
     """Test a query request."""
     # Mock demo devices as fahrenheit to see if we convert to celsius
     hass_fixture.config.units.temperature_unit = const.TEMP_FAHRENHEIT
@@ -264,13 +259,13 @@ def test_query_climate_request_f(hass_fixture, assistant_client, auth_header):
             }
         ],
     }
-    result = yield from assistant_client.post(
+    result = await assistant_client.post(
         ga.const.GOOGLE_ASSISTANT_API_ENDPOINT,
         data=json.dumps(data),
         headers=auth_header,
     )
     assert result.status == 200
-    body = yield from result.json()
+    body = await result.json()
     assert body.get("requestId") == reqid
     devices = body["payload"]["devices"]
     assert len(devices) == 3
@@ -297,8 +292,7 @@ def test_query_climate_request_f(hass_fixture, assistant_client, auth_header):
     hass_fixture.config.units.temperature_unit = const.TEMP_CELSIUS
 
 
-@asyncio.coroutine
-def test_execute_request(hass_fixture, assistant_client, auth_header):
+async def test_execute_request(hass_fixture, assistant_client, auth_header):
     """Test an execute request."""
     reqid = "5711642932632160985"
     data = {
@@ -357,13 +351,13 @@ def test_execute_request(hass_fixture, assistant_client, auth_header):
             }
         ],
     }
-    result = yield from assistant_client.post(
+    result = await assistant_client.post(
         ga.const.GOOGLE_ASSISTANT_API_ENDPOINT,
         data=json.dumps(data),
         headers=auth_header,
     )
     assert result.status == 200
-    body = yield from result.json()
+    body = await result.json()
     assert body.get("requestId") == reqid
     commands = body["payload"]["commands"]
     assert len(commands) == 6

--- a/tests/components/google_assistant/test_init.py
+++ b/tests/components/google_assistant/test_init.py
@@ -1,6 +1,4 @@
 """The tests for google-assistant init."""
-import asyncio
-
 from homeassistant.components import google_assistant as ga
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
@@ -8,19 +6,18 @@ from homeassistant.setup import async_setup_component
 GA_API_KEY = "Agdgjsj399sdfkosd932ksd"
 
 
-@asyncio.coroutine
-def test_request_sync_service(aioclient_mock, hass):
+async def test_request_sync_service(aioclient_mock, hass):
     """Test that it posts to the request_sync url."""
     aioclient_mock.post(ga.const.REQUEST_SYNC_BASE_URL, status=200)
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         "google_assistant",
         {"google_assistant": {"project_id": "test_project", "api_key": GA_API_KEY}},
     )
 
     assert aioclient_mock.call_count == 0
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         ga.const.DOMAIN,
         ga.const.SERVICE_REQUEST_SYNC,
         blocking=True,

--- a/tests/components/google_domains/test_init.py
+++ b/tests/components/google_domains/test_init.py
@@ -1,5 +1,4 @@
 """Test the Google Domains component."""
-import asyncio
 from datetime import timedelta
 
 import pytest
@@ -37,12 +36,11 @@ def setup_google_domains(hass, aioclient_mock):
     )
 
 
-@asyncio.coroutine
-def test_setup(hass, aioclient_mock):
+async def test_setup(hass, aioclient_mock):
     """Test setup works if update passes."""
     aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="nochg 0.0.0.0")
 
-    result = yield from async_setup_component(
+    result = await async_setup_component(
         hass,
         google_domains.DOMAIN,
         {
@@ -57,16 +55,15 @@ def test_setup(hass, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
     async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert aioclient_mock.call_count == 2
 
 
-@asyncio.coroutine
-def test_setup_fails_if_update_fails(hass, aioclient_mock):
+async def test_setup_fails_if_update_fails(hass, aioclient_mock):
     """Test setup fails if first update fails."""
     aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="nohost")
 
-    result = yield from async_setup_component(
+    result = await async_setup_component(
         hass,
         google_domains.DOMAIN,
         {


### PR DESCRIPTION
## Description:

Migrate google_* tests from coroutine to async/await:

- google_assistant
- google_domains

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
