### PR TITLE
Add search integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -279,6 +279,7 @@ homeassistant/components/samsungtv/* @escoand
 homeassistant/components/scene/* @home-assistant/core
 homeassistant/components/scrape/* @fabaff
 homeassistant/components/script/* @home-assistant/core
+homeassistant/components/search/* @home-assistant/core
 homeassistant/components/sense/* @kbickar
 homeassistant/components/sensibo/* @andrey-git
 homeassistant/components/sentry/* @dcramer

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -183,6 +183,24 @@ def get_entity_ids(
     return [ent_id for ent_id in entity_ids if ent_id.startswith(domain_filter)]
 
 
+@bind_hass
+def groups_with_entity(hass: HomeAssistantType, entity_id: str) -> List[str]:
+    """Get all groups that contain this entity.
+
+    Async friendly.
+    """
+    if DOMAIN not in hass.data:
+        return []
+
+    groups = []
+
+    for group in hass.data[DOMAIN].entities:
+        if entity_id in group.tracking:
+            groups.append(group.entity_id)
+
+    return groups
+
+
 async def async_setup(hass, config):
     """Set up all groups found defined in the configuration."""
     component = hass.data.get(DOMAIN)

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -1,7 +1,7 @@
 """Allow users to set and activate scenes."""
 from collections import namedtuple
 import logging
-from typing import Set
+from typing import List
 
 import voluptuous as vol
 
@@ -110,36 +110,36 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @callback
-def scenes_with_entity(hass: HomeAssistant, entity_id: str) -> Set[str]:
+def scenes_with_entity(hass: HomeAssistant, entity_id: str) -> List[str]:
     """Return all scenes that reference the entity."""
     if DATA_PLATFORM not in hass.data:
-        return set()
+        return []
 
     platform = hass.data[DATA_PLATFORM]
 
-    results = set()
+    results = []
 
     for scene_entity in platform.entities.values():
         if entity_id in scene_entity.scene_config.states:
-            results.add(scene_entity.entity_id)
+            results.append(scene_entity.entity_id)
 
     return results
 
 
 @callback
-def entities_in_scene(hass: HomeAssistant, entity_id: str) -> Set[str]:
+def entities_in_scene(hass: HomeAssistant, entity_id: str) -> List[str]:
     """Return all entities in a scene."""
     if DATA_PLATFORM not in hass.data:
-        return set()
+        return []
 
     platform = hass.data[DATA_PLATFORM]
 
     entity = platform.entities.get(entity_id)
 
     if entity is None:
-        return set()
+        return []
 
-    return set(entity.scene_config.states)
+    return list(entity.scene_config.states)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -128,7 +128,7 @@ def scenes_with_entity(hass: HomeAssistant, entity_id: str) -> Set[str]:
 
 @callback
 def entities_in_scene(hass: HomeAssistant, entity_id: str) -> Set[str]:
-    """Return all scenes that reference the entity."""
+    """Return all entities in a scene."""
     if DATA_PLATFORM not in hass.data:
         return set()
 

--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -22,7 +22,16 @@ async def async_setup(hass: HomeAssistant, config: dict):
     {
         vol.Required("type"): "search/related",
         vol.Required("item_type"): vol.In(
-            ("area", "device", "entity", "script", "scene", "automation", "group")
+            (
+                "area",
+                "automation",
+                "config_entry",
+                "device",
+                "entity",
+                "group",
+                "scene",
+                "script",
+            )
         ),
         vol.Required("item_id"): str,
     }

--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -1,0 +1,132 @@
+"""The Search integration."""
+from collections import defaultdict
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.helpers import device_registry, entity_registry
+
+DOMAIN = "search"
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Search component."""
+    websocket_api.async_register_command(hass, websocket_search)
+    return True
+
+
+@websocket_api.async_response
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "search",
+        vol.Required("item_type"): vol.In(
+            ("area", "device", "entity", "script", "scene", "automation")
+        ),
+        vol.Required("item_id"): str,
+    }
+)
+async def websocket_search(hass, connection, msg):
+    """Handle search."""
+    searcher = Searcher(
+        hass,
+        await device_registry.async_get_registry(hass),
+        await entity_registry.async_get_registry(hass),
+    )
+    connection.send_result(
+        msg["id"], await searcher.search(msg["item_type"], msg["item_id"])
+    )
+
+
+class Searcher:
+    """Find related things."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device_reg: device_registry.DeviceRegistry,
+        entity_reg: entity_registry.EntityRegistry,
+    ):
+        """Search results."""
+        self.hass = hass
+        self._device_reg = device_reg
+        self._entity_reg = entity_reg
+        self.results = defaultdict(set)
+        self._to_resolve = set()
+
+    async def search(self, item_type, item_id):
+        """Find results."""
+        self._add_or_resolve(item_type, item_id)
+
+        while self._to_resolve:
+            search_type, search_id = self._to_resolve.pop()
+            await getattr(self, f"_resolve_{search_type}")(search_id)
+
+        # Remove entry into graph from search results.
+        self.results[item_type].remove(item_id)
+        # Clean up entity results with types that are represented as entities
+        self.results["entity"] -= self.results["script"]
+        self.results["entity"] -= self.results["scene"]
+        self.results["entity"] -= self.results["automation"]
+
+        # Filter out empty sets.
+        return {key: val for key, val in self.results.items() if val}
+
+    def _add_or_resolve(self, item_type, item_id):
+        """Add an item to explore."""
+        if item_id in self.results[item_type]:
+            return
+
+        self.results[item_type].add(item_id)
+        self._to_resolve.add((item_type, item_id))
+
+    async def _resolve_area(self, area_id) -> None:
+        """Resolve an area."""
+        for device in device_registry.async_entries_for_area(self._device_reg, area_id):
+            self._add_or_resolve("device", device.id)
+
+    async def _resolve_device(self, device_id) -> None:
+        """Resolve a device."""
+        device_entry = self._device_reg.async_get(device_id)
+        # Unlikely entry doesn't exist, but let's guard for bad data.
+        if device_entry is not None:
+            if device_entry.area_id:
+                self._add_or_resolve("area", device_entry.area_id)
+
+            # We do not resolve device_entry.via_device_id because that
+            # device is not related data-wise inside HA.
+
+        for entity_entry in entity_registry.async_entries_for_device(
+            self._entity_reg, device_id
+        ):
+            self._add_or_resolve("entity", entity_entry.entity_id)
+
+        # Extra: Find automations that reference this device
+
+    async def _resolve_entity(self, entity_id) -> None:
+        """Resolve an entity."""
+        # Extra: Find automations, scripts, scenes that reference this entity.
+
+        # Find devices
+        entity_entry = self._entity_reg.async_get(entity_id)
+        if entity_entry is not None:
+            if entity_entry.device_id:
+                self._add_or_resolve("device", entity_entry.device_id)
+
+        domain = split_entity_id(entity_id)[0]
+
+        # We can expand these types into more types.
+        if domain in ("scene", "script", "automation"):
+            self._add_or_resolve(domain, entity_id)
+
+    async def _resolve_automation(self, automation_id) -> None:
+        """Resolve an automation."""
+        # Extra: Check with automation integration what entities/devices they reference
+
+    async def _resolve_script(self, script_id) -> None:
+        """Resolve a script."""
+        # Extra: Check with script integration what entities/devices they reference
+
+    async def _resolve_scene(self, scene_id) -> None:
+        """Resolve a scene."""
+        # Extra: Check with scene integration what entities they reference

--- a/homeassistant/components/search/manifest.json
+++ b/homeassistant/components/search/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "search",
+  "name": "Search",
+  "documentation": "https://www.home-assistant.io/integrations/search",
+  "requirements": [],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": ["websocket_api"],
+  "codeowners": ["@home-assistant/core"]
+}

--- a/homeassistant/components/search/manifest.json
+++ b/homeassistant/components/search/manifest.json
@@ -7,5 +7,6 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": ["websocket_api"],
+  "after_dependencies": ["scene", "group"],
   "codeowners": ["@home-assistant/core"]
 }

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -375,3 +375,15 @@ async def async_get_registry(hass: HomeAssistantType) -> DeviceRegistry:
 def async_entries_for_area(registry: DeviceRegistry, area_id: str) -> List[DeviceEntry]:
     """Return entries that match an area."""
     return [device for device in registry.devices.values() if device.area_id == area_id]
+
+
+@callback
+def async_entries_for_config_entry(
+    registry: DeviceRegistry, config_entry_id: str
+) -> List[DeviceEntry]:
+    """Return entries that match a config entry."""
+    return [
+        device
+        for device in registry.devices.values()
+        if config_entry_id in device.config_entries
+    ]

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -445,6 +445,18 @@ def async_entries_for_device(
     ]
 
 
+@callback
+def async_entries_for_config_entry(
+    registry: EntityRegistry, config_entry_id: str
+) -> List[RegistryEntry]:
+    """Return entries that match a config entry."""
+    return [
+        entry
+        for entry in registry.entities.values()
+        if entry.config_entry_id == config_entry_id
+    ]
+
+
 async def _async_migrate(entities: Dict[str, Any]) -> Dict[str, List[Dict[str, Any]]]:
     """Migrate the YAML config file to storage helper format."""
     return {

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 import voluptuous as vol
 
+from homeassistant.components.homeassistant import scene as ha_scene
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
@@ -209,3 +210,51 @@ async def test_ensure_no_intersection(hass):
         await hass.async_block_till_done()
     assert "entities and snapshot_entities must not overlap" in str(ex.value)
     assert hass.states.get("scene.hallo") is None
+
+
+async def test_scenes_with_entity(hass):
+    """Test finding scenes with a specific entity."""
+    assert await async_setup_component(
+        hass,
+        "scene",
+        {
+            "scene": [
+                {"name": "scene_1", "entities": {"light.kitchen": "on"}},
+                {"name": "scene_2", "entities": {"light.living_room": "off"}},
+                {
+                    "name": "scene_3",
+                    "entities": {"light.kitchen": "on", "light.living_room": "off"},
+                },
+            ]
+        },
+    )
+
+    assert ha_scene.scenes_with_entity(hass, "light.kitchen") == {
+        "scene.scene_1",
+        "scene.scene_3",
+    }
+
+
+async def test_entities_in_scene(hass):
+    """Test finding entities in a scene."""
+    assert await async_setup_component(
+        hass,
+        "scene",
+        {
+            "scene": [
+                {"name": "scene_1", "entities": {"light.kitchen": "on"}},
+                {"name": "scene_2", "entities": {"light.living_room": "off"}},
+                {
+                    "name": "scene_3",
+                    "entities": {"light.kitchen": "on", "light.living_room": "off"},
+                },
+            ]
+        },
+    )
+
+    for scene_id, entities in (
+        ("scene.scene_1", {"light.kitchen"}),
+        ("scene.scene_2", {"light.living_room"}),
+        ("scene.scene_3", {"light.kitchen", "light.living_room"}),
+    ):
+        assert ha_scene.entities_in_scene(hass, scene_id) == entities

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -229,10 +229,10 @@ async def test_scenes_with_entity(hass):
         },
     )
 
-    assert ha_scene.scenes_with_entity(hass, "light.kitchen") == {
+    assert ha_scene.scenes_with_entity(hass, "light.kitchen") == [
         "scene.scene_1",
         "scene.scene_3",
-    }
+    ]
 
 
 async def test_entities_in_scene(hass):
@@ -253,8 +253,8 @@ async def test_entities_in_scene(hass):
     )
 
     for scene_id, entities in (
-        ("scene.scene_1", {"light.kitchen"}),
-        ("scene.scene_2", {"light.living_room"}),
-        ("scene.scene_3", {"light.kitchen", "light.living_room"}),
+        ("scene.scene_1", ["light.kitchen"]),
+        ("scene.scene_2", ["light.living_room"]),
+        ("scene.scene_3", ["light.kitchen", "light.living_room"]),
     ):
         assert ha_scene.entities_in_scene(hass, scene_id) == entities

--- a/tests/components/search/__init__.py
+++ b/tests/components/search/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Search integration."""

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -1,0 +1,125 @@
+"""Tests for Search integration."""
+from homeassistant.components import search
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_search(hass):
+    """Test that search works."""
+    area_reg = await hass.helpers.area_registry.async_get_registry()
+    device_reg = await hass.helpers.device_registry.async_get_registry()
+    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+
+    living_room_area = area_reg.async_create("Living Room")
+
+    # Light strip with 2 lights.
+    wled_config_entry = MockConfigEntry(domain="wled")
+    wled_config_entry.add_to_hass(hass)
+
+    wled_device = device_reg.async_get_or_create(
+        config_entry_id=wled_config_entry.entry_id,
+        name="Light Strip",
+        identifiers=({"wled", "wled-1"}),
+    )
+
+    device_reg.async_update_device(wled_device.id, area_id=living_room_area.id)
+
+    wled_segment_1 = entity_reg.async_get_or_create(
+        "light",
+        "wled",
+        "wled-1-seg-1",
+        suggested_object_id="living room light strip segment 1",
+        config_entry=wled_config_entry,
+        device_id=wled_device.id,
+    )
+    wled_segment_2 = entity_reg.async_get_or_create(
+        "light",
+        "wled",
+        "wled-1-seg-2",
+        suggested_object_id="living room light strip segment 2",
+        config_entry=wled_config_entry,
+        device_id=wled_device.id,
+    )
+
+    # Non related info.
+    kitchen_area = area_reg.async_create("Kitchen")
+
+    hue_config_entry = MockConfigEntry(domain="hue")
+    hue_config_entry.add_to_hass(hass)
+
+    hue_device = device_reg.async_get_or_create(
+        config_entry_id=hue_config_entry.entry_id,
+        name="Light Strip",
+        identifiers=({"hue", "hue-1"}),
+    )
+
+    device_reg.async_update_device(hue_device.id, area_id=kitchen_area.id)
+
+    entity_reg.async_get_or_create(
+        "light",
+        "hue",
+        "hue-1-seg-1",
+        suggested_object_id="living room light strip segment 1",
+        config_entry=hue_config_entry,
+        device_id=hue_device.id,
+    )
+    entity_reg.async_get_or_create(
+        "light",
+        "hue",
+        "hue-1-seg-2",
+        suggested_object_id="living room light strip segment 2",
+        config_entry=hue_config_entry,
+        device_id=hue_device.id,
+    )
+
+    expected = {
+        "area": {living_room_area.id},
+        "device": {wled_device.id},
+        "entity": {wled_segment_1.entity_id, wled_segment_2.entity_id},
+    }
+
+    # Explore the graph from every node and make sure we find the same results
+    for search_type, search_id in (
+        ("area", living_room_area.id),
+        ("device", wled_device.id),
+        ("entity", wled_segment_1.entity_id),
+        ("entity", wled_segment_2.entity_id),
+    ):
+        searcher = search.Searcher(hass, device_reg, entity_reg)
+        results = await searcher.search(search_type, search_id)
+        # Add the item we searched for, it's omitted from results
+        results.setdefault(search_type, set()).add(search_id)
+        assert (
+            results == expected
+        ), f"Results for {search_type}/{search_id} do not match up"
+
+
+async def test_ws_api(hass, hass_ws_client):
+    """Test WS API."""
+    assert await async_setup_component(hass, "search", {})
+
+    area_reg = await hass.helpers.area_registry.async_get_registry()
+    device_reg = await hass.helpers.device_registry.async_get_registry()
+
+    kitchen_area = area_reg.async_create("Kitchen")
+
+    hue_config_entry = MockConfigEntry(domain="hue")
+    hue_config_entry.add_to_hass(hass)
+
+    hue_device = device_reg.async_get_or_create(
+        config_entry_id=hue_config_entry.entry_id,
+        name="Light Strip",
+        identifiers=({"hue", "hue-1"}),
+    )
+
+    device_reg.async_update_device(hue_device.id, area_id=kitchen_area.id)
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 1, "type": "search", "item_type": "device", "item_id": hue_device.id}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {"area": [kitchen_area.id]}

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -117,7 +117,7 @@ async def test_search(hass):
         ("scene", "scene.scene_wled_seg_1"),
     ):
         searcher = search.Searcher(hass, device_reg, entity_reg)
-        results = await searcher.search(search_type, search_id)
+        results = searcher.async_search(search_type, search_id)
         # Add the item we searched for, it's omitted from results
         results.setdefault(search_type, set()).add(search_id)
 
@@ -127,7 +127,7 @@ async def test_search(hass):
 
     # For combined scene, needs to return everything.
     searcher = search.Searcher(hass, device_reg, entity_reg)
-    assert await searcher.search("scene", "scene.scene_wled_hue") == {
+    assert searcher.async_search("scene", "scene.scene_wled_hue") == {
         "config_entry": {wled_config_entry.entry_id, hue_config_entry.entry_id},
         "area": {living_room_area.id, kitchen_area.id},
         "device": {wled_device.id, hue_device.id},
@@ -164,7 +164,12 @@ async def test_ws_api(hass, hass_ws_client):
     client = await hass_ws_client(hass)
 
     await client.send_json(
-        {"id": 1, "type": "search", "item_type": "device", "item_id": hue_device.id}
+        {
+            "id": 1,
+            "type": "search/related",
+            "item_type": "device",
+            "item_id": hue_device.id,
+        }
     )
     response = await client.receive_json()
     assert response["success"]


### PR DESCRIPTION
## Description:
Our data is interconnected, making it a graph. This means that we can also search it as a graph. This integration can give you related items based on any node in the graph. Currently implemented areas, devices, entities, config entry, scene. Leaving script/automation for a future PR.

<img width="745" alt="image" src="https://user-images.githubusercontent.com/1444314/71894213-edcb7c00-314d-11ea-898d-26be3981e19d.png">


Goal of this integration will be to provide related data in the UI. Example use cases:
 - Show scenes that impact a specific area
 - List automations that use a specific input_boolean

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
