### PR TITLE
Be consistent with Home Assistant and Hass.io spelling

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -208,7 +208,7 @@ def check_pid(pid_file: str) -> None:
     except OSError:
         # PID does not exist
         return
-    print("Fatal Error: HomeAssistant is already running.")
+    print("Fatal Error: Home Assistant is already running.")
     sys.exit(1)
 
 
@@ -252,7 +252,7 @@ def cmdline() -> List[str]:
 
 
 async def setup_and_run_hass(config_dir: str, args: argparse.Namespace) -> int:
-    """Set up HASS and run."""
+    """Set up Home Assistant and run."""
     from homeassistant import bootstrap, core
 
     hass = core.HomeAssistant()

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -200,7 +200,7 @@ class Data:
 
 @AUTH_PROVIDERS.register("homeassistant")
 class HassAuthProvider(AuthProvider):
-    """Auth provider based on a local storage of users in HASS config dir."""
+    """Auth provider based on a local storage of users in Home Assistant config dir."""
 
     DEFAULT_TITLE = "Home Assistant Local"
 

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -170,7 +170,7 @@ async def async_unload_entry(hass, config_entry):
 
 
 def setup_hass_services(hass):
-    """Home assistant services."""
+    """Home Assistant services."""
 
     def change_setting(call):
         """Change an Abode system setting."""

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -55,7 +55,7 @@ class AbodeLight(AbodeDevice, Light):
             self._device.set_color(kwargs[ATTR_HS_COLOR])
 
         if ATTR_BRIGHTNESS in kwargs and self._device.is_dimmable:
-            # Convert HASS brightness (0-255) to Abode brightness (0-99)
+            # Convert Home Assistant brightness (0-255) to Abode brightness (0-99)
             # If 100 is sent to Abode, response is 99 causing an error
             self._device.set_level(ceil(kwargs[ATTR_BRIGHTNESS] * 99 / 255.0))
         else:
@@ -78,7 +78,7 @@ class AbodeLight(AbodeDevice, Light):
             # Abode returns 100 during device initialization and device refresh
             if brightness == 100:
                 return 255
-            # Convert Abode brightness (0-99) to HASS brightness (0-255)
+            # Convert Abode brightness (0-99) to Home Assistant brightness (0-255)
             return ceil(brightness * 255 / 99.0)
 
     @property

--- a/homeassistant/components/aftership/sensor.py
+++ b/homeassistant/components/aftership/sensor.py
@@ -77,7 +77,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([instance], True)
 
     async def handle_add_tracking(call):
-        """Call when a user adds a new Aftership tracking from HASS."""
+        """Call when a user adds a new Aftership tracking from Home Assistant."""
         title = call.data.get(CONF_TITLE)
         slug = call.data.get(CONF_SLUG)
         tracking_number = call.data[CONF_TRACKING_NUMBER]
@@ -93,7 +93,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
 
     async def handle_remove_tracking(call):
-        """Call when a user removes an Aftership tracking from HASS."""
+        """Call when a user removes an Aftership tracking from Home Assistant."""
         slug = call.data[CONF_SLUG]
         tracking_number = call.data[CONF_TRACKING_NUMBER]
 

--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -194,7 +194,7 @@ class AirVisualSensor(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return f"{self._location_id}_{self._locale}_{self._type}"
 
     @property

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -213,7 +213,7 @@ class Alert(ToggleEntity):
 
     @property
     def should_poll(self):
-        """HASS need not poll these entities."""
+        """Home Assistant need not poll these entities."""
         return False
 
     @property

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -165,7 +165,7 @@ def setup(hass, config):
         _LOGGER.debug("August HTTP session closed.")
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, close_http_session)
-    _LOGGER.debug("Registered for HASS stop event")
+    _LOGGER.debug("Registered for Home Assistant stop event")
 
     return setup_august(hass, config, api, authenticator)
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -323,7 +323,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         await self.async_update_ha_state()
 
     async def async_will_remove_from_hass(self):
-        """Remove listeners when removing automation from HASS."""
+        """Remove listeners when removing automation from Home Assistant."""
         await super().async_will_remove_from_hass()
         await self.async_disable()
 

--- a/homeassistant/components/bbb_gpio/__init__.py
+++ b/homeassistant/components/bbb_gpio/__init__.py
@@ -19,7 +19,7 @@ def setup(hass, config):
         GPIO.cleanup()
 
     def prepare_gpio(event):
-        """Stuff to do when home assistant starts."""
+        """Stuff to do when Home Assistant starts."""
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)

--- a/homeassistant/components/beewi_smartclim/sensor.py
+++ b/homeassistant/components/beewi_smartclim/sensor.py
@@ -88,7 +88,7 @@ class BeewiSmartclimSensor(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return f"{self._mac}_{self._device}"
 
     @property

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -31,7 +31,7 @@ class BMWDeviceTracker:
     def update(self) -> None:
         """Update the device info.
 
-        Only update the state in home assistant if tracking in
+        Only update the state in Home Assistant if tracking in
         the car is enabled.
         """
         dev_id = slugify(self.vehicle.name)

--- a/homeassistant/components/buienradar/camera.py
+++ b/homeassistant/components/buienradar/camera.py
@@ -134,7 +134,7 @@ class BuienradarCam(Camera):
 
         Uses ayncio conditions to make sure only one task enters the critical
         section at the same time. Otherwise, two http requests would start
-        when two tabs with home assistant are open.
+        when two tabs with Home Assistant are open.
 
         The condition is entered in two sections because otherwise the lock
         would be held while doing the http request.

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -203,7 +203,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     timeframe = config.get(CONF_TIMEFRAME, DEFAULT_TIMEFRAME)
 
     if None in (latitude, longitude):
-        _LOGGER.error("Latitude or longitude not set in HomeAssistant config")
+        _LOGGER.error("Latitude or longitude not set in Home Assistant config")
         return False
 
     coordinates = {CONF_LATITUDE: float(latitude), CONF_LONGITUDE: float(longitude)}

--- a/homeassistant/components/cloud/stt.py
+++ b/homeassistant/components/cloud/stt.py
@@ -52,7 +52,7 @@ class CloudProvider(Provider):
     """NabuCasa speech API provider."""
 
     def __init__(self, cloud: Cloud) -> None:
-        """Hass NabuCasa Speech to text."""
+        """Home Assistant NabuCasa Speech to text."""
         self.cloud = cloud
 
     @property

--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -23,7 +23,7 @@
       },
       "hassio_confirm": {
         "title": "deCONZ Zigbee gateway via Hass.io add-on",
-        "description": "Do you want to configure Home Assistant to connect to the deCONZ gateway provided by the hass.io add-on {addon}?",
+        "description": "Do you want to configure Home Assistant to connect to the deCONZ gateway provided by the Hass.io add-on {addon}?",
         "data": {
           "allow_clip_sensor": "Allow importing virtual sensors",
           "allow_deconz_groups": "Allow importing deCONZ groups"

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -219,7 +219,7 @@ class DlnaDmrDevice(MediaPlayerDevice):
         return self._available
 
     async def _async_on_hass_stop(self, event):
-        """Event handler on HASS stop."""
+        """Event handler on Home Assistant stop."""
         with await self.hass.data[DLNA_DMR_DATA]["lock"]:
             await self._device.async_unsubscribe_services()
 

--- a/homeassistant/components/downloader/__init__.py
+++ b/homeassistant/components/downloader/__init__.py
@@ -44,7 +44,7 @@ def setup(hass, config):
     """Listen for download events to download files."""
     download_path = config[DOMAIN][CONF_DOWNLOAD_DIR]
 
-    # If path is relative, we assume relative to HASS config dir
+    # If path is relative, we assume relative to Home Assistant config dir
     if not os.path.isabs(download_path):
         download_path = hass.config.path(download_path)
 

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -27,7 +27,7 @@ ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]
 
 MANUFACTURER = "ecobee"
 
-# Translates ecobee API weatherSymbol to HASS usable names
+# Translates ecobee API weatherSymbol to Home Assistant usable names
 # https://www.ecobee.com/home/developer/api/documentation/v1/objects/WeatherForecast.shtml
 ECOBEE_WEATHER_SYMBOL_TO_HASS = {
     0: "sunny",

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -44,7 +44,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     vacuums = []
     for device in hass.data[ECOVACS_DEVICES]:
         vacuums.append(EcovacsVacuum(device))
-    _LOGGER.debug("Adding Ecovacs Vacuums to Hass: %s", vacuums)
+    _LOGGER.debug("Adding Ecovacs Vacuums to Home Assistant: %s", vacuums)
     add_entities(vacuums, True)
 
 

--- a/homeassistant/components/egardia/__init__.py
+++ b/homeassistant/components/egardia/__init__.py
@@ -119,7 +119,7 @@ def setup(hass, config):
                 """Handle Home Assistant stop event."""
                 server.stop()
 
-            # listen to home assistant stop event
+            # listen to Home Assistant stop event
             hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop_event)
 
         except OSError:

--- a/homeassistant/components/elgato/const.py
+++ b/homeassistant/components/elgato/const.py
@@ -3,7 +3,7 @@
 # Integration domain
 DOMAIN = "elgato"
 
-# Hass data keys
+# Home Assistant data keys
 DATA_ELGATO_CLIENT = "elgato_client"
 
 # Attributes

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -35,7 +35,7 @@ class DescriptionXmlView(HomeAssistantView):
 <URLBase>http://{0}:{1}/</URLBase>
 <device>
 <deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>
-<friendlyName>HASS Bridge ({0})</friendlyName>
+<friendlyName>Home Assistant Bridge ({0})</friendlyName>
 <manufacturer>Royal Philips Electronics</manufacturer>
 <manufacturerURL>http://www.philips.com</manufacturerURL>
 <modelDescription>Philips hue Personal Wireless Lighting</modelDescription>

--- a/homeassistant/components/ephember/climate.py
+++ b/homeassistant/components/ephember/climate.py
@@ -199,10 +199,10 @@ class EphEmberThermostat(ClimateDevice):
 
     @staticmethod
     def map_mode_hass_eph(operation_mode):
-        """Map from home assistant mode to eph mode."""
+        """Map from Home Assistant mode to eph mode."""
         return getattr(ZoneMode, HA_STATE_TO_EPH.get(operation_mode), None)
 
     @staticmethod
     def map_mode_eph_hass(operation_mode):
-        """Map from eph mode to home assistant mode."""
+        """Map from eph mode to Home Assistant mode."""
         return EPH_TO_HA_STATE.get(operation_mode.name, HVAC_MODE_HEAT_COOL)

--- a/homeassistant/components/flunearyou/sensor.py
+++ b/homeassistant/components/flunearyou/sensor.py
@@ -142,7 +142,7 @@ class FluNearYouSensor(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return f"{self.fny.latitude},{self.fny.longitude}_{self._kind}"
 
     @property

--- a/homeassistant/components/futurenow/light.py
+++ b/homeassistant/components/futurenow/light.py
@@ -55,12 +55,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 def to_futurenow_level(level):
-    """Convert the given HASS light level (0-255) to FutureNow (0-100)."""
+    """Convert the given Home Assistant light level (0-255) to FutureNow (0-100)."""
     return int((level * 100) / 255)
 
 
 def to_hass_level(level):
-    """Convert the given FutureNow (0-100) light level to HASS (0-255)."""
+    """Convert the given FutureNow (0-100) light level to Home Assistant (0-255)."""
     return int((level * 255) / 100)
 
 

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -582,12 +582,12 @@ class Group(Entity):
         self._async_update_group_state()
 
     async def async_added_to_hass(self):
-        """Handle addition to HASS."""
+        """Handle addition to Home Assistant."""
         if self.tracking:
             self.async_start()
 
     async def async_will_remove_from_hass(self):
-        """Handle removal from HASS."""
+        """Handle removal from Home Assistant."""
         if self._async_unsub_state_changed:
             self._async_unsub_state_changed()
             self._async_unsub_state_changed = None

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -113,7 +113,7 @@ class LightGroup(light.Light):
         await self.async_update()
 
     async def async_will_remove_from_hass(self):
-        """Handle removal from HASS."""
+        """Handle removal from Home Assistant."""
         if self._async_unsub_state_changed is not None:
             self._async_unsub_state_changed()
             self._async_unsub_state_changed = None

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -136,7 +136,7 @@ def get_homeassistant_version(hass):
 @callback
 @bind_hass
 def is_hassio(hass):
-    """Return true if hass.io is loaded.
+    """Return true if Hass.io is loaded.
 
     Async friendly.
     """
@@ -171,7 +171,7 @@ async def async_setup(hass, config):
         if user and user.refresh_tokens:
             refresh_token = list(user.refresh_tokens.values())[0]
 
-            # Migrate old hass.io users to be admin.
+            # Migrate old Hass.io users to be admin.
             if not user.is_admin:
                 await hass.auth.async_update_user(user, group_ids=[GROUP_ID_ADMIN])
 
@@ -219,7 +219,7 @@ async def async_setup(hass, config):
         snapshot = data.pop(ATTR_SNAPSHOT, None)
         payload = None
 
-        # Pass data to hass.io API
+        # Pass data to Hass.io API
         if service.service == SERVICE_ADDON_STDIN:
             payload = data[ATTR_INPUT]
         elif MAP_SERVICE_API[service.service][3]:

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -226,7 +226,7 @@ class HERETravelTimeSensor(Entity):
 
         @callback
         def delayed_sensor_update(event):
-            """Update sensor after homeassistant started."""
+            """Update sensor after Home Assistant started."""
             self.async_schedule_update_ha_state(True)
 
         self.hass.bus.async_listen_once(

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -109,7 +109,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up home assistant scene entries."""
+    """Set up Home Assistant scene entries."""
     _process_scenes_config(hass, async_add_entities, config)
 
     # This platform can be loaded multiple times. Only first time register the service.

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -422,7 +422,7 @@ class TelevisionMediaPlayer(HomeAccessory):
                     self.char_input_source.set_value(index)
                 else:
                     _LOGGER.warning(
-                        "%s: Sources out of sync. Restart HomeAssistant",
+                        "%s: Sources out of sync. Restart Home Assistant",
                         self.entity_id,
                     )
                     self.char_input_source.set_value(0)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -122,7 +122,7 @@ class HKDevice:
         self.hass.helpers.dispatcher.async_dispatcher_send(self.signal_state_updated)
 
     async def async_setup(self):
-        """Prepare to use a paired HomeKit device in homeassistant."""
+        """Prepare to use a paired HomeKit device in Home Assistant."""
         cache = self.hass.data[ENTITY_MAP].get_map(self.unique_id)
         if not cache:
             if await self.async_refresh_entity_map(self.config_num):

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -412,7 +412,7 @@ def setup(hass, config):
     # Start server thread, connect to hosts, initialize to receive events
     homematic.start()
 
-    # Stops server when HASS is shutting down
+    # Stops server when Home Assistant is shutting down
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, hass.data[DATA_HOMEMATIC].stop)
 
     # Init homematic hubs
@@ -600,7 +600,7 @@ def _system_callback_handler(hass, config, src, *args):
             if hmdevice.EVENTNODE:
                 hmdevice.setEventCallback(callback=bound_event_callback, bequeath=True)
 
-        # Create HASS entities
+        # Create Home Assistant entities
         if addresses:
             for component_name, discovery_type in (
                 ("switch", DISCOVER_SWITCHES),
@@ -616,7 +616,7 @@ def _system_callback_handler(hass, config, src, *args):
                 found_devices = _get_devices(hass, discovery_type, addresses, interface)
 
                 # When devices of this type are found
-                # they are setup in HASS and a discovery event is fired
+                # they are setup in Home Assistant and a discovery event is fired
                 if found_devices:
                     discovery.load_platform(
                         hass,
@@ -969,7 +969,7 @@ class HMDevice(Entity):
             self._available = not self._hmdevice.UNREACH
             has_changed = True
 
-        # If it has changed data point, update HASS
+        # If it has changed data point, update Home Assistant
         if has_changed:
             self.schedule_update_ha_state()
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -17,7 +17,7 @@ from .const import DOMAIN, LOGGER  # pylint: disable=unused-import
 from .errors import AuthenticationRequired, CannotConnect
 
 HUE_MANUFACTURERURL = "http://www.philips.com"
-HUE_IGNORED_BRIDGE_NAMES = ["HASS Bridge", "Espalexa"]
+HUE_IGNORED_BRIDGE_NAMES = ["Home Assistant Bridge", "Espalexa"]
 
 
 class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -36,7 +36,7 @@ STATE_ATTRIBUTE_ROOM_NAME = "roomName"
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up home assistant scene entries."""
+    """Set up Home Assistant scene entries."""
 
     hub_address = config.get(HUB_ADDRESS)
     websession = async_get_clientsession(hass)

--- a/homeassistant/components/idteck_prox/__init__.py
+++ b/homeassistant/components/idteck_prox/__init__.py
@@ -73,7 +73,7 @@ class IdteckReader:
         self._connection = rfk101py(self._host, self._port, self._callback)
 
     def _callback(self, card):
-        """Send a keycard event message into HASS whenever a card is read."""
+        """Send a keycard event message into Home Assistant whenever a card is read."""
         self.hass.bus.fire(
             EVENT_IDTECK_PROX_KEYCARD, {"card": card, "name": self._name}
         )

--- a/homeassistant/components/ihc/ihc_auto_setup.yaml
+++ b/homeassistant/components/ihc/ihc_auto_setup.yaml
@@ -1,5 +1,5 @@
 # IHC auto setup configuration.
-# To customize this, copy this file to the home assistant configuration
+# To customize this, copy this file to the Home Assistant configuration
 # folder and make your changes.
 
 binary_sensor:

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -232,7 +232,7 @@ class IQVIAEntity(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return f"{self._zip_code}_{self._type}"
 
     @property

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -56,8 +56,8 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-# Do not use the Hass consts for the states here - we're matching exact API
-# responses, not using them for Hass states
+# Do not use the Home Assistant consts for the states here - we're matching
+# exact API responses, not using them for Home Assistant states
 NODE_FILTERS = {
     "binary_sensor": {
         "uom": [],
@@ -157,7 +157,7 @@ SUPPORTED_DOMAINS = [
 ]
 SUPPORTED_PROGRAM_DOMAINS = ["binary_sensor", "lock", "fan", "cover", "switch"]
 
-# ISY Scenes are more like Switches than Hass Scenes
+# ISY Scenes are more like Switches than Home Assistant Scenes
 # (they can turn off, and report their state)
 SCENE_DOMAIN = "switch"
 

--- a/homeassistant/components/isy994/binary_sensor.py
+++ b/homeassistant/components/isy994/binary_sensor.py
@@ -100,8 +100,8 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
 
     Often times, a single device is represented by multiple nodes in the ISY,
     allowing for different nuances in how those devices report their on and
-    off events. This class turns those multiple nodes in to a single Hass
-    entity and handles both ways that ISY binary sensors can work.
+    off events. This class turns those multiple nodes in to a single Home
+    Assistant entity and handles both ways that ISY binary sensors can work.
     """
 
     def __init__(self, node) -> None:

--- a/homeassistant/components/keba/__init__.py
+++ b/homeassistant/components/keba/__init__.py
@@ -66,7 +66,7 @@ async def async_setup(hass, config):
         _LOGGER.error("Could not find a charging station at %s", host)
         return False
 
-    # Set failsafe mode at start up of home assistant
+    # Set failsafe mode at start up of Home Assistant
     failsafe = config[DOMAIN][CONF_FS]
     timeout = config[DOMAIN][CONF_FS_TIMEOUT] if failsafe else 0
     fallback = config[DOMAIN][CONF_FS_FALLBACK] if failsafe else 0

--- a/homeassistant/components/keyboard/services.yaml
+++ b/homeassistant/components/keyboard/services.yaml
@@ -1,17 +1,17 @@
 volume_up:
-  description: Simulates a key press of the "Volume Up" button on HomeAssistant's host machine.
+  description: Simulates a key press of the "Volume Up" button on Home Assistant's host machine.
 
 volume_down:
-  description: Simulates a key press of the "Volume Down" button on HomeAssistant's host machine.
+  description: Simulates a key press of the "Volume Down" button on Home Assistant's host machine.
 
 volume_mute:
-  description: Simulates a key press of the "Volume Mute" button on HomeAssistant's host machine.
+  description: Simulates a key press of the "Volume Mute" button on Home Assistant's host machine.
 
 media_play_pause:
-  description: Simulates a key press of the "Media Play/Pause" button on HomeAssistant's host machine.
+  description: Simulates a key press of the "Media Play/Pause" button on Home Assistant's host machine.
 
 media_next_track:
-  description: Simulates a key press of the "Media Next Track" button on HomeAssistant's host machine.
+  description: Simulates a key press of the "Media Next Track" button on Home Assistant's host machine.
 
 media_prev_track:
-  description: Simulates a key press of the "Media Previous Track" button on HomeAssistant's host machine.
+  description: Simulates a key press of the "Media Previous Track" button on Home Assistant's host machine.

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -322,7 +322,7 @@ class KNXExposeTime:
 
 
 class KNXExposeSensor:
-    """Object to Expose HASS entity to KNX bus."""
+    """Object to Expose Home Assistant entity to KNX bus."""
 
     def __init__(self, hass, xknx, expose_type, entity_id, address):
         """Initialize of Expose class."""

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -189,7 +189,7 @@ class KNXCover(CoverDevice):
             await self.device.set_angle(tilt_position)
 
     def start_auto_updater(self):
-        """Start the autoupdater to update HASS while cover is moving."""
+        """Start the autoupdater to update Home Assistant while cover is moving."""
         if self._unsubscribe_auto_updater is None:
             self._unsubscribe_auto_updater = async_track_utc_time_change(
                 self.hass, self.auto_updater_hook

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -195,7 +195,7 @@ def humanify(hass, events):
 
     Will try to group events if possible:
     - if 2+ sensor updates in GROUP_BY_MINUTES, show last
-    - if home assistant stop and start happen in same minute call it restarted
+    - if Home Assistant stop and start happen in same minute call it restarted
     """
     domain_prefixes = tuple(f"{dom}." for dom in CONTINUOUS_DOMAINS)
 

--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -19,12 +19,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 def to_lutron_level(level):
-    """Convert the given HASS light level (0-255) to Lutron (0.0-100.0)."""
+    """Convert the given Home Assistant light level (0-255) to Lutron (0.0-100.0)."""
     return float((level * 100) / 255)
 
 
 def to_hass_level(level):
-    """Convert the given Lutron (0.0-100.0) light level to HASS (0-255)."""
+    """Convert the given Lutron (0.0-100.0) light level to Home Assistant (0-255)."""
     return int((level * 255) / 100)
 
 

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -155,7 +155,7 @@ class MaxCubeClimate(ClimateDevice):
 
     @staticmethod
     def map_temperature_max_hass(temperature):
-        """Map Temperature from MAX! to HASS."""
+        """Map Temperature from MAX! to Home Assistant."""
         if temperature is None:
             return 0.0
 

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -239,7 +239,7 @@ class MicrosoftFaceGroupEntity(Entity):
 
 
 class MicrosoftFace:
-    """Microsoft Face api for HomeAssistant."""
+    """Microsoft Face api for Home Assistant."""
 
     def __init__(self, hass, server_loc, api_key, timeout, entities):
         """Initialize Microsoft Face api."""

--- a/homeassistant/components/minio/__init__.py
+++ b/homeassistant/components/minio/__init__.py
@@ -170,7 +170,7 @@ def get_minio_endpoint(host: str, port: int) -> str:
 
 
 class QueueListener(threading.Thread):
-    """Forward events from queue into HASS event bus."""
+    """Forward events from queue into Home Assistant event bus."""
 
     def __init__(self, hass):
         """Create queue."""
@@ -179,7 +179,7 @@ class QueueListener(threading.Thread):
         self._queue = Queue()
 
     def run(self):
-        """Listen to queue events, and forward them to HASS event bus."""
+        """Listen to queue events, and forward them to Home Assistant event bus."""
         _LOGGER.info("Running QueueListener")
         while True:
             event = self._queue.get()

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -307,7 +307,7 @@ class MqttClimate(
         MqttEntityDeviceInfo.__init__(self, device_config, config_entry)
 
     async def async_added_to_hass(self):
-        """Handle being added to home assistant."""
+        """Handle being added to Home Assistant."""
         await super().async_added_to_hass()
         await self._subscribe_topics()
 

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -15,7 +15,7 @@
       },
       "hassio_confirm": {
         "title": "MQTT Broker via Hass.io add-on",
-        "description": "Do you want to configure Home Assistant to connect to the MQTT broker provided by the hass.io add-on {addon}?",
+        "description": "Do you want to configure Home Assistant to connect to the MQTT broker provided by the Hass.io add-on {addon}?",
         "data": {
           "discovery": "Enable discovery"
         }

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -97,7 +97,7 @@ class MyQDevice(CoverDevice):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return self._device.device_id
 
     async def async_close_cover(self, **kwargs):

--- a/homeassistant/components/nissan_leaf/sensor.py
+++ b/homeassistant/components/nissan_leaf/sensor.py
@@ -83,7 +83,7 @@ class LeafRangeSensor(LeafEntity):
     def log_registration(self):
         """Log registration."""
         _LOGGER.debug(
-            "Registered LeafRangeSensor integration with HASS for VIN %s",
+            "Registered LeafRangeSensor integration with Home Assistant for VIN %s",
             self.car.leaf.vin,
         )
 

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -32,7 +32,7 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
     def log_registration(self):
         """Log registration."""
         _LOGGER.debug(
-            "Registered LeafClimateSwitch integration with HASS for VIN %s",
+            "Registered LeafClimateSwitch integration with Home Assistant for VIN %s",
             self.car.leaf.vin,
         )
 

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -75,7 +75,7 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorDevice):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return f"{self._latitude}_{self._longitude}_{self._sensor_type}"
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/openuv/sensor.py
+++ b/homeassistant/components/openuv/sensor.py
@@ -97,7 +97,7 @@ class OpenUvSensor(OpenUvEntity):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return f"{self._latitude}_{self._longitude}_{self._sensor_type}"
 
     @property

--- a/homeassistant/components/orangepi_gpio/__init__.py
+++ b/homeassistant/components/orangepi_gpio/__init__.py
@@ -21,7 +21,7 @@ async def async_setup(hass, config):
         GPIO.cleanup()
 
     def prepare_gpio(event):
-        """Stuff to do when home assistant starts."""
+        """Stuff to do when Home Assistant starts."""
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)

--- a/homeassistant/components/oru/sensor.py
+++ b/homeassistant/components/oru/sensor.py
@@ -50,7 +50,7 @@ class CurrentEnergyUsageSensor(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return self.meter.meter_id
 
     @property

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -1,1 +1,1 @@
-"""Plugwise Climate (current only Anna) component for HomeAssistant."""
+"""Plugwise Climate (current only Anna) component for Home Assistant."""

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -1,4 +1,4 @@
-"""Plugwise Climate component for HomeAssistant."""
+"""Plugwise Climate component for Home Assistant."""
 
 import logging
 

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -376,7 +376,7 @@ class PS4Device(MediaPlayerDevice):
             self._unique_id = format_unique_id(self._creds, status["host-id"])
 
     async def async_will_remove_from_hass(self):
-        """Remove Entity from Hass."""
+        """Remove Entity from Home Assistant."""
         # Close TCP Transport.
         if self._ps4.connected:
             await self._ps4.close()

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -40,9 +40,9 @@ OPERATION_LIST = [HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF]
 CT30_FAN_OPERATION_LIST = [STATE_ON, HVAC_MODE_AUTO]
 CT80_FAN_OPERATION_LIST = [STATE_ON, STATE_CIRCULATE, HVAC_MODE_AUTO]
 
-# Mappings from radiotherm json data codes to and from HASS state
+# Mappings from radiotherm json data codes to and from Home Assistant state
 # flags.  CODE is the thermostat integer code and these map to and
-# from HASS state flags.
+# from Home Assistant state flags.
 
 # Programmed temperature mode of the thermostat.
 CODE_TO_TEMP_MODE = {
@@ -220,7 +220,7 @@ class RadioThermostat(ClimateDevice):
         """Update and validate the data from the thermostat."""
         # Radio thermostats are very slow, and sometimes don't respond
         # very quickly.  So we need to keep the number of calls to them
-        # to a bare minimum or we'll hit the HASS 10 sec warning.  We
+        # to a bare minimum or we'll hit the Home Assistant 10 sec warning.  We
         # have to make one call to /tstat to get temps but we'll try and
         # keep the other calls to a minimum.  Even with this, these
         # thermostats tend to time out sometimes when they're actively

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -76,7 +76,7 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return "{0}_{1}".format(
             self.rainmachine.device_mac.replace(":", ""), self._sensor_type
         )

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -72,7 +72,7 @@ class RainMachineSensor(RainMachineEntity):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return "{0}_{1}".format(
             self.rainmachine.device_mac.replace(":", ""), self._sensor_type
         )

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -143,7 +143,7 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return "{0}_{1}_{2}".format(
             self.rainmachine.device_mac.replace(":", ""),
             self._switch_type,

--- a/homeassistant/components/ring/light.py
+++ b/homeassistant/components/ring/light.py
@@ -76,7 +76,7 @@ class RingLight(Light):
         return self._light_on
 
     def _set_light(self, new_state):
-        """Update light state, and causes HASS to correctly update."""
+        """Update light state, and causes Home Assistant to correctly update."""
         self._device.lights = new_state
         self._light_on = new_state == ON_STATE
         self._no_updates_until = dt_util.utcnow() + SKIP_UPDATES_DELAY

--- a/homeassistant/components/ring/switch.py
+++ b/homeassistant/components/ring/switch.py
@@ -78,7 +78,7 @@ class SirenSwitch(BaseRingSwitch):
         self._siren_on = False
 
     def _set_switch(self, new_state):
-        """Update switch state, and causes HASS to correctly update."""
+        """Update switch state, and causes Home Assistant to correctly update."""
         self._device.siren = new_state
         self._siren_on = new_state > 0
         self._no_updates_until = dt_util.utcnow() + SKIP_UPDATES_DELAY

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -120,7 +120,7 @@ class RokuDevice(MediaPlayerDevice):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return self._device_info.serial_num
 
     @property

--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -18,7 +18,7 @@ def setup(hass, config):
         GPIO.cleanup()
 
     def prepare_gpio(event):
-        """Stuff to do when home assistant starts."""
+        """Stuff to do when Home Assistant starts."""
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)

--- a/homeassistant/components/rpi_pfio/__init__.py
+++ b/homeassistant/components/rpi_pfio/__init__.py
@@ -22,7 +22,7 @@ def setup(hass, config):
         PFIO.deinit()
 
     def prepare_pfio(event):
-        """Stuff to do when home assistant starts."""
+        """Stuff to do when Home Assistant starts."""
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_pfio)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_pfio)

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -150,7 +150,7 @@ async def async_setup(hass, config):
 
     @callback
     def alarm_status_update_callback():
-        """Send status update received from alarm to home assistant."""
+        """Send status update received from alarm to Home Assistant."""
         _LOGGER.debug("Sending request to update panel state")
         async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE)
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -217,7 +217,7 @@ class ScriptEntity(ToggleEntity):
         self.script.async_stop()
 
     async def async_will_remove_from_hass(self):
-        """Stop script and remove service when it will be removed from HASS."""
+        """Stop script and remove service when it will be removed from Home Assistant."""
         if self.script.is_running:
             self.script.async_stop()
 

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -129,7 +129,7 @@ class SeventeenTrackSummarySensor(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return "summary_{0}_{1}".format(self._data.account_id, slugify(self._status))
 
     @property
@@ -212,7 +212,7 @@ class SeventeenTrackPackageSensor(Entity):
 
     @property
     def unique_id(self):
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return UNIQUE_ID_TEMPLATE.format(self._data.account_id, self._tracking_number)
 
     async def async_update(self):

--- a/homeassistant/components/skybell/light.py
+++ b/homeassistant/components/skybell/light.py
@@ -27,12 +27,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 def _to_skybell_level(level):
-    """Convert the given HASS light level (0-255) to Skybell (0-100)."""
+    """Convert the given Home Assistant light level (0-255) to Skybell (0-100)."""
     return int((level * 100) / 255)
 
 
 def _to_hass_level(level):
-    """Convert the given Skybell (0-100) light level to HASS (0-255)."""
+    """Convert the given Skybell (0-100) light level to Home Assistant (0-255)."""
     return int((level * 255) / 100)
 
 

--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -110,7 +110,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         if not config_sensors:  # Use all sensors by default
             config_sensors = {s.name: [] for s in sensor_def}
 
-        # Prepare all HASS sensor entities
+        # Prepare all Home Assistant sensor entities
         for name, attr in config_sensors.items():
             sub_sensors = [sensor_def[s] for s in attr]
             hass_sensors.append(SMAsensor(sensor_def[name], sub_sensors))

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -88,7 +88,7 @@ async def validate_installed_app(api, installed_app_id: str):
 
 
 def validate_webhook_requirements(hass: HomeAssistantType) -> bool:
-    """Ensure HASS is setup properly to receive webhooks."""
+    """Ensure Home Assistant is setup properly to receive webhooks."""
     if hass.components.cloud.async_active_subscription():
         return True
     if hass.data[DOMAIN][CONF_CLOUDHOOK_URL] is not None:

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -183,7 +183,7 @@ class MailNotificationService(BaseNotificationService):
             msg["From"] = f"{self._sender_name} <{self._sender}>"
         else:
             msg["From"] = self._sender
-        msg["X-Mailer"] = "HomeAssistant"
+        msg["X-Mailer"] = "Home Assistant"
         msg["Date"] = email.utils.format_datetime(dt_util.now())
         msg["Message-Id"] = email.utils.make_msgid()
 

--- a/homeassistant/components/somfy/api.py
+++ b/homeassistant/components/somfy/api.py
@@ -1,4 +1,4 @@
-"""API for Somfy bound to HASS OAuth."""
+"""API for Somfy bound to Home Assistant OAuth."""
 from asyncio import run_coroutine_threadsafe
 from typing import Dict, Union
 

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -76,7 +76,7 @@ async def async_setup(hass, config):
     """Track the state of the sun."""
     if config.get(CONF_ELEVATION) is not None:
         _LOGGER.warning(
-            "Elevation is now configured in home assistant core. "
+            "Elevation is now configured in Home Assistant core. "
             "See https://home-assistant.io/docs/configuration/basic/"
         )
     Sun(hass)

--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -78,7 +78,7 @@ class SwitchBot(SwitchDevice, RestoreEntity):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return self._mac.replace(":", "")
 
     @property

--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -100,7 +100,7 @@ async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
     await v2bridge.start()
 
     async def async_stop_bridge(event: EventType) -> None:
-        """On homeassistant stop, gracefully stop the bridge if running."""
+        """On Home Assistant stop, gracefully stop the bridge if running."""
         await v2bridge.stop()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_bridge)

--- a/homeassistant/components/switchmate/switch.py
+++ b/homeassistant/components/switchmate/switch.py
@@ -46,7 +46,7 @@ class SwitchmateEntity(SwitchDevice):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return self._mac.replace(":", "")
 
     @property

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -152,7 +152,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(project_devices)
 
     def handle_new_task(call):
-        """Call when a user creates a new Todoist Task from HASS."""
+        """Call when a user creates a new Todoist Task from Home Assistant."""
         project_name = call.data[PROJECT_NAME]
         project_id = project_id_lookup[project_name]
 
@@ -571,7 +571,7 @@ class TodoistProjectData:
             if self.event[END] is not None:
                 self.event[END] = {DATETIME: self.event[END].strftime(DATE_STR_FORMAT)}
             else:
-                # HASS gets cranky if a calendar event never ends
+                # Home Assistant gets cranky if a calendar event never ends
                 # Let's set our "due date" to tomorrow
                 self.event[END] = {
                     DATETIME: (datetime.utcnow() + timedelta(days=1)).strftime(

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -109,7 +109,7 @@ async def async_setup(hass, config):
         if newest is None or "dev" in current_version:
             return
 
-        # Load data from supervisor on hass.io
+        # Load data from supervisor on Hass.io
         if hass.components.hassio.is_hassio():
             newest = hass.components.hassio.get_homeassistant_version()
 

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -1,4 +1,4 @@
-"""Hass representation of an UPnP/IGD."""
+"""Home Assistant representation of an UPnP/IGD."""
 import asyncio
 from ipaddress import IPv4Address
 
@@ -14,7 +14,7 @@ from .const import CONF_LOCAL_IP, DOMAIN, LOGGER as _LOGGER
 
 
 class Device:
-    """Hass representation of an UPnP/IGD."""
+    """Home Assistant representation of an UPnP/IGD."""
 
     def __init__(self, igd_device):
         """Initialize UPnP/IGD device."""

--- a/homeassistant/components/uscis/sensor.py
+++ b/homeassistant/components/uscis/sensor.py
@@ -24,7 +24,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the platform in HASS and Case Information."""
+    """Set up the platform in Home Assistant and Case Information."""
     uscis = UscisSensor(config["case_id"], config[CONF_FRIENDLY_NAME])
     uscis.update()
     if uscis.valid_case_id:

--- a/homeassistant/components/velbus/services.yaml
+++ b/homeassistant/components/velbus/services.yaml
@@ -1,2 +1,2 @@
 sync_clock:
-  description: Sync the velbus modules clock to the HASS clock, this is the same as the 'sync clock' from VelbusLink
+  description: Sync the velbus modules clock to the Home Assistant clock, this is the same as the 'sync clock' from VelbusLink

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -63,7 +63,7 @@ class WemoBinarySensor(BinarySensorDevice):
         self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):
-        """Wemo sensor added to HASS."""
+        """Wemo sensor added to Home Assistant."""
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -232,7 +232,7 @@ class WemoHumidifier(FanEntity):
         return SUPPORTED_FEATURES
 
     async def async_added_to_hass(self):
-        """Wemo humidifier added to HASS."""
+        """Wemo humidifier added to Home Assistant."""
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -96,7 +96,7 @@ class WemoLight(Light):
         self._unique_id = self.wemo.uniqueID
 
     async def async_added_to_hass(self):
-        """Wemo light added to HASS."""
+        """Wemo light added to Home Assistant."""
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
@@ -231,7 +231,7 @@ class WemoDimmer(Light):
         self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):
-        """Wemo dimmer added to HASS."""
+        """Wemo dimmer added to Home Assistant."""
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -196,7 +196,7 @@ class WemoSwitch(SwitchDevice):
         self.wemo.off()
 
     async def async_added_to_hass(self):
-        """Wemo switch added to HASS."""
+        """Wemo switch added to Home Assistant."""
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -695,7 +695,7 @@ class WinkAuthCallbackView(HomeAssistantView):
 
         response_message = """Wink has been successfully authorized!
          You can close this window now! For the best results you should reboot
-         HomeAssistant"""
+         Home Assistant"""
         html_response = """<html><head><title>Wink Auth</title></head>
                 <body><h1>{}</h1></body></html>"""
 

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -309,7 +309,7 @@ class WithingsHealthSensor(Entity):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique, HASS-friendly identifier for this entity."""
+        """Return a unique, Home Assistant friendly identifier for this entity."""
         return "withings_{}_{}_{}".format(
             self._slug, self._user_id, slugify(self._attribute.measurement)
         )

--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -3,7 +3,7 @@
 # Integration domain
 DOMAIN = "wled"
 
-# Hass data keys
+# Home Assistant data keys
 DATA_WLED_CLIENT = "wled_client"
 DATA_WLED_TIMER = "wled_timer"
 DATA_WLED_UPDATED = "wled_updated"

--- a/homeassistant/components/wunderground/sensor.py
+++ b/homeassistant/components/wunderground/sensor.py
@@ -171,7 +171,7 @@ class WUDailySimpleForecastSensorConfig(WUSensorConfig):
         :param field: field name to use as value
         :param wu_unit: "fahrenheit", "celsius", "degrees" etc. see the example json at:
                 https://www.wunderground.com/weather/api/d/docs?d=data/forecast&MR=1
-        :param ha_unit: corresponding unit in home assistant
+        :param ha_unit: corresponding unit in Home Assistant
         """
         super().__init__(
             friendly_name=friendly_name,

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -232,7 +232,7 @@ class YamahaDevice(MediaPlayerDevice):
         self._zone.update_status()
 
     def update_hass(self):
-        """Push updates to HASS."""
+        """Push updates to Home Assistant."""
         if self.entity_id:
             _LOGGER.debug("update_hass: pushing updates")
             self.schedule_update_ha_state()

--- a/homeassistant/components/yessssms/notify.py
+++ b/homeassistant/components/yessssms/notify.py
@@ -67,7 +67,7 @@ class YesssSMSNotificationService(BaseNotificationService):
     def send_message(self, message="", **kwargs):
         """Send a SMS message via Yesss.at's website."""
         if self.yesss.account_is_suspended():
-            # only retry to login after HASS was restarted with (hopefully)
+            # only retry to login after Home Assistant was restarted with (hopefully)
             # new login data.
             _LOGGER.error(
                 "Account is suspended, cannot send SMS. "

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -96,7 +96,7 @@ def async_active_zone(hass, latitude, longitude, radius=0):
 
 
 async def async_setup(hass, config):
-    """Set up configured zones as well as home assistant zone if necessary."""
+    """Set up configured zones as well as Home Assistant zone if necessary."""
     hass.data[DOMAIN] = {}
     entities: Set[str] = set()
     zone_entries = configured_zones(hass)

--- a/homeassistant/components/zwave/cover.py
+++ b/homeassistant/components/zwave/cover.py
@@ -340,7 +340,7 @@ class FibaroFGRM222(ZwaveRollershutter):
             # Note: This is safe to do even if the user has accidentally set
             # this configuration parameter, or configuration parameter 10 to
             # something other than venetian blind mode. The controller will just
-            # ignore potential tilt settings sent from home assistant in this
+            # ignore potential tilt settings sent from Home Assistant in this
             # case.
             self._has_tilt_mode = True
             _LOGGER.info(

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -141,7 +141,7 @@ start_network:
   description: Start the Z-Wave network. This might take a while, depending on how big your Z-Wave network is.
 
 stop_network:
-  description: Stop the Z-Wave network, all updates into HASS will stop.
+  description: Stop the Z-Wave network, all updates into Home Assistant will stop.
 
 soft_reset:
   description: This will reset the controller without removing its data. Use carefully because not all controllers support this. Refer to your controller's manual.

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -192,7 +192,7 @@ class HomeAssistant:
         return self.state in (CoreState.starting, CoreState.running)
 
     def start(self) -> int:
-        """Start home assistant.
+        """Start Home Assistant.
 
         Note: This function is only used for testing.
         For regular use, use "await hass.run()".
@@ -217,7 +217,7 @@ class HomeAssistant:
         This method is a coroutine.
         """
         if self.state != CoreState.not_running:
-            raise RuntimeError("HASS is already running")
+            raise RuntimeError("Home Assistant is already running")
 
         # _async_stop will set this instead of stopping the loop
         self._stopped = asyncio.Event()

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -168,7 +168,7 @@ class RestoreStateData:
             self.hass.async_create_task(self.async_dump_states())
 
         # Dump the initial states now. This helps minimize the risk of having
-        # old states loaded by overwritting the last states once home assistant
+        # old states loaded by overwriting the last states once Home Assistant
         # has started and the old states have been read.
         _async_dump_states()
 

--- a/script/scaffold/templates/config_flow_oauth2/integration/api.py
+++ b/script/scaffold/templates/config_flow_oauth2/integration/api.py
@@ -1,4 +1,4 @@
-"""API for NEW_NAME bound to HASS OAuth."""
+"""API for NEW_NAME bound to Home Assistant OAuth."""
 from asyncio import run_coroutine_threadsafe
 
 from aiohttp import ClientSession

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -17,7 +17,7 @@ from tests.common import CLIENT_ID, MockUser, ensure_auth_manager_loaded, flush_
 
 @pytest.fixture
 def mock_hass(loop):
-    """Hass mock with minimum amount of data set to make it work with auth."""
+    """Home Assistant mock with minimum amount of data set to make it work with auth."""
     hass = Mock()
     hass.config.skip_pip = True
     return hass

--- a/tests/components/adguard/test_config_flow.py
+++ b/tests/components/adguard/test_config_flow.py
@@ -223,7 +223,7 @@ async def test_hassio_confirm(hass, aioclient_mock):
 
 
 async def test_hassio_connection_error(hass, aioclient_mock):
-    """Test we show hassio confirm form on AdGuard Home connection error."""
+    """Test we show Hass.io confirm form on AdGuard Home connection error."""
     aioclient_mock.get(
         "http://mock-adguard:3000/control/status", exc=aiohttp.ClientError
     )

--- a/tests/components/almond/test_init.py
+++ b/tests/components/almond/test_init.py
@@ -78,7 +78,7 @@ async def test_set_up_oauth_no_external_url(hass, aioclient_mock):
 
 
 async def test_set_up_hassio(hass, aioclient_mock):
-    """Test we do not set up Almond to connect to HA if we use hassio."""
+    """Test we do not set up Almond to connect to HA if we use Hass.io."""
     entry = MockConfigEntry(
         domain="almond",
         data={
@@ -97,7 +97,7 @@ async def test_set_up_hassio(hass, aioclient_mock):
 
 
 async def test_set_up_local(hass, aioclient_mock):
-    """Test we do not set up Almond to connect to HA if we use hassio."""
+    """Test we do not set up Almond to connect to HA if we use Hass.io."""
     entry = MockConfigEntry(
         domain="almond",
         data={"type": const.TYPE_LOCAL, "host": "http://localhost:9999"},

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -17,7 +17,7 @@ from tests.common import async_mock_service
 
 @pytest.fixture
 def mock_api_client(hass, hass_client):
-    """Start the Hass HTTP component and return admin API client."""
+    """Start the Home Assistant HTTP component and return admin API client."""
     hass.loop.run_until_complete(async_setup_component(hass, "api", {}))
     return hass.loop.run_until_complete(hass_client())
 

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -102,7 +102,7 @@ def test_auth_code_store_expiration():
 
 
 async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
-    """Test the current user command with homeassistant creds."""
+    """Test the current user command with Home Assistant creds."""
     assert await async_setup_component(hass, "auth", {})
 
     refresh_token = await hass.auth.async_validate_access_token(hass_access_token)

--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -9,7 +9,7 @@ from tests.common import async_mock_service, mock_coro
 
 
 async def test_if_fires_on_hass_start(hass):
-    """Test the firing when HASS starts."""
+    """Test the firing when Home Assistant starts."""
     calls = async_mock_service(hass, "test", "automation")
     hass.state = CoreState.not_running
     config = {
@@ -41,7 +41,7 @@ async def test_if_fires_on_hass_start(hass):
 
 
 async def test_if_fires_on_hass_shutdown(hass):
-    """Test the firing when HASS starts."""
+    """Test the firing when Home Assistant shuts down."""
     calls = async_mock_service(hass, "test", "automation")
     hass.state = CoreState.not_running
 

--- a/tests/components/folder_watcher/test_init.py
+++ b/tests/components/folder_watcher/test_init.py
@@ -31,7 +31,7 @@ async def test_valid_path_setup(hass):
 
 @MockDependency("watchdog", "events")
 def test_event(mock_watchdog):
-    """Check that HASS events are fired correctly on watchdog event."""
+    """Check that Home Assistant events are fired correctly on watchdog event."""
 
     class MockPatternMatchingEventHandler:
         """Mock base class for the pattern matcher event handler."""

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -22,14 +22,14 @@ CONFIG_THEMES = {DOMAIN: {CONF_THEMES: {"happy": {"primary-color": "red"}}}}
 
 @pytest.fixture
 def mock_http_client(hass, aiohttp_client):
-    """Start the Hass HTTP component."""
+    """Start the Home Assistant HTTP component."""
     hass.loop.run_until_complete(async_setup_component(hass, "frontend", {}))
     return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
 
 
 @pytest.fixture
 def mock_http_client_with_themes(hass, aiohttp_client):
-    """Start the Hass HTTP component."""
+    """Start the Home Assistant HTTP component."""
     hass.loop.run_until_complete(
         async_setup_component(
             hass,
@@ -42,7 +42,7 @@ def mock_http_client_with_themes(hass, aiohttp_client):
 
 @pytest.fixture
 def mock_http_client_with_urls(hass, aiohttp_client):
-    """Start the Hass HTTP component."""
+    """Start the Home Assistant HTTP component."""
     hass.loop.run_until_complete(
         async_setup_component(
             hass,

--- a/tests/components/hassio/__init__.py
+++ b/tests/components/hassio/__init__.py
@@ -1,3 +1,3 @@
-"""Tests for Hassio component."""
+"""Tests for Hass.io component."""
 
 HASSIO_TOKEN = "123456"

--- a/tests/components/hassio/test_handler.py
+++ b/tests/components/hassio/test_handler.py
@@ -31,7 +31,7 @@ async def test_api_ping_exeption(hassio_handler, aioclient_mock):
 
 
 async def test_api_homeassistant_info(hassio_handler, aioclient_mock):
-    """Test setup with API homeassistant info."""
+    """Test setup with API Home Assistant info."""
     aioclient_mock.get(
         "http://127.0.0.1/homeassistant/info",
         json={"result": "ok", "data": {"last_version": "10.0"}},
@@ -43,7 +43,7 @@ async def test_api_homeassistant_info(hassio_handler, aioclient_mock):
 
 
 async def test_api_homeassistant_info_error(hassio_handler, aioclient_mock):
-    """Test setup with API homeassistant info error."""
+    """Test setup with API Home Assistant info error."""
     aioclient_mock.get(
         "http://127.0.0.1/homeassistant/info", json={"result": "error", "message": None}
     )
@@ -55,7 +55,7 @@ async def test_api_homeassistant_info_error(hassio_handler, aioclient_mock):
 
 
 async def test_api_homeassistant_stop(hassio_handler, aioclient_mock):
-    """Test setup with API HomeAssistant stop."""
+    """Test setup with API Home Assistant stop."""
     aioclient_mock.post("http://127.0.0.1/homeassistant/stop", json={"result": "ok"})
 
     assert await hassio_handler.stop_homeassistant()
@@ -63,7 +63,7 @@ async def test_api_homeassistant_stop(hassio_handler, aioclient_mock):
 
 
 async def test_api_homeassistant_restart(hassio_handler, aioclient_mock):
-    """Test setup with API HomeAssistant restart."""
+    """Test setup with API Home Assistant restart."""
     aioclient_mock.post("http://127.0.0.1/homeassistant/restart", json={"result": "ok"})
 
     assert await hassio_handler.restart_homeassistant()

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -261,7 +261,7 @@ async def setup_test_accessories(hass, accessories):
 
 
 async def device_config_changed(hass, accessories):
-    """Discover new devices added to HomeAssistant at runtime."""
+    """Discover new devices added to Home Assistant at runtime."""
     # Update the accessories our FakePairing knows about
     controller = hass.data[CONTROLLER]
     pairing = controller.pairings["00:00:00:00:00:00"]
@@ -307,7 +307,7 @@ async def setup_test_component(hass, services, capitalize=False, suffix=None):
             domain = HOMEKIT_ACCESSORY_DISPATCH[service_name]
             break
 
-    assert domain, "Cannot map test homekit services to homeassistant domain"
+    assert domain, "Cannot map test homekit services to Home Assistant domain"
 
     accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
     accessory.services.extend(services)

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -240,7 +240,7 @@ async def test_bridge_ssdp_emulated_hue(hass):
     result = await flow.async_step_ssdp(
         {
             ssdp.ATTR_SSDP_LOCATION: "http://0.0.0.0/",
-            ssdp.ATTR_UPNP_FRIENDLY_NAME: "HASS Bridge",
+            ssdp.ATTR_UPNP_FRIENDLY_NAME: "Home Assistant Bridge",
             ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.HUE_MANUFACTURERURL,
             ssdp.ATTR_UPNP_SERIAL: "1234",
         }

--- a/tests/components/mailbox/test_init.py
+++ b/tests/components/mailbox/test_init.py
@@ -9,7 +9,7 @@ import homeassistant.components.mailbox as mailbox
 
 @pytest.fixture
 def mock_http_client(hass, hass_client):
-    """Start the Hass HTTP component."""
+    """Start the Home Assistant HTTP component."""
     config = {mailbox.DOMAIN: {"platform": "demo"}}
     hass.loop.run_until_complete(async_setup_component(hass, mailbox.DOMAIN, config))
     return hass.loop.run_until_complete(hass_client())

--- a/tests/components/minio/test_minio.py
+++ b/tests/components/minio/test_minio.py
@@ -155,7 +155,7 @@ async def test_minio_listen(hass, caplog, minio_client_event):
 
 
 async def test_queue_listener():
-    """Tests QueueListener firing events on Hass event bus."""
+    """Tests QueueListener firing events on Home Assistant event bus."""
     hass = MagicMock()
 
     queue_listener = QueueListener(hass)

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -40,7 +40,7 @@ def mock_dev_track(mock_device_tracker_conf):
 
 @pytest.fixture
 def mock_client(hass, aiohttp_client):
-    """Start the Hass HTTP component."""
+    """Start the Home Assistant HTTP component."""
     mock_component(hass, "group")
     mock_component(hass, "zone")
     mock_component(hass, "device_tracker")

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -55,7 +55,7 @@ class TestPlant(unittest.TestCase):
     """Tests for component "plant"."""
 
     def setUp(self):
-        """Create test instance of home assistant."""
+        """Create test instance of Home Assistant."""
         self.hass = get_test_home_assistant()
         self.hass.start()
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -89,7 +89,7 @@ class TestRecorder(unittest.TestCase):
 
 @pytest.fixture
 def hass_recorder():
-    """HASS fixture with in-memory recorder."""
+    """Home Assistant fixture with in-memory recorder."""
     hass = get_test_home_assistant()
 
     def setup_recorder(config=None):

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -11,7 +11,7 @@ from tests.common import get_test_home_assistant, init_recorder_component
 
 @pytest.fixture
 def hass_recorder():
-    """HASS fixture with in-memory recorder."""
+    """Home Assistant fixture with in-memory recorder."""
     hass = get_test_home_assistant()
 
     def setup_recorder(config=None):

--- a/tests/components/remember_the_milk/test_init.py
+++ b/tests/components/remember_the_milk/test_init.py
@@ -16,7 +16,7 @@ class TestConfiguration(unittest.TestCase):
     """Basic tests for the class RememberTheMilkConfiguration."""
 
     def setUp(self):
-        """Set up test home assistant main loop."""
+        """Set up test Home Assistant main loop."""
         self.hass = get_test_home_assistant()
         self.profile = "myprofile"
         self.token = "mytoken"
@@ -32,7 +32,7 @@ class TestConfiguration(unittest.TestCase):
         )
 
     def tearDown(self):
-        """Exit home assistant."""
+        """Exit Home Assistant."""
         self.hass.stop()
 
     def test_create_new(self):

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -200,7 +200,7 @@ async def test_turn_on_with_minimal_brightness(hass, light_devices):
     """
     Test lights set to lowest brightness when converted scale would be zero.
 
-    SmartThings light brightness is a percentage (0-100), but HASS uses a
+    SmartThings light brightness is a percentage (0-100), but Home Assistant uses a
     0-255 scale.  This tests if a really low value (1-2) is passed, we don't
     set the level to zero, which turns off the lights in SmartThings.
     """

--- a/tests/components/smhi/test_config_flow.py
+++ b/tests/components/smhi/test_config_flow.py
@@ -11,7 +11,7 @@ from tests.common import mock_coro
 
 # pylint: disable=protected-access
 async def test_homeassistant_location_exists() -> None:
-    """Test if homeassistant location exists it should return True."""
+    """Test if Home Assistant location exists it should return True."""
     hass = Mock()
     flow = config_flow.SmhiFlowHandler()
     flow.hass = hass
@@ -119,7 +119,7 @@ async def test_flow_show_form() -> None:
     flow = config_flow.SmhiFlowHandler()
     flow.hass = hass
 
-    # Test show form when home assistant config exists and
+    # Test show form when Home Assistant config exists and
     # home is already configured, then new config is allowed
     with patch.object(
         flow, "_show_config_form", return_value=mock_coro()
@@ -133,7 +133,7 @@ async def test_flow_show_form() -> None:
         await flow.async_step_user()
         assert len(config_form.mock_calls) == 1
 
-    # Test show form when home assistant config not and
+    # Test show form when Home Assistant config not and
     # home is not configured
     with patch.object(
         flow, "_show_config_form", return_value=mock_coro()
@@ -158,7 +158,7 @@ async def test_flow_show_form_name_exists() -> None:
     flow = config_flow.SmhiFlowHandler()
     flow.hass = hass
     test_data = {"name": "home", CONF_LONGITUDE: "0", CONF_LATITUDE: "0"}
-    # Test show form when home assistant config exists and
+    # Test show form when Home Assistant config exists and
     # home is already configured, then new config is allowed
     with patch.object(
         flow, "_show_config_form", return_value=mock_coro()

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -31,7 +31,7 @@ class TestNotifySmtp(unittest.TestCase):
             "testuser",
             "testpass",
             ["recip1@example.com", "testrecip@test.com"],
-            "HomeAssistant",
+            "Home Assistant",
             0,
         )
 
@@ -49,8 +49,8 @@ class TestNotifySmtp(unittest.TestCase):
             "Content-Transfer-Encoding: 7bit\n"
             "Subject: Home Assistant\n"
             "To: recip1@example.com,testrecip@test.com\n"
-            "From: HomeAssistant <test@test.com>\n"
-            "X-Mailer: HomeAssistant\n"
+            "From: Home Assistant <test@test.com>\n"
+            "X-Mailer: Home Assistant\n"
             "Date: [^\n]+\n"
             "Message-Id: <[^@]+@[^>]+>\n"
             "\n"

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -241,7 +241,7 @@ def log_error_from_test_path(path):
 
 
 async def test_homeassistant_path(hass, hass_client):
-    """Test error logged from homeassistant path."""
+    """Test error logged from Home Assistant path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     with patch(
         "homeassistant.components.system_log.HOMEASSISTANT_PATH",

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -253,7 +253,7 @@ async def test_error_fetching_new_version_invalid_response(hass, aioclient_mock)
 async def test_new_version_shows_entity_after_hour_hassio(
     hass, mock_get_uuid, mock_get_newest_version, mock_utcnow
 ):
-    """Test if binary sensor gets updated if new version is available / hass.io."""
+    """Test if binary sensor gets updated if new version is available / Hass.io."""
     mock_get_uuid.return_value = MOCK_HUUID
     mock_get_newest_version.return_value = mock_coro((NEW_VERSION, RELEASE_NOTES))
     mock_component(hass, "hassio")

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -54,7 +54,7 @@ class ComponentFactory:
 
         self.init_controller_mock.side_effect = init_controller
 
-        # Setup home assistant.
+        # Setup Home Assistant.
         assert await async_setup_component(hass, DOMAIN, hass_config)
         await hass.async_block_till_done()
 

--- a/tests/components/withings/common.py
+++ b/tests/components/withings/common.py
@@ -47,7 +47,7 @@ def assert_state_equals(
 
 
 async def setup_hass(hass: HomeAssistant) -> dict:
-    """Configure home assistant."""
+    """Configure Home Assistant."""
     profiles = ["Person0", "Person1", "Person2", "Person3", "Person4"]
 
     hass_config = {

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -1,1 +1,1 @@
-"""Tests the HASS workday binary sensor."""
+"""Tests the Home Assistant workday binary sensor."""

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -1,4 +1,4 @@
-"""Tests the HASS workday binary sensor."""
+"""Tests the Home Assistant workday binary sensor."""
 from datetime import date
 from unittest.mock import patch
 

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -174,7 +174,7 @@ async def async_test_on_off_from_hass(hass, cluster, entity_id):
 
 
 async def async_test_off_from_hass(hass, cluster, entity_id):
-    """Test turning off the light from homeassistant."""
+    """Test turning off the light from Home Assistant."""
     with patch(
         "zigpy.zcl.Cluster.request",
         return_value=mock_coro([0x01, zcl_f.Status.SUCCESS]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def hass_storage():
 
 @pytest.fixture
 def hass(loop, hass_storage):
-    """Fixture to provide a test instance of HASS."""
+    """Fixture to provide a test instance of Home Assistant."""
     hass = loop.run_until_complete(async_test_home_assistant(loop))
 
     yield hass

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -20,7 +20,7 @@ MOCK_DATA2 = {"goodbye": "cruel world"}
 
 @pytest.fixture
 def store(hass):
-    """Fixture of a store that prevents writing on HASS stop."""
+    """Fixture of a store that prevents writing on Home Assistant stop."""
     yield storage.Store(hass, MOCK_VERSION, MOCK_KEY)
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -857,7 +857,7 @@ def test_regex_match(hass):
 
     tpl = template.Template(
         """
-{{ 'home assistant test' | regex_match('Home', True) }}
+{{ 'Home Assistant test' | regex_match('home', True) }}
             """,
         hass,
     )
@@ -865,7 +865,7 @@ def test_regex_match(hass):
 
     tpl = template.Template(
         """
-    {{ 'Another home assistant test' | regex_match('home') }}
+    {{ 'Another Home Assistant test' | regex_match('Home') }}
                     """,
         hass,
     )
@@ -873,7 +873,7 @@ def test_regex_match(hass):
 
     tpl = template.Template(
         """
-{{ ['home assistant test'] | regex_match('.*assist') }}
+{{ ['Home Assistant test'] | regex_match('.*Assist') }}
             """,
         hass,
     )
@@ -892,7 +892,7 @@ def test_regex_search(hass):
 
     tpl = template.Template(
         """
-{{ 'home assistant test' | regex_search('Home', True) }}
+{{ 'Home Assistant test' | regex_search('home', True) }}
             """,
         hass,
     )
@@ -900,7 +900,7 @@ def test_regex_search(hass):
 
     tpl = template.Template(
         """
-    {{ 'Another home assistant test' | regex_search('home') }}
+    {{ 'Another Home Assistant test' | regex_search('Home') }}
                     """,
         hass,
     )
@@ -908,7 +908,7 @@ def test_regex_search(hass):
 
     tpl = template.Template(
         """
-{{ ['home assistant test'] | regex_search('assist') }}
+{{ ['Home Assistant test'] | regex_search('Assist') }}
             """,
         hass,
     )
@@ -927,11 +927,11 @@ def test_regex_replace(hass):
 
     tpl = template.Template(
         """
-{{ ['home hinderant test'] | regex_replace('hinder', 'assist') }}
+{{ ['Home hinderant test'] | regex_replace('hinder', 'Assist') }}
             """,
         hass,
     )
-    assert tpl.async_render() == "['home assistant test']"
+    assert tpl.async_render() == "['Home Assistant test']"
 
 
 def test_regex_findall_index(hass):

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -1,4 +1,4 @@
-"""Test homeassistant distance utility functions."""
+"""Test Home Assistant distance utility functions."""
 
 import pytest
 

--- a/tests/util/test_pressure.py
+++ b/tests/util/test_pressure.py
@@ -1,4 +1,4 @@
-"""Test homeassistant pressure utility functions."""
+"""Test Home Assistant pressure utility functions."""
 import pytest
 
 from homeassistant.const import (

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -1,4 +1,4 @@
-"""Test homeassistant volume utility functions."""
+"""Test Home Assistant volume utility functions."""
 
 import pytest
 


### PR DESCRIPTION

## Description:

Not touching the "HA" abbreviation here, there's a lot of that and I think it's ok.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
