### PR TITLE
Migrate freedns tests from coroutine to async/await

### DIFF
--- a/tests/components/freedns/test_init.py
+++ b/tests/components/freedns/test_init.py
@@ -1,6 +1,4 @@
 """Test the FreeDNS component."""
-import asyncio
-
 import pytest
 
 from homeassistant.components import freedns
@@ -37,8 +35,7 @@ def setup_freedns(hass, aioclient_mock):
     )
 
 
-@asyncio.coroutine
-def test_setup(hass, aioclient_mock):
+async def test_setup(hass, aioclient_mock):
     """Test setup works if update passes."""
     params = {}
     params[ACCESS_TOKEN] = ""
@@ -46,7 +43,7 @@ def test_setup(hass, aioclient_mock):
         UPDATE_URL, params=params, text="ERROR: Address has not changed."
     )
 
-    result = yield from async_setup_component(
+    result = await async_setup_component(
         hass,
         freedns.DOMAIN,
         {
@@ -60,18 +57,17 @@ def test_setup(hass, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
     async_fire_time_changed(hass, utcnow() + UPDATE_INTERVAL)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert aioclient_mock.call_count == 2
 
 
-@asyncio.coroutine
-def test_setup_fails_if_wrong_token(hass, aioclient_mock):
+async def test_setup_fails_if_wrong_token(hass, aioclient_mock):
     """Test setup fails if first update fails through wrong token."""
     params = {}
     params[ACCESS_TOKEN] = ""
     aioclient_mock.get(UPDATE_URL, params=params, text="ERROR: Invalid update URL (2)")
 
-    result = yield from async_setup_component(
+    result = await async_setup_component(
         hass,
         freedns.DOMAIN,
         {


### PR DESCRIPTION
## Description:

Migrate freedns tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
