### PR TITLE
Add unique ID to elgato config entries

### DIFF
--- a/homeassistant/components/elgato/config_flow.py
+++ b/homeassistant/components/elgato/config_flow.py
@@ -36,9 +36,8 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
             return self._show_setup_form({"base": "connection_error"})
 
         # Check if already configured
-        if await self._device_already_configured(info):
-            # This serial number is already configured
-            return self.async_abort(reason="already_configured")
+        await self.async_set_unique_id(info.serial_number)
+        self._abort_if_unique_id_configured()
 
         return self.async_create_entry(
             title=info.serial_number,
@@ -64,9 +63,8 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="connection_error")
 
         # Check if already configured
-        if await self._device_already_configured(info):
-            # This serial number is already configured
-            return self.async_abort(reason="already_configured")
+        await self.async_set_unique_id(info.serial_number)
+        self._abort_if_unique_id_configured()
 
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context.update(
@@ -97,9 +95,8 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="connection_error")
 
         # Check if already configured
-        if await self._device_already_configured(info):
-            # This serial number is already configured
-            return self.async_abort(reason="already_configured")
+        await self.async_set_unique_id(info.serial_number)
+        self._abort_if_unique_id_configured()
 
         return self.async_create_entry(
             title=self.context.get(CONF_SERIAL_NUMBER),
@@ -137,10 +134,3 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
         session = async_get_clientsession(self.hass)
         elgato = Elgato(host, port=port, session=session,)
         return await elgato.info()
-
-    async def _device_already_configured(self, info: Info) -> bool:
-        """Return if a Elgato Key Light is already configured."""
-        for entry in self._async_current_entries():
-            if entry.data[CONF_SERIAL_NUMBER] == info.serial_number:
-                return True
-        return False

--- a/tests/components/elgato/__init__.py
+++ b/tests/components/elgato/__init__.py
@@ -33,6 +33,7 @@ async def init_integration(
 
     entry = MockConfigEntry(
         domain=DOMAIN,
+        unique_id="CN11A1A00001",
         data={
             CONF_HOST: "example.local",
             CONF_PORT: 9123,


### PR DESCRIPTION
## Description:

Add unique ID to Elgato Key Light config entries, as created by #29806.
Additionally, some tests are made more robust.

There is no migration implemented for this PR, since this integration is planned for its initial release in 0.104. So it would be awesome to get this in before the beta cut.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
