### PR TITLE
Bump ring to 0.2.9

### DIFF
--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ring",
   "name": "Ring",
   "documentation": "https://www.home-assistant.io/integrations/ring",
-  "requirements": ["ring_doorbell==0.2.8"],
+  "requirements": ["ring_doorbell==0.2.9"],
   "dependencies": ["ffmpeg"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1750,7 +1750,7 @@ rfk101py==0.0.1
 rflink==0.0.50
 
 # homeassistant.components.ring
-ring_doorbell==0.2.8
+ring_doorbell==0.2.9
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -560,7 +560,7 @@ restrictedpython==5.0
 rflink==0.0.50
 
 # homeassistant.components.ring
-ring_doorbell==0.2.8
+ring_doorbell==0.2.9
 
 # homeassistant.components.yamaha
 rxv==0.6.0


### PR DESCRIPTION
# Description:
Bump Ring component to 0.2.9. This PR should address some extra DNS queries being performed by the underlying library. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

