### PR TITLE
Use collection helpers for input_boolean

### DIFF
--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -217,5 +217,4 @@ class InputBoolean(ToggleEntity, RestoreEntity):
     async def async_update_config(self, config: typing.Dict) -> None:
         """Handle when the config is updated."""
         self._config = config
-        self._state = config.get(CONF_INITIAL, self._state)
         self.async_write_ha_state()

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -218,4 +218,4 @@ class InputBoolean(ToggleEntity, RestoreEntity):
         """Handle when the config is updated."""
         self._config = config
         self._state = config.get(CONF_INITIAL, self._state)
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -52,7 +52,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
 STORAGE_KEY = DOMAIN
-STORAKE_VERSION = 1
+STORAGE_VERSION = 1
 
 
 class InputBooleanStorageCollection(collection.StorageCollection):
@@ -104,7 +104,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     )
 
     storage_collection = InputBooleanStorageCollection(
-        Store(hass, STORAKE_VERSION, STORAGE_KEY),
+        Store(hass, STORAGE_VERSION, STORAGE_KEY),
         logging.getLogger(f"{__name__}_storage_collection"),
         id_manager,
     )

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -109,7 +109,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         id_manager,
     )
     collection.attach_entity_component_collection(
-        component, storage_collection, lambda conf: InputBoolean(conf)
+        component, storage_collection, InputBoolean
     )
 
     await yaml_collection.async_load(_filter_yaml(config))

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -5,6 +5,7 @@ import typing
 import voluptuous as vol
 
 from homeassistant.const import (
+    ATTR_EDITABLE,
     CONF_ICON,
     CONF_ID,
     CONF_NAME,
@@ -154,8 +155,10 @@ class InputBoolean(ToggleEntity, RestoreEntity):
     def __init__(self, config: typing.Optional[dict], from_yaml: bool = False):
         """Initialize a boolean input."""
         self._config = config
+        self._editable = True
         self._state = config.get(CONF_INITIAL)
         if from_yaml:
+            self._editable = False
             self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
 
     @property
@@ -167,6 +170,11 @@ class InputBoolean(ToggleEntity, RestoreEntity):
     def name(self):
         """Return name of the boolean input."""
         return self._config.get(CONF_NAME)
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the entity."""
+        return {ATTR_EDITABLE: self._editable}
 
     @property
     def icon(self):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -318,6 +318,7 @@ ATTR_GPS_ACCURACY = "gps_accuracy"
 ATTR_ASSUMED_STATE = "assumed_state"
 ATTR_STATE = "state"
 
+ATTR_EDITABLE = "editable"
 ATTR_OPTION = "option"
 
 # Bitfield of supported component features for the entity

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -263,7 +263,7 @@ async def test_reload(hass, hass_admin_user):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
-    assert STATE_OFF == state_2.state
+    assert STATE_ON == state_2.state  # reload is not supposed to change entity state
     assert "Hello World reloaded" == state_2.attributes.get(ATTR_FRIENDLY_NAME)
     assert "mdi:work_reloaded" == state_2.attributes.get(ATTR_ICON)
 

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -3,11 +3,15 @@
 import logging
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.input_boolean import CONF_INITIAL, DOMAIN, is_on
 from homeassistant.const import (
+    ATTR_EDITABLE,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
+    ATTR_NAME,
     SERVICE_RELOAD,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
@@ -22,6 +26,26 @@ from homeassistant.setup import async_setup_component
 from tests.common import mock_component, mock_restore_cache
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def storage_setup(hass, hass_storage):
+    """Storage setup."""
+
+    async def _storage(items=None, config=None):
+        if items is None:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {"items": [{"id": "from_storage", "name": "from storage"}]},
+            }
+        else:
+            hass_storage[DOMAIN] = items
+        if config is None:
+            config = {DOMAIN: {}}
+        return await async_setup_component(hass, DOMAIN, config)
+
+    return _storage
 
 
 async def test_config(hass):
@@ -242,3 +266,71 @@ async def test_reload(hass, hass_admin_user):
     assert STATE_OFF == state_2.state
     assert "Hello World reloaded" == state_2.attributes.get(ATTR_FRIENDLY_NAME)
     assert "mdi:work_reloaded" == state_2.attributes.get(ATTR_ICON)
+
+
+async def test_load_person_storage(hass, storage_setup):
+    """Test set up from storage."""
+    assert await storage_setup()
+    state = hass.states.get(f"{DOMAIN}.from_storage")
+    assert state.state == STATE_OFF
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "from storage"
+    assert state.attributes.get(ATTR_EDITABLE)
+
+
+async def test_editable_state_attribute(hass, storage_setup):
+    """Test editable attribute."""
+    assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
+
+    state = hass.states.get(f"{DOMAIN}.from_storage")
+    assert state.state == STATE_OFF
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "from storage"
+    assert state.attributes.get(ATTR_EDITABLE)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state.state == STATE_OFF
+    assert not state.attributes.get(ATTR_EDITABLE)
+
+
+async def test_ws_list(hass, hass_ws_client, storage_setup):
+    """Test listing via WS."""
+    assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 6, "type": f"{DOMAIN}/list"})
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    storage_ent = "from_storage"
+    yaml_ent = "from_yaml"
+    result = {item["id"]: item for item in resp["result"]}
+
+    assert len(result) == 1
+    assert storage_ent in result
+    assert yaml_ent not in result
+    assert result[storage_ent][ATTR_NAME] == "from storage"
+
+
+async def test_ws_delete(hass, hass_ws_client, storage_setup):
+    """Test WS delete cleans up entity registry."""
+    assert await storage_setup()
+
+    input_id = "from_storage"
+    input_entity_id = f"{DOMAIN}.{input_id}"
+    ent_reg = await entity_registry.async_get_registry(hass)
+
+    state = hass.states.get(input_entity_id)
+    assert state is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 6, "type": f"{DOMAIN}/delete", f"{DOMAIN}_id": f"{input_id}"}
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(input_entity_id)
+    assert state is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import Context, CoreState, State
+from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component, mock_restore_cache
@@ -169,6 +170,7 @@ async def test_input_boolean_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
+    ent_reg = await entity_registry.async_get_registry(hass)
 
     _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
 
@@ -195,6 +197,10 @@ async def test_reload(hass, hass_admin_user):
     assert state_2 is not None
     assert state_3 is None
     assert STATE_ON == state_2.state
+
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
 
     with patch(
         "homeassistant.config.load_yaml_config_file",
@@ -228,6 +234,10 @@ async def test_reload(hass, hass_admin_user):
     assert state_1 is None
     assert state_2 is not None
     assert state_3 is not None
+
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
     assert STATE_OFF == state_2.state
     assert "Hello World reloaded" == state_2.attributes.get(ATTR_FRIENDLY_NAME)


### PR DESCRIPTION
## Description:
Use collections helpers from #30313 to manage `input_boolean` entities.
Need to add tests, but wanted some feed back:

@balloob just need some clarifications: https://github.com/Adminiuga/home-assistant/blob/d78b8e7df99b7e3c1e826f8638553c2c3f72f3ac/homeassistant/components/person/__init__.py#L204 is just a hint what would be used for the `unique_id`, isn't it? For person integration it was required by `CONFIG_SCHEMA`. How should we approach cases like `input_boolean`? Should introduce a new __required__ field in `CREATE_SCHEMA` or should we just make `name` field mandatory? For now I went with requiring the name field. 

**Related issue (if applicable):** fixes #30494 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
