### PR TITLE
Cleanup of state handling in webostv

### DIFF
--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     SERVICE_VOLUME_MUTE,
+    STATE_ON,
 )
 from homeassistant.setup import async_setup_component
 
@@ -78,7 +79,7 @@ async def test_select_source_with_empty_source_list(hass, client):
     await hass.services.async_call(media_player.DOMAIN, SERVICE_SELECT_SOURCE, data)
     await hass.async_block_till_done()
 
-    assert hass.states.is_state(ENTITY_ID, "playing")
+    assert hass.states.is_state(ENTITY_ID, STATE_ON)
     client.launch_app.assert_not_called()
     client.set_input.assert_not_called()
 


### PR DESCRIPTION
## Breaking Change:

Entity will have STATE_ON when tv is on instead of STATE_PLAYING or STATE_PAUSED as was previously the case. Users will need to update automations that depend on entity state.

## Description:
Now that the tv state is updated with asynchronous callbacks, there is no need to directly manipulate the state variables when calling commands.  Since the currently known methods cannot distinguish between play and pause states, and the pause command anyways acts as a play-pause toggle, the state handling is further simplified by replacing STATE_PLAYING/STATE_PAUSED with simply STATE_ON, with the advantage that it is no longer possible to go out of sync with the actual state of the tv.
