### PR TITLE
Add LED control of push buttons and bump velbus-library

### DIFF
--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -94,7 +94,8 @@ class VelbusLight(VelbusEntity, Light):
             try:
                 if ATTR_BRIGHTNESS in kwargs:
                     self._module.set_dimmer_state(
-                        self._channel, kwargs[ATTR_BRIGHTNESS],
+                        self._channel,
+                        kwargs[ATTR_BRIGHTNESS],
                         kwargs.get(ATTR_TRANSITION, 0),
                     )
                 else:

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -5,8 +5,12 @@ from velbus.util import VelbusException
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_FLASH,
     ATTR_TRANSITION,
+    FLASH_LONG,
+    FLASH_SHORT,
     SUPPORT_BRIGHTNESS,
+    SUPPORT_FLASH,
     SUPPORT_TRANSITION,
     Light,
 )
@@ -37,9 +41,28 @@ class VelbusLight(VelbusEntity, Light):
     """Representation of a Velbus light."""
 
     @property
+    def name(self):
+        """Return the display name of this entity."""
+        if self._module.light_is_buttonled(self._channel):
+            return "LED " + self._module.get_name(self._channel)
+        else:
+            return self._module.get_name(self._channel)
+
+    @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+        if self._module.light_is_buttonled(self._channel):
+            return SUPPORT_FLASH
+        else:
+            return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+
+    @property
+    def entity_registry_enabled_default(self):
+        """Disable Button LEDs by default."""
+        if self._module.light_is_buttonled(self._channel):
+            return False
+        else:
+            return True
 
     @property
     def is_on(self):
@@ -53,25 +76,45 @@ class VelbusLight(VelbusEntity, Light):
 
     def turn_on(self, **kwargs):
         """Instruct the Velbus light to turn on."""
-        try:
-            if ATTR_BRIGHTNESS in kwargs:
-                self._module.set_dimmer_state(
-                    self._channel,
-                    kwargs[ATTR_BRIGHTNESS],
-                    kwargs.get(ATTR_TRANSITION, 0),
-                )
+        if self._module.light_is_buttonled(self._channel):
+            if ATTR_FLASH in kwargs:
+                if kwargs[ATTR_FLASH] == FLASH_LONG:
+                    action = "slow"
+                elif kwargs[ATTR_FLASH] == FLASH_SHORT:
+                    action = "fast"
+                else:
+                    action = "on"
             else:
-                self._module.restore_dimmer_state(
-                    self._channel, kwargs.get(ATTR_TRANSITION, 0),
-                )
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+                action = "on"
+            try:
+                self._module.set_led_state(self._channel, action)
+            except VelbusException as err:
+                _LOGGER.error("A Velbus error occurred: %s", err)
+        else:
+            try:
+                if ATTR_BRIGHTNESS in kwargs:
+                    self._module.set_dimmer_state(
+                        self._channel, kwargs[ATTR_BRIGHTNESS],
+                        kwargs.get(ATTR_TRANSITION, 0),
+                    )
+                else:
+                    self._module.restore_dimmer_state(
+                        self._channel, kwargs.get(ATTR_TRANSITION, 0),
+                    )
+            except VelbusException as err:
+                _LOGGER.error("A Velbus error occurred: %s", err)
 
     def turn_off(self, **kwargs):
         """Instruct the velbus light to turn off."""
-        try:
-            self._module.set_dimmer_state(
-                self._channel, 0, kwargs.get(ATTR_TRANSITION, 0),
-            )
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        if self._module.light_is_buttonled(self._channel):
+            try:
+                self._module.set_led_state(self._channel, "off")
+            except VelbusException as err:
+                _LOGGER.error("A Velbus error occurred: %s", err)
+        else:
+            try:
+                self._module.set_dimmer_state(
+                    self._channel, 0, kwargs.get(ATTR_TRANSITION, 0),
+                )
+            except VelbusException as err:
+                _LOGGER.error("A Velbus error occurred: %s", err)

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -76,31 +76,31 @@ class VelbusLight(VelbusEntity, Light):
         if self._module.light_is_buttonled(self._channel):
             if ATTR_FLASH in kwargs:
                 if kwargs[ATTR_FLASH] == FLASH_LONG:
-                    action = "slow"
+                    attr, *args = "set_led_state", self._channel, "slow"
                 elif kwargs[ATTR_FLASH] == FLASH_SHORT:
-                    action = "fast"
+                    attr, *args = "set_led_state", self._channel, "fast"
                 else:
-                    action = "on"
+                    attr, *args = "set_led_state", self._channel, "on"
             else:
-                action = "on"
-            try:
-                self._module.set_led_state(self._channel, action)
-            except VelbusException as err:
-                _LOGGER.error("A Velbus error occurred: %s", err)
+                attr, *args = "set_led_state", self._channel, "on"
         else:
-            try:
-                if ATTR_BRIGHTNESS in kwargs:
-                    self._module.set_dimmer_state(
-                        self._channel,
-                        kwargs[ATTR_BRIGHTNESS],
-                        kwargs.get(ATTR_TRANSITION, 0),
-                    )
-                else:
-                    self._module.restore_dimmer_state(
-                        self._channel, kwargs.get(ATTR_TRANSITION, 0),
-                    )
-            except VelbusException as err:
-                _LOGGER.error("A Velbus error occurred: %s", err)
+            if ATTR_BRIGHTNESS in kwargs:
+                attr, *args = (
+                    "set_dimmer_state",
+                    self._channel,
+                    kwargs[ATTR_BRIGHTNESS],
+                    kwargs.get(ATTR_TRANSITION, 0),
+                )
+            else:
+                attr, *args = (
+                    "restore_dimmer_state",
+                    self._channel,
+                    kwargs.get(ATTR_TRANSITION, 0),
+                )
+        try:
+            getattr(self._module, attr)(*args)
+        except VelbusException as err:
+            _LOGGER.error("A Velbus error occurred: %s", err)
 
     def turn_off(self, **kwargs):
         """Instruct the velbus light to turn off."""

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -45,24 +45,21 @@ class VelbusLight(VelbusEntity, Light):
         """Return the display name of this entity."""
         if self._module.light_is_buttonled(self._channel):
             return "LED " + self._module.get_name(self._channel)
-        else:
-            return self._module.get_name(self._channel)
+        return self._module.get_name(self._channel)
 
     @property
     def supported_features(self):
         """Flag supported features."""
         if self._module.light_is_buttonled(self._channel):
             return SUPPORT_FLASH
-        else:
-            return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+        return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 
     @property
     def entity_registry_enabled_default(self):
         """Disable Button LEDs by default."""
         if self._module.light_is_buttonled(self._channel):
             return False
-        else:
-            return True
+        return True
 
     @property
     def is_on(self):

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -44,7 +44,7 @@ class VelbusLight(VelbusEntity, Light):
     def name(self):
         """Return the display name of this entity."""
         if self._module.light_is_buttonled(self._channel):
-            return "LED " + self._module.get_name(self._channel)
+            return f"LED {self._module.get_name(self._channel)}"
         return self._module.get_name(self._channel)
 
     @property
@@ -105,14 +105,15 @@ class VelbusLight(VelbusEntity, Light):
     def turn_off(self, **kwargs):
         """Instruct the velbus light to turn off."""
         if self._module.light_is_buttonled(self._channel):
-            try:
-                self._module.set_led_state(self._channel, "off")
-            except VelbusException as err:
-                _LOGGER.error("A Velbus error occurred: %s", err)
+            attr, *args = "set_led_state", self._channel, "off"
         else:
-            try:
-                self._module.set_dimmer_state(
-                    self._channel, 0, kwargs.get(ATTR_TRANSITION, 0),
-                )
-            except VelbusException as err:
-                _LOGGER.error("A Velbus error occurred: %s", err)
+            attr, *args = (
+                "set_dimmer_state",
+                self._channel,
+                0,
+                kwargs.get(ATTR_TRANSITION, 0),
+            )
+        try:
+            getattr(self._module, attr)(*args)
+        except VelbusException as err:
+            _LOGGER.error("A Velbus error occurred: %s", err)

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -3,7 +3,7 @@
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
   "requirements": [
-    "python-velbus==2.0.32"
+    "python-velbus==2.0.35"
   ],
   "config_flow": true,
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1635,7 +1635,7 @@ python-telnet-vlc==1.0.4
 python-twitch-client==0.6.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.32
+python-velbus==2.0.35
 
 # homeassistant.components.vlc
 python-vlc==1.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -530,7 +530,7 @@ python-miio==0.4.8
 python-nest==4.1.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.32
+python-velbus==2.0.35
 
 # homeassistant.components.awair
 python_awair==0.0.4


### PR DESCRIPTION
## Description:
Add the option to control LEDs of Velbus pushbuttons. This gives the user the possibillity to link an Velbus button to an entity of Home Assistant

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11623

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
