### PR TITLE
fix problem with attr_fritz

### DIFF
--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -84,7 +84,7 @@ class FritzBoxScanner(DeviceScanner):
         ip_device = self.fritz_box.get_specific_host_entry(device).get("NewIPAddress")
 
         if not ip_device:
-            return None
+            return {}
         return {"ip": ip_device, "mac": device}
 
     def _update_info(self):


### PR DESCRIPTION
## Breaking Change:

Fix https://github.com/home-assistant/home-assistant/pull/30350#issuecomment-570284682

## Description:
get_extra_attributes should return {} in case of powerline

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/home-assistant/home-assistant/pull/30350#issuecomment-570284682
Please verify @ReneNulschDE

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
