### PR TITLE
Bump adguardhome to 0.4.0

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -61,7 +61,6 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         password=entry.data[CONF_PASSWORD],
         tls=entry.data[CONF_SSL],
         verify_ssl=entry.data[CONF_VERIFY_SSL],
-        loop=hass.loop,
         session=session,
     )
 

--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -79,7 +79,6 @@ class AdGuardHomeFlowHandler(ConfigFlow):
             password=user_input.get(CONF_PASSWORD),
             tls=user_input[CONF_SSL],
             verify_ssl=user_input[CONF_VERIFY_SSL],
-            loop=self.hass.loop,
             session=session,
         )
 
@@ -161,7 +160,6 @@ class AdGuardHomeFlowHandler(ConfigFlow):
             self._hassio_discovery[CONF_HOST],
             port=self._hassio_discovery[CONF_PORT],
             tls=False,
-            loop=self.hass.loop,
             session=session,
         )
 

--- a/homeassistant/components/adguard/manifest.json
+++ b/homeassistant/components/adguard/manifest.json
@@ -1,13 +1,9 @@
 {
-    "domain": "adguard",
-    "name": "AdGuard Home",
-    "config_flow": true,
-    "documentation": "https://www.home-assistant.io/integrations/adguard",
-    "requirements": [
-        "adguardhome==0.3.0"
-    ],
-    "dependencies": [],
-    "codeowners": [
-        "@frenck"
-    ]
+  "domain": "adguard",
+  "name": "AdGuard Home",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/adguard",
+  "requirements": ["adguardhome==0.4.0"],
+  "dependencies": [],
+  "codeowners": ["@frenck"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -117,7 +117,7 @@ adafruit-circuitpython-mcp230xx==1.1.2
 adb-shell==0.1.0
 
 # homeassistant.components.adguard
-adguardhome==0.3.0
+adguardhome==0.4.0
 
 # homeassistant.components.frontier_silicon
 afsapi==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -32,7 +32,7 @@ abodepy==0.16.7
 adb-shell==0.1.0
 
 # homeassistant.components.adguard
-adguardhome==0.3.0
+adguardhome==0.4.0
 
 # homeassistant.components.geonetnz_quakes
 aio_geojson_geonetnz_quakes==0.11


### PR DESCRIPTION
## Description:

Bumps `adguardhome` to 0.4.0.
Changelog: <https://github.com/frenck/python-adguardhome/releases/tag/v0.4.0>

Passing in the loop has been deprecated as of Python 3.8, and has been removed from the `adguardhome` package.

Fixes an issue with an incorrect value that didn't match the unit of measurement.

**Related issue (if applicable):** fixes #28437

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
