### PR TITLE
Remove ZHA establish device mappings function

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -27,7 +27,6 @@ from .core.const import (
     DOMAIN,
     RadioType,
 )
-from .core.registries import establish_device_mappings
 
 DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({vol.Optional(ha_const.CONF_TYPE): cv.string})
 
@@ -87,7 +86,6 @@ async def async_setup_entry(hass, config_entry):
 
     Will automatically load components to support devices found on the network.
     """
-    establish_device_mappings()
 
     for component in COMPONENTS:
         hass.data[DATA_ZHA][component] = hass.data[DATA_ZHA].get(component, {})

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -37,47 +37,26 @@ SMARTTHINGS_ACCELERATION_CLUSTER = 0xFC02
 SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE = 0x8000
 SMARTTHINGS_HUMIDITY_CLUSTER = 0xFC45
 
-REMOTE_DEVICE_TYPES = collections.defaultdict(list)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.COLOR_CONTROLLER
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.COLOR_DIMMER_SWITCH
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.COLOR_SCENE_CONTROLLER
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.DIMMER_SWITCH
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.NON_COLOR_CONTROLLER
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.NON_COLOR_SCENE_CONTROLLER
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.REMOTE_CONTROL
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
-    zigpy.profiles.zha.DeviceType.SCENE_SELECTOR
-)
+REMOTE_DEVICE_TYPES = {
+    zigpy.profiles.zha.PROFILE_ID: [
+        zigpy.profiles.zha.DeviceType.COLOR_CONTROLLER,
+        zigpy.profiles.zha.DeviceType.COLOR_DIMMER_SWITCH,
+        zigpy.profiles.zha.DeviceType.COLOR_SCENE_CONTROLLER,
+        zigpy.profiles.zha.DeviceType.DIMMER_SWITCH,
+        zigpy.profiles.zha.DeviceType.NON_COLOR_CONTROLLER,
+        zigpy.profiles.zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
+        zigpy.profiles.zha.DeviceType.REMOTE_CONTROL,
+        zigpy.profiles.zha.DeviceType.SCENE_SELECTOR,
+    ],
+    zigpy.profiles.zll.PROFILE_ID: [
+        zigpy.profiles.zll.DeviceType.COLOR_CONTROLLER,
+        zigpy.profiles.zll.DeviceType.COLOR_SCENE_CONTROLLER,
+        zigpy.profiles.zll.DeviceType.CONTROL_BRIDGE,
+        zigpy.profiles.zll.DeviceType.CONTROLLER,
+        zigpy.profiles.zll.DeviceType.SCENE_CONTROLLER,
+    ],
+}
 
-REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
-    zigpy.profiles.zll.DeviceType.COLOR_CONTROLLER
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
-    zigpy.profiles.zll.DeviceType.COLOR_SCENE_CONTROLLER
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
-    zigpy.profiles.zll.DeviceType.CONTROL_BRIDGE
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
-    zigpy.profiles.zll.DeviceType.CONTROLLER
-)
-REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
-    zigpy.profiles.zll.DeviceType.SCENE_CONTROLLER
-)
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     # this works for now but if we hit conflicts we can break it out to
     # a different dict that is keyed by manufacturer
@@ -98,18 +77,21 @@ SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     zcl.clusters.security.IasZone: BINARY_SENSOR,
     zcl.clusters.smartenergy.Metering: SENSOR,
 }
+
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {zcl.clusters.general.OnOff: BINARY_SENSOR}
+
 SWITCH_CLUSTERS = SetRegistry()
 
 BINARY_SENSOR_CLUSTERS = SetRegistry()
 BINARY_SENSOR_CLUSTERS.add(SMARTTHINGS_ACCELERATION_CLUSTER)
+
 BINDABLE_CLUSTERS = SetRegistry()
 CHANNEL_ONLY_CLUSTERS = SetRegistry()
 CLUSTER_REPORT_CONFIGS = {}
 CUSTOM_CLUSTER_MAPPINGS = {}
-DEVICE_CLASS = collections.defaultdict(dict)
-DEVICE_CLASS[zigpy.profiles.zha.PROFILE_ID].update(
-    {
+
+DEVICE_CLASS = {
+    zigpy.profiles.zha.PROFILE_ID: {
         SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE: DEVICE_TRACKER,
         zigpy.profiles.zha.DeviceType.COLOR_DIMMABLE_LIGHT: LIGHT,
         zigpy.profiles.zha.DeviceType.COLOR_TEMPERATURE_LIGHT: LIGHT,
@@ -123,11 +105,8 @@ DEVICE_CLASS[zigpy.profiles.zha.PROFILE_ID].update(
         zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT_SWITCH: SWITCH,
         zigpy.profiles.zha.DeviceType.ON_OFF_PLUG_IN_UNIT: SWITCH,
         zigpy.profiles.zha.DeviceType.SMART_PLUG: SWITCH,
-    }
-)
-
-DEVICE_CLASS[zigpy.profiles.zll.PROFILE_ID].update(
-    {
+    },
+    zigpy.profiles.zll.PROFILE_ID: {
         zigpy.profiles.zll.DeviceType.COLOR_LIGHT: LIGHT,
         zigpy.profiles.zll.DeviceType.COLOR_TEMPERATURE_LIGHT: LIGHT,
         zigpy.profiles.zll.DeviceType.DIMMABLE_LIGHT: LIGHT,
@@ -135,12 +114,14 @@ DEVICE_CLASS[zigpy.profiles.zll.PROFILE_ID].update(
         zigpy.profiles.zll.DeviceType.EXTENDED_COLOR_LIGHT: LIGHT,
         zigpy.profiles.zll.DeviceType.ON_OFF_LIGHT: LIGHT,
         zigpy.profiles.zll.DeviceType.ON_OFF_PLUGIN_UNIT: SWITCH,
-    }
-)
+    },
+}
+
 DEVICE_TRACKER_CLUSTERS = SetRegistry()
 EVENT_RELAY_CLUSTERS = SetRegistry()
 LIGHT_CLUSTERS = SetRegistry()
 OUTPUT_CHANNEL_ONLY_CLUSTERS = SetRegistry()
+
 RADIO_TYPES = {
     RadioType.ezsp.name: {
         ZHA_GW_RADIO: bellows.ezsp.EZSP,

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -33,24 +33,136 @@ from . import channels  # noqa: F401 pylint: disable=unused-import
 from .const import CONTROLLER, ZHA_GW_RADIO, ZHA_GW_RADIO_DESCRIPTION, RadioType
 from .decorators import CALLABLE_T, DictRegistry, SetRegistry
 
+SMARTTHINGS_ACCELERATION_CLUSTER = 0xFC02
+SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE = 0x8000
+SMARTTHINGS_HUMIDITY_CLUSTER = 0xFC45
+
+REMOTE_DEVICE_TYPES = collections.defaultdict(list)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.COLOR_CONTROLLER
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.COLOR_DIMMER_SWITCH
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.COLOR_SCENE_CONTROLLER
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.DIMMER_SWITCH
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.NON_COLOR_CONTROLLER
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.NON_COLOR_SCENE_CONTROLLER
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.REMOTE_CONTROL
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zha.PROFILE_ID].append(
+    zigpy.profiles.zha.DeviceType.SCENE_SELECTOR
+)
+
+REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
+    zigpy.profiles.zll.DeviceType.COLOR_CONTROLLER
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
+    zigpy.profiles.zll.DeviceType.COLOR_SCENE_CONTROLLER
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
+    zigpy.profiles.zll.DeviceType.CONTROL_BRIDGE
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
+    zigpy.profiles.zll.DeviceType.CONTROLLER
+)
+REMOTE_DEVICE_TYPES[zigpy.profiles.zll.PROFILE_ID].append(
+    zigpy.profiles.zll.DeviceType.SCENE_CONTROLLER
+)
+SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
+    # this works for now but if we hit conflicts we can break it out to
+    # a different dict that is keyed by manufacturer
+    SMARTTHINGS_ACCELERATION_CLUSTER: BINARY_SENSOR,
+    SMARTTHINGS_HUMIDITY_CLUSTER: SENSOR,
+    zcl.clusters.closures.DoorLock: LOCK,
+    zcl.clusters.general.AnalogInput.cluster_id: SENSOR,
+    zcl.clusters.general.MultistateInput.cluster_id: SENSOR,
+    zcl.clusters.general.OnOff: SWITCH,
+    zcl.clusters.general.PowerConfiguration: SENSOR,
+    zcl.clusters.homeautomation.ElectricalMeasurement: SENSOR,
+    zcl.clusters.hvac.Fan: FAN,
+    zcl.clusters.measurement.IlluminanceMeasurement: SENSOR,
+    zcl.clusters.measurement.OccupancySensing: BINARY_SENSOR,
+    zcl.clusters.measurement.PressureMeasurement: SENSOR,
+    zcl.clusters.measurement.RelativeHumidity: SENSOR,
+    zcl.clusters.measurement.TemperatureMeasurement: SENSOR,
+    zcl.clusters.security.IasZone: BINARY_SENSOR,
+    zcl.clusters.smartenergy.Metering: SENSOR,
+}
+SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {zcl.clusters.general.OnOff: BINARY_SENSOR}
+SWITCH_CLUSTERS = SetRegistry()
+
 BINARY_SENSOR_CLUSTERS = SetRegistry()
+BINARY_SENSOR_CLUSTERS.add(SMARTTHINGS_ACCELERATION_CLUSTER)
 BINDABLE_CLUSTERS = SetRegistry()
 CHANNEL_ONLY_CLUSTERS = SetRegistry()
 CLUSTER_REPORT_CONFIGS = {}
 CUSTOM_CLUSTER_MAPPINGS = {}
 DEVICE_CLASS = collections.defaultdict(dict)
+DEVICE_CLASS[zigpy.profiles.zha.PROFILE_ID].update(
+    {
+        SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE: DEVICE_TRACKER,
+        zigpy.profiles.zha.DeviceType.COLOR_DIMMABLE_LIGHT: LIGHT,
+        zigpy.profiles.zha.DeviceType.COLOR_TEMPERATURE_LIGHT: LIGHT,
+        zigpy.profiles.zha.DeviceType.DIMMABLE_BALLAST: LIGHT,
+        zigpy.profiles.zha.DeviceType.DIMMABLE_LIGHT: LIGHT,
+        zigpy.profiles.zha.DeviceType.DIMMABLE_PLUG_IN_UNIT: LIGHT,
+        zigpy.profiles.zha.DeviceType.EXTENDED_COLOR_LIGHT: LIGHT,
+        zigpy.profiles.zha.DeviceType.LEVEL_CONTROLLABLE_OUTPUT: LIGHT,
+        zigpy.profiles.zha.DeviceType.ON_OFF_BALLAST: SWITCH,
+        zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT: LIGHT,
+        zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT_SWITCH: SWITCH,
+        zigpy.profiles.zha.DeviceType.ON_OFF_PLUG_IN_UNIT: SWITCH,
+        zigpy.profiles.zha.DeviceType.SMART_PLUG: SWITCH,
+    }
+)
+
+DEVICE_CLASS[zigpy.profiles.zll.PROFILE_ID].update(
+    {
+        zigpy.profiles.zll.DeviceType.COLOR_LIGHT: LIGHT,
+        zigpy.profiles.zll.DeviceType.COLOR_TEMPERATURE_LIGHT: LIGHT,
+        zigpy.profiles.zll.DeviceType.DIMMABLE_LIGHT: LIGHT,
+        zigpy.profiles.zll.DeviceType.DIMMABLE_PLUGIN_UNIT: LIGHT,
+        zigpy.profiles.zll.DeviceType.EXTENDED_COLOR_LIGHT: LIGHT,
+        zigpy.profiles.zll.DeviceType.ON_OFF_LIGHT: LIGHT,
+        zigpy.profiles.zll.DeviceType.ON_OFF_PLUGIN_UNIT: SWITCH,
+    }
+)
 DEVICE_TRACKER_CLUSTERS = SetRegistry()
 EVENT_RELAY_CLUSTERS = SetRegistry()
 LIGHT_CLUSTERS = SetRegistry()
 OUTPUT_CHANNEL_ONLY_CLUSTERS = SetRegistry()
-RADIO_TYPES = {}
-REMOTE_DEVICE_TYPES = collections.defaultdict(list)
-SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}
-SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {}
-SWITCH_CLUSTERS = SetRegistry()
-SMARTTHINGS_ACCELERATION_CLUSTER = 0xFC02
-SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE = 0x8000
-SMARTTHINGS_HUMIDITY_CLUSTER = 0xFC45
+RADIO_TYPES = {
+    RadioType.ezsp.name: {
+        ZHA_GW_RADIO: bellows.ezsp.EZSP,
+        CONTROLLER: bellows.zigbee.application.ControllerApplication,
+        ZHA_GW_RADIO_DESCRIPTION: "EZSP",
+    },
+    RadioType.deconz.name: {
+        ZHA_GW_RADIO: zigpy_deconz.api.Deconz,
+        CONTROLLER: zigpy_deconz.zigbee.application.ControllerApplication,
+        ZHA_GW_RADIO_DESCRIPTION: "Deconz",
+    },
+    RadioType.xbee.name: {
+        ZHA_GW_RADIO: zigpy_xbee.api.XBee,
+        CONTROLLER: zigpy_xbee.zigbee.application.ControllerApplication,
+        ZHA_GW_RADIO_DESCRIPTION: "XBee",
+    },
+    RadioType.zigate.name: {
+        ZHA_GW_RADIO: zigpy_zigate.api.ZiGate,
+        CONTROLLER: zigpy_zigate.zigbee.application.ControllerApplication,
+        ZHA_GW_RADIO_DESCRIPTION: "ZiGate",
+    },
+}
 
 COMPONENT_CLUSTERS = {
     BINARY_SENSOR: BINARY_SENSOR_CLUSTERS,
@@ -60,115 +172,6 @@ COMPONENT_CLUSTERS = {
 }
 
 ZIGBEE_CHANNEL_REGISTRY = DictRegistry()
-
-
-def establish_device_mappings():
-    """Establish mappings between ZCL objects and HA ZHA objects.
-
-    These cannot be module level, as importing bellows must be done in a
-    in a function.
-    """
-    RADIO_TYPES[RadioType.ezsp.name] = {
-        ZHA_GW_RADIO: bellows.ezsp.EZSP,
-        CONTROLLER: bellows.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "EZSP",
-    }
-
-    RADIO_TYPES[RadioType.deconz.name] = {
-        ZHA_GW_RADIO: zigpy_deconz.api.Deconz,
-        CONTROLLER: zigpy_deconz.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "Deconz",
-    }
-
-    RADIO_TYPES[RadioType.xbee.name] = {
-        ZHA_GW_RADIO: zigpy_xbee.api.XBee,
-        CONTROLLER: zigpy_xbee.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "XBee",
-    }
-
-    RADIO_TYPES[RadioType.zigate.name] = {
-        ZHA_GW_RADIO: zigpy_zigate.api.ZiGate,
-        CONTROLLER: zigpy_zigate.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "ZiGate",
-    }
-
-    BINARY_SENSOR_CLUSTERS.add(SMARTTHINGS_ACCELERATION_CLUSTER)
-
-    DEVICE_CLASS[zigpy.profiles.zha.PROFILE_ID].update(
-        {
-            SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE: DEVICE_TRACKER,
-            zigpy.profiles.zha.DeviceType.COLOR_DIMMABLE_LIGHT: LIGHT,
-            zigpy.profiles.zha.DeviceType.COLOR_TEMPERATURE_LIGHT: LIGHT,
-            zigpy.profiles.zha.DeviceType.DIMMABLE_BALLAST: LIGHT,
-            zigpy.profiles.zha.DeviceType.DIMMABLE_LIGHT: LIGHT,
-            zigpy.profiles.zha.DeviceType.DIMMABLE_PLUG_IN_UNIT: LIGHT,
-            zigpy.profiles.zha.DeviceType.EXTENDED_COLOR_LIGHT: LIGHT,
-            zigpy.profiles.zha.DeviceType.LEVEL_CONTROLLABLE_OUTPUT: LIGHT,
-            zigpy.profiles.zha.DeviceType.ON_OFF_BALLAST: SWITCH,
-            zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT: LIGHT,
-            zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT_SWITCH: SWITCH,
-            zigpy.profiles.zha.DeviceType.ON_OFF_PLUG_IN_UNIT: SWITCH,
-            zigpy.profiles.zha.DeviceType.SMART_PLUG: SWITCH,
-        }
-    )
-
-    DEVICE_CLASS[zigpy.profiles.zll.PROFILE_ID].update(
-        {
-            zigpy.profiles.zll.DeviceType.COLOR_LIGHT: LIGHT,
-            zigpy.profiles.zll.DeviceType.COLOR_TEMPERATURE_LIGHT: LIGHT,
-            zigpy.profiles.zll.DeviceType.DIMMABLE_LIGHT: LIGHT,
-            zigpy.profiles.zll.DeviceType.DIMMABLE_PLUGIN_UNIT: LIGHT,
-            zigpy.profiles.zll.DeviceType.EXTENDED_COLOR_LIGHT: LIGHT,
-            zigpy.profiles.zll.DeviceType.ON_OFF_LIGHT: LIGHT,
-            zigpy.profiles.zll.DeviceType.ON_OFF_PLUGIN_UNIT: SWITCH,
-        }
-    )
-
-    SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update(
-        {
-            # this works for now but if we hit conflicts we can break it out to
-            # a different dict that is keyed by manufacturer
-            SMARTTHINGS_ACCELERATION_CLUSTER: BINARY_SENSOR,
-            SMARTTHINGS_HUMIDITY_CLUSTER: SENSOR,
-            zcl.clusters.closures.DoorLock: LOCK,
-            zcl.clusters.general.AnalogInput.cluster_id: SENSOR,
-            zcl.clusters.general.MultistateInput.cluster_id: SENSOR,
-            zcl.clusters.general.OnOff: SWITCH,
-            zcl.clusters.general.PowerConfiguration: SENSOR,
-            zcl.clusters.homeautomation.ElectricalMeasurement: SENSOR,
-            zcl.clusters.hvac.Fan: FAN,
-            zcl.clusters.measurement.IlluminanceMeasurement: SENSOR,
-            zcl.clusters.measurement.OccupancySensing: BINARY_SENSOR,
-            zcl.clusters.measurement.PressureMeasurement: SENSOR,
-            zcl.clusters.measurement.RelativeHumidity: SENSOR,
-            zcl.clusters.measurement.TemperatureMeasurement: SENSOR,
-            zcl.clusters.security.IasZone: BINARY_SENSOR,
-            zcl.clusters.smartenergy.Metering: SENSOR,
-        }
-    )
-
-    SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS.update(
-        {zcl.clusters.general.OnOff: BINARY_SENSOR}
-    )
-
-    zha = zigpy.profiles.zha
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(zha.DeviceType.COLOR_CONTROLLER)
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(zha.DeviceType.COLOR_DIMMER_SWITCH)
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(zha.DeviceType.COLOR_SCENE_CONTROLLER)
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(zha.DeviceType.DIMMER_SWITCH)
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(zha.DeviceType.NON_COLOR_CONTROLLER)
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(
-        zha.DeviceType.NON_COLOR_SCENE_CONTROLLER
-    )
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(zha.DeviceType.REMOTE_CONTROL)
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID].append(zha.DeviceType.SCENE_SELECTOR)
-
-    zll = zigpy.profiles.zll
-    REMOTE_DEVICE_TYPES[zll.PROFILE_ID].append(zll.DeviceType.COLOR_CONTROLLER)
-    REMOTE_DEVICE_TYPES[zll.PROFILE_ID].append(zll.DeviceType.COLOR_SCENE_CONTROLLER)
-    REMOTE_DEVICE_TYPES[zll.PROFILE_ID].append(zll.DeviceType.CONTROL_BRIDGE)
-    REMOTE_DEVICE_TYPES[zll.PROFILE_ID].append(zll.DeviceType.CONTROLLER)
-    REMOTE_DEVICE_TYPES[zll.PROFILE_ID].append(zll.DeviceType.SCENE_CONTROLLER)
 
 
 def set_or_callable(value):

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -9,7 +9,6 @@ from zigpy.application import ControllerApplication
 from homeassistant import config_entries
 from homeassistant.components.zha.core.const import COMPONENTS, DATA_ZHA, DOMAIN
 from homeassistant.components.zha.core.gateway import ZHAGateway
-from homeassistant.components.zha.core.registries import establish_device_mappings
 from homeassistant.components.zha.core.store import async_get_registry
 from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
 
@@ -41,7 +40,6 @@ async def zha_gateway_fixture(hass, config_entry):
     Create a ZHAGateway object that can be used to interact with as if we
     had a real zigbee network running.
     """
-    establish_device_mappings()
     for component in COMPONENTS:
         hass.data[DATA_ZHA][component] = hass.data[DATA_ZHA].get(component, {})
     zha_storage = await async_get_registry(hass)


### PR DESCRIPTION
## Description:
This PR performs some housekeeping in ZHA. We were using a function to establish some mappings. We don't need to do this now that we can use top level imports. This PR removes the function in favor of direct initialization. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]