### PR TITLE
Bump twentemilieu to 0.2.0

### DIFF
--- a/homeassistant/components/twentemilieu/manifest.json
+++ b/homeassistant/components/twentemilieu/manifest.json
@@ -1,13 +1,9 @@
 {
-    "domain": "twentemilieu",
-    "name": "Twente Milieu",
-    "config_flow": true,
-    "documentation": "https://www.home-assistant.io/integrations/twentemilieu",
-    "requirements": [
-        "twentemilieu==0.1.0"
-    ],
-    "dependencies": [],
-    "codeowners": [
-        "@frenck"
-    ]
+  "domain": "twentemilieu",
+  "name": "Twente Milieu",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/twentemilieu",
+  "requirements": ["twentemilieu==0.2.0"],
+  "dependencies": [],
+  "codeowners": ["@frenck"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1978,7 +1978,7 @@ transmissionrpc==0.11
 tuyaha==0.0.5
 
 # homeassistant.components.twentemilieu
-twentemilieu==0.1.0
+twentemilieu==0.2.0
 
 # homeassistant.components.twilio
 twilio==6.32.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -618,7 +618,7 @@ toonapilib==3.2.4
 transmissionrpc==0.11
 
 # homeassistant.components.twentemilieu
-twentemilieu==0.1.0
+twentemilieu==0.2.0
 
 # homeassistant.components.twilio
 twilio==6.32.0


### PR DESCRIPTION
## Description:

Bump twentemilieu to 0.2.0

Changelog: <https://github.com/frenck/python-twentemilieu/releases/tag/v0.2.0>

**Related issue (if applicable):** fixes #29904

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
