### PR TITLE
Added VERIFY_SSL variable to OctoPrint component

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SENSORS,
     CONF_SSL,
+    CONF_VERIFY_SSL,
     CONTENT_TYPE_JSON,
     TEMP_CELSIUS,
 )
@@ -94,6 +95,7 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Required(CONF_API_KEY): cv.string,
                         vol.Required(CONF_HOST): cv.string,
                         vol.Optional(CONF_SSL, default=False): cv.boolean,
+                        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
                         vol.Optional(CONF_PORT, default=80): cv.port,
                         vol.Optional(CONF_PATH, default="/"): ensure_valid_path,
                         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -134,11 +136,14 @@ def setup(hass, config):
         base_url = "http{}://{}:{}{}api/".format(
             ssl, printer[CONF_HOST], printer[CONF_PORT], printer[CONF_PATH]
         )
+        verify_ssl = printer[CONF_VERIFY_SSL]
         api_key = printer[CONF_API_KEY]
         number_of_tools = printer[CONF_NUMBER_OF_TOOLS]
         bed = printer[CONF_BED]
         try:
-            octoprint_api = OctoPrintAPI(base_url, api_key, bed, number_of_tools)
+            octoprint_api = OctoPrintAPI(
+                base_url, api_key, bed, number_of_tools, verify_ssl
+            )
             printers[base_url] = octoprint_api
             octoprint_api.get("printer")
             octoprint_api.get("job")
@@ -170,7 +175,7 @@ def setup(hass, config):
 class OctoPrintAPI:
     """Simple JSON wrapper for OctoPrint's API."""
 
-    def __init__(self, api_url, key, bed, number_of_tools):
+    def __init__(self, api_url, key, bed, number_of_tools, verify_ssl):
         """Initialize OctoPrint API and set headers needed later."""
         self.api_url = api_url
         self.headers = {CONTENT_TYPE: CONTENT_TYPE_JSON, "X-Api-Key": key}
@@ -183,6 +188,7 @@ class OctoPrintAPI:
         self.job_error_logged = False
         self.bed = bed
         self.number_of_tools = number_of_tools
+        self.verify_ssl = verify_ssl
 
     def get_tools(self):
         """Get the list of tools that temperature is monitored on."""
@@ -215,7 +221,9 @@ class OctoPrintAPI:
 
         url = self.api_url + endpoint
         try:
-            response = requests.get(url, headers=self.headers, timeout=9)
+            response = requests.get(
+                url, headers=self.headers, timeout=9, verify=self.verify_ssl
+            )
             response.raise_for_status()
             if endpoint == "job":
                 self.job_last_reading[0] = response.json()


### PR DESCRIPTION
Added configuration variable of VERIFY_SSL defaulted to True to OctoPrint for self-signed certs on HTTPS connection.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11629

## Example entry for `configuration.yaml` (if applicable):
```yaml
octoprint:
  - host: xxx.xxx.xxx.xxx
    port: 443
    api_key: xxxxxxxxxxx
    ssl: true
    verify_ssl: false
    name: My Self Signed Printer
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
