### PR TITLE
Migrate media_player tests from coroutine to async/await

### DIFF
--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -44,28 +44,23 @@ class AsyncMediaPlayer(mp.MediaPlayerDevice):
             | mp.const.SUPPORT_TURN_ON
         )
 
-    @asyncio.coroutine
-    def async_set_volume_level(self, volume):
+    async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         self._volume = volume
 
-    @asyncio.coroutine
-    def async_media_play(self):
+    async def async_media_play(self):
         """Send play command."""
         self._state = STATE_PLAYING
 
-    @asyncio.coroutine
-    def async_media_pause(self):
+    async def async_media_pause(self):
         """Send pause command."""
         self._state = STATE_PAUSED
 
-    @asyncio.coroutine
-    def async_turn_on(self):
+    async def async_turn_on(self):
         """Turn the media player on."""
         self._state = STATE_ON
 
-    @asyncio.coroutine
-    def async_turn_off(self):
+    async def async_turn_off(self):
         """Turn the media player off."""
         self._state = STATE_OFF
 
@@ -129,21 +124,19 @@ class SyncMediaPlayer(mp.MediaPlayerDevice):
         else:
             self._state = STATE_OFF
 
-    @asyncio.coroutine
-    def async_media_play_pause(self):
+    async def async_media_play_pause(self):
         """Create a coroutine to wrap the future returned by ABC.
 
         This allows the run_coroutine_threadsafe helper to be used.
         """
-        yield from super().async_media_play_pause()
+        await super().async_media_play_pause()
 
-    @asyncio.coroutine
-    def async_toggle(self):
+    async def async_toggle(self):
         """Create a coroutine to wrap the future returned by ABC.
 
         This allows the run_coroutine_threadsafe helper to be used.
         """
-        yield from super().async_toggle()
+        await super().async_toggle()
 
 
 class TestAsyncMediaPlayer(unittest.TestCase):


### PR DESCRIPTION
## Description:

Migrate media_player tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
