### PR TITLE
Update homekit AirQualitySensor to pass more than Particulate Density

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     DEFAULT_AUTO_START,
     DEFAULT_PORT,
     DEFAULT_SAFE_MODE,
+    DEVICE_CLASS_AIR_QUALITY,
     DEVICE_CLASS_CO,
     DEVICE_CLASS_CO2,
     DEVICE_CLASS_PM25,
@@ -239,6 +240,11 @@ def get_accessory(hass, driver, state, aid, config):
         elif device_class == DEVICE_CLASS_HUMIDITY and unit == "%":
             a_type = "HumiditySensor"
         elif device_class == DEVICE_CLASS_PM25 or DEVICE_CLASS_PM25 in state.entity_id:
+            a_type = "AirQualitySensor"
+        elif (
+            device_class == DEVICE_CLASS_AIR_QUALITY
+            or DEVICE_CLASS_AIR_QUALITY in state.entity_id
+        ):
             a_type = "AirQualitySensor"
         elif device_class == DEVICE_CLASS_CO:
             a_type = "CarbonMonoxideSensor"

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -7,13 +7,10 @@ HOMEKIT_NOTIFY_ID = 4663548
 
 # #### Attributes ####
 ATTR_DISPLAY_NAME = "display_name"
-ATTR_NITROGEN_DIOXIDE_DENSITY = "nitrogen_dioxide_density"
-ATTR_PM_DENSITY = "pm_density"
-ATTR_PM_SIZE = "pm_size"
-ATTR_PM_2_5_DENSITY = "pm_2_5_density"
-ATTR_PM_10_DENSITY = "pm_10_density"
+ATTR_PM = "particulate_matter"
+ATTR_PM_SIZE = "particulate_matter_size"
 ATTR_VALUE = "value"
-ATTR_VOC_DENSITY = "voc_density"
+ATTR_VOC_DENSITY = "volatile_organic_compounds"
 
 # #### Config ####
 CONF_ADVERTISE_IP = "advertise_ip"

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -7,7 +7,13 @@ HOMEKIT_NOTIFY_ID = 4663548
 
 # #### Attributes ####
 ATTR_DISPLAY_NAME = "display_name"
+ATTR_NITROGEN_DIOXIDE_DENSITY = "nitrogen_dioxide_density"
+ATTR_PM_DENSITY = "pm_density"
+ATTR_PM_SIZE = "pm_size"
+ATTR_PM_2_5_DENSITY = "pm_2_5_density"
+ATTR_PM_10_DENSITY = "pm_10_density"
 ATTR_VALUE = "value"
+ATTR_VOC_DENSITY = "voc_density"
 
 # #### Config ####
 CONF_ADVERTISE_IP = "advertise_ip"
@@ -85,6 +91,7 @@ SERV_WINDOW_COVERING = "WindowCovering"
 CHAR_ACTIVE = "Active"
 CHAR_ACTIVE_IDENTIFIER = "ActiveIdentifier"
 CHAR_AIR_PARTICULATE_DENSITY = "AirParticulateDensity"
+CHAR_AIR_PARTICULATE_SIZE = "AirParticulateSize"
 CHAR_AIR_QUALITY = "AirQuality"
 CHAR_BATTERY_LEVEL = "BatteryLevel"
 CHAR_BRIGHTNESS = "Brightness"
@@ -123,9 +130,12 @@ CHAR_MODEL = "Model"
 CHAR_MOTION_DETECTED = "MotionDetected"
 CHAR_MUTE = "Mute"
 CHAR_NAME = "Name"
+CHAR_NITROGEN_DIOXIDE_DENSITY = "NitrogenDioxideDensity"
 CHAR_OCCUPANCY_DETECTED = "OccupancyDetected"
 CHAR_ON = "On"
 CHAR_OUTLET_IN_USE = "OutletInUse"
+CHAR_PM_2_5_DENSITY = "PM2.5Density"
+CHAR_PM_10_DENSITY = "PM10Density"
 CHAR_POSITION_STATE = "PositionState"
 CHAR_REMOTE_KEY = "RemoteKey"
 CHAR_ROTATION_DIRECTION = "RotationDirection"
@@ -143,10 +153,14 @@ CHAR_TARGET_SECURITY_STATE = "SecuritySystemTargetState"
 CHAR_TARGET_TEMPERATURE = "TargetTemperature"
 CHAR_TEMP_DISPLAY_UNITS = "TemperatureDisplayUnits"
 CHAR_VALVE_TYPE = "ValveType"
+CHAR_VOC_DENSITY = "VOCDensity"
 CHAR_VOLUME = "Volume"
 CHAR_VOLUME_SELECTOR = "VolumeSelector"
 CHAR_VOLUME_CONTROL_TYPE = "VolumeControlType"
 
+# #### Characteristic Values ####
+CHAR_VALUE_AIR_PARTICULATE_SIZE_PM2_5 = 0
+CHAR_VALUE_AIR_PARTICULATE_SIZE_PM10 = 1
 
 # #### Properties ####
 PROP_MAX_VALUE = "maxValue"
@@ -165,6 +179,7 @@ DEVICE_CLASS_MOTION = "motion"
 DEVICE_CLASS_OCCUPANCY = "occupancy"
 DEVICE_CLASS_OPENING = "opening"
 DEVICE_CLASS_PM25 = "pm25"
+DEVICE_CLASS_AIR_QUALITY = "air_quality"
 DEVICE_CLASS_SMOKE = "smoke"
 DEVICE_CLASS_WINDOW = "window"
 

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -319,9 +319,8 @@ class AirQualitySensor(HomeAccessory):
             # (https://developer.apple.com/documentation/homekit/hmcharacteristicvalueairparticulatesize)
             pm_size_char_value = None
             if pm_size:
-                try:
-                    pm_size_char_value = pm_size_to_homekit(pm_size)
-                except (ValueError):
+                pm_size_char_value = pm_size_to_homekit(pm_size)
+                if pm_size_char_value is None:
                     _LOGGER.warning(
                         "%s: Given pm_size is not valid value, ignoring.",
                         self.entity_id,

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -41,7 +41,6 @@ from .const import (
     CHAR_PM_10_DENSITY,
     CHAR_SMOKE_DETECTED,
     CHAR_VALUE_AIR_PARTICULATE_SIZE_PM2_5,
-    CHAR_VALUE_AIR_PARTICULATE_SIZE_PM10,
     CHAR_VOC_DENSITY,
     DEVICE_CLASS_CO2,
     DEVICE_CLASS_DOOR,
@@ -69,7 +68,12 @@ from .const import (
     THRESHOLD_CO,
     THRESHOLD_CO2,
 )
-from .util import convert_to_float, density_to_air_quality, temperature_to_homekit
+from .util import (
+    convert_to_float,
+    density_to_air_quality,
+    pm_size_to_homekit,
+    temperature_to_homekit,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -315,13 +319,11 @@ class AirQualitySensor(HomeAccessory):
             # (https://developer.apple.com/documentation/homekit/hmcharacteristicvalueairparticulatesize)
             pm_size_char_value = None
             if pm_size:
-                if pm_size == 2.5:
-                    pm_size_char_value = CHAR_VALUE_AIR_PARTICULATE_SIZE_PM2_5
-                elif pm_size == 10:
-                    pm_size_char_value = CHAR_VALUE_AIR_PARTICULATE_SIZE_PM10
-                else:
+                try:
+                    pm_size_char_value = pm_size_to_homekit(pm_size)
+                except (ValueError):
                     _LOGGER.warning(
-                        "%s: Given pm_size is not valid value (2.5, 10), ignoring.",
+                        "%s: Given pm_size is not valid value, ignoring.",
                         self.entity_id,
                     )
 

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -3,6 +3,7 @@ import logging
 
 from pyhap.const import CATEGORY_SENSOR
 
+from homeassistant.components.air_quality import ATTR_NO2, ATTR_PM_2_5, ATTR_PM_10
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -14,10 +15,7 @@ from homeassistant.const import (
 from . import TYPES
 from .accessories import HomeAccessory
 from .const import (
-    ATTR_NITROGEN_DIOXIDE_DENSITY,
-    ATTR_PM_2_5_DENSITY,
-    ATTR_PM_10_DENSITY,
-    ATTR_PM_DENSITY,
+    ATTR_PM,
     ATTR_PM_SIZE,
     ATTR_VOC_DENSITY,
     CHAR_AIR_PARTICULATE_DENSITY,
@@ -150,16 +148,12 @@ class AirQualitySensor(HomeAccessory):
         chars = []
         current_state = self.hass.states.get(self.entity_id)
         nitrogen_dioxide_density = convert_to_float(
-            current_state.attributes.get(ATTR_NITROGEN_DIOXIDE_DENSITY)
+            current_state.attributes.get(ATTR_NO2)
         )
         voc_density = convert_to_float(current_state.attributes.get(ATTR_VOC_DENSITY))
-        pm_2_5_density = convert_to_float(
-            current_state.attributes.get(ATTR_PM_2_5_DENSITY)
-        )
-        pm_10_density = convert_to_float(
-            current_state.attributes.get(ATTR_PM_10_DENSITY)
-        )
-        pm_density = convert_to_float(current_state.attributes.get(ATTR_PM_DENSITY))
+        pm_2_5_density = convert_to_float(current_state.attributes.get(ATTR_PM_2_5))
+        pm_10_density = convert_to_float(current_state.attributes.get(ATTR_PM_10))
+        pm_density = convert_to_float(current_state.attributes.get(ATTR_PM))
         pm_size = convert_to_float(current_state.attributes.get(ATTR_PM_SIZE))
         device_class = current_state.attributes.get(ATTR_DEVICE_CLASS)
 
@@ -232,13 +226,11 @@ class AirQualitySensor(HomeAccessory):
 
     def update_state(self, new_state):
         """Update accessory after state change."""
-        nitrogen_dioxide_density = convert_to_float(
-            new_state.attributes.get(ATTR_NITROGEN_DIOXIDE_DENSITY)
-        )
+        nitrogen_dioxide_density = convert_to_float(new_state.attributes.get(ATTR_NO2))
         voc_density = convert_to_float(new_state.attributes.get(ATTR_VOC_DENSITY))
-        pm_2_5_density = convert_to_float(new_state.attributes.get(ATTR_PM_2_5_DENSITY))
-        pm_10_density = convert_to_float(new_state.attributes.get(ATTR_PM_10_DENSITY))
-        pm_density = convert_to_float(new_state.attributes.get(ATTR_PM_DENSITY))
+        pm_2_5_density = convert_to_float(new_state.attributes.get(ATTR_PM_2_5))
+        pm_10_density = convert_to_float(new_state.attributes.get(ATTR_PM_10))
+        pm_density = convert_to_float(new_state.attributes.get(ATTR_PM))
         pm_size = convert_to_float(new_state.attributes.get(ATTR_PM_SIZE))
 
         # if device class or entity ID contain DEVICE_CLASS_PM25 then assume state is a PM25 reading

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -17,6 +17,8 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.util.temperature as temp_util
 
 from .const import (
+    CHAR_VALUE_AIR_PARTICULATE_SIZE_PM2_5,
+    CHAR_VALUE_AIR_PARTICULATE_SIZE_PM10,
     CONF_FEATURE,
     CONF_FEATURE_LIST,
     CONF_LINKED_BATTERY_SENSOR,
@@ -254,3 +256,16 @@ def density_to_air_quality(density):
     if density <= 150:
         return 4
     return 5
+
+
+def pm_size_to_homekit(pm_size):
+    """Map the given PM size to value HomeKit Expects.
+
+    See https://developer.apple.com/documentation/homekit/hmcharacteristicvalueairparticulatesize for details.
+    """
+    if pm_size == 2.5:
+        return CHAR_VALUE_AIR_PARTICULATE_SIZE_PM2_5
+    elif pm_size == 10:
+        return CHAR_VALUE_AIR_PARTICULATE_SIZE_PM10
+    else:
+        raise ValueError("given PM size not recognized.")

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -265,7 +265,6 @@ def pm_size_to_homekit(pm_size):
     """
     if pm_size == 2.5:
         return CHAR_VALUE_AIR_PARTICULATE_SIZE_PM2_5
-    elif pm_size == 10:
+    if pm_size == 10:
         return CHAR_VALUE_AIR_PARTICULATE_SIZE_PM10
-    else:
-        raise ValueError("given PM size not recognized.")
+    return None

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -1,9 +1,7 @@
 """Test different accessory types: Sensors."""
+from homeassistant.components.air_quality import ATTR_NO2, ATTR_PM_2_5, ATTR_PM_10
 from homeassistant.components.homekit.const import (
-    ATTR_NITROGEN_DIOXIDE_DENSITY,
-    ATTR_PM_2_5_DENSITY,
-    ATTR_PM_10_DENSITY,
-    ATTR_PM_DENSITY,
+    ATTR_PM,
     ATTR_PM_SIZE,
     ATTR_VOC_DENSITY,
     CHAR_VALUE_AIR_PARTICULATE_SIZE_PM2_5,
@@ -130,10 +128,10 @@ async def test_air_quality_all_props_update_all_props(hass, hk_driver):
         entity_id,
         5,
         {
-            ATTR_NITROGEN_DIOXIDE_DENSITY: 10,
-            ATTR_PM_2_5_DENSITY: 20,
-            ATTR_PM_10_DENSITY: 30,
-            ATTR_PM_DENSITY: 40,
+            ATTR_NO2: 10,
+            ATTR_PM_2_5: 20,
+            ATTR_PM_10: 30,
+            ATTR_PM: 40,
             ATTR_PM_SIZE: 2.5,
             ATTR_VOC_DENSITY: 60,
         },
@@ -159,10 +157,10 @@ async def test_air_quality_all_props_update_all_props(hass, hk_driver):
         entity_id,
         5,
         {
-            ATTR_NITROGEN_DIOXIDE_DENSITY: 10,
-            ATTR_PM_2_5_DENSITY: 20,
-            ATTR_PM_10_DENSITY: 30,
-            ATTR_PM_DENSITY: 40,
+            ATTR_NO2: 10,
+            ATTR_PM_2_5: 20,
+            ATTR_PM_10: 30,
+            ATTR_PM: 40,
             ATTR_PM_SIZE: 2.5,
             ATTR_VOC_DENSITY: 60,
         },
@@ -182,10 +180,10 @@ async def test_air_quality_all_props_update_all_props(hass, hk_driver):
         entity_id,
         1,
         {
-            ATTR_NITROGEN_DIOXIDE_DENSITY: 1,
-            ATTR_PM_2_5_DENSITY: 2,
-            ATTR_PM_10_DENSITY: 3,
-            ATTR_PM_DENSITY: 4,
+            ATTR_NO2: 1,
+            ATTR_PM_2_5: 2,
+            ATTR_PM_10: 3,
+            ATTR_PM: 4,
             ATTR_PM_SIZE: 10,
             ATTR_VOC_DENSITY: 6,
         },
@@ -209,10 +207,10 @@ async def test_air_quality_all_props_update_one_prop(hass, hk_driver):
         entity_id,
         5,
         {
-            ATTR_NITROGEN_DIOXIDE_DENSITY: 10,
-            ATTR_PM_2_5_DENSITY: 20,
-            ATTR_PM_10_DENSITY: 30,
-            ATTR_PM_DENSITY: 40,
+            ATTR_NO2: 10,
+            ATTR_PM_2_5: 20,
+            ATTR_PM_10: 30,
+            ATTR_PM: 40,
             ATTR_PM_SIZE: 2.5,
             ATTR_VOC_DENSITY: 60,
         },
@@ -238,10 +236,10 @@ async def test_air_quality_all_props_update_one_prop(hass, hk_driver):
         entity_id,
         5,
         {
-            ATTR_NITROGEN_DIOXIDE_DENSITY: 10,
-            ATTR_PM_2_5_DENSITY: 20,
-            ATTR_PM_10_DENSITY: 30,
-            ATTR_PM_DENSITY: 40,
+            ATTR_NO2: 10,
+            ATTR_PM_2_5: 20,
+            ATTR_PM_10: 30,
+            ATTR_PM: 40,
             ATTR_PM_SIZE: 2.5,
             ATTR_VOC_DENSITY: 60,
         },
@@ -257,7 +255,7 @@ async def test_air_quality_all_props_update_one_prop(hass, hk_driver):
     assert acc.char_voc_density.value == 60
 
     # test changing one value
-    hass.states.async_set(entity_id, 5, {ATTR_NITROGEN_DIOXIDE_DENSITY: 1})
+    hass.states.async_set(entity_id, 5, {ATTR_NO2: 1})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -319,7 +317,7 @@ async def test_air_quality_state_and_nitrogen_dioxide_density(hass, hk_driver):
     """Test air quality sensor with only state and nitrogen dioxide density is updated after state change."""
     entity_id = "sensor.air_quality"
 
-    hass.states.async_set(entity_id, 5, {ATTR_NITROGEN_DIOXIDE_DENSITY: 1})
+    hass.states.async_set(entity_id, 5, {ATTR_NO2: 1})
     await hass.async_block_till_done()
     acc = AirQualitySensor(hass, hk_driver, "Air Quality", entity_id, 2, None)
     await hass.async_add_job(acc.run)
@@ -337,7 +335,7 @@ async def test_air_quality_state_and_nitrogen_dioxide_density(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test initial set of values
-    hass.states.async_set(entity_id, 5, {ATTR_NITROGEN_DIOXIDE_DENSITY: 1})
+    hass.states.async_set(entity_id, 5, {ATTR_NO2: 1})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -349,7 +347,7 @@ async def test_air_quality_state_and_nitrogen_dioxide_density(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test changing value
-    hass.states.async_set(entity_id, 5, {ATTR_NITROGEN_DIOXIDE_DENSITY: 10})
+    hass.states.async_set(entity_id, 5, {ATTR_NO2: 10})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -365,7 +363,7 @@ async def test_air_quality_state_and_pm_2_5_density_only(hass, hk_driver):
     """Test air quality sensor with only state and pm 2.5 density is updated after state change."""
     entity_id = "sensor.air_quality"
 
-    hass.states.async_set(entity_id, 5, {ATTR_PM_2_5_DENSITY: 2})
+    hass.states.async_set(entity_id, 5, {ATTR_PM_2_5: 2})
     await hass.async_block_till_done()
     acc = AirQualitySensor(hass, hk_driver, "Air Quality", entity_id, 2, None)
     await hass.async_add_job(acc.run)
@@ -383,7 +381,7 @@ async def test_air_quality_state_and_pm_2_5_density_only(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test initial set of values
-    hass.states.async_set(entity_id, 5, {ATTR_PM_2_5_DENSITY: 2})
+    hass.states.async_set(entity_id, 5, {ATTR_PM_2_5: 2})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -395,7 +393,7 @@ async def test_air_quality_state_and_pm_2_5_density_only(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test changing value
-    hass.states.async_set(entity_id, 5, {ATTR_PM_2_5_DENSITY: 20})
+    hass.states.async_set(entity_id, 5, {ATTR_PM_2_5: 20})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -411,7 +409,7 @@ async def test_air_quality_state_and_pm_10_density_only(hass, hk_driver):
     """Test air quality sensor with only state and pm 10 density is updated after state change."""
     entity_id = "sensor.air_quality"
 
-    hass.states.async_set(entity_id, 5, {ATTR_PM_10_DENSITY: 3})
+    hass.states.async_set(entity_id, 5, {ATTR_PM_10: 3})
     await hass.async_block_till_done()
     acc = AirQualitySensor(hass, hk_driver, "Air Quality", entity_id, 2, None)
     await hass.async_add_job(acc.run)
@@ -429,7 +427,7 @@ async def test_air_quality_state_and_pm_10_density_only(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test initial set of values
-    hass.states.async_set(entity_id, 5, {ATTR_PM_10_DENSITY: 3})
+    hass.states.async_set(entity_id, 5, {ATTR_PM_10: 3})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -441,7 +439,7 @@ async def test_air_quality_state_and_pm_10_density_only(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test changing value
-    hass.states.async_set(entity_id, 5, {ATTR_PM_10_DENSITY: 30})
+    hass.states.async_set(entity_id, 5, {ATTR_PM_10: 30})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -457,7 +455,7 @@ async def test_air_quality_state_and_particulate_density_only(hass, hk_driver):
     """Test air quality sensor with only state and particulate density is updated after state change."""
     entity_id = "sensor.air_quality"
 
-    hass.states.async_set(entity_id, 5, {ATTR_PM_DENSITY: 4})
+    hass.states.async_set(entity_id, 5, {ATTR_PM: 4})
     await hass.async_block_till_done()
     acc = AirQualitySensor(hass, hk_driver, "Air Quality", entity_id, 2, None)
     await hass.async_add_job(acc.run)
@@ -475,7 +473,7 @@ async def test_air_quality_state_and_particulate_density_only(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test initial set of values
-    hass.states.async_set(entity_id, 5, {ATTR_PM_DENSITY: 4})
+    hass.states.async_set(entity_id, 5, {ATTR_PM: 4})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5
@@ -487,7 +485,7 @@ async def test_air_quality_state_and_particulate_density_only(hass, hk_driver):
     assert not hasattr(acc, "char_voc_density")
 
     # test changing value
-    hass.states.async_set(entity_id, 5, {ATTR_PM_DENSITY: 40})
+    hass.states.async_set(entity_id, 5, {ATTR_PM: 40})
     await hass.async_block_till_done()
 
     assert acc.char_air_quality.value == 5

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -83,9 +83,9 @@ async def test_humidity(hass, hk_driver):
     assert acc.char_humidity.value == 20
 
 
-async def test_air_quality(hass, hk_driver):
+async def test_air_quality_pm25(hass, hk_driver):
     """Test if accessory is updated after state change."""
-    entity_id = "sensor.air_quality"
+    entity_id = "sensor.pm25"
 
     hass.states.async_set(entity_id, None)
     await hass.async_block_till_done()
@@ -95,23 +95,23 @@ async def test_air_quality(hass, hk_driver):
     assert acc.aid == 2
     assert acc.category == 10  # Sensor
 
-    assert acc.char_density.value == 0
-    assert acc.char_quality.value == 0
+    assert acc.char_particulate_density.value == 0
+    assert acc.char_air_quality.value == 0
 
     hass.states.async_set(entity_id, STATE_UNKNOWN)
     await hass.async_block_till_done()
-    assert acc.char_density.value == 0
-    assert acc.char_quality.value == 0
+    assert acc.char_particulate_density.value == 0
+    assert acc.char_air_quality.value == 0
 
     hass.states.async_set(entity_id, "34")
     await hass.async_block_till_done()
-    assert acc.char_density.value == 34
-    assert acc.char_quality.value == 1
+    assert acc.char_particulate_density.value == 34
+    assert acc.char_air_quality.value == 1
 
     hass.states.async_set(entity_id, "200")
     await hass.async_block_till_done()
-    assert acc.char_density.value == 200
-    assert acc.char_quality.value == 5
+    assert acc.char_particulate_density.value == 200
+    assert acc.char_air_quality.value == 5
 
 
 async def test_co(hass, hk_driver):


### PR DESCRIPTION
##  Description:

Makes it so the Homekit `AirQualitySensor` can actually send all the different types of Characteristics that HomeKit allows for an Air Quality Sensor.

## Doc Update PR:
https://github.com/home-assistant/home-assistant.io/pull/11614

## Example entry for `configuration.yaml` (if applicable):
```yaml
dyson:
  username: !secret dyson_username
  password: !secret dyson_password
  language: US

homekit:
  auto_start: false
  filter:
    include_domains:
      - switch
      - fan
      - sensor

sensor:
  - platform: template
    sensors:
      dyson_master_bedroom_air_quality_aggrigate:
        friendly_name: "Master Bedroom Air Quality (Aggrigate)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'air_quality_index') %}
          {% if state <= 0 %}
            1
          {% elif state <= 50 %}
            2
          {% elif state <= 100 %}
            3
          {% elif state <= 150 %}
            4
          {% elif state > 150 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          air_quality: "{{ state_attr('air_quality.dyson_master_bedroom', 'air_quality_index') }}"
          nitrogen_dioxide_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'nitrogen_dioxide') }}"
          voc_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'volatile_organic_compounds') }}"
          pm_2_5_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') }}"
          pm_10_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_10') }}"

      dyson_master_bedroom_air_quality_pm_2_5:
        friendly_name: "Master Bedroom Air Quality (PM2.5)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') %}
          {% if state <= 0 %}
            1
          {% elif state <= 35 %}
            2
          {% elif state <= 53 %}
            3
          {% elif state <= 70 %}
            4
          {% elif state > 70 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          pm_2_5_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') }}"

      dyson_master_bedroom_air_quality_pm_10:
        friendly_name: "Master Bedroom Air Quality (PM10)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_10') %}
          {% if state <= 0 %}
            1
          {% elif state <= 50 %}
            2
          {% elif state <= 75 %}
            3
          {% elif state <= 100 %}
            4
          {% elif state > 100 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          pm_10_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_10') }}"

      dyson_master_bedroom_air_quality_voc:
        friendly_name: "Master Bedroom Air Quality (VOC)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'volatile_organic_compounds') %}
          {% if state <= 0 %}
            1
          {% elif state <= 3 %}
            2
          {% elif state <= 6 %}
            3
          {% elif state <= 8  %}
            4
          {% elif state > 8 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          voc_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'volatile_organic_compounds') }}"

      dyson_master_bedroom_air_quality_no2:
        friendly_name: "Master Bedroom Air Quality (NO2)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'nitrogen_dioxide') %}
          {% if state <= 0 %}
            1
          {% elif state <= 3 %}
            2
          {% elif state <= 6 %}
            3
          {% elif state <= 8  %}
            4
          {% elif state > 8 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          nitrogen_dioxide_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'nitrogen_dioxide') }}"

      dyson_master_bedroom_air_quality_all_props:
        friendly_name: "Master Bedroom Air Quality (ALL PROPS)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'air_quality_index') %}
          {% if state <= 0 %}
            1
          {% elif state <= 50 %}
            2
          {% elif state <= 100 %}
            3
          {% elif state <= 150 %}
            4
          {% elif state > 150 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          air_quality: "{{ state_attr('air_quality.dyson_master_bedroom', 'air_quality_index') }}"
          nitrogen_dioxide_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'nitrogen_dioxide') }}"
          voc_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'volatile_organic_compounds') }}"
          pm_2_5_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') }}"
          pm_10_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_10') }}"
          pm_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') }}"
          pm_size: 2.5

      dyson_master_bedroom_air_quality_pm_2_5_legacy:
        friendly_name: "Master Bedroom Air Quality (PM2.5) (Legacy)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') %}
          {% if state <= 0 %}
            1
          {% elif state <= 35 %}
            2
          {% elif state <= 53 %}
            3
          {% elif state <= 70 %}
            4
          {% elif state > 70 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          pm_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') }}"
          pm_size: 2.5

      dyson_master_bedroom_air_quality_pm_10_legacy:
        friendly_name: "Master Bedroom Air Quality (PM10) (Legacy)"
        value_template: >-
          {% set state = state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_10') %}
          {% if state <= 0 %}
            1
          {% elif state <= 50 %}
            2
          {% elif state <= 75 %}
            3
          {% elif state <= 100 %}
            4
          {% elif state > 100 %}
            5
          {% else %}
            0
          {% endif %}
        attribute_templates:
          pm_density: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_10') }}"
          pm_size: 10

      dyson_master_bedroom_pm25:
        friendly_name: "Master Bedroom PM2.5 (Legacy)"
        value_template: "{{ state_attr('air_quality.dyson_master_bedroom', 'particulate_matter_2_5') }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
