### PR TITLE
Make Axis integration use config entry unique id

### DIFF
--- a/homeassistant/components/axis/.translations/en.json
+++ b/homeassistant/components/axis/.translations/en.json
@@ -4,7 +4,8 @@
             "already_configured": "Device is already configured",
             "bad_config_file": "Bad data from config file",
             "link_local_address": "Link local addresses are not supported",
-            "not_axis_device": "Discovered device not an Axis device"
+            "not_axis_device": "Discovered device not an Axis device",
+            "updated_configuration": "Updated device configuration with new host address"
         },
         "error": {
             "already_configured": "Device is already configured",

--- a/homeassistant/components/axis/__init__.py
+++ b/homeassistant/components/axis/__init__.py
@@ -29,6 +29,12 @@ async def async_setup_entry(hass, config_entry):
     if not await device.async_setup():
         return False
 
+    # 0.104 introduced config entry unique id, this makes upgrading possible
+    if config_entry.unique_id is None:
+        hass.config_entries.async_update_entry(
+            config_entry, unique_id=device.api.vapix.params.system_serialnumber
+        )
+
     hass.data[DOMAIN][device.serial] = device
 
     await device.async_update_device_registry()

--- a/homeassistant/components/axis/binary_sensor.py
+++ b/homeassistant/components/axis/binary_sensor.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from axis.event_stream import CLASS_INPUT, CLASS_OUTPUT
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import CONF_MAC, CONF_TRIGGER_TIME
+from homeassistant.const import CONF_TRIGGER_TIME
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_point_in_utc_time
@@ -17,8 +17,7 @@ from .const import DOMAIN as AXIS_DOMAIN
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Axis binary sensor."""
-    serial_number = config_entry.data[CONF_MAC]
-    device = hass.data[AXIS_DOMAIN][serial_number]
+    device = hass.data[AXIS_DOMAIN][config_entry.unique_id]
 
     @callback
     def async_add_sensor(event_id):

--- a/homeassistant/components/axis/camera.py
+++ b/homeassistant/components/axis/camera.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_DEVICE,
     CONF_HOST,
-    CONF_MAC,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
@@ -32,8 +31,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Axis camera video stream."""
     filter_urllib3_logging()
 
-    serial_number = config_entry.data[CONF_MAC]
-    device = hass.data[AXIS_DOMAIN][serial_number]
+    device = hass.data[AXIS_DOMAIN][config_entry.unique_id]
 
     config = {
         CONF_NAME: config_entry.data[CONF_NAME],

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -12,12 +12,10 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
 )
-from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
 
 from .const import CONF_MODEL, DOMAIN
 from .device import get_device
-from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
+from .errors import AuthenticationRequired, CannotConnect
 
 AXIS_OUI = {"00408C", "ACCC8E", "B8A44F"}
 
@@ -29,30 +27,7 @@ PLATFORMS = ["camera"]
 
 AXIS_INCLUDE = EVENT_TYPES + PLATFORMS
 
-AXIS_DEFAULT_HOST = "192.168.0.90"
-AXIS_DEFAULT_USERNAME = "root"
-AXIS_DEFAULT_PASSWORD = "pass"
 DEFAULT_PORT = 80
-
-DEVICE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_HOST, default=AXIS_DEFAULT_HOST): cv.string,
-        vol.Optional(CONF_USERNAME, default=AXIS_DEFAULT_USERNAME): cv.string,
-        vol.Optional(CONF_PASSWORD, default=AXIS_DEFAULT_PASSWORD): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-@callback
-def configured_devices(hass):
-    """Return a set of the configured devices."""
-    return {
-        entry.data[CONF_MAC]: entry
-        for entry in hass.config_entries.async_entries(DOMAIN)
-    }
 
 
 class AxisFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -90,15 +65,12 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
                 self.serial_number = device.vapix.params.system_serialnumber
 
-                if self.serial_number in configured_devices(self.hass):
-                    raise AlreadyConfigured
+                await self.async_set_unique_id(self.serial_number)
+                self._abort_if_unique_id_configured()
 
                 self.model = device.vapix.params.prodnbr
 
                 return await self._create_entry()
-
-            except AlreadyConfigured:
-                errors["base"] = "already_configured"
 
             except AuthenticationRequired:
                 errors["base"] = "faulty_credentials"
@@ -147,40 +119,39 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         title = f"{self.model} - {self.serial_number}"
         return self.async_create_entry(title=title, data=data)
 
-    async def _update_entry(self, entry, host):
-        """Update existing entry if it is the same device."""
+    async def _update_entry(self, entry, host, port):
+        """Update existing entry."""
+        if (
+            entry.data[CONF_DEVICE][CONF_HOST] == host
+            and entry.data[CONF_DEVICE][CONF_PORT] == port
+        ):
+            return self.async_abort(reason="already_configured")
+
         entry.data[CONF_DEVICE][CONF_HOST] = host
+        entry.data[CONF_DEVICE][CONF_PORT] = port
+
         self.hass.config_entries.async_update_entry(entry)
+        return self.async_abort(reason="updated_configuration")
 
     async def async_step_zeroconf(self, discovery_info):
-        """Prepare configuration for a discovered Axis device.
+        """Prepare configuration for a discovered Axis device."""
+        serial_number = discovery_info["properties"]["macaddress"]
 
-        This flow is triggered by the discovery component.
-        """
-        serialnumber = discovery_info["properties"]["macaddress"]
-
-        if serialnumber[:6] not in AXIS_OUI:
+        if serial_number[:6] not in AXIS_OUI:
             return self.async_abort(reason="not_axis_device")
 
         if discovery_info[CONF_HOST].startswith("169.254"):
             return self.async_abort(reason="link_local_address")
 
-        # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-        self.context["macaddress"] = serialnumber
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if serial_number == entry.unique_id:
+                return await self._update_entry(
+                    entry,
+                    host=discovery_info[CONF_HOST],
+                    port=discovery_info[CONF_PORT],
+                )
 
-        if any(
-            serialnumber == flow["context"]["macaddress"]
-            for flow in self._async_in_progress()
-        ):
-            return self.async_abort(reason="already_in_progress")
-
-        device_entries = configured_devices(self.hass)
-
-        if serialnumber in device_entries:
-            entry = device_entries[serialnumber]
-            await self._update_entry(entry, discovery_info[CONF_HOST])
-            return self.async_abort(reason="already_configured")
-
+        await self.async_set_unique_id(serial_number)
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context["title_placeholders"] = {
             "name": discovery_info["hostname"][:-7],

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -119,7 +119,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         title = f"{self.model} - {self.serial_number}"
         return self.async_create_entry(title=title, data=data)
 
-    async def _update_entry(self, entry, host, port):
+    def _update_entry(self, entry, host, port):
         """Update existing entry."""
         if (
             entry.data[CONF_DEVICE][CONF_HOST] == host
@@ -145,7 +145,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if serial_number == entry.unique_id:
-                return await self._update_entry(
+                return self._update_entry(
                     entry,
                     host=discovery_info[CONF_HOST],
                     port=discovery_info[CONF_PORT],

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -56,8 +56,8 @@ class AxisNetworkDevice:
 
     @property
     def serial(self):
-        """Return the mac of this device."""
-        return self.config_entry.data[CONF_MAC]
+        """Return the serial number of this device."""
+        return self.config_entry.unique_id
 
     async def async_update_device_registry(self):
         """Update device registry."""

--- a/homeassistant/components/axis/strings.json
+++ b/homeassistant/components/axis/strings.json
@@ -23,7 +23,8 @@
             "already_configured": "Device is already configured",
             "bad_config_file": "Bad data from config file",
             "link_local_address": "Link local addresses are not supported",
-            "not_axis_device": "Discovered device not an Axis device"
+            "not_axis_device": "Discovered device not an Axis device",
+            "updated_configuration": "Updated device configuration with new host address"
         }
     }
 }

--- a/homeassistant/components/axis/switch.py
+++ b/homeassistant/components/axis/switch.py
@@ -3,7 +3,6 @@
 from axis.event_stream import CLASS_OUTPUT
 
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import CONF_MAC
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -13,8 +12,7 @@ from .const import DOMAIN as AXIS_DOMAIN
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Axis switch."""
-    serial_number = config_entry.data[CONF_MAC]
-    device = hass.data[AXIS_DOMAIN][serial_number]
+    device = hass.data[AXIS_DOMAIN][config_entry.unique_id]
 
     @callback
     def async_add_switch(event_id):

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -18,7 +18,7 @@ DEVICE_DATA = {
     axis.device.CONF_HOST: "1.2.3.4",
     axis.device.CONF_USERNAME: "username",
     axis.device.CONF_PASSWORD: "password",
-    axis.device.CONF_PORT: 1234,
+    axis.device.CONF_PORT: 80,
 }
 
 ENTRY_OPTIONS = {axis.device.CONF_CAMERA: True, axis.device.CONF_EVENTS: True}


### PR DESCRIPTION
## Description:


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]