### PR TITLE
Bump elgato to 0.2.0

### DIFF
--- a/homeassistant/components/elgato/manifest.json
+++ b/homeassistant/components/elgato/manifest.json
@@ -3,7 +3,7 @@
   "name": "Elgato Key Light",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/elgato",
-  "requirements": ["elgato==0.1.0"],
+  "requirements": ["elgato==0.2.0"],
   "dependencies": [],
   "zeroconf": ["_elg._tcp.local."],
   "codeowners": ["@frenck"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -465,7 +465,7 @@ ecoaliface==0.4.0
 eebrightbox==0.0.4
 
 # homeassistant.components.elgato
-elgato==0.1.0
+elgato==0.2.0
 
 # homeassistant.components.eliqonline
 eliqonline==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -165,7 +165,7 @@ dsmr_parser==0.12
 eebrightbox==0.0.4
 
 # homeassistant.components.elgato
-elgato==0.1.0
+elgato==0.2.0
 
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.8


### PR DESCRIPTION
## Description:

Bump `elgato` to 0.2.0
Changelog: <https://github.com/frenck/python-elgato/releases/tag/v0.2.0>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
