### PR TITLE
Fix async call inside sync context

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -67,9 +67,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
         hass.data[DOMAIN][entry.entry_id] = discovery_info
 
         for category in COMPONENT_TYPES:
-            hass.add_job(
-                hass.config_entries.async_forward_entry_setup(entry, category)
-            )
+            hass.add_job(hass.config_entries.async_forward_entry_setup(entry, category))
 
     try:
         controller = velbus.Controller(entry.data[CONF_PORT])

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
         hass.data[DOMAIN][entry.entry_id] = discovery_info
 
         for category in COMPONENT_TYPES:
-            hass.async_create_task(
+            hass.add_job(
                 hass.config_entries.async_forward_entry_setup(entry, category)
             )
 


### PR DESCRIPTION
## Description:
As suggested [here](https://github.com/home-assistant/home-assistant/pull/30184#issuecomment-569498441) changed the async task into sync job.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
