### PR TITLE
Only return remote UI url if remote UI enabled

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -155,6 +155,9 @@ def async_remote_ui_url(hass) -> str:
     if not async_is_logged_in(hass):
         raise CloudNotAvailable
 
+    if not hass.data[DOMAIN].client.prefs.remote_enabled:
+        raise CloudNotAvailable
+
     if not hass.data[DOMAIN].remote.instance_domain:
         raise CloudNotAvailable
 

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -163,3 +163,27 @@ async def test_on_connect(hass, mock_cloud_fixture):
         await hass.async_block_till_done()
 
     assert len(mock_load.mock_calls) == 0
+
+
+async def test_remote_ui_url(hass, mock_cloud_fixture):
+    """Test getting remote ui url."""
+    cl = hass.data["cloud"]
+
+    # Not logged in
+    with pytest.raises(cloud.CloudNotAvailable):
+        cloud.async_remote_ui_url(hass)
+
+    with patch.object(cloud, "async_is_logged_in", return_value=True):
+        # Remote not enabled
+        with pytest.raises(cloud.CloudNotAvailable):
+            cloud.async_remote_ui_url(hass)
+
+        await cl.client.prefs.async_update(remote_enabled=True)
+
+        # No instance domain
+        with pytest.raises(cloud.CloudNotAvailable):
+            cloud.async_remote_ui_url(hass)
+
+        cl.remote._instance_domain = "example.com"
+
+        assert cloud.async_remote_ui_url(hass) == "https://example.com"


### PR DESCRIPTION
## Description:
Only return the cloud remote UI url if the remote UI is enabled.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant-android/issues/216

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
