### PR TITLE
Add generic command/button functionality to webostv

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -365,6 +365,7 @@ homeassistant/components/waqi/* @andrey-git
 homeassistant/components/watson_tts/* @rutkai
 homeassistant/components/weather/* @fabaff
 homeassistant/components/weblink/* @home-assistant/core
+homeassistant/components/webostv/* @bendavid
 homeassistant/components/websocket_api/* @home-assistant/core
 homeassistant/components/wemo/* @sqldiablo
 homeassistant/components/withings/* @vangorra

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -6,5 +6,5 @@
     "aiopylgtv==0.2.4"
   ],
   "dependencies": ["configurator"],
-  "codeowners": []
+  "codeowners": ["@bendavid"]
 }

--- a/homeassistant/components/webostv/services.yaml
+++ b/homeassistant/components/webostv/services.yaml
@@ -1,0 +1,26 @@
+# Describes the format for available webostv services	
+
+button:
+  description: 'Send a button press command.'
+  fields:
+    entity_id:
+      description: Name(s) of the webostv entities where to run the API method.
+      example: 'media_player.living_room_tv'
+    button:
+      description: Name of the button to press.  Known possible values are 
+        LEFT, RIGHT, DOWN, UP, HOME, BACK, ENTER, DASH, INFO, ASTERISK, CC, EXIT,
+        MUTE, RED, GREEN, BLUE, VOLUMEUP, VOLUMEDOWN, CHANNELUP, CHANNELDOWN,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+      example: 'LEFT'
+
+command:
+  description: 'Send a command.'
+  fields:
+    entity_id:
+      description: Name(s) of the webostv entities where to run the API method.
+      example: 'media_player.living_room_tv'
+    command:
+      description: Endpoint of the command.  Known valid endpoints are listed in
+        https://github.com/TheRealLink/pylgtv/blob/master/pylgtv/endpoints.py
+      example: 'media.controls/rewind'
+

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -9,7 +9,13 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_VOLUME_MUTED,
     SERVICE_SELECT_SOURCE,
 )
-from homeassistant.components.webostv import DOMAIN
+from homeassistant.components.webostv import (
+    ATTR_BUTTON,
+    ATTR_COMMAND,
+    DOMAIN,
+    SERVICE_BUTTON,
+    SERVICE_COMMAND,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,
@@ -75,3 +81,34 @@ async def test_select_source_with_empty_source_list(hass, client):
     assert hass.states.is_state(ENTITY_ID, "playing")
     client.launch_app.assert_not_called()
     client.set_input.assert_not_called()
+
+
+async def test_button(hass, client):
+    """Test generic button functionality."""
+
+    await setup_webostv(hass)
+
+    data = {
+        ATTR_ENTITY_ID: ENTITY_ID,
+        ATTR_BUTTON: "test",
+    }
+    await hass.services.async_call(DOMAIN, SERVICE_BUTTON, data)
+    await hass.async_block_till_done()
+
+    client.button.assert_called_once()
+    client.button.assert_called_with("test")
+
+
+async def test_command(hass, client):
+    """Test generic button functionality."""
+
+    await setup_webostv(hass)
+
+    data = {
+        ATTR_ENTITY_ID: ENTITY_ID,
+        ATTR_COMMAND: "test",
+    }
+    await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
+    await hass.async_block_till_done()
+
+    client.request.assert_called_with("test")


### PR DESCRIPTION
Adds generic command and button functionality to webostv

## Example entry for `configuration.yaml`:
```yaml
home_button:
  sequence:
    - service: webostv.button
      data:
        entity_id:  media_player.lg_webos_smart_tv
        button: "HOME"

rewind_command:
  sequence:
    - service: webostv.command
      data:
        entity_id:  media_player.lg_webos_smart_tv
        command: "media.controls/rewind"
```

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/11584