### PR TITLE
Fix AVM FRITZ!DECT switch total consumption

### DIFF
--- a/homeassistant/components/fritzdect/switch.py
+++ b/homeassistant/components/fritzdect/switch.py
@@ -209,7 +209,7 @@ class FritzDectSwitchData:
         try:
             self.state = actor.get_state()
             self.current_consumption = (actor.get_power() or 0.0) / 1000
-            self.total_consumption = (actor.get_energy() or 0.0) / 100000
+            self.total_consumption = (actor.get_energy() or 0.0) / 1000
         except (RequestException, HTTPError):
             _LOGGER.error("Request to actor failed")
             self.state = None


### PR DESCRIPTION
Bugfix for total_consumption of fritz switch dect component.

actor.get_energy() returns Wh, so division by 1000 is correct

## Breaking Change:
None
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
