### PR TITLE
Migrate generic tests from coroutine to async/await

### DIFF
--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -5,12 +5,11 @@ from unittest import mock
 from homeassistant.setup import async_setup_component
 
 
-@asyncio.coroutine
-def test_fetching_url(aioclient_mock, hass, hass_client):
+async def test_fetching_url(aioclient_mock, hass, hass_client):
     """Test that it fetches the given url."""
     aioclient_mock.get("http://example.com", text="hello world")
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         "camera",
         {
@@ -24,25 +23,24 @@ def test_fetching_url(aioclient_mock, hass, hass_client):
         },
     )
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == 200
     assert aioclient_mock.call_count == 1
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "hello world"
 
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
     assert aioclient_mock.call_count == 2
 
 
-@asyncio.coroutine
-def test_fetching_without_verify_ssl(aioclient_mock, hass, hass_client):
+async def test_fetching_without_verify_ssl(aioclient_mock, hass, hass_client):
     """Test that it fetches the given url when ssl verify is off."""
     aioclient_mock.get("https://example.com", text="hello world")
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         "camera",
         {
@@ -57,19 +55,18 @@ def test_fetching_without_verify_ssl(aioclient_mock, hass, hass_client):
         },
     )
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_fetching_url_with_verify_ssl(aioclient_mock, hass, hass_client):
+async def test_fetching_url_with_verify_ssl(aioclient_mock, hass, hass_client):
     """Test that it fetches the given url when ssl verify is explicitly on."""
     aioclient_mock.get("https://example.com", text="hello world")
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         "camera",
         {
@@ -84,22 +81,21 @@ def test_fetching_url_with_verify_ssl(aioclient_mock, hass, hass_client):
         },
     )
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_limit_refetch(aioclient_mock, hass, hass_client):
+async def test_limit_refetch(aioclient_mock, hass, hass_client):
     """Test that it fetches the given url."""
     aioclient_mock.get("http://example.com/5a", text="hello world")
     aioclient_mock.get("http://example.com/10a", text="hello world")
     aioclient_mock.get("http://example.com/15a", text="hello planet")
     aioclient_mock.get("http://example.com/20a", status=404)
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         "camera",
         {
@@ -112,51 +108,50 @@ def test_limit_refetch(aioclient_mock, hass, hass_client):
         },
     )
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
 
     hass.states.async_set("sensor.temp", "5")
 
     with mock.patch("async_timeout.timeout", side_effect=asyncio.TimeoutError()):
-        resp = yield from client.get("/api/camera_proxy/camera.config_test")
+        resp = await client.get("/api/camera_proxy/camera.config_test")
         assert aioclient_mock.call_count == 0
         assert resp.status == 500
 
     hass.states.async_set("sensor.temp", "10")
 
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
     assert aioclient_mock.call_count == 1
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "hello world"
 
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
     assert aioclient_mock.call_count == 1
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "hello world"
 
     hass.states.async_set("sensor.temp", "15")
 
     # Url change = fetch new image
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
     assert aioclient_mock.call_count == 2
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "hello planet"
 
     # Cause a template render error
     hass.states.async_remove("sensor.temp")
-    resp = yield from client.get("/api/camera_proxy/camera.config_test")
+    resp = await client.get("/api/camera_proxy/camera.config_test")
     assert aioclient_mock.call_count == 2
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "hello planet"
 
 
-@asyncio.coroutine
-def test_camera_content_type(aioclient_mock, hass, hass_client):
+async def test_camera_content_type(aioclient_mock, hass, hass_client):
     """Test generic camera with custom content_type."""
     svg_image = "<some image>"
     urlsvg = "https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg"
@@ -172,22 +167,22 @@ def test_camera_content_type(aioclient_mock, hass, hass_client):
     cam_config_normal.pop("content_type")
     cam_config_normal["name"] = "config_test_jpg"
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass, "camera", {"camera": [cam_config_svg, cam_config_normal]}
     )
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp_1 = yield from client.get("/api/camera_proxy/camera.config_test_svg")
+    resp_1 = await client.get("/api/camera_proxy/camera.config_test_svg")
     assert aioclient_mock.call_count == 1
     assert resp_1.status == 200
     assert resp_1.content_type == "image/svg+xml"
-    body = yield from resp_1.text()
+    body = await resp_1.text()
     assert body == svg_image
 
-    resp_2 = yield from client.get("/api/camera_proxy/camera.config_test_jpg")
+    resp_2 = await client.get("/api/camera_proxy/camera.config_test_jpg")
     assert aioclient_mock.call_count == 2
     assert resp_2.status == 200
     assert resp_2.content_type == "image/jpeg"
-    body = yield from resp_2.text()
+    body = await resp_2.text()
     assert body == svg_image


### PR DESCRIPTION
## Description:

Migrate generic tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
