### PR TITLE
Improve WLED pure white support for RGBW

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -186,6 +186,11 @@ class WLEDLight(Light, WLEDDeviceEntity):
                 hue, sat = self._color
                 data[ATTR_COLOR_PRIMARY] = color_util.color_hsv_to_RGB(hue, sat, 100)
 
+            # On a RGBW strip, when the color is pure white, disable the RGB LEDs in
+            # WLED by setting RGB to 0,0,0
+            if data[ATTR_COLOR_PRIMARY] == (255, 255, 255):
+                data[ATTR_COLOR_PRIMARY] = (0, 0, 0)
+
             # Add requested or last known white value
             if ATTR_WHITE_VALUE in kwargs:
                 data[ATTR_COLOR_PRIMARY] += (kwargs[ATTR_WHITE_VALUE],)

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -193,3 +193,20 @@ async def test_rgbw_light(
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_HS_COLOR) == (28.874, 72.522)
     assert state.attributes.get(ATTR_WHITE_VALUE) == 100
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.wled_rgbw_light",
+            ATTR_RGB_COLOR: (255, 255, 255),
+            ATTR_WHITE_VALUE: 100,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.wled_rgbw_light")
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_HS_COLOR) == (0, 0)
+    assert state.attributes.get(ATTR_WHITE_VALUE) == 100


### PR DESCRIPTION
## Breaking Change:

When using WLED with RGBW strips, setting the color in Home Assistant to white, will turn off the RGB LEDs of the strip and use the W channel only.

## Description:

WLED supports RGBW strips, however, when selecting white in Home Assistant as the color, the RGB leds will still be turned on, since WLED expects an (R, G, B, W) value.

I've discussed this with @aircookie (creator of WLED), and we think it is best to turn of the RGB channels off using (0,0,0) when white is selected in Home Assistant (255,255,255).

This allows the user to have a pure white LED strip, while still being able to control the brightness.

This behavior is changed because of a numerous of complaints in the WLED Discord chat.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

**Example entry for `configuration.yaml` (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
