### PR TITLE
Allow specific status codes while notifying mobile_app devices

### DIFF
--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -134,6 +134,10 @@ class MobileAppNotificationService(BaseNotificationService):
                     response = await self._session.post(push_url, json=data)
                     result = await response.json()
 
+                if response.status in [200, 201, 202]:
+                    log_rate_limits(self.hass, entry_data[ATTR_DEVICE_NAME], result)
+                    continue
+
                 fallback_error = result.get("errorMessage", "Unknown error")
                 fallback_message = "Internal server error, please try again later: {}".format(
                     fallback_error

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -134,10 +134,6 @@ class MobileAppNotificationService(BaseNotificationService):
                     response = await self._session.post(push_url, json=data)
                     result = await response.json()
 
-                if response.status == 201:
-                    log_rate_limits(self.hass, entry_data[ATTR_DEVICE_NAME], result)
-                    return
-
                 fallback_error = result.get("errorMessage", "Unknown error")
                 fallback_message = "Internal server error, please try again later: {}".format(
                     fallback_error


### PR DESCRIPTION
## Description:

Notifications for the `mobile_app:` integration using the service `notify.notify` were only going to the first device because the loop was returning on a 201 status.  201 is a valid status, so removing the check allows the loop to proceed to other devices.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
