### PR TITLE
Add support for the voltage sensor on the greeneye GEM

### DIFF
--- a/homeassistant/components/greeneye_monitor/__init__.py
+++ b/homeassistant/components/greeneye_monitor/__init__.py
@@ -28,6 +28,7 @@ CONF_SENSORS = "sensors"
 CONF_SENSOR_TYPE = "sensor_type"
 CONF_TEMPERATURE_SENSORS = "temperature_sensors"
 CONF_TIME_UNIT = "time_unit"
+CONF_VOLTAGE_SENSORS = "voltage"
 
 DATA_GREENEYE_MONITOR = "greeneye_monitor"
 DOMAIN = "greeneye_monitor"
@@ -35,6 +36,7 @@ DOMAIN = "greeneye_monitor"
 SENSOR_TYPE_CURRENT = "current_sensor"
 SENSOR_TYPE_PULSE_COUNTER = "pulse_counter"
 SENSOR_TYPE_TEMPERATURE = "temperature_sensor"
+SENSOR_TYPE_VOLTAGE = "voltage_sensor"
 
 TEMPERATURE_UNIT_CELSIUS = "C"
 
@@ -54,6 +56,12 @@ TEMPERATURE_SENSORS_SCHEMA = vol.Schema(
         ),
     }
 )
+
+VOLTAGE_SENSOR_SCHEMA = vol.Schema(
+    {vol.Required(CONF_NUMBER): vol.Range(1, 1), vol.Required(CONF_NAME): cv.string}
+)
+
+VOLTAGE_SENSORS_SCHEMA = vol.All(cv.ensure_list, [VOLTAGE_SENSOR_SCHEMA])
 
 PULSE_COUNTER_SCHEMA = vol.Schema(
     {
@@ -97,6 +105,7 @@ MONITOR_SCHEMA = vol.Schema(
             default={CONF_TEMPERATURE_UNIT: TEMPERATURE_UNIT_CELSIUS, CONF_SENSORS: []},
         ): TEMPERATURE_SENSORS_SCHEMA,
         vol.Optional(CONF_PULSE_COUNTERS, default=[]): PULSE_COUNTERS_SCHEMA,
+        vol.Optional(CONF_VOLTAGE_SENSORS, default=[]): VOLTAGE_SENSORS_SCHEMA,
     }
 )
 
@@ -140,6 +149,16 @@ async def async_setup(hass, config):
                 }
             )
 
+        voltage_configs = monitor_config[CONF_VOLTAGE_SENSORS]
+        for voltage_config in voltage_configs:
+            all_sensors.append(
+                {
+                    CONF_SENSOR_TYPE: SENSOR_TYPE_VOLTAGE,
+                    **monitor_serial_number,
+                    **voltage_config,
+                }
+            )
+
         sensor_configs = monitor_config[CONF_TEMPERATURE_SENSORS]
         if sensor_configs:
             temperature_unit = {
@@ -168,7 +187,7 @@ async def async_setup(hass, config):
     if not all_sensors:
         _LOGGER.error(
             "Configuration must specify at least one "
-            "channel, pulse counter or temperature sensor"
+            "channel, voltage, pulse counter or temperature sensor"
         )
         return False
 

--- a/homeassistant/components/greeneye_monitor/__init__.py
+++ b/homeassistant/components/greeneye_monitor/__init__.py
@@ -58,7 +58,7 @@ TEMPERATURE_SENSORS_SCHEMA = vol.Schema(
 )
 
 VOLTAGE_SENSOR_SCHEMA = vol.Schema(
-    {vol.Required(CONF_NUMBER): vol.Range(1, 1), vol.Required(CONF_NAME): cv.string}
+    {vol.Required(CONF_NUMBER): vol.Range(1, 48), vol.Required(CONF_NAME): cv.string}
 )
 
 VOLTAGE_SENSORS_SCHEMA = vol.All(cv.ensure_list, [VOLTAGE_SENSOR_SCHEMA])

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -16,6 +16,7 @@ from . import (
     SENSOR_TYPE_CURRENT,
     SENSOR_TYPE_PULSE_COUNTER,
     SENSOR_TYPE_TEMPERATURE,
+    SENSOR_TYPE_VOLTAGE,
     TIME_UNIT_HOUR,
     TIME_UNIT_MINUTE,
     TIME_UNIT_SECOND,
@@ -31,6 +32,7 @@ UNIT_WATTS = POWER_WATT
 COUNTER_ICON = "mdi:counter"
 CURRENT_SENSOR_ICON = "mdi:flash"
 TEMPERATURE_ICON = "mdi:thermometer"
+VOLTAGE_ICON = "mdi:current-ac"
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -68,6 +70,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                     sensor[CONF_NUMBER],
                     sensor[CONF_NAME],
                     sensor[CONF_TEMPERATURE_UNIT],
+                )
+            )
+        elif sensor_type == SENSOR_TYPE_VOLTAGE:
+            entities.append(
+                VoltageSensor(
+                    sensor[CONF_MONITOR_SERIAL_NUMBER],
+                    sensor[CONF_NUMBER],
+                    sensor[CONF_NAME],
                 )
             )
 
@@ -276,3 +286,35 @@ class TemperatureSensor(GEMSensor):
     def unit_of_measurement(self):
         """Return the unit of measurement for this sensor (user specified)."""
         return self._unit
+
+
+class VoltageSensor(GEMSensor):
+    """Entity showing voltage."""
+
+    def __init__(self, monitor_serial_number, number, name):
+        """Construct the entity."""
+        super().__init__(monitor_serial_number, name, "volts", number)
+        self._monitor = None
+
+    def _get_sensor(self, monitor):
+        """Wire the updates to a current channel."""
+        self._monitor = monitor
+        return monitor.channels[self._number - 1]
+
+    @property
+    def icon(self):
+        """Return the icon that should represent this sensor in the UI."""
+        return VOLTAGE_ICON
+
+    @property
+    def state(self):
+        """Return the current voltage being reported by this sensor."""
+        if not self._monitor.voltage:
+            return None
+
+        return self._monitor.voltage
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement for this sensor."""
+        return "V"


### PR DESCRIPTION
## Description:
Add support for the voltage sensor on the greeneye GEM.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11632

## Example entry for `configuration.yaml` (if applicable):
```yaml
greeneye_monitor:
  port: 8084
  monitors:
    - serial_number: "XXXXXX"
      voltage:
        - number: 1
          name: mainhouse_volts
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
