### PR TITLE
deCONZ - Support Fyrtur/Kadrilj battery sensors

### DIFF
--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
   "requirements": [
-    "pydeconz==66"
+    "pydeconz==67"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -1,5 +1,13 @@
 """Support for deCONZ sensors."""
-from pydeconz.sensor import Consumption, Daylight, LightLevel, Power, Switch, Thermostat
+from pydeconz.sensor import (
+    Battery,
+    Consumption,
+    Daylight,
+    LightLevel,
+    Power,
+    Switch,
+    Thermostat,
+)
 
 from homeassistant.const import ATTR_TEMPERATURE, ATTR_VOLTAGE, DEVICE_CLASS_BATTERY
 from homeassistant.core import callback
@@ -53,7 +61,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     hass.async_create_task(new_event.async_update_device_registry())
                     gateway.events.append(new_event)
 
-            elif new and not sensor.BINARY and sensor.type not in Thermostat.ZHATYPE:
+            elif (
+                new
+                and sensor.BINARY is False
+                and sensor.type not in Battery.ZHATYPE + Thermostat.ZHATYPE
+            ):
 
                 new_sensor = DeconzSensor(sensor, gateway)
                 entity_handler.add_entity(new_sensor)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1187,7 +1187,7 @@ pydaikin==1.6.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==66
+pydeconz==67
 
 # homeassistant.components.delijn
 pydelijn==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -410,7 +410,7 @@ pycoolmasternet==0.0.4
 pydaikin==1.6.1
 
 # homeassistant.components.deconz
-pydeconz==66
+pydeconz==67
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Sensor.binary is None means unsupported sensor
Dont create ordinary sensor on zhabattery type

**Related issue (if applicable):** depends on #30122

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.