### PR TITLE
Correct integration names in manifests (A-B)

### DIFF
--- a/homeassistant/components/acer_projector/manifest.json
+++ b/homeassistant/components/acer_projector/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "acer_projector",
-  "name": "Acer projector",
+  "name": "Acer Projector",
   "documentation": "https://www.home-assistant.io/integrations/acer_projector",
   "requirements": ["pyserial==3.1.1"],
   "dependencies": [],

--- a/homeassistant/components/ads/manifest.json
+++ b/homeassistant/components/ads/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ads",
-  "name": "Ads",
+  "name": "ADS",
   "documentation": "https://www.home-assistant.io/integrations/ads",
   "requirements": ["pyads==3.0.7"],
   "dependencies": [],

--- a/homeassistant/components/aftership/manifest.json
+++ b/homeassistant/components/aftership/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aftership",
-  "name": "Aftership",
+  "name": "AfterShip",
   "documentation": "https://www.home-assistant.io/integrations/aftership",
   "requirements": ["pyaftership==0.1.2"],
   "dependencies": [],

--- a/homeassistant/components/air_quality/manifest.json
+++ b/homeassistant/components/air_quality/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "air_quality",
-  "name": "Air quality",
+  "name": "Air Quality",
   "documentation": "https://www.home-assistant.io/integrations/air_quality",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/airvisual/manifest.json
+++ b/homeassistant/components/airvisual/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "airvisual",
-  "name": "Airvisual",
+  "name": "AirVisual",
   "documentation": "https://www.home-assistant.io/integrations/airvisual",
   "requirements": ["pyairvisual==3.0.1"],
   "dependencies": [],

--- a/homeassistant/components/aladdin_connect/manifest.json
+++ b/homeassistant/components/aladdin_connect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aladdin_connect",
-  "name": "Aladdin connect",
+  "name": "Aladdin Connect",
   "documentation": "https://www.home-assistant.io/integrations/aladdin_connect",
   "requirements": ["aladdin_connect==0.3"],
   "dependencies": [],

--- a/homeassistant/components/alarm_control_panel/manifest.json
+++ b/homeassistant/components/alarm_control_panel/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "alarm_control_panel",
-  "name": "Alarm control panel",
+  "name": "Alarm Control Panel",
   "documentation": "https://www.home-assistant.io/integrations/alarm_control_panel",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/alarmdecoder/manifest.json
+++ b/homeassistant/components/alarmdecoder/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "alarmdecoder",
-  "name": "Alarmdecoder",
+  "name": "AlarmDecoder",
   "documentation": "https://www.home-assistant.io/integrations/alarmdecoder",
   "requirements": ["alarmdecoder==1.13.9"],
   "dependencies": [],

--- a/homeassistant/components/alarmdotcom/manifest.json
+++ b/homeassistant/components/alarmdotcom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "alarmdotcom",
-  "name": "Alarmdotcom",
+  "name": "Alarm.com",
   "documentation": "https://www.home-assistant.io/integrations/alarmdotcom",
   "requirements": ["pyalarmdotcom==0.3.2"],
   "dependencies": [],

--- a/homeassistant/components/alexa/manifest.json
+++ b/homeassistant/components/alexa/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "alexa",
-  "name": "Alexa",
+  "name": "Amazon Alexa",
   "documentation": "https://www.home-assistant.io/integrations/alexa",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/amazon_polly/manifest.json
+++ b/homeassistant/components/amazon_polly/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "amazon_polly",
-  "name": "Amazon polly",
+  "name": "Amazon Polly",
   "documentation": "https://www.home-assistant.io/integrations/amazon_polly",
   "requirements": ["boto3==1.9.252"],
   "dependencies": [],

--- a/homeassistant/components/ambient_station/manifest.json
+++ b/homeassistant/components/ambient_station/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ambient_station",
-  "name": "Ambient station",
+  "name": "Ambient Weather Station",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ambient_station",
   "requirements": ["aioambient==1.0.2"],

--- a/homeassistant/components/ampio/manifest.json
+++ b/homeassistant/components/ampio/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ampio",
-  "name": "Ampio",
+  "name": "Ampio Smart Smog System",
   "documentation": "https://www.home-assistant.io/integrations/ampio",
   "requirements": ["asmog==0.0.6"],
   "dependencies": [],

--- a/homeassistant/components/android_ip_webcam/manifest.json
+++ b/homeassistant/components/android_ip_webcam/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "android_ip_webcam",
-  "name": "Android ip webcam",
+  "name": "Android IP Webcam",
   "documentation": "https://www.home-assistant.io/integrations/android_ip_webcam",
   "requirements": ["pydroid-ipcam==0.8"],
   "dependencies": [],

--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "androidtv",
-  "name": "Androidtv",
+  "name": "Android TV",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
     "adb-shell==0.1.0",

--- a/homeassistant/components/anel_pwrctrl/manifest.json
+++ b/homeassistant/components/anel_pwrctrl/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "anel_pwrctrl",
-  "name": "Anel pwrctrl",
+  "name": "Anel NET-PwrCtrl",
   "documentation": "https://www.home-assistant.io/integrations/anel_pwrctrl",
   "requirements": ["anel_pwrctrl-homeassistant==0.0.1.dev2"],
   "dependencies": [],

--- a/homeassistant/components/anthemav/manifest.json
+++ b/homeassistant/components/anthemav/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "anthemav",
-  "name": "Anthemav",
+  "name": "Anthem A/V Receivers",
   "documentation": "https://www.home-assistant.io/integrations/anthemav",
   "requirements": ["anthemav==1.1.10"],
   "dependencies": [],

--- a/homeassistant/components/apcupsd/manifest.json
+++ b/homeassistant/components/apcupsd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "apcupsd",
-  "name": "Apcupsd",
+  "name": "APCUPSd",
   "documentation": "https://www.home-assistant.io/integrations/apcupsd",
   "requirements": ["apcaccess==0.0.13"],
   "dependencies": [],

--- a/homeassistant/components/apns/manifest.json
+++ b/homeassistant/components/apns/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "apns",
-  "name": "Apns",
+  "name": "Apple Push Notification Service (APNS)",
   "documentation": "https://www.home-assistant.io/integrations/apns",
   "requirements": ["apns2==0.3.0"],
   "dependencies": [],

--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "apple_tv",
-  "name": "Apple tv",
+  "name": "Apple TV",
   "documentation": "https://www.home-assistant.io/integrations/apple_tv",
   "requirements": ["pyatv==0.3.13"],
   "dependencies": ["configurator"],

--- a/homeassistant/components/aqualogic/manifest.json
+++ b/homeassistant/components/aqualogic/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aqualogic",
-  "name": "Aqualogic",
+  "name": "AquaLogic",
   "documentation": "https://www.home-assistant.io/integrations/aqualogic",
   "requirements": ["aqualogic==1.0"],
   "dependencies": [],

--- a/homeassistant/components/aquostv/manifest.json
+++ b/homeassistant/components/aquostv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aquostv",
-  "name": "Aquostv",
+  "name": "Sharp Aquos TV",
   "documentation": "https://www.home-assistant.io/integrations/aquostv",
   "requirements": ["sharp_aquos_rc==0.3.2"],
   "dependencies": [],

--- a/homeassistant/components/arcam_fmj/manifest.json
+++ b/homeassistant/components/arcam_fmj/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "arcam_fmj",
-  "name": "Arcam FMJ Receiver control",
+  "name": "Arcam FMJ Receivers",
   "config_flow": false,
   "documentation": "https://www.home-assistant.io/integrations/arcam_fmj",
   "requirements": ["arcam-fmj==0.4.3"],

--- a/homeassistant/components/arest/manifest.json
+++ b/homeassistant/components/arest/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "arest",
-  "name": "Arest",
+  "name": "aREST",
   "documentation": "https://www.home-assistant.io/integrations/arest",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/arwn/manifest.json
+++ b/homeassistant/components/arwn/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "arwn",
-  "name": "Arwn",
+  "name": "Ambient Radio Weather Network",
   "documentation": "https://www.home-assistant.io/integrations/arwn",
   "requirements": [],
   "dependencies": ["mqtt"],

--- a/homeassistant/components/asterisk_cdr/manifest.json
+++ b/homeassistant/components/asterisk_cdr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "asterisk_cdr",
-  "name": "Asterisk cdr",
+  "name": "Asterisk Call Data Recorder",
   "documentation": "https://www.home-assistant.io/integrations/asterisk_cdr",
   "requirements": [],
   "dependencies": ["asterisk_mbox"],

--- a/homeassistant/components/asterisk_cdr/manifest.json
+++ b/homeassistant/components/asterisk_cdr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "asterisk_cdr",
-  "name": "Asterisk Call Data Recorder",
+  "name": "Asterisk Call Detail Records",
   "documentation": "https://www.home-assistant.io/integrations/asterisk_cdr",
   "requirements": [],
   "dependencies": ["asterisk_mbox"],

--- a/homeassistant/components/asterisk_mbox/manifest.json
+++ b/homeassistant/components/asterisk_mbox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "asterisk_mbox",
-  "name": "Asterisk mbox",
+  "name": "Asterisk Voicemail",
   "documentation": "https://www.home-assistant.io/integrations/asterisk_mbox",
   "requirements": ["asterisk_mbox==0.5.0"],
   "dependencies": [],

--- a/homeassistant/components/aten_pe/manifest.json
+++ b/homeassistant/components/aten_pe/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aten_pe",
-  "name": "ATEN eco PDUs",
+  "name": "ATEN Rack PDU",
   "documentation": "https://www.home-assistant.io/integrations/aten_pe",
   "requirements": ["atenpdu==0.3.0"],
   "dependencies": [],

--- a/homeassistant/components/atome/manifest.json
+++ b/homeassistant/components/atome/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "atome",
-  "name": "Atome",
+  "name": "Atome Linky",
   "documentation": "https://www.home-assistant.io/integrations/atome",
   "dependencies": [],
   "codeowners": ["@baqs"],

--- a/homeassistant/components/avion/manifest.json
+++ b/homeassistant/components/avion/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "avion",
-  "name": "Avion",
+  "name": "Avi-on",
   "documentation": "https://www.home-assistant.io/integrations/avion",
   "requirements": ["avion==0.10"],
   "dependencies": [],

--- a/homeassistant/components/aws/manifest.json
+++ b/homeassistant/components/aws/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aws",
-  "name": "Aws",
+  "name": "Amazon Web Services",
   "documentation": "https://www.home-assistant.io/integrations/aws",
   "requirements": ["aiobotocore==0.10.4"],
   "dependencies": [],

--- a/homeassistant/components/baidu/manifest.json
+++ b/homeassistant/components/baidu/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "baidu",
-  "name": "Baidu TTS",
+  "name": "Baidu",
   "documentation": "https://www.home-assistant.io/integrations/baidu",
   "requirements": ["baidu-aip==1.6.6"],
   "dependencies": [],

--- a/homeassistant/components/baidu/manifest.json
+++ b/homeassistant/components/baidu/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "baidu",
-  "name": "Baidu",
+  "name": "Baidu TTS",
   "documentation": "https://www.home-assistant.io/integrations/baidu",
   "requirements": ["baidu-aip==1.6.6"],
   "dependencies": [],

--- a/homeassistant/components/bbb_gpio/manifest.json
+++ b/homeassistant/components/bbb_gpio/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bbb_gpio",
-  "name": "Bbb gpio",
+  "name": "BeagleBone Black GPIO",
   "documentation": "https://www.home-assistant.io/integrations/bbb_gpio",
   "requirements": ["Adafruit_BBIO==1.0.0"],
   "dependencies": [],

--- a/homeassistant/components/bh1750/manifest.json
+++ b/homeassistant/components/bh1750/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bh1750",
-  "name": "Bh1750",
+  "name": "BH1750",
   "documentation": "https://www.home-assistant.io/integrations/bh1750",
   "requirements": ["i2csense==0.0.4", "smbus-cffi==0.5.1"],
   "dependencies": [],

--- a/homeassistant/components/binary_sensor/manifest.json
+++ b/homeassistant/components/binary_sensor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "binary_sensor",
-  "name": "Binary sensor",
+  "name": "Binary Sensor",
   "documentation": "https://www.home-assistant.io/integrations/binary_sensor",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/blackbird/manifest.json
+++ b/homeassistant/components/blackbird/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "blackbird",
-  "name": "Blackbird",
+  "name": "Monoprice Blackbird Matrix Switch",
   "documentation": "https://www.home-assistant.io/integrations/blackbird",
   "requirements": ["pyblackbird==0.5"],
   "dependencies": [],

--- a/homeassistant/components/blinksticklight/manifest.json
+++ b/homeassistant/components/blinksticklight/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "blinksticklight",
-  "name": "Blinksticklight",
+  "name": "BlinkStick",
   "documentation": "https://www.home-assistant.io/integrations/blinksticklight",
   "requirements": ["blinkstick==1.1.8"],
   "dependencies": [],

--- a/homeassistant/components/blinkt/manifest.json
+++ b/homeassistant/components/blinkt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "blinkt",
-  "name": "Blinkt",
+  "name": "Blinkt!",
   "documentation": "https://www.home-assistant.io/integrations/blinkt",
   "requirements": ["blinkt==0.1.0"],
   "dependencies": [],

--- a/homeassistant/components/blockchain/manifest.json
+++ b/homeassistant/components/blockchain/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "blockchain",
-  "name": "Blockchain",
+  "name": "Blockchain.info",
   "documentation": "https://www.home-assistant.io/integrations/blockchain",
   "requirements": ["python-blockchain-api==0.0.2"],
   "dependencies": [],

--- a/homeassistant/components/bloomsky/manifest.json
+++ b/homeassistant/components/bloomsky/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bloomsky",
-  "name": "Bloomsky",
+  "name": "BloomSky",
   "documentation": "https://www.home-assistant.io/integrations/bloomsky",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/bluetooth_le_tracker/manifest.json
+++ b/homeassistant/components/bluetooth_le_tracker/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bluetooth_le_tracker",
-  "name": "Bluetooth le tracker",
+  "name": "Bluetooth LE Tracker",
   "documentation": "https://www.home-assistant.io/integrations/bluetooth_le_tracker",
   "requirements": ["pygatt[GATTTOOL]==4.0.5"],
   "dependencies": [],

--- a/homeassistant/components/bluetooth_tracker/manifest.json
+++ b/homeassistant/components/bluetooth_tracker/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bluetooth_tracker",
-  "name": "Bluetooth tracker",
+  "name": "Bluetooth Tracker",
   "documentation": "https://www.home-assistant.io/integrations/bluetooth_tracker",
   "requirements": ["bt_proximity==0.2", "pybluez==0.22"],
   "dependencies": [],

--- a/homeassistant/components/bme280/manifest.json
+++ b/homeassistant/components/bme280/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bme280",
-  "name": "Bme280",
+  "name": "Bosch BME280 Environmental Sensor",
   "documentation": "https://www.home-assistant.io/integrations/bme280",
   "requirements": ["i2csense==0.0.4", "smbus-cffi==0.5.1"],
   "dependencies": [],

--- a/homeassistant/components/bme680/manifest.json
+++ b/homeassistant/components/bme680/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bme680",
-  "name": "Bme680",
+  "name": "Bosch BME680 Environmental Sensor",
   "documentation": "https://www.home-assistant.io/integrations/bme680",
   "requirements": ["bme680==1.0.5", "smbus-cffi==0.5.1"],
   "dependencies": [],

--- a/homeassistant/components/bom/manifest.json
+++ b/homeassistant/components/bom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bom",
-  "name": "Bom",
+  "name": "Australian Bureau of Meteorology (BOM)",
   "documentation": "https://www.home-assistant.io/integrations/bom",
   "requirements": ["bomradarloop==0.1.3"],
   "dependencies": [],

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "braviatv",
-  "name": "Braviatv",
+  "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
   "requirements": ["braviarc-homeassistant==0.3.7.dev0", "getmac==0.8.1"],
   "dependencies": ["configurator"],

--- a/homeassistant/components/brunt/manifest.json
+++ b/homeassistant/components/brunt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "brunt",
-  "name": "Brunt",
+  "name": "Brunt Blind Engine",
   "documentation": "https://www.home-assistant.io/integrations/brunt",
   "requirements": ["brunt==0.1.3"],
   "dependencies": [],

--- a/homeassistant/components/bt_home_hub_5/manifest.json
+++ b/homeassistant/components/bt_home_hub_5/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bt_home_hub_5",
-  "name": "Bt home hub 5",
+  "name": "BT Home Hub 5",
   "documentation": "https://www.home-assistant.io/integrations/bt_home_hub_5",
   "requirements": ["bthomehub5-devicelist==0.1.1"],
   "dependencies": [],

--- a/homeassistant/components/bt_smarthub/manifest.json
+++ b/homeassistant/components/bt_smarthub/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bt_smarthub",
-  "name": "Bt smarthub",
+  "name": "BT Smart Hub",
   "documentation": "https://www.home-assistant.io/integrations/bt_smarthub",
   "requirements": ["btsmarthub_devicelist==0.1.3"],
   "dependencies": [],


### PR DESCRIPTION
## Description:

I'm working on getting some things synced between our documentation and the codebase (making the codebase the source of truth). The title/name of the integration is a great starting point for this.

However, the product/brand/integration names are often misspelled, incorrect or incomplete. This PR corrects a bunch of those.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. 

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
