### PR TITLE
Bump miflora to 0.6.0 and bluepy to 1.3.0

### DIFF
--- a/homeassistant/components/decora/manifest.json
+++ b/homeassistant/components/decora/manifest.json
@@ -2,10 +2,7 @@
   "domain": "decora",
   "name": "Decora",
   "documentation": "https://www.home-assistant.io/integrations/decora",
-  "requirements": [
-    "bluepy==1.1.4",
-    "decora==0.6"
-  ],
+  "requirements": ["bluepy==1.3.0", "decora==0.6"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/miflora/manifest.json
+++ b/homeassistant/components/miflora/manifest.json
@@ -2,13 +2,7 @@
   "domain": "miflora",
   "name": "Miflora",
   "documentation": "https://www.home-assistant.io/integrations/miflora",
-  "requirements": [
-    "bluepy==1.1.4",
-    "miflora==0.4.0"
-  ],
+  "requirements": ["bluepy==1.3.0", "miflora==0.6.0"],
   "dependencies": [],
-  "codeowners": [
-    "@danielhiversen",
-    "@ChristianKuehnel"
-  ]
+  "codeowners": ["@danielhiversen", "@ChristianKuehnel"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -318,7 +318,7 @@ blockchain==1.4.4
 
 # homeassistant.components.decora
 # homeassistant.components.miflora
-# bluepy==1.1.4
+# bluepy==1.3.0
 
 # homeassistant.components.bme680
 # bme680==1.0.5
@@ -846,7 +846,7 @@ meteofrance==0.3.7
 mficlient==0.3.0
 
 # homeassistant.components.miflora
-miflora==0.4.0
+miflora==0.6.0
 
 # homeassistant.components.mill
 millheater==0.3.4


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #28472 and fixes #30006<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally. (tested by https://github.com/home-assistant/home-assistant/issues/28472#issuecomment-555945112)
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
