### PR TITLE
Fix WLED light transition duration

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -143,8 +143,13 @@ class WLEDLight(Light, WLEDDeviceEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
+        data = {ATTR_ON: False, ATTR_SEGMENT_ID: self._segment}
+
+        if ATTR_TRANSITION in kwargs:
+            data[ATTR_TRANSITION] = kwargs[ATTR_TRANSITION] * 1000
+
         try:
-            await self.wled.light(on=False)
+            await self.wled.light(**data)
             self._state = False
         except WLEDError:
             _LOGGER.error("An error occurred while turning off WLED light.")
@@ -168,7 +173,7 @@ class WLEDLight(Light, WLEDDeviceEntity):
             data[ATTR_COLOR_PRIMARY] = color_util.color_hsv_to_RGB(hue, sat, 100)
 
         if ATTR_TRANSITION in kwargs:
-            data[ATTR_TRANSITION] = kwargs[ATTR_TRANSITION]
+            data[ATTR_TRANSITION] = kwargs[ATTR_TRANSITION] * 1000
 
         if ATTR_BRIGHTNESS in kwargs:
             data[ATTR_BRIGHTNESS] = kwargs[ATTR_BRIGHTNESS]

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -90,7 +90,7 @@ async def test_switch_change_state(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light"},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_TRANSITION: 5},
         blocking=True,
     )
     await hass.async_block_till_done()


### PR DESCRIPTION
## Description:

Fixes WLED transitions durations. WLED and the `wled` package expects them in ms, while Home Assistant works in seconds. This caused it to appear like the transition wasn't working (which it did, but 1000x faster).

It also addresses an issue where transitions on turning the light off were not implemented at all.

**Related issue (if applicable):** #30489 (related, does not fix it). fixes #30488

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
