### PR TITLE
Migrate group tests from coroutine to async/await

### DIFF
--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the Group components."""
 # pylint: disable=protected-access
-import asyncio
 from collections import OrderedDict
 import unittest
 from unittest.mock import patch
@@ -481,25 +480,23 @@ class TestComponentsGroup(unittest.TestCase):
         assert group_state.attributes.get(ATTR_FRIENDLY_NAME) == "friendly_name"
 
 
-@asyncio.coroutine
-def test_service_group_services(hass):
+async def test_service_group_services(hass):
     """Check if service are available."""
     with assert_setup_component(0, "group"):
-        yield from async_setup_component(hass, "group", {"group": {}})
+        await async_setup_component(hass, "group", {"group": {}})
 
     assert hass.services.has_service("group", group.SERVICE_SET)
     assert hass.services.has_service("group", group.SERVICE_REMOVE)
 
 
 # pylint: disable=invalid-name
-@asyncio.coroutine
-def test_service_group_set_group_remove_group(hass):
+async def test_service_group_set_group_remove_group(hass):
     """Check if service are available."""
     with assert_setup_component(0, "group"):
-        yield from async_setup_component(hass, "group", {"group": {}})
+        await async_setup_component(hass, "group", {"group": {}})
 
     common.async_set_group(hass, "user_test_group", name="Test")
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     group_state = hass.states.get("group.user_test_group")
     assert group_state
@@ -513,7 +510,7 @@ def test_service_group_set_group_remove_group(hass):
         visible=False,
         entity_ids=["test.entity_bla1"],
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     group_state = hass.states.get("group.user_test_group")
     assert group_state
@@ -531,7 +528,7 @@ def test_service_group_set_group_remove_group(hass):
         control="hidden",
         add=["test.entity_id2"],
     )
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     group_state = hass.states.get("group.user_test_group")
     assert group_state
@@ -546,7 +543,7 @@ def test_service_group_set_group_remove_group(hass):
     )
 
     common.async_remove(hass, "user_test_group")
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     group_state = hass.states.get("group.user_test_group")
     assert group_state is None


### PR DESCRIPTION
## Description:

Migrate group tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
