### PR TITLE
Bump wled to 0.2.1

### DIFF
--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -34,7 +34,7 @@ from .const import (
     DOMAIN,
 )
 
-SCAN_INTERVAL = timedelta(seconds=5)
+SCAN_INTERVAL = timedelta(seconds=10)
 WLED_COMPONENTS = (LIGHT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Create WLED instance for this entry
     session = async_get_clientsession(hass)
-    wled = WLED(entry.data[CONF_HOST], loop=hass.loop, session=session)
+    wled = WLED(entry.data[CONF_HOST], session=session)
 
     # Ensure we can connect and talk to it
     try:

--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -75,7 +75,7 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
 
         errors = {}
         session = async_get_clientsession(self.hass)
-        wled = WLED(user_input[CONF_HOST], loop=self.hass.loop, session=session)
+        wled = WLED(user_input[CONF_HOST], session=session)
 
         try:
             device = await wled.update()

--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -3,7 +3,7 @@
   "name": "WLED",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wled",
-  "requirements": ["wled==0.2.0"],
+  "requirements": ["wled==0.2.1"],
   "dependencies": [],
   "zeroconf": ["_wled._tcp.local."],
   "codeowners": ["@frenck"]

--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -3,7 +3,7 @@
   "name": "WLED",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wled",
-  "requirements": ["wled==0.1.0"],
+  "requirements": ["wled==0.2.0"],
   "dependencies": [],
   "zeroconf": ["_wled._tcp.local."],
   "codeowners": ["@frenck"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2049,7 +2049,7 @@ wirelesstagpy==0.4.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.1.0
+wled==0.2.0
 
 # homeassistant.components.wunderlist
 wunderpy2==0.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2049,7 +2049,7 @@ wirelesstagpy==0.4.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.2.0
+wled==0.2.1
 
 # homeassistant.components.wunderlist
 wunderpy2==0.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -647,7 +647,7 @@ watchdog==0.8.3
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.1.0
+wled==0.2.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.startca

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -647,7 +647,7 @@ watchdog==0.8.3
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.2.0
+wled==0.2.1
 
 # homeassistant.components.bluesound
 # homeassistant.components.startca


### PR DESCRIPTION
## Description:

Bump wled to 0.2.1
Changelog 0.2.0: <https://github.com/frenck/python-wled/releases/tag/v0.2.0>
Changelog 0.2.1: <https://github.com/frenck/python-wled/releases/tag/v0.2.1>

- Removes passing in loop (feature has been removed from wled package as well)
- Increases timeout (wled package) and scan_interval.
- Fixes override default transition time, respecting WLED's settings.

The increment of the scan interval is making the integration less responsive, however, it gives the device more time to respond (e.g., when in E131 mode, or other reasons).

**Related issue (if applicable):** fixes #30489

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

**Example entry for `configuration.yaml` (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
