### PR TITLE
Reassignment of maxcube HVAC modes, HVAC actions and presets

### DIFF
--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -123,8 +123,7 @@ class MaxCubeClimate(ClimateDevice):
             return (
                 CURRENT_HVAC_IDLE if self.valve_position() == 0 else CURRENT_HVAC_HEAT
             )
-        else:
-            return None
+        return None
 
     @property
     def target_temperature(self):
@@ -155,14 +154,13 @@ class MaxCubeClimate(ClimateDevice):
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
         if self.map_mode_max_hass(device.mode) == PRESET_BOOST:
             return PRESET_BOOST
-        elif self.map_mode_max_hass(device.mode) == PRESET_AWAY:
+        if self.map_mode_max_hass(device.mode) == PRESET_AWAY:
             return PRESET_AWAY
-        elif self.target_temperature == self.comfort_temperature():
+        if self.target_temperature == self.comfort_temperature():
             return PRESET_COMFORT
-        elif self.target_temperature == self.eco_temperature():
+        if self.target_temperature == self.eco_temperature():
             return PRESET_ECO
-        else:
-            return None
+        return None
 
     @property
     def preset_modes(self):


### PR DESCRIPTION
## Breaking Change:
HAVC modes and presets are changed, unfortunately it require to update the automation's / scripts.

## Description:
The eQ-3 MAX! thermostats operate in the following modes:

- Auto: Operation according to a stored schedule
- Manual: Heat to a target temperature
- Boost: Maximum heating for n seconds
- Comfort: Set target temperature to a stored value
- Eco: Set target temperature to a stored value
- Vacation : Set the temperature to a fixed value for a certain time

In the previous implementation there was only the HAVC mode "HVAC_MODE_AUTO" and the default settings "manu", "boost", and "absence", but this does not match the actual behaviour of the thermostat. Also it was not possible to return from "Manual" mode to "Auto" mode, because there was no function to set the HAVC mode.

So I have reassigned the modes. Now, there a two HAVC modes "HVAC_MODE_AUTO and HVAC_MODE_HEAT", all other modes are presets. In the course of this work i have also implemented the "HVAC Aktion".
This implementation now behaves similar to the "eQ-3 MAX! Portal" and (in my opinion) it fits to the HASS way to support a thermostat.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
