### PR TITLE
Migrate local_file tests from coroutine to async/await

### DIFF
--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -1,5 +1,4 @@
 """The tests for local file camera component."""
-import asyncio
 from unittest import mock
 
 from homeassistant.components.local_file.const import DOMAIN, SERVICE_UPDATE_FILE_PATH
@@ -8,15 +7,14 @@ from homeassistant.setup import async_setup_component
 from tests.common import mock_registry
 
 
-@asyncio.coroutine
-def test_loading_file(hass, hass_client):
+async def test_loading_file(hass, hass_client):
     """Test that it loads image from disk."""
     mock_registry(hass)
 
     with mock.patch("os.path.isfile", mock.Mock(return_value=True)), mock.patch(
         "os.access", mock.Mock(return_value=True)
     ):
-        yield from async_setup_component(
+        await async_setup_component(
             hass,
             "camera",
             {
@@ -28,26 +26,25 @@ def test_loading_file(hass, hass_client):
             },
         )
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     m_open = mock.mock_open(read_data=b"hello")
     with mock.patch(
         "homeassistant.components.local_file.camera.open", m_open, create=True
     ):
-        resp = yield from client.get("/api/camera_proxy/camera.config_test")
+        resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == 200
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == "hello"
 
 
-@asyncio.coroutine
-def test_file_not_readable(hass, caplog):
+async def test_file_not_readable(hass, caplog):
     """Test a warning is shown setup when file is not readable."""
     with mock.patch("os.path.isfile", mock.Mock(return_value=True)), mock.patch(
         "os.access", mock.Mock(return_value=False)
     ):
-        yield from async_setup_component(
+        await async_setup_component(
             hass,
             "camera",
             {
@@ -64,8 +61,7 @@ def test_file_not_readable(hass, caplog):
     assert "mock.file" in caplog.text
 
 
-@asyncio.coroutine
-def test_camera_content_type(hass, hass_client):
+async def test_camera_content_type(hass, hass_client):
     """Test local_file camera content_type."""
     cam_config_jpg = {
         "name": "test_jpg",
@@ -88,43 +84,43 @@ def test_camera_content_type(hass, hass_client):
         "file_path": "/path/to/image",
     }
 
-    yield from async_setup_component(
+    await async_setup_component(
         hass,
         "camera",
         {"camera": [cam_config_jpg, cam_config_png, cam_config_svg, cam_config_noext]},
     )
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     image = "hello"
     m_open = mock.mock_open(read_data=image.encode())
     with mock.patch(
         "homeassistant.components.local_file.camera.open", m_open, create=True
     ):
-        resp_1 = yield from client.get("/api/camera_proxy/camera.test_jpg")
-        resp_2 = yield from client.get("/api/camera_proxy/camera.test_png")
-        resp_3 = yield from client.get("/api/camera_proxy/camera.test_svg")
-        resp_4 = yield from client.get("/api/camera_proxy/camera.test_no_ext")
+        resp_1 = await client.get("/api/camera_proxy/camera.test_jpg")
+        resp_2 = await client.get("/api/camera_proxy/camera.test_png")
+        resp_3 = await client.get("/api/camera_proxy/camera.test_svg")
+        resp_4 = await client.get("/api/camera_proxy/camera.test_no_ext")
 
     assert resp_1.status == 200
     assert resp_1.content_type == "image/jpeg"
-    body = yield from resp_1.text()
+    body = await resp_1.text()
     assert body == image
 
     assert resp_2.status == 200
     assert resp_2.content_type == "image/png"
-    body = yield from resp_2.text()
+    body = await resp_2.text()
     assert body == image
 
     assert resp_3.status == 200
     assert resp_3.content_type == "image/svg+xml"
-    body = yield from resp_3.text()
+    body = await resp_3.text()
     assert body == image
 
     # default mime type
     assert resp_4.status == 200
     assert resp_4.content_type == "image/jpeg"
-    body = yield from resp_4.text()
+    body = await resp_4.text()
     assert body == image
 
 


### PR DESCRIPTION
## Description:

Migrate local_file tests from coroutine to async/await

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
