### PR TITLE
Fix upnp raw sensor state formatting when None

### DIFF
--- a/homeassistant/components/upnp/sensor.py
+++ b/homeassistant/components/upnp/sensor.py
@@ -126,6 +126,9 @@ class RawUPnPIGDSensor(UpnpSensor):
     @property
     def state(self) -> str:
         """Return the state of the device."""
+        if self._state is None:
+            return None
+
         return format(self._state, "d")
 
     @property


### PR DESCRIPTION
## Description:
The `state()` method of the `RawUPnPIGDSensor` class will cause an exception if `self._state` is still `None`. The problem was reported in this forum topic:

[Error doing job: Task exception was never retrieved - upnp/sensor.py](https://community.home-assistant.io/t/error-doing-job-task-exception-was-never-retrieved-upnp-sensor-py/159937)

It was also noted in comments in these issues:

[15257](https://github.com/home-assistant/home-assistant/issues/15257#issuecomment-473526625)
[20893](https://github.com/home-assistant/home-assistant/issues/20893#issuecomment-500032608)

Reviewing history discovered this bug was introduced in release 0.80.0 by PR #16300 by [this change](https://github.com/home-assistant/home-assistant/pull/16300/commits/d732f8eca2201e0ad8ade2abb282f3507647de1e#diff-84943428c9ff6482af587201fc782346R127). Prior to that (in [release 0.79.3](https://github.com/home-assistant/home-assistant/blob/07972c84a15740a8de47883749f7eb9301bcdc89/homeassistant/components/sensor/upnp.py#L64-L66)) `self._state` was checked before formatting, similar to what is now done in the `state()` method of the `KBytePerSecondUPnPIGDSensor` and `PacketsPerSecondUPnPIGDSensor` classes.

The fix in this PR is to check the state before formatting just like in the two other classes.

**Related issue (if applicable):**
This does not directly fix any currently open issues.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
