### PR TITLE
Fire restarted event on restarting active timer

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -177,7 +177,7 @@ class Timer(RestoreEntity):
             newduration = duration
 
         event = EVENT_TIMER_STARTED
-        if self._state == STATUS_PAUSED:
+        if self._state == STATUS_ACTIVE or self._state == STATUS_PAUSED:
             event = EVENT_TIMER_RESTARTED
 
         self._state = STATUS_ACTIVE

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -120,6 +120,8 @@ async def test_methods_and_events(hass):
         {"call": SERVICE_START, "state": STATUS_ACTIVE, "event": EVENT_TIMER_STARTED},
         {"call": SERVICE_PAUSE, "state": STATUS_PAUSED, "event": EVENT_TIMER_PAUSED},
         {"call": SERVICE_CANCEL, "state": STATUS_IDLE, "event": EVENT_TIMER_CANCELLED},
+        {"call": SERVICE_START, "state": STATUS_ACTIVE, "event": EVENT_TIMER_STARTED},
+        {"call": SERVICE_START, "state": STATUS_ACTIVE, "event": EVENT_TIMER_RESTARTED},
     ]
 
     expectedEvents = 0
@@ -284,3 +286,70 @@ async def test_config_reload(hass, hass_admin_user, hass_read_only_user):
     assert STATUS_IDLE == state_3.state
     assert ATTR_ICON not in state_3.attributes
     assert ATTR_FRIENDLY_NAME not in state_3.attributes
+
+
+async def test_timer_restarted_event(hass):
+    """Ensure restarted event is called after starting a paused or running timer."""
+    hass.state = CoreState.starting
+
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"test1": {CONF_DURATION: 10}}})
+
+    state = hass.states.get("timer.test1")
+    assert state
+    assert state.state == STATUS_IDLE
+
+    results = []
+
+    def fake_event_listener(event):
+        """Fake event listener for trigger."""
+        results.append(event)
+
+    hass.bus.async_listen(EVENT_TIMER_STARTED, fake_event_listener)
+    hass.bus.async_listen(EVENT_TIMER_RESTARTED, fake_event_listener)
+    hass.bus.async_listen(EVENT_TIMER_PAUSED, fake_event_listener)
+    hass.bus.async_listen(EVENT_TIMER_FINISHED, fake_event_listener)
+    hass.bus.async_listen(EVENT_TIMER_CANCELLED, fake_event_listener)
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_START, {CONF_ENTITY_ID: "timer.test1"}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("timer.test1")
+    assert state
+    assert state.state == STATUS_ACTIVE
+
+    assert results[-1].event_type == EVENT_TIMER_STARTED
+    assert len(results) == 1
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_START, {CONF_ENTITY_ID: "timer.test1"}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("timer.test1")
+    assert state
+    assert state.state == STATUS_ACTIVE
+
+    assert results[-1].event_type == EVENT_TIMER_RESTARTED
+    assert len(results) == 2
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_PAUSE, {CONF_ENTITY_ID: "timer.test1"}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("timer.test1")
+    assert state
+    assert state.state == STATUS_PAUSED
+
+    assert results[-1].event_type == EVENT_TIMER_PAUSED
+    assert len(results) == 3
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_START, {CONF_ENTITY_ID: "timer.test1"}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("timer.test1")
+    assert state
+    assert state.state == STATUS_ACTIVE
+
+    assert results[-1].event_type == EVENT_TIMER_RESTARTED
+    assert len(results) == 4


### PR DESCRIPTION
## Breaking Change:

Can break automations that should trigger on every timer start event.

## Description:

Currently, the restart event is only triggered for paused timers, which is not ideal.

**Related issue (if applicable):** fixes #30448 

