### PR TITLE
Add OpenERZ API integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -269,6 +269,7 @@ homeassistant/components/ohmconnect/* @robbiet480
 homeassistant/components/ombi/* @larssont
 homeassistant/components/onboarding/* @home-assistant/core
 homeassistant/components/onewire/* @garbled1
+homeassistant/components/openerz/* @misialq
 homeassistant/components/opentherm_gw/* @mvn23
 homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff

--- a/homeassistant/components/openerz/__init__.py
+++ b/homeassistant/components/openerz/__init__.py
@@ -1,0 +1,1 @@
+"""The Open ERZ API integration."""

--- a/homeassistant/components/openerz/__init__.py
+++ b/homeassistant/components/openerz/__init__.py
@@ -1,1 +1,3 @@
 """The Open ERZ API integration."""
+
+DOMAIN = "sensor"

--- a/homeassistant/components/openerz/manifest.json
+++ b/homeassistant/components/openerz/manifest.json
@@ -7,6 +7,6 @@
     "@misialq"
   ],
   "requirements": [
-    "testfixtures==6.10.3"
+    "openerz-api==0.1.0"
   ]
 }

--- a/homeassistant/components/openerz/manifest.json
+++ b/homeassistant/components/openerz/manifest.json
@@ -1,0 +1,8 @@
+{
+    "domain": "openerz",
+    "name": "Open ERZ",
+    "documentation": "https://www.home-assistant.io/components/openerz",
+    "dependencies": [],
+    "codeowners": ["@misialq"],
+    "requirements": []
+  }

--- a/homeassistant/components/openerz/manifest.json
+++ b/homeassistant/components/openerz/manifest.json
@@ -1,8 +1,12 @@
 {
-    "domain": "openerz",
-    "name": "Open ERZ",
-    "documentation": "https://www.home-assistant.io/components/openerz",
-    "dependencies": [],
-    "codeowners": ["@misialq"],
-    "requirements": ["testfixtures==6.10.3"]
-  }
+  "domain": "openerz",
+  "name": "Open ERZ",
+  "documentation": "https://www.home-assistant.io/integrations/openerz",
+  "dependencies": [],
+  "codeowners": [
+    "@misialq"
+  ],
+  "requirements": [
+    "testfixtures==6.10.3"
+  ]
+}

--- a/homeassistant/components/openerz/manifest.json
+++ b/homeassistant/components/openerz/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://www.home-assistant.io/components/openerz",
     "dependencies": [],
     "codeowners": ["@misialq"],
-    "requirements": []
+    "requirements": ["testfixtures==6.10.3"]
   }

--- a/homeassistant/components/openerz/sensor.py
+++ b/homeassistant/components/openerz/sensor.py
@@ -15,7 +15,7 @@ SCAN_INTERVAL = timedelta(hours=12)
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required("zip"): cv.string,
+        vol.Required("zip"): cv.positive_int,
         vol.Required("waste_type", default="waste"): cv.string,
         vol.Optional("name"): cv.string,
     }
@@ -105,7 +105,7 @@ class OpenERZSensor(Entity):
         result_list = response_json.get("result")
         first_scheduled_pickup = result_list[0]
         if (
-            str(first_scheduled_pickup["zip"]) == self.zip
+            first_scheduled_pickup["zip"] == self.zip
             and first_scheduled_pickup["type"] == self.waste_type
         ):
             return first_scheduled_pickup["date"]
@@ -118,7 +118,7 @@ class OpenERZSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
 
-        return f"ERZ - {self.friendly_name} ({self.zip})"
+        return self.friendly_name
 
     @property
     def state(self):

--- a/homeassistant/components/openerz/sensor.py
+++ b/homeassistant/components/openerz/sensor.py
@@ -10,11 +10,12 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
+SCAN_INTERVAL = timedelta(hours=12)
 
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required("postcode"): cv.slugify,
+        vol.Required("zip"): cv.string,
         vol.Required("waste_type", default="waste"): cv.string,
         vol.Optional("name"): cv.string,
     }
@@ -24,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
     openerz_config = {
-        "postcode": config["postcode"],
+        "zip": config["zip"],
         "waste_type": config["waste_type"],
         "name": config.get("name"),
     }
@@ -38,7 +39,7 @@ class OpenERZSensor(Entity):
         """Initialize the sensor."""
         self._state = None
         self.openerz_config = openerz_config
-        self.postcode = self.openerz_config["postcode"]
+        self.zip = self.openerz_config["zip"]
         self.waste_type = self.openerz_config["waste_type"]
         self.friendly_name = self.openerz_config.get("name")
         self.start_date = datetime.now()
@@ -70,7 +71,7 @@ class OpenERZSensor(Entity):
         end_date = self.end_date.strftime("%Y-%m-%d")
 
         payload = {
-            "zip": self.postcode,
+            "zip": self.zip,
             "start": start_date,
             "end": end_date,
             "offset": 0,
@@ -91,7 +92,7 @@ class OpenERZSensor(Entity):
         if not self.last_api_response.ok:
             _LOGGER.warning(
                 "Last request to OpenERZ was not succesful. Status code: %d",
-                self.last_api_response.status.code,
+                self.last_api_response.status_code,
             )
             return None
 
@@ -102,7 +103,7 @@ class OpenERZSensor(Entity):
         result_list = response_json.get("result")
         first_scheduled_pickup = result_list[0]
         if (
-            str(first_scheduled_pickup["zip"]) == self.postcode
+            first_scheduled_pickup["zip"] == self.zip
             and first_scheduled_pickup["type"] == self.waste_type
         ):
             return first_scheduled_pickup["date"]
@@ -117,7 +118,7 @@ class OpenERZSensor(Entity):
         """Return the name of the sensor."""
 
         return (
-            f"ERZ - {self.friendly_name} ({self.postcode})"
+            f"ERZ - {self.friendly_name} ({self.zip})"
             if self.friendly_name
             else "Zürich Entsorgungs-Kalender"
         )

--- a/homeassistant/components/openerz/sensor.py
+++ b/homeassistant/components/openerz/sensor.py
@@ -1,0 +1,140 @@
+"""Support for OpenERZ API for Zurich city waste disposal system."""
+from datetime import datetime, timedelta
+import logging
+
+import requests
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Validation of the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required("postcode"): cv.slugify,
+        vol.Required("waste_type", default="waste"): cv.string,
+        vol.Optional("name"): cv.string,
+    }
+)
+
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+    openerz_config = {
+        "postcode": config["postcode"],
+        "waste_type": config["waste_type"],
+        "name": config.get("name"),
+    }
+    add_entities([OpenERZSensor(openerz_config)])
+
+
+class OpenERZSensor(Entity):
+    """Representation of a Sensor."""
+
+    def __init__(self, openerz_config):
+        """Initialize the sensor."""
+        self._state = None
+        self.openerz_config = openerz_config
+        self.postcode = self.openerz_config["postcode"]
+        self.waste_type = self.openerz_config["waste_type"]
+        self.friendly_name = self.openerz_config.get("name")
+        self.start_date = datetime.now()
+        self.end_date = None
+        self.last_api_response = None
+
+        self.update()
+
+    def update_start_date(self):
+        """Set the start day to today."""
+
+        self.start_date = datetime.now()
+
+    def find_end_date(self, day_offset=31):
+        """Find the end date for the request, given an offset expressed in days.
+
+        Args:
+        day_offset (int): difference in days between start and end date of the request
+        """
+
+        self.end_date = self.start_date + timedelta(days=day_offset)
+
+    def make_api_request(self):
+        """Construct a request and send it to the OpenERZ API."""
+
+        headers = {"accept": "application/json"}
+
+        start_date = self.start_date.strftime("%Y-%m-%d")
+        end_date = self.end_date.strftime("%Y-%m-%d")
+
+        payload = {
+            "zip": self.postcode,
+            "start": start_date,
+            "end": end_date,
+            "offset": 0,
+            "limit": 0,
+            "lang": "en",
+            "sort": "date",
+        }
+        url = f"http://openerz.metaodi.ch/api/calendar/{self.waste_type}.json"
+
+        try:
+            self.last_api_response = requests.get(url, params=payload, headers=headers)
+        except requests.exceptions.ConnectionError as e:
+            _LOGGER.error("ConnectionError while making request to OpenERZ: %s", e)
+
+    def parse_api_response(self):
+        """Parse the JSON response received from the OpenERZ API and return a date of the next pickup."""
+
+        if not self.last_api_response.ok:
+            _LOGGER.warning(
+                "Last request to OpenERZ was not succesful. Status code: %d",
+                self.last_api_response.status.code,
+            )
+            return None
+
+        response_json = self.last_api_response.json()
+        if response_json["_metadata"]["total_count"] == 0:
+            _LOGGER.warning("Request to OpenERZ returned no results.")
+            return None
+        result_list = response_json.get("result")
+        first_scheduled_pickup = result_list[0]
+        if (
+            str(first_scheduled_pickup["zip"]) == self.postcode
+            and first_scheduled_pickup["type"] == self.waste_type
+        ):
+            return first_scheduled_pickup["date"]
+        else:
+            _LOGGER.warning(
+                "Either zip or waste type does not match the ones specified in the configuration."
+            )
+            return None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+
+        return (
+            f"ERZ - {self.friendly_name} ({self.postcode})"
+            if self.friendly_name
+            else "Zürich Entsorgungs-Kalender"
+        )
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+
+        return self._state
+
+    def update(self):
+        """Fetch new state data for the sensor.
+
+        This is the only method that should fetch new data for Home Assistant.
+        """
+
+        self.update_start_date()
+        self.find_end_date(day_offset=31)
+        self.make_api_request()
+        self._state = self.parse_api_response()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -966,6 +966,9 @@ onvif-zeep-async==0.2.0
 # homeassistant.components.opencv
 # opencv-python-headless==4.2.0.32
 
+# homeassistant.components.openerz
+openerz-api==0.1.0
+
 # homeassistant.components.openevse
 openevsewifi==0.4
 
@@ -2015,9 +2018,6 @@ tesla-powerwall==0.1.3
 
 # homeassistant.components.tesla
 teslajsonpy==0.6.0
-
-# homeassistant.components.openerz
-testfixtures==6.10.3
 
 # homeassistant.components.thermoworks_smoke
 thermoworks_smoke==0.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2016,6 +2016,9 @@ tesla-powerwall==0.1.3
 # homeassistant.components.tesla
 teslajsonpy==0.6.0
 
+# homeassistant.components.openerz
+testfixtures==6.10.3
+
 # homeassistant.components.thermoworks_smoke
 thermoworks_smoke==0.1.8
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -737,6 +737,9 @@ tesla-powerwall==0.1.3
 # homeassistant.components.tesla
 teslajsonpy==0.6.0
 
+# homeassistant.components.openerz
+testfixtures==6.10.3
+
 # homeassistant.components.toon
 toonapilib==3.2.4
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -374,6 +374,9 @@ numpy==1.18.1
 # homeassistant.components.google
 oauth2client==4.0.0
 
+# homeassistant.components.openerz
+openerz-api==0.1.0
+
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
 paho-mqtt==1.5.0
@@ -736,9 +739,6 @@ tesla-powerwall==0.1.3
 
 # homeassistant.components.tesla
 teslajsonpy==0.6.0
-
-# homeassistant.components.openerz
-testfixtures==6.10.3
 
 # homeassistant.components.toon
 toonapilib==3.2.4

--- a/tests/components/openerz/__init__.py
+++ b/tests/components/openerz/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for OpenERZ component."""

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -63,6 +63,20 @@ class TestOpenERZSensor(unittest.TestCase):
         "homeassistant.components.openerz.sensor.OpenERZSensor.update",
         return_value=True,
     )
+    def test_sensor_init_no_name(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+
+            del self.mock_config["name"]
+            test_openerz = OpenERZSensor(self.mock_config)
+
+            self.assertEqual(test_openerz.friendly_name, "glass")
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
     def test_sensor_update_start_date(self, patched_update):
         """Test whether all values initialized properly."""
         with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -1,0 +1,281 @@
+"""Tests for OpenERZ component."""
+from datetime import datetime
+import unittest
+from unittest.mock import patch
+
+from testfixtures import LogCapture
+
+from homeassistant.components.openerz.sensor import OpenERZSensor
+
+MOCK_DATETIME = datetime(
+    year=2019, month=12, day=10, hour=11, minute=15, second=0, microsecond=0
+)
+
+
+class MockAPIResponse:
+    """Provide fake response from the OpenERZ API."""
+
+    def __init__(self, is_ok, status_code, json_data):
+        """Initialize all the values."""
+        self.ok = is_ok
+        self.status_code = status_code
+        self.json_data = json_data
+
+    def json(self):
+        """Return response data."""
+        return self.json_data
+
+
+class TestOpenERZSensor(unittest.TestCase):
+    """Test the OpenERZ sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.mock_datetime = MOCK_DATETIME
+        self.mock_config = {
+            "platform": "openerz",
+            "name": "test_name",
+            "zip": "1234",
+            "waste_type": "glass",
+            "entity_id": "sensor.erz_glass_1234",
+        }
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_init(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+
+            test_openerz = OpenERZSensor(self.mock_config)
+
+            self.assertEqual(test_openerz.zip, "1234")
+            self.assertEqual(test_openerz.waste_type, "glass")
+            self.assertEqual(test_openerz.friendly_name, "test_name")
+            self.assertEqual(test_openerz.start_date, self.mock_datetime)
+            self.assertIsNone(test_openerz.end_date)
+            self.assertIsNone(test_openerz.last_api_response)
+            patched_update.assert_called_once()
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_update_start_date(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+            test_openerz = OpenERZSensor(self.mock_config)
+
+            patched_time.now.return_value = self.mock_datetime.replace(day=11)
+            test_openerz.update_start_date()
+
+            expected_start_date = datetime(
+                year=2019, month=12, day=11, hour=11, minute=15, second=0, microsecond=0
+            )
+            self.assertEqual(test_openerz.start_date, expected_start_date)
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_find_end_date(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+            test_openerz = OpenERZSensor(self.mock_config)
+
+            test_openerz.find_end_date()
+
+            expected_end_date = datetime(
+                year=2020, month=1, day=10, hour=11, minute=15, second=0, microsecond=0
+            )
+            self.assertEqual(test_openerz.end_date, expected_end_date)
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_make_api_request(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch(
+            "homeassistant.components.openerz.sensor.requests"
+        ) as patched_requests:
+            patched_requests.get.return_value = {}
+            with patch(
+                "homeassistant.components.openerz.sensor.datetime"
+            ) as patched_time:
+                patched_time.now.return_value = self.mock_datetime
+                test_openerz = OpenERZSensor(self.mock_config)
+                test_openerz.end_date = self.mock_datetime.replace(
+                    year=2020, month=1, day=10
+                )
+                test_openerz.make_api_request()
+
+                expected_headers = {"accept": "application/json"}
+                expected_url = "http://openerz.metaodi.ch/api/calendar/glass.json"
+                expected_payload = {
+                    "zip": "1234",
+                    "start": "2019-12-10",
+                    "end": "2020-01-10",
+                    "offset": 0,
+                    "limit": 0,
+                    "lang": "en",
+                    "sort": "date",
+                }
+                used_args, used_kwargs = patched_requests.get.call_args_list[0]
+                print(used_args)
+                print(used_kwargs)
+                self.assertEqual(used_args[0], expected_url)
+                self.assertDictEqual(used_kwargs["headers"], expected_headers)
+                self.assertDictEqual(used_kwargs["params"], expected_payload)
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_parse_api_response_ok(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+            test_openerz = OpenERZSensor(self.mock_config)
+            test_openerz.end_date = self.mock_datetime.replace(
+                year=2020, month=1, day=10
+            )
+
+            response_data = {
+                "_metadata": {"total_count": 1},
+                "result": [{"zip": "1234", "type": "glass", "date": "2020-01-10"}],
+            }
+            test_openerz.last_api_response = MockAPIResponse(True, 200, response_data)
+
+            test_pickup_date = test_openerz.parse_api_response()
+            self.assertEqual(test_pickup_date, "2020-01-10")
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_parse_api_response_no_dates(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+            test_openerz = OpenERZSensor(self.mock_config)
+            test_openerz.end_date = self.mock_datetime.replace(
+                year=2020, month=1, day=10
+            )
+
+            response_data = {"_metadata": {"total_count": 0}, "result": []}
+
+            with LogCapture() as captured_logs:
+                test_openerz.last_api_response = MockAPIResponse(
+                    True, 200, response_data
+                )
+
+                test_pickup_date = test_openerz.parse_api_response()
+                self.assertIsNone(test_pickup_date)
+                captured_logs.check_present(
+                    (
+                        "homeassistant.components.openerz.sensor",
+                        "WARNING",
+                        "Request to OpenERZ returned no results.",
+                    )
+                )
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_parse_api_response_wrong_zip(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+            test_openerz = OpenERZSensor(self.mock_config)
+            test_openerz.end_date = self.mock_datetime.replace(
+                year=2020, month=1, day=10
+            )
+
+            response_data = {
+                "_metadata": {"total_count": 1},
+                "result": [{"zip": "1235", "type": "glass", "date": "2020-01-10"}],
+            }
+
+            with LogCapture() as captured_logs:
+                test_openerz.last_api_response = MockAPIResponse(
+                    True, 200, response_data
+                )
+
+                test_pickup_date = test_openerz.parse_api_response()
+                self.assertIsNone(test_pickup_date)
+                captured_logs.check_present(
+                    (
+                        "homeassistant.components.openerz.sensor",
+                        "WARNING",
+                        "Either zip or waste type does not match the ones specified in the configuration.",
+                    )
+                )
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_parse_api_response_wrong_type(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+            test_openerz = OpenERZSensor(self.mock_config)
+            test_openerz.end_date = self.mock_datetime.replace(
+                year=2020, month=1, day=10
+            )
+
+            response_data = {
+                "_metadata": {"total_count": 1},
+                "result": [{"zip": "1234", "type": "metal", "date": "2020-01-10"}],
+            }
+
+            with LogCapture() as captured_logs:
+                test_openerz.last_api_response = MockAPIResponse(
+                    True, 200, response_data
+                )
+
+                test_pickup_date = test_openerz.parse_api_response()
+                self.assertIsNone(test_pickup_date)
+                captured_logs.check_present(
+                    (
+                        "homeassistant.components.openerz.sensor",
+                        "WARNING",
+                        "Either zip or waste type does not match the ones specified in the configuration.",
+                    )
+                )
+
+    @patch(
+        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
+        return_value=True,
+    )
+    def test_sensor_parse_api_response_not_ok(self, patched_update):
+        """Test whether all values initialized properly."""
+        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
+            patched_time.now.return_value = self.mock_datetime
+            test_openerz = OpenERZSensor(self.mock_config)
+            test_openerz.end_date = self.mock_datetime.replace(
+                year=2020, month=1, day=10
+            )
+
+            response_data = {"result": [{}]}
+
+            with LogCapture() as captured_logs:
+                test_openerz.last_api_response = MockAPIResponse(
+                    False, 404, response_data
+                )
+
+                test_pickup_date = test_openerz.parse_api_response()
+                self.assertIsNone(test_pickup_date)
+                captured_logs.check_present(
+                    (
+                        "homeassistant.components.openerz.sensor",
+                        "WARNING",
+                        "Last request to OpenERZ was not succesful. Status code: 404",
+                    )
+                )

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -1,353 +1,69 @@
 """Tests for OpenERZ component."""
-from datetime import datetime
-import unittest
-from unittest.mock import patch
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
 
-from requests.exceptions import RequestException
-from testfixtures import LogCapture
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.setup import async_setup_component
 
-from homeassistant.components.openerz.sensor import OpenERZSensor
-
-MOCK_DATETIME = datetime(
-    year=2019, month=12, day=10, hour=11, minute=15, second=0, microsecond=0
-)
-
-
-class MockAPIResponse:
-    """Provide fake response from the OpenERZ API."""
-
-    def __init__(self, is_ok, status_code, json_data):
-        """Initialize all the values."""
-        self.ok = is_ok
-        self.status_code = status_code
-        self.json_data = json_data
-
-    def json(self):
-        """Return response data."""
-        return self.json_data
+MOCK_CONFIG = {
+    "sensor": {
+        "platform": "openerz",
+        "name": "test_name",
+        "zip": 1234,
+        "waste_type": "glass",
+    }
+}
 
 
-class TestOpenERZSensor(unittest.TestCase):
-    """Test the OpenERZ sensor."""
-
-    def setup_method(self, method):
-        """Set up things to be run when tests are started."""
-        self.mock_datetime = MOCK_DATETIME
-        self.mock_config = {
-            "platform": "openerz",
-            "name": "test_name",
-            "zip": 1234,
-            "waste_type": "glass",
-            "entity_id": "sensor.erz_glass_1234",
-        }
-
-    @patch(
+async def test_sensor_init(hass):
+    """Test whether all values initialized properly."""
+    with patch(
         "homeassistant.components.openerz.sensor.OpenERZSensor.update",
         return_value=True,
-    )
-    def test_sensor_init(self, patched_update):
-        """Test whether all values initialized properly."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
+    ) as patched_update:
+        await async_setup_component(hass, SENSOR_DOMAIN, MOCK_CONFIG)
 
-            test_openerz = OpenERZSensor(self.mock_config)
+        entity_id = "sensor.test_name"
+        test_openerz = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
 
-            self.assertEqual(test_openerz.zip, 1234)
-            self.assertEqual(test_openerz.waste_type, "glass")
-            self.assertEqual(test_openerz.friendly_name, "test_name")
-            self.assertEqual(test_openerz.start_date, self.mock_datetime)
-            self.assertIsNone(test_openerz.end_date)
-            self.assertIsNone(test_openerz.last_api_response)
-            self.assertEqual(test_openerz.name, "test_name")
-            patched_update.assert_called_once()
+        assert test_openerz.zip == 1234
+        assert test_openerz.waste_type == "glass"
+        assert test_openerz.friendly_name == "test_name"
+        patched_update.assert_called_once()
 
-    @patch(
+
+async def test_sensor_init_missing_type(hass):
+    """Test whether default waste type set properly."""
+    mock_config_copy = deepcopy(MOCK_CONFIG)
+    del mock_config_copy["sensor"]["waste_type"]
+    with patch(
         "homeassistant.components.openerz.sensor.OpenERZSensor.update",
         return_value=True,
-    )
-    def test_sensor_init_no_name(self, patched_update):
-        """Test whether all values initialized properly when name not provided."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
+    ) as patched_update:
+        await async_setup_component(hass, SENSOR_DOMAIN, mock_config_copy)
 
-            del self.mock_config["name"]
-            test_openerz = OpenERZSensor(self.mock_config)
+        entity_id = "sensor.test_name"
+        test_openerz = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
 
-            self.assertEqual(test_openerz.friendly_name, "glass")
-            self.assertEqual(test_openerz.name, "glass")
+        assert test_openerz.zip == 1234
+        assert test_openerz.waste_type == "waste"
+        assert test_openerz.friendly_name == "test_name"
+        patched_update.assert_called_once()
 
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_update_start_date(self, patched_update):
-        """Test whether start date is updated correctly."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-            test_openerz = OpenERZSensor(self.mock_config)
 
-            patched_time.now.return_value = self.mock_datetime.replace(day=11)
-            test_openerz.update_start_date()
+async def test_sensor_state(hass):
+    """Test whether default waste type set properly."""
+    with patch(
+        "homeassistant.components.openerz.sensor.OpenERZConnector"
+    ) as patched_connector:
+        pickup_instance = MagicMock()
+        pickup_instance.find_next_pickup.return_value = "2020-12-12"
+        patched_connector.return_value = pickup_instance
 
-            expected_start_date = datetime(
-                year=2019, month=12, day=11, hour=11, minute=15, second=0, microsecond=0
-            )
-            self.assertEqual(test_openerz.start_date, expected_start_date)
+        await async_setup_component(hass, SENSOR_DOMAIN, MOCK_CONFIG)
 
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_find_end_date(self, patched_update):
-        """Test whether end date is correctly set."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-            test_openerz = OpenERZSensor(self.mock_config)
+        entity_id = "sensor.test_name"
+        test_openerz_state = hass.states.get(entity_id).state
 
-            test_openerz.find_end_date()
-
-            expected_end_date = datetime(
-                year=2020, month=1, day=10, hour=11, minute=15, second=0, microsecond=0
-            )
-            self.assertEqual(test_openerz.end_date, expected_end_date)
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_make_api_request(self, patched_update):
-        """Test making API requests."""
-        with patch(
-            "homeassistant.components.openerz.sensor.requests"
-        ) as patched_requests:
-            patched_requests.get.return_value = {}
-            with patch(
-                "homeassistant.components.openerz.sensor.datetime"
-            ) as patched_time:
-                patched_time.now.return_value = self.mock_datetime
-                test_openerz = OpenERZSensor(self.mock_config)
-                test_openerz.end_date = self.mock_datetime.replace(
-                    year=2020, month=1, day=10
-                )
-                test_openerz.make_api_request()
-
-                expected_headers = {"accept": "application/json"}
-                expected_url = "http://openerz.metaodi.ch/api/calendar/glass.json"
-                expected_payload = {
-                    "zip": 1234,
-                    "start": "2019-12-10",
-                    "end": "2020-01-10",
-                    "offset": 0,
-                    "limit": 0,
-                    "lang": "en",
-                    "sort": "date",
-                }
-                used_args, used_kwargs = patched_requests.get.call_args_list[0]
-                self.assertEqual(used_args[0], expected_url)
-                self.assertDictEqual(used_kwargs["headers"], expected_headers)
-                self.assertDictEqual(used_kwargs["params"], expected_payload)
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_make_api_request_connection_error(self, patched_update):
-        """Test making API requests."""
-        with patch(
-            "homeassistant.components.openerz.sensor.requests.get"
-        ) as patched_get:
-            patched_get.side_effect = RequestException("Connection timed out")
-            with patch(
-                "homeassistant.components.openerz.sensor.datetime"
-            ) as patched_time:
-                patched_time.now.return_value = self.mock_datetime
-                test_openerz = OpenERZSensor(self.mock_config)
-                test_openerz.end_date = self.mock_datetime.replace(
-                    year=2020, month=1, day=10
-                )
-                with LogCapture() as captured_logs:
-                    test_openerz.make_api_request()
-                    captured_logs.check_present(
-                        (
-                            "homeassistant.components.openerz.sensor",
-                            "ERROR",
-                            "RequestException while making request to OpenERZ: Connection timed out",
-                        ),
-                        order_matters=False,
-                    )
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_parse_api_response_ok(self, patched_update):
-        """Test whether API response is parsed correctly."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-            test_openerz = OpenERZSensor(self.mock_config)
-            test_openerz.end_date = self.mock_datetime.replace(
-                year=2020, month=1, day=10
-            )
-
-            response_data = {
-                "_metadata": {"total_count": 1},
-                "result": [{"zip": 1234, "type": "glass", "date": "2020-01-10"}],
-            }
-            test_openerz.last_api_response = MockAPIResponse(True, 200, response_data)
-
-            test_pickup_date = test_openerz.parse_api_response()
-            self.assertEqual(test_pickup_date, "2020-01-10")
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_parse_api_response_no_data(self, patched_update):
-        """Test whether API response is parsed correctly when no data returned."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-            test_openerz = OpenERZSensor(self.mock_config)
-            test_openerz.end_date = self.mock_datetime.replace(
-                year=2020, month=1, day=10
-            )
-
-            response_data = {"_metadata": {"total_count": 0}, "result": []}
-
-            with LogCapture() as captured_logs:
-                test_openerz.last_api_response = MockAPIResponse(
-                    True, 200, response_data
-                )
-
-                test_pickup_date = test_openerz.parse_api_response()
-                self.assertIsNone(test_pickup_date)
-                captured_logs.check_present(
-                    (
-                        "homeassistant.components.openerz.sensor",
-                        "WARNING",
-                        "Request to OpenERZ returned no results.",
-                    )
-                )
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_parse_api_response_wrong_zip(self, patched_update):
-        """Test handling unexpected zip in API response."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-            test_openerz = OpenERZSensor(self.mock_config)
-            test_openerz.end_date = self.mock_datetime.replace(
-                year=2020, month=1, day=10
-            )
-
-            response_data = {
-                "_metadata": {"total_count": 1},
-                "result": [{"zip": 1235, "type": "glass", "date": "2020-01-10"}],
-            }
-
-            with LogCapture() as captured_logs:
-                test_openerz.last_api_response = MockAPIResponse(
-                    True, 200, response_data
-                )
-
-                test_pickup_date = test_openerz.parse_api_response()
-                self.assertIsNone(test_pickup_date)
-                captured_logs.check_present(
-                    (
-                        "homeassistant.components.openerz.sensor",
-                        "WARNING",
-                        "Either zip or waste type does not match the ones specified in the configuration.",
-                    )
-                )
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_parse_api_response_wrong_type(self, patched_update):
-        """Test handling unexpected waste type in API response."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-            test_openerz = OpenERZSensor(self.mock_config)
-            test_openerz.end_date = self.mock_datetime.replace(
-                year=2020, month=1, day=10
-            )
-
-            response_data = {
-                "_metadata": {"total_count": 1},
-                "result": [{"zip": 1234, "type": "metal", "date": "2020-01-10"}],
-            }
-
-            with LogCapture() as captured_logs:
-                test_openerz.last_api_response = MockAPIResponse(
-                    True, 200, response_data
-                )
-
-                test_pickup_date = test_openerz.parse_api_response()
-                self.assertIsNone(test_pickup_date)
-                captured_logs.check_present(
-                    (
-                        "homeassistant.components.openerz.sensor",
-                        "WARNING",
-                        "Either zip or waste type does not match the ones specified in the configuration.",
-                    )
-                )
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    )
-    def test_sensor_parse_api_response_not_ok(self, patched_update):
-        """Test handling of an erroneous API response."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-            test_openerz = OpenERZSensor(self.mock_config)
-            test_openerz.end_date = self.mock_datetime.replace(
-                year=2020, month=1, day=10
-            )
-
-            response_data = {"result": [{}]}
-
-            with LogCapture() as captured_logs:
-                test_openerz.last_api_response = MockAPIResponse(
-                    False, 404, response_data
-                )
-
-                test_pickup_date = test_openerz.parse_api_response()
-                self.assertIsNone(test_pickup_date)
-                captured_logs.check_present(
-                    (
-                        "homeassistant.components.openerz.sensor",
-                        "WARNING",
-                        "Last request to OpenERZ was not successful. Status code: 404",
-                    )
-                )
-
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update_start_date",
-        return_value=True,
-    )
-    @patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.make_api_request",
-        return_value=True,
-    )
-    def test_sensor_update(self, patched_request, patched_start_date):
-        """Test whether state gets updated properly."""
-        with patch("homeassistant.components.openerz.sensor.datetime") as patched_time:
-            patched_time.now.return_value = self.mock_datetime
-
-            with patch(
-                "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-                return_value=True,
-            ):
-                test_openerz = OpenERZSensor(self.mock_config)
-
-            response_data = {
-                "_metadata": {"total_count": 1},
-                "result": [{"zip": 1234, "type": "glass", "date": "2020-01-10"}],
-            }
-            test_openerz.last_api_response = MockAPIResponse(True, 200, response_data)
-            test_openerz.update()
-
-            self.assertEqual(test_openerz.state, "2020-01-10")
+        assert test_openerz_state == "2020-12-12"
+        pickup_instance.find_next_pickup.assert_called_once()

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -26,6 +26,8 @@ async def test_sensor_init(hass):
         entity_id = "sensor.test_name"
         test_openerz = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
 
+        await hass.async_block_till_done()
+
         assert test_openerz.zip == 1234
         assert test_openerz.waste_type == "glass"
         assert test_openerz.friendly_name == "test_name"
@@ -44,6 +46,8 @@ async def test_sensor_init_missing_type(hass):
 
         entity_id = "sensor.test_name"
         test_openerz = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
+
+        await hass.async_block_till_done()
 
         assert test_openerz.zip == 1234
         assert test_openerz.waste_type == "waste"
@@ -64,6 +68,8 @@ async def test_sensor_state(hass):
 
         entity_id = "sensor.test_name"
         test_openerz_state = hass.states.get(entity_id).state
+
+        await hass.async_block_till_done()
 
         assert test_openerz_state == "2020-12-12"
         pickup_instance.find_next_pickup.assert_called_once()

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -36,7 +36,7 @@ class TestOpenERZSensor(unittest.TestCase):
         self.mock_config = {
             "platform": "openerz",
             "name": "test_name",
-            "zip": "1234",
+            "zip": 1234,
             "waste_type": "glass",
             "entity_id": "sensor.erz_glass_1234",
         }
@@ -52,13 +52,13 @@ class TestOpenERZSensor(unittest.TestCase):
 
             test_openerz = OpenERZSensor(self.mock_config)
 
-            self.assertEqual(test_openerz.zip, "1234")
+            self.assertEqual(test_openerz.zip, 1234)
             self.assertEqual(test_openerz.waste_type, "glass")
             self.assertEqual(test_openerz.friendly_name, "test_name")
             self.assertEqual(test_openerz.start_date, self.mock_datetime)
             self.assertIsNone(test_openerz.end_date)
             self.assertIsNone(test_openerz.last_api_response)
-            self.assertEqual(test_openerz.name, "ERZ - test_name (1234)")
+            self.assertEqual(test_openerz.name, "test_name")
             patched_update.assert_called_once()
 
     @patch(
@@ -74,7 +74,7 @@ class TestOpenERZSensor(unittest.TestCase):
             test_openerz = OpenERZSensor(self.mock_config)
 
             self.assertEqual(test_openerz.friendly_name, "glass")
-            self.assertEqual(test_openerz.name, "ERZ - glass (1234)")
+            self.assertEqual(test_openerz.name, "glass")
 
     @patch(
         "homeassistant.components.openerz.sensor.OpenERZSensor.update",
@@ -134,7 +134,7 @@ class TestOpenERZSensor(unittest.TestCase):
                 expected_headers = {"accept": "application/json"}
                 expected_url = "http://openerz.metaodi.ch/api/calendar/glass.json"
                 expected_payload = {
-                    "zip": "1234",
+                    "zip": 1234,
                     "start": "2019-12-10",
                     "end": "2020-01-10",
                     "offset": 0,
@@ -191,7 +191,7 @@ class TestOpenERZSensor(unittest.TestCase):
 
             response_data = {
                 "_metadata": {"total_count": 1},
-                "result": [{"zip": "1234", "type": "glass", "date": "2020-01-10"}],
+                "result": [{"zip": 1234, "type": "glass", "date": "2020-01-10"}],
             }
             test_openerz.last_api_response = MockAPIResponse(True, 200, response_data)
 
@@ -243,7 +243,7 @@ class TestOpenERZSensor(unittest.TestCase):
 
             response_data = {
                 "_metadata": {"total_count": 1},
-                "result": [{"zip": "1235", "type": "glass", "date": "2020-01-10"}],
+                "result": [{"zip": 1235, "type": "glass", "date": "2020-01-10"}],
             }
 
             with LogCapture() as captured_logs:
@@ -276,7 +276,7 @@ class TestOpenERZSensor(unittest.TestCase):
 
             response_data = {
                 "_metadata": {"total_count": 1},
-                "result": [{"zip": "1234", "type": "metal", "date": "2020-01-10"}],
+                "result": [{"zip": 1234, "type": "metal", "date": "2020-01-10"}],
             }
 
             with LogCapture() as captured_logs:
@@ -345,7 +345,7 @@ class TestOpenERZSensor(unittest.TestCase):
 
             response_data = {
                 "_metadata": {"total_count": 1},
-                "result": [{"zip": "1234", "type": "glass", "date": "2020-01-10"}],
+                "result": [{"zip": 1234, "type": "glass", "date": "2020-01-10"}],
             }
             test_openerz.last_api_response = MockAPIResponse(True, 200, response_data)
             test_openerz.update()

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -1,5 +1,4 @@
 """Tests for OpenERZ component."""
-from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -18,41 +17,21 @@ MOCK_CONFIG = {
 async def test_sensor_init(hass):
     """Test whether all values initialized properly."""
     with patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    ) as patched_update:
+        "homeassistant.components.openerz.sensor.OpenERZConnector"
+    ) as patched_connector:
+        pickup_instance = MagicMock()
+        pickup_instance.find_next_pickup.return_value = "2020-12-12"
+        patched_connector.return_value = pickup_instance
+
         await async_setup_component(hass, SENSOR_DOMAIN, MOCK_CONFIG)
 
         entity_id = "sensor.test_name"
-        test_openerz = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
+        test_openerz_name = hass.data[SENSOR_DOMAIN].get_entity(entity_id).name
 
         await hass.async_block_till_done()
 
-        assert test_openerz.zip == 1234
-        assert test_openerz.waste_type == "glass"
-        assert test_openerz.friendly_name == "test_name"
-        patched_update.assert_called_once()
-
-
-async def test_sensor_init_missing_type(hass):
-    """Test whether default waste type set properly."""
-    mock_config_copy = deepcopy(MOCK_CONFIG)
-    del mock_config_copy["sensor"]["waste_type"]
-    with patch(
-        "homeassistant.components.openerz.sensor.OpenERZSensor.update",
-        return_value=True,
-    ) as patched_update:
-        await async_setup_component(hass, SENSOR_DOMAIN, mock_config_copy)
-
-        entity_id = "sensor.test_name"
-        test_openerz = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
-
-        await hass.async_block_till_done()
-
-        assert test_openerz.zip == 1234
-        assert test_openerz.waste_type == "waste"
-        assert test_openerz.friendly_name == "test_name"
-        patched_update.assert_called_once()
+        assert test_openerz_name == "test_name"
+        pickup_instance.find_next_pickup.assert_called_once()
 
 
 async def test_sensor_state(hass):

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -14,26 +14,6 @@ MOCK_CONFIG = {
 }
 
 
-async def test_sensor_init(hass):
-    """Test whether all values initialized properly."""
-    with patch(
-        "homeassistant.components.openerz.sensor.OpenERZConnector"
-    ) as patched_connector:
-        pickup_instance = MagicMock()
-        pickup_instance.find_next_pickup.return_value = "2020-12-12"
-        patched_connector.return_value = pickup_instance
-
-        await async_setup_component(hass, SENSOR_DOMAIN, MOCK_CONFIG)
-
-        entity_id = "sensor.test_name"
-        test_openerz_name = hass.data[SENSOR_DOMAIN].get_entity(entity_id).name
-
-        await hass.async_block_till_done()
-
-        assert test_openerz_name == "test_name"
-        pickup_instance.find_next_pickup.assert_called_once()
-
-
 async def test_sensor_state(hass):
     """Test whether default waste type set properly."""
     with patch(
@@ -44,11 +24,12 @@ async def test_sensor_state(hass):
         patched_connector.return_value = pickup_instance
 
         await async_setup_component(hass, SENSOR_DOMAIN, MOCK_CONFIG)
+        await hass.async_block_till_done()
 
         entity_id = "sensor.test_name"
         test_openerz_state = hass.states.get(entity_id).state
-
-        await hass.async_block_till_done()
+        test_openerz_name = hass.data[SENSOR_DOMAIN].get_entity(entity_id).name
 
         assert test_openerz_state == "2020-12-12"
+        assert test_openerz_name == "test_name"
         pickup_instance.find_next_pickup.assert_called_once()

--- a/tests/components/openerz/test_sensor.py
+++ b/tests/components/openerz/test_sensor.py
@@ -27,9 +27,8 @@ async def test_sensor_state(hass):
         await hass.async_block_till_done()
 
         entity_id = "sensor.test_name"
-        test_openerz_state = hass.states.get(entity_id).state
-        test_openerz_name = hass.data[SENSOR_DOMAIN].get_entity(entity_id).name
+        test_openerz_state = hass.states.get(entity_id)
 
-        assert test_openerz_state == "2020-12-12"
-        assert test_openerz_name == "test_name"
+        assert test_openerz_state.state == "2020-12-12"
+        assert test_openerz_state.name == "test_name"
         pickup_instance.find_next_pickup.assert_called_once()


### PR DESCRIPTION
## Description:
This PR adds OpenERZ API integration for receiving waste pickup dates provided by Entsorgung und Recycling Zürich (ERZ).

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11619

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: openerz
    name: Cardboard
    zip: 8001
    waste_type: cardboard
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
