### PR TITLE
Add unique id property for Vizio devices so they get added to entity registry

### DIFF
--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Vizio",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
   "requirements": [
-    "pyvizio==0.0.7"
+    "pyvizio==0.0.9"
   ],
   "dependencies": [],
   "codeowners": ["@raman325"]

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -202,7 +202,7 @@ class VizioDevice(MediaPlayerDevice):
         return self._supported_commands
 
     @property
-    def _unique_id(self):
+    def unique_id(self):
         """Return the unique id of the device."""
         return self._unique_id
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -136,6 +137,12 @@ class VizioDevice(MediaPlayerDevice):
         self._device = Vizio(DEVICE_ID, host, DEFAULT_NAME, token, device_type)
         self._max_volume = float(self._device.get_max_volume())
 
+        esn = self._device.get_esn()
+        if esn:
+            self._unique_id = f"{self._device_type}-{esn}"
+        else:
+            self._unique_id = f"{self._device_type}-{slugify(host)}"
+
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Retrieve latest state of the device."""
@@ -195,6 +202,11 @@ class VizioDevice(MediaPlayerDevice):
     def supported_features(self):
         """Flag device features that are supported."""
         return self._supported_commands
+
+    @property
+    def _unique_id(self):
+        """Return the unique id of the device."""
+        return self._unique_id
 
     def turn_on(self):
         """Turn the device on."""

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -65,9 +65,7 @@ def validate_auth(config):
     token = config.get(CONF_ACCESS_TOKEN)
     if config[CONF_DEVICE_CLASS] == "tv" and (token is None or token == ""):
         raise vol.Invalid(
-            "When '{}' is 'tv' then '{}' is required.".format(
-                CONF_DEVICE_CLASS, CONF_ACCESS_TOKEN
-            ),
+            f"When '{CONF_DEVICE_CLASS}' is 'tv' then '{CONF_ACCESS_TOKEN}' is required.",
             path=[CONF_ACCESS_TOKEN],
         )
     return config

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -133,7 +133,11 @@ class VizioDevice(MediaPlayerDevice):
         self._supported_commands = SUPPORTED_COMMANDS[device_type]
         self._device = Vizio(DEVICE_ID, host, DEFAULT_NAME, token, device_type)
         self._max_volume = float(self._device.get_max_volume())
-        self._unique_id = f"{device_type}-{self._device.get_esn()}"
+
+        self._unique_id = None
+        esn = self._device.get_esn()
+        if esn:
+            self._unique_id = f"{device_type}-{esn}"
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -139,9 +139,9 @@ class VizioDevice(MediaPlayerDevice):
 
         esn = self._device.get_esn()
         if esn:
-            self._unique_id = f"{self._device_type}-{esn}"
+            self._unique_id = f"{device_type}-{esn}"
         else:
-            self._unique_id = f"{self._device_type}-{slugify(host)}"
+            self._unique_id = f"{device_type}-{slugify(host)}"
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -27,7 +27,6 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,12 +133,7 @@ class VizioDevice(MediaPlayerDevice):
         self._supported_commands = SUPPORTED_COMMANDS[device_type]
         self._device = Vizio(DEVICE_ID, host, DEFAULT_NAME, token, device_type)
         self._max_volume = float(self._device.get_max_volume())
-
-        esn = self._device.get_esn()
-        if esn:
-            self._unique_id = f"{device_type}-{esn}"
-        else:
-            self._unique_id = f"{device_type}-{slugify(host)}"
+        self._unique_id = f"{device_type}-{self._device.get_esn()}"
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -133,11 +133,7 @@ class VizioDevice(MediaPlayerDevice):
         self._supported_commands = SUPPORTED_COMMANDS[device_type]
         self._device = Vizio(DEVICE_ID, host, DEFAULT_NAME, token, device_type)
         self._max_volume = float(self._device.get_max_volume())
-
-        self._unique_id = None
-        esn = self._device.get_esn()
-        if esn:
-            self._unique_id = f"{device_type}-{esn}"
+        self._unique_id = self._device.get_esn()
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1693,7 +1693,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.7
+pyvizio==0.0.9
 
 # homeassistant.components.velux
 pyvlx==0.2.12


### PR DESCRIPTION
## Description:
Adds a unique ID to each entity as part of a `pyvizio` package update to get the device's ESN. Falls back to device's host and port when the ESN is unable to be retrieved because I wasn't able to test all scenarios in the package update.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
