### PR TITLE
Implemented media_play & media_pause / push to version 0.7.11 of denonavr

### DIFF
--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denonavr",
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
   "requirements": [
-    "denonavr==0.7.10"
+    "denonavr==0.7.11"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -94,7 +94,6 @@ NewHost = namedtuple("NewHost", ["host", "name"])
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Denon platform."""
-
     # Initialize list with receivers to be started
     receivers = []
 
@@ -365,8 +364,16 @@ class DenonDevice(MediaPlayerDevice):
         return attributes
 
     def media_play_pause(self):
-        """Simulate play pause media player."""
+        """Play or pause the media player."""
         return self._receiver.toggle_play_pause()
+
+    def media_play(self):
+        """Send play command."""
+        return self._receiver.play()
+
+    def media_pause(self):
+        """Send pause command."""
+        return self._receiver.pause()
 
     def media_previous_track(self):
         """Send previous track command."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -420,7 +420,7 @@ defusedxml==0.6.0
 deluge-client==1.7.1
 
 # homeassistant.components.denonavr
-denonavr==0.7.10
+denonavr==0.7.11
 
 # homeassistant.components.directv
 directpy==0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -150,7 +150,7 @@ datadog==0.15.0
 defusedxml==0.6.0
 
 # homeassistant.components.denonavr
-denonavr==0.7.10
+denonavr==0.7.11
 
 # homeassistant.components.directv
 directpy==0.5


### PR DESCRIPTION
Description:

Implemented media_play and media_pause function of home-assistant for this component.

More changes in version 0.7.11 of denonavr:
- Add support for Marantz SR70xx
- Bug fix for sound mode "All Zone stereo" being disabled automatically
- New sound modes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
