### PR TITLE
Spell Zigbee consistently, with lowercase "b"

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -646,7 +646,7 @@ def entity_to_json(config, entity):
         and (entity_features & SUPPORT_COLOR)
         and (entity_features & SUPPORT_COLOR_TEMP)
     ):
-        # Extended Color light (ZigBee Device ID: 0x0210)
+        # Extended Color light (Zigbee Device ID: 0x0210)
         # Same as Color light, but which supports additional setting of color temperature
         retval["type"] = "Extended color light"
         retval["modelid"] = "HASS231"
@@ -664,7 +664,7 @@ def entity_to_json(config, entity):
         else:
             retval["state"][HUE_API_STATE_COLORMODE] = "ct"
     elif (entity_features & SUPPORT_BRIGHTNESS) and (entity_features & SUPPORT_COLOR):
-        # Color light (ZigBee Device ID: 0x0200)
+        # Color light (Zigbee Device ID: 0x0200)
         # Supports on/off, dimming and color control (hue/saturation, enhanced hue, color loop and XY)
         retval["type"] = "Color light"
         retval["modelid"] = "HASS213"
@@ -680,7 +680,7 @@ def entity_to_json(config, entity):
     elif (entity_features & SUPPORT_BRIGHTNESS) and (
         entity_features & SUPPORT_COLOR_TEMP
     ):
-        # Color temperature light (ZigBee Device ID: 0x0220)
+        # Color temperature light (Zigbee Device ID: 0x0220)
         # Supports groups, scenes, on/off, dimming, and setting of a color temperature
         retval["type"] = "Color temperature light"
         retval["modelid"] = "HASS312"
@@ -697,13 +697,13 @@ def entity_to_json(config, entity):
             | SUPPORT_TARGET_TEMPERATURE
         )
     ) or entity.domain == script.DOMAIN:
-        # Dimmable light (ZigBee Device ID: 0x0100)
+        # Dimmable light (Zigbee Device ID: 0x0100)
         # Supports groups, scenes, on/off and dimming
         retval["type"] = "Dimmable light"
         retval["modelid"] = "HASS123"
         retval["state"].update({HUE_API_STATE_BRI: state[STATE_BRIGHTNESS]})
     else:
-        # On/off light (ZigBee Device ID: 0x0000)
+        # On/off light (Zigbee Device ID: 0x0000)
         # Supports groups, scenes and on/off control
         retval["type"] = "On/off light"
         retval["modelid"] = "HASS321"

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -1,7 +1,7 @@
 # Describes the format for available zha services
 
 permit:
-  description: Allow nodes to join the ZigBee network.
+  description: Allow nodes to join the Zigbee network.
   fields:
     duration:
       description: Time to permit joins, in seconds
@@ -11,7 +11,7 @@ permit:
       example: "00:0d:6f:00:05:7d:2d:34"
 
 remove:
-  description: Remove a node from the ZigBee network.
+  description: Remove a node from the Zigbee network.
   fields:
     ieee_address:
       description: IEEE address of the node to remove

--- a/homeassistant/components/zigbee/__init__.py
+++ b/homeassistant/components/zigbee/__init__.py
@@ -325,7 +325,7 @@ class ZigBeeDigitalIn(Entity):
         except ZIGBEE_TX_FAILURE:
             _LOGGER.warning(
                 "Transmission failure when attempting to get sample from "
-                "ZigBee device at address: %s",
+                "Zigbee device at address: %s",
                 hexlify(self._config.address),
             )
             return
@@ -348,7 +348,7 @@ class ZigBeeDigitalOut(ZigBeeDigitalIn):
     """Representation of a GPIO pin configured as a digital input."""
 
     def _set_state(self, state):
-        """Initialize the ZigBee digital out device."""
+        """Initialize the Zigbee digital out device."""
         try:
             DEVICE.set_gpio_pin(
                 self._config.pin, self._config.bool2state[state], self._config.address
@@ -356,12 +356,12 @@ class ZigBeeDigitalOut(ZigBeeDigitalIn):
         except ZIGBEE_TX_FAILURE:
             _LOGGER.warning(
                 "Transmission failure when attempting to set output pin on "
-                "ZigBee device at address: %s",
+                "Zigbee device at address: %s",
                 hexlify(self._config.address),
             )
             return
         except ZIGBEE_EXCEPTION as exc:
-            _LOGGER.exception("Unable to set digital pin on ZigBee device: %s", exc)
+            _LOGGER.exception("Unable to set digital pin on Zigbee device: %s", exc)
             return
         self._state = state
         if not self.should_poll:
@@ -376,19 +376,19 @@ class ZigBeeDigitalOut(ZigBeeDigitalIn):
         self._set_state(False)
 
     def update(self):
-        """Ask the ZigBee device what its output is set to."""
+        """Ask the Zigbee device what its output is set to."""
         try:
             pin_state = DEVICE.get_gpio_pin(self._config.pin, self._config.address)
         except ZIGBEE_TX_FAILURE:
             _LOGGER.warning(
                 "Transmission failure when attempting to get output pin status"
-                " from ZigBee device at address: %s",
+                " from Zigbee device at address: %s",
                 hexlify(self._config.address),
             )
             return
         except ZIGBEE_EXCEPTION as exc:
             _LOGGER.exception(
-                "Unable to get output pin status from ZigBee device: %s", exc
+                "Unable to get output pin status from Zigbee device: %s", exc
             )
             return
         self._state = self._config.state2bool[pin_state]
@@ -462,8 +462,8 @@ class ZigBeeAnalogIn(Entity):
         except ZIGBEE_TX_FAILURE:
             _LOGGER.warning(
                 "Transmission failure when attempting to get sample from "
-                "ZigBee device at address: %s",
+                "Zigbee device at address: %s",
                 hexlify(self._config.address),
             )
         except ZIGBEE_EXCEPTION as exc:
-            _LOGGER.exception("Unable to get sample from ZigBee device: %s", exc)
+            _LOGGER.exception("Unable to get sample from Zigbee device: %s", exc)

--- a/homeassistant/components/zigbee/sensor.py
+++ b/homeassistant/components/zigbee/sensor.py
@@ -27,9 +27,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the ZigBee platform.
+    """Set up the Zigbee platform.
 
-    Uses the 'type' config value to work out which type of ZigBee sensor we're
+    Uses the 'type' config value to work out which type of Zigbee sensor we're
     dealing with and instantiates the relevant classes to handle it.
     """
     typ = config.get(CONF_TYPE)
@@ -37,7 +37,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     try:
         sensor_class, config_class = TYPE_CLASSES[typ]
     except KeyError:
-        _LOGGER.exception("Unknown ZigBee sensor type: %s", typ)
+        _LOGGER.exception("Unknown Zigbee sensor type: %s", typ)
         return
 
     add_entities([sensor_class(hass, config_class(config))], True)
@@ -73,11 +73,11 @@ class ZigBeeTemperatureSensor(Entity):
         except zigbee.ZIGBEE_TX_FAILURE:
             _LOGGER.warning(
                 "Transmission failure when attempting to get sample from "
-                "ZigBee device at address: %s",
+                "Zigbee device at address: %s",
                 hexlify(self._config.address),
             )
         except zigbee.ZIGBEE_EXCEPTION as exc:
-            _LOGGER.exception("Unable to get sample from ZigBee device: %s", exc)
+            _LOGGER.exception("Unable to get sample from Zigbee device: %s", exc)
 
 
 # This must be below the classes to which it refers.


### PR DESCRIPTION

## Description:

https://zigbeealliance.org/developer_resources/zigbee-specification/
"Please note that this uses old branding, Zigbee is always a lowercase
 B, not a capital. This change occurred shortly after the official
 release of this document."

Also other docs at https://zigbeealliance.org/solution_type/zigbee/,
https://github.com/zigpy/zigpy/issues/111

Addressing comments and docs here only, not symbols in code.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
