### PR TITLE
Correct names in manifests (C-L)

### DIFF
--- a/homeassistant/components/caldav/manifest.json
+++ b/homeassistant/components/caldav/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "caldav",
-  "name": "Caldav",
+  "name": "CalDav",
   "documentation": "https://www.home-assistant.io/integrations/caldav",
   "requirements": ["caldav==0.6.1"],
   "dependencies": [],

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cast",
-  "name": "Cast",
+  "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
   "requirements": ["pychromecast==4.0.1"],

--- a/homeassistant/components/cert_expiry/manifest.json
+++ b/homeassistant/components/cert_expiry/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cert_expiry",
-  "name": "Cert expiry",
+  "name": "Certificate Expiry",
   "documentation": "https://www.home-assistant.io/integrations/cert_expiry",
   "requirements": [],
   "config_flow": true,

--- a/homeassistant/components/cisco_ios/manifest.json
+++ b/homeassistant/components/cisco_ios/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cisco_ios",
-  "name": "Cisco ios",
+  "name": "Cisco IOS",
   "documentation": "https://www.home-assistant.io/integrations/cisco_ios",
   "requirements": ["pexpect==4.6.0"],
   "dependencies": [],

--- a/homeassistant/components/cisco_mobility_express/manifest.json
+++ b/homeassistant/components/cisco_mobility_express/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cisco_mobility_express",
-  "name": "Cisco mobility express",
+  "name": "Cisco Mobility Express",
   "documentation": "https://www.home-assistant.io/integrations/cisco_mobility_express",
   "requirements": ["ciscomobilityexpress==0.3.3"],
   "dependencies": [],

--- a/homeassistant/components/cisco_webex_teams/manifest.json
+++ b/homeassistant/components/cisco_webex_teams/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cisco_webex_teams",
-  "name": "Cisco webex teams",
+  "name": "Cisco Webex Teams",
   "documentation": "https://www.home-assistant.io/integrations/cisco_webex_teams",
   "requirements": ["webexteamssdk==1.1.1"],
   "dependencies": [],

--- a/homeassistant/components/ciscospark/manifest.json
+++ b/homeassistant/components/ciscospark/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ciscospark",
-  "name": "Ciscospark",
+  "name": "Cisco Spark",
   "documentation": "https://www.home-assistant.io/integrations/ciscospark",
   "requirements": ["ciscosparkapi==0.4.2"],
   "dependencies": [],

--- a/homeassistant/components/citybikes/manifest.json
+++ b/homeassistant/components/citybikes/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "citybikes",
-  "name": "Citybikes",
+  "name": "CityBikes",
   "documentation": "https://www.home-assistant.io/integrations/citybikes",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/clementine/manifest.json
+++ b/homeassistant/components/clementine/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "clementine",
-  "name": "Clementine",
+  "name": "Clementine Music Player",
   "documentation": "https://www.home-assistant.io/integrations/clementine",
   "requirements": ["python-clementine-remote==1.0.1"],
   "dependencies": [],

--- a/homeassistant/components/clicksend/manifest.json
+++ b/homeassistant/components/clicksend/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "clicksend",
-  "name": "Clicksend",
+  "name": "ClickSend SMS",
   "documentation": "https://www.home-assistant.io/integrations/clicksend",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/clicksend_tts/manifest.json
+++ b/homeassistant/components/clicksend_tts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "clicksend_tts",
-  "name": "Clicksend tts",
+  "name": "ClickSend TTS",
   "documentation": "https://www.home-assistant.io/integrations/clicksend_tts",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cloud",
-  "name": "Cloud",
+  "name": "Home Assistant Cloud",
   "documentation": "https://www.home-assistant.io/integrations/cloud",
   "requirements": ["hass-nabucasa==0.30"],
   "dependencies": ["http", "webhook"],

--- a/homeassistant/components/cmus/manifest.json
+++ b/homeassistant/components/cmus/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cmus",
-  "name": "Cmus",
+  "name": "cmus",
   "documentation": "https://www.home-assistant.io/integrations/cmus",
   "requirements": ["pycmus==0.1.1"],
   "dependencies": [],

--- a/homeassistant/components/co2signal/manifest.json
+++ b/homeassistant/components/co2signal/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "co2signal",
-  "name": "Co2signal",
+  "name": "CO2 Signal",
   "documentation": "https://www.home-assistant.io/integrations/co2signal",
   "requirements": ["co2signal==0.4.2"],
   "dependencies": [],

--- a/homeassistant/components/coinmarketcap/manifest.json
+++ b/homeassistant/components/coinmarketcap/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "coinmarketcap",
-  "name": "Coinmarketcap",
+  "name": "CoinMarketCap",
   "documentation": "https://www.home-assistant.io/integrations/coinmarketcap",
   "requirements": ["coinmarketcap==5.0.3"],
   "dependencies": [],

--- a/homeassistant/components/comed_hourly_pricing/manifest.json
+++ b/homeassistant/components/comed_hourly_pricing/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "comed_hourly_pricing",
-  "name": "Comed hourly pricing",
+  "name": "ComEd Hourly Pricing",
   "documentation": "https://www.home-assistant.io/integrations/comed_hourly_pricing",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/comfoconnect/manifest.json
+++ b/homeassistant/components/comfoconnect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "comfoconnect",
-  "name": "Comfoconnect",
+  "name": "Zehnder ComfoAir Q",
   "documentation": "https://www.home-assistant.io/integrations/comfoconnect",
   "requirements": ["pycomfoconnect==0.3"],
   "dependencies": [],

--- a/homeassistant/components/command_line/manifest.json
+++ b/homeassistant/components/command_line/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "command_line",
-  "name": "Command line",
+  "name": "Command Line",
   "documentation": "https://www.home-assistant.io/integrations/command_line",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/coolmaster/manifest.json
+++ b/homeassistant/components/coolmaster/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "coolmaster",
-  "name": "Coolmaster",
+  "name": "CoolMasterNet",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/coolmaster",
   "requirements": ["pycoolmasternet==0.0.4"],

--- a/homeassistant/components/cppm_tracker/manifest.json
+++ b/homeassistant/components/cppm_tracker/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cppm_tracker",
-  "name": "Cppm tracker",
+  "name": "Aruba ClearPass",
   "documentation": "https://www.home-assistant.io/integrations/cppm_tracker",
   "requirements": ["clearpasspy==1.0.2"],
   "dependencies": [],

--- a/homeassistant/components/cpuspeed/manifest.json
+++ b/homeassistant/components/cpuspeed/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cpuspeed",
-  "name": "Cpuspeed",
+  "name": "CPU Speed",
   "documentation": "https://www.home-assistant.io/integrations/cpuspeed",
   "requirements": ["py-cpuinfo==5.0.0"],
   "dependencies": [],

--- a/homeassistant/components/crimereports/manifest.json
+++ b/homeassistant/components/crimereports/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "crimereports",
-  "name": "Crimereports",
+  "name": "Crime Reports",
   "documentation": "https://www.home-assistant.io/integrations/crimereports",
   "requirements": ["crimereports==1.0.1"],
   "dependencies": [],

--- a/homeassistant/components/cups/manifest.json
+++ b/homeassistant/components/cups/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "cups",
-  "name": "Cups",
+  "name": "CUPS",
   "documentation": "https://www.home-assistant.io/integrations/cups",
   "requirements": ["pycups==1.9.73"],
   "dependencies": [],

--- a/homeassistant/components/currencylayer/manifest.json
+++ b/homeassistant/components/currencylayer/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "currencylayer",
-  "name": "Currencylayer",
+  "name": "currencylayer",
   "documentation": "https://www.home-assistant.io/integrations/currencylayer",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "daikin",
-  "name": "Daikin",
+  "name": "Daikin AC",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
   "requirements": ["pydaikin==1.6.1"],

--- a/homeassistant/components/danfoss_air/manifest.json
+++ b/homeassistant/components/danfoss_air/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "danfoss_air",
-  "name": "Danfoss air",
+  "name": "Danfoss Air",
   "documentation": "https://www.home-assistant.io/integrations/danfoss_air",
   "requirements": ["pydanfossair==0.1.0"],
   "dependencies": [],

--- a/homeassistant/components/darksky/manifest.json
+++ b/homeassistant/components/darksky/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "darksky",
-  "name": "Darksky",
+  "name": "Dark Sky",
   "documentation": "https://www.home-assistant.io/integrations/darksky",
   "requirements": ["python-forecastio==1.4.0"],
   "dependencies": [],

--- a/homeassistant/components/ddwrt/manifest.json
+++ b/homeassistant/components/ddwrt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ddwrt",
-  "name": "Ddwrt",
+  "name": "DD-WRT",
   "documentation": "https://www.home-assistant.io/integrations/ddwrt",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "deconz",
-  "name": "Deconz",
+  "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
   "requirements": ["pydeconz==67"],

--- a/homeassistant/components/decora/manifest.json
+++ b/homeassistant/components/decora/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "decora",
-  "name": "Decora",
+  "name": "Leviton Decora",
   "documentation": "https://www.home-assistant.io/integrations/decora",
   "requirements": ["bluepy==1.3.0", "decora==0.6"],
   "dependencies": [],

--- a/homeassistant/components/decora_wifi/manifest.json
+++ b/homeassistant/components/decora_wifi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "decora_wifi",
-  "name": "Decora wifi",
+  "name": "Leviton Decora Wi-Fi",
   "documentation": "https://www.home-assistant.io/integrations/decora_wifi",
   "requirements": ["decora_wifi==1.4"],
   "dependencies": [],

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "default_config",
-  "name": "Default config",
+  "name": "Default Csonfig",
   "documentation": "https://www.home-assistant.io/integrations/default_config",
   "requirements": [],
   "dependencies": [

--- a/homeassistant/components/denon/manifest.json
+++ b/homeassistant/components/denon/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "denon",
-  "name": "Denon",
+  "name": "Denon Network Receivers",
   "documentation": "https://www.home-assistant.io/integrations/denon",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "denonavr",
-  "name": "Denonavr",
+  "name": "Denon AVR Network Receivers",
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
   "requirements": ["denonavr==0.7.11"],
   "dependencies": [],

--- a/homeassistant/components/deutsche_bahn/manifest.json
+++ b/homeassistant/components/deutsche_bahn/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "deutsche_bahn",
-  "name": "Deutsche bahn",
+  "name": "Deutsche Bahn",
   "documentation": "https://www.home-assistant.io/integrations/deutsche_bahn",
   "requirements": ["schiene==0.23"],
   "dependencies": [],

--- a/homeassistant/components/device_automation/manifest.json
+++ b/homeassistant/components/device_automation/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "device_automation",
-  "name": "Device automation",
+  "name": "Device Automation",
   "documentation": "https://www.home-assistant.io/integrations/device_automation",
   "requirements": [],
   "dependencies": ["webhook"],

--- a/homeassistant/components/device_sun_light_trigger/manifest.json
+++ b/homeassistant/components/device_sun_light_trigger/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "device_sun_light_trigger",
-  "name": "Device sun light trigger",
+  "name": "Presence-based Lights",
   "documentation": "https://www.home-assistant.io/integrations/device_sun_light_trigger",
   "requirements": [],
   "dependencies": ["device_tracker", "group", "light", "person"],

--- a/homeassistant/components/device_tracker/manifest.json
+++ b/homeassistant/components/device_tracker/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "device_tracker",
-  "name": "Device tracker",
+  "name": "Device Tracker",
   "documentation": "https://www.home-assistant.io/integrations/device_tracker",
   "requirements": [],
   "dependencies": ["group", "zone"],

--- a/homeassistant/components/dht/manifest.json
+++ b/homeassistant/components/dht/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dht",
-  "name": "Dht",
+  "name": "DHT Sensor",
   "documentation": "https://www.home-assistant.io/integrations/dht",
   "requirements": ["Adafruit-DHT==1.4.0"],
   "dependencies": [],

--- a/homeassistant/components/digital_ocean/manifest.json
+++ b/homeassistant/components/digital_ocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "digital_ocean",
-  "name": "Digital ocean",
+  "name": "Digital Ocean",
   "documentation": "https://www.home-assistant.io/integrations/digital_ocean",
   "requirements": ["python-digitalocean==1.13.2"],
   "dependencies": [],

--- a/homeassistant/components/digitalloggers/manifest.json
+++ b/homeassistant/components/digitalloggers/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "digitalloggers",
-  "name": "Digitalloggers",
+  "name": "Digital Loggers",
   "documentation": "https://www.home-assistant.io/integrations/digitalloggers",
   "requirements": ["dlipower==0.7.165"],
   "dependencies": [],

--- a/homeassistant/components/directv/manifest.json
+++ b/homeassistant/components/directv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "directv",
-  "name": "Directv",
+  "name": "DirecTV",
   "documentation": "https://www.home-assistant.io/integrations/directv",
   "requirements": ["directpy==0.5"],
   "dependencies": [],

--- a/homeassistant/components/dlib_face_detect/manifest.json
+++ b/homeassistant/components/dlib_face_detect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dlib_face_detect",
-  "name": "Dlib face detect",
+  "name": "Dlib Face Detect",
   "documentation": "https://www.home-assistant.io/integrations/dlib_face_detect",
   "requirements": ["face_recognition==1.2.3"],
   "dependencies": [],

--- a/homeassistant/components/dlib_face_identify/manifest.json
+++ b/homeassistant/components/dlib_face_identify/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dlib_face_identify",
-  "name": "Dlib face identify",
+  "name": "Dlib Face Identify",
   "documentation": "https://www.home-assistant.io/integrations/dlib_face_identify",
   "requirements": ["face_recognition==1.2.3"],
   "dependencies": [],

--- a/homeassistant/components/dlink/manifest.json
+++ b/homeassistant/components/dlink/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dlink",
-  "name": "Dlink",
+  "name": "D-Link Wi-Fi Smart Plugs",
   "documentation": "https://www.home-assistant.io/integrations/dlink",
   "requirements": ["pyW215==0.6.0"],
   "dependencies": [],

--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dlna_dmr",
-  "name": "Dlna dmr",
+  "name": "DLNA Digital Media Renderer",
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
   "requirements": ["async-upnp-client==0.14.12"],
   "dependencies": [],

--- a/homeassistant/components/dnsip/manifest.json
+++ b/homeassistant/components/dnsip/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dnsip",
-  "name": "Dnsip",
+  "name": "DNS IP",
   "documentation": "https://www.home-assistant.io/integrations/dnsip",
   "requirements": ["aiodns==2.0.0"],
   "dependencies": [],

--- a/homeassistant/components/dominos/manifest.json
+++ b/homeassistant/components/dominos/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dominos",
-  "name": "Dominos",
+  "name": "Dominos Pizza",
   "documentation": "https://www.home-assistant.io/integrations/dominos",
   "requirements": ["pizzapi==0.0.3"],
   "dependencies": ["http"],

--- a/homeassistant/components/doorbird/manifest.json
+++ b/homeassistant/components/doorbird/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "doorbird",
-  "name": "Doorbird",
+  "name": "DoorBird",
   "documentation": "https://www.home-assistant.io/integrations/doorbird",
   "requirements": ["doorbirdpy==2.0.8"],
   "dependencies": ["http"],

--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dsmr",
-  "name": "Dsmr",
+  "name": "DSMR Slimme Meter",
   "documentation": "https://www.home-assistant.io/integrations/dsmr",
   "requirements": ["dsmr_parser==0.12"],
   "dependencies": [],

--- a/homeassistant/components/dte_energy_bridge/manifest.json
+++ b/homeassistant/components/dte_energy_bridge/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dte_energy_bridge",
-  "name": "Dte energy bridge",
+  "name": "DTE Energy Bridge",
   "documentation": "https://www.home-assistant.io/integrations/dte_energy_bridge",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/dublin_bus_transport/manifest.json
+++ b/homeassistant/components/dublin_bus_transport/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dublin_bus_transport",
-  "name": "Dublin bus transport",
+  "name": "Dublin Bus",
   "documentation": "https://www.home-assistant.io/integrations/dublin_bus_transport",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/duckdns/manifest.json
+++ b/homeassistant/components/duckdns/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "duckdns",
-  "name": "Duckdns",
+  "name": "Duck DNS",
   "documentation": "https://www.home-assistant.io/integrations/duckdns",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/duke_energy/manifest.json
+++ b/homeassistant/components/duke_energy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "duke_energy",
-  "name": "Duke energy",
+  "name": "Duke Energy",
   "documentation": "https://www.home-assistant.io/integrations/duke_energy",
   "requirements": ["pydukeenergy==0.0.6"],
   "dependencies": [],

--- a/homeassistant/components/dunehd/manifest.json
+++ b/homeassistant/components/dunehd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dunehd",
-  "name": "Dunehd",
+  "name": "DuneHD",
   "documentation": "https://www.home-assistant.io/integrations/dunehd",
   "requirements": ["pdunehd==1.3"],
   "dependencies": [],

--- a/homeassistant/components/dwd_weather_warnings/manifest.json
+++ b/homeassistant/components/dwd_weather_warnings/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dwd_weather_warnings",
-  "name": "Dwd weather warnings",
+  "name": "Deutsche Wetter Dienst (DWD) Weather Warnings",
   "documentation": "https://www.home-assistant.io/integrations/dwd_weather_warnings",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/dweet/manifest.json
+++ b/homeassistant/components/dweet/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dweet",
-  "name": "Dweet",
+  "name": "dweet.io",
   "documentation": "https://www.home-assistant.io/integrations/dweet",
   "requirements": ["dweepy==0.3.0"],
   "dependencies": [],

--- a/homeassistant/components/ebox/manifest.json
+++ b/homeassistant/components/ebox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ebox",
-  "name": "Ebox",
+  "name": "EBox",
   "documentation": "https://www.home-assistant.io/integrations/ebox",
   "requirements": ["pyebox==1.1.4"],
   "dependencies": [],

--- a/homeassistant/components/ebusd/manifest.json
+++ b/homeassistant/components/ebusd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ebusd",
-  "name": "Ebusd",
+  "name": "ebusd",
   "documentation": "https://www.home-assistant.io/integrations/ebusd",
   "requirements": ["ebusdpy==0.0.16"],
   "dependencies": [],

--- a/homeassistant/components/ecoal_boiler/manifest.json
+++ b/homeassistant/components/ecoal_boiler/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ecoal_boiler",
-  "name": "Ecoal boiler",
+  "name": "eSterownik eCoal.pl Boiler",
   "documentation": "https://www.home-assistant.io/integrations/ecoal_boiler",
   "requirements": ["ecoaliface==0.4.0"],
   "dependencies": [],

--- a/homeassistant/components/econet/manifest.json
+++ b/homeassistant/components/econet/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "econet",
-  "name": "Econet",
+  "name": "Rheem EcoNET Water Products",
   "documentation": "https://www.home-assistant.io/integrations/econet",
   "requirements": ["pyeconet==0.0.11"],
   "dependencies": [],

--- a/homeassistant/components/eddystone_temperature/manifest.json
+++ b/homeassistant/components/eddystone_temperature/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "eddystone_temperature",
-  "name": "Eddystone temperature",
+  "name": "Eddystone",
   "documentation": "https://www.home-assistant.io/integrations/eddystone_temperature",
   "requirements": ["beacontools[scan]==1.2.3", "construct==2.9.45"],
   "dependencies": [],

--- a/homeassistant/components/ee_brightbox/manifest.json
+++ b/homeassistant/components/ee_brightbox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ee_brightbox",
-  "name": "Ee brightbox",
+  "name": "EE Bright Box",
   "documentation": "https://www.home-assistant.io/integrations/ee_brightbox",
   "requirements": ["eebrightbox==0.0.4"],
   "dependencies": [],

--- a/homeassistant/components/eight_sleep/manifest.json
+++ b/homeassistant/components/eight_sleep/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "eight_sleep",
-  "name": "Eight sleep",
+  "name": "Eight Sleep",
   "documentation": "https://www.home-assistant.io/integrations/eight_sleep",
   "requirements": ["pyeight==0.1.2"],
   "dependencies": [],

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "elkm1",
-  "name": "Elkm1",
+  "name": "Elk-M1 Control",
   "documentation": "https://www.home-assistant.io/integrations/elkm1",
   "requirements": ["elkm1-lib==0.7.15"],
   "dependencies": [],

--- a/homeassistant/components/emoncms_history/manifest.json
+++ b/homeassistant/components/emoncms_history/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "emoncms_history",
-  "name": "Emoncms history",
+  "name": "Emoncms History",
   "documentation": "https://www.home-assistant.io/integrations/emoncms_history",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/emulated_hue/manifest.json
+++ b/homeassistant/components/emulated_hue/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "emulated_hue",
-  "name": "Emulated hue",
+  "name": "Emulated Hue",
   "documentation": "https://www.home-assistant.io/integrations/emulated_hue",
   "requirements": ["aiohttp_cors==0.7.0"],
   "dependencies": [],

--- a/homeassistant/components/emulated_roku/manifest.json
+++ b/homeassistant/components/emulated_roku/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "emulated_roku",
-  "name": "Emulated roku",
+  "name": "Emulated Roku",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/emulated_roku",
   "requirements": ["emulated_roku==0.1.8"],

--- a/homeassistant/components/enigma2/manifest.json
+++ b/homeassistant/components/enigma2/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "enigma2",
-  "name": "Enigma2",
+  "name": "Enigma2 (OpenWebif)",
   "documentation": "https://www.home-assistant.io/integrations/enigma2",
   "requirements": ["openwebifpy==3.1.1"],
   "dependencies": [],

--- a/homeassistant/components/enocean/manifest.json
+++ b/homeassistant/components/enocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "enocean",
-  "name": "Enocean",
+  "name": "EnOcean",
   "documentation": "https://www.home-assistant.io/integrations/enocean",
   "requirements": ["enocean==0.50"],
   "dependencies": [],

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "enphase_envoy",
-  "name": "Enphase envoy",
+  "name": "Enphase Envoy",
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "requirements": ["envoy_reader==0.11.0"],
   "dependencies": [],

--- a/homeassistant/components/entur_public_transport/manifest.json
+++ b/homeassistant/components/entur_public_transport/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "entur_public_transport",
-  "name": "Entur public transport",
+  "name": "Entur",
   "documentation": "https://www.home-assistant.io/integrations/entur_public_transport",
   "requirements": ["enturclient==0.2.1"],
   "dependencies": [],

--- a/homeassistant/components/envirophat/manifest.json
+++ b/homeassistant/components/envirophat/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "envirophat",
-  "name": "Envirophat",
+  "name": "Enviro pHAT",
   "documentation": "https://www.home-assistant.io/integrations/envirophat",
   "requirements": ["envirophat==0.0.6", "smbus-cffi==0.5.1"],
   "dependencies": [],

--- a/homeassistant/components/ephember/manifest.json
+++ b/homeassistant/components/ephember/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ephember",
-  "name": "Ephember",
+  "name": "EPH Controls",
   "documentation": "https://www.home-assistant.io/integrations/ephember",
   "requirements": ["pyephember==0.3.1"],
   "dependencies": [],

--- a/homeassistant/components/eq3btsmart/manifest.json
+++ b/homeassistant/components/eq3btsmart/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "eq3btsmart",
-  "name": "Eq3btsmart",
+  "name": "EQ3 Bluetooth Smart Thermostats",
   "documentation": "https://www.home-assistant.io/integrations/eq3btsmart",
   "requirements": ["construct==2.9.45", "python-eq3bt==0.1.11"],
   "dependencies": [],

--- a/homeassistant/components/eufy/manifest.json
+++ b/homeassistant/components/eufy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "eufy",
-  "name": "Eufy",
+  "name": "eufy",
   "documentation": "https://www.home-assistant.io/integrations/eufy",
   "requirements": ["lakeside==0.12"],
   "dependencies": [],

--- a/homeassistant/components/everlights/manifest.json
+++ b/homeassistant/components/everlights/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "everlights",
-  "name": "Everlights",
+  "name": "EverLights",
   "documentation": "https://www.home-assistant.io/integrations/everlights",
   "requirements": ["pyeverlights==0.1.0"],
   "dependencies": [],

--- a/homeassistant/components/evohome/manifest.json
+++ b/homeassistant/components/evohome/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "evohome",
-  "name": "Evohome",
+  "name": "Honeywell evohome / Total Connect Comfort",
   "documentation": "https://www.home-assistant.io/integrations/evohome",
   "requirements": ["evohome-async==0.3.4b1"],
   "dependencies": [],

--- a/homeassistant/components/facebook/manifest.json
+++ b/homeassistant/components/facebook/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "facebook",
-  "name": "Facebook",
+  "name": "Facebook Messenger",
   "documentation": "https://www.home-assistant.io/integrations/facebook",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/fail2ban/manifest.json
+++ b/homeassistant/components/fail2ban/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fail2ban",
-  "name": "Fail2ban",
+  "name": "Fail2Ban",
   "documentation": "https://www.home-assistant.io/integrations/fail2ban",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/familyhub/manifest.json
+++ b/homeassistant/components/familyhub/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "familyhub",
-  "name": "Familyhub",
+  "name": "Samsung Family Hub",
   "documentation": "https://www.home-assistant.io/integrations/familyhub",
   "requirements": ["python-family-hub-local==0.0.2"],
   "dependencies": [],

--- a/homeassistant/components/fastdotcom/manifest.json
+++ b/homeassistant/components/fastdotcom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fastdotcom",
-  "name": "Fastdotcom",
+  "name": "Fast.com",
   "documentation": "https://www.home-assistant.io/integrations/fastdotcom",
   "requirements": ["fastdotcom==0.0.3"],
   "dependencies": [],

--- a/homeassistant/components/ffmpeg/manifest.json
+++ b/homeassistant/components/ffmpeg/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ffmpeg",
-  "name": "Ffmpeg",
+  "name": "FFmpeg",
   "documentation": "https://www.home-assistant.io/integrations/ffmpeg",
   "requirements": ["ha-ffmpeg==2.0"],
   "dependencies": [],

--- a/homeassistant/components/ffmpeg_motion/manifest.json
+++ b/homeassistant/components/ffmpeg_motion/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ffmpeg_motion",
-  "name": "Ffmpeg motion",
+  "name": "FFmpeg Motion",
   "documentation": "https://www.home-assistant.io/integrations/ffmpeg_motion",
   "requirements": [],
   "dependencies": ["ffmpeg"],

--- a/homeassistant/components/ffmpeg_noise/manifest.json
+++ b/homeassistant/components/ffmpeg_noise/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ffmpeg_noise",
-  "name": "Ffmpeg noise",
+  "name": "FFmpeg Noise",
   "documentation": "https://www.home-assistant.io/integrations/ffmpeg_noise",
   "requirements": [],
   "dependencies": ["ffmpeg"],

--- a/homeassistant/components/filesize/manifest.json
+++ b/homeassistant/components/filesize/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "filesize",
-  "name": "Filesize",
+  "name": "File Size",
   "documentation": "https://www.home-assistant.io/integrations/filesize",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/fints/manifest.json
+++ b/homeassistant/components/fints/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fints",
-  "name": "Fints",
+  "name": "FinTS",
   "documentation": "https://www.home-assistant.io/integrations/fints",
   "requirements": ["fints==1.0.1"],
   "dependencies": [],

--- a/homeassistant/components/flume/manifest.json
+++ b/homeassistant/components/flume/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "flume",
-  "name": "Flume",
+  "name": "flume",
   "documentation": "https://www.home-assistant.io/integrations/flume/",
   "requirements": ["pyflume==0.2.4"],
   "dependencies": [],

--- a/homeassistant/components/flunearyou/manifest.json
+++ b/homeassistant/components/flunearyou/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "flunearyou",
-  "name": "Flunearyou",
+  "name": "Flu Near You",
   "documentation": "https://www.home-assistant.io/integrations/flunearyou",
   "requirements": ["pyflunearyou==1.0.3"],
   "dependencies": [],

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "flux_led",
-  "name": "Flux led",
+  "name": "Flux LED/MagicLight",
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
   "requirements": ["flux_led==0.22"],
   "dependencies": [],

--- a/homeassistant/components/folder_watcher/manifest.json
+++ b/homeassistant/components/folder_watcher/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "folder_watcher",
-  "name": "Folder watcher",
+  "name": "Folder Watcher",
   "documentation": "https://www.home-assistant.io/integrations/folder_watcher",
   "requirements": ["watchdog==0.8.3"],
   "dependencies": [],

--- a/homeassistant/components/fortigate/manifest.json
+++ b/homeassistant/components/fortigate/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fortigate",
-  "name": "Fortigate",
+  "name": "FortiGate",
   "documentation": "https://www.home-assistant.io/integrations/fortigate",
   "dependencies": [],
   "codeowners": ["@kifeo"],

--- a/homeassistant/components/free_mobile/manifest.json
+++ b/homeassistant/components/free_mobile/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "free_mobile",
-  "name": "Free mobile",
+  "name": "Free Mobile",
   "documentation": "https://www.home-assistant.io/integrations/free_mobile",
   "requirements": ["freesms==0.1.2"],
   "dependencies": [],

--- a/homeassistant/components/freedns/manifest.json
+++ b/homeassistant/components/freedns/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "freedns",
-  "name": "Freedns",
+  "name": "FreeDNS",
   "documentation": "https://www.home-assistant.io/integrations/freedns",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fritz",
-  "name": "Fritz",
+  "name": "AVM Fritzbox",
   "documentation": "https://www.home-assistant.io/integrations/fritz",
   "requirements": ["fritzconnection==0.8.4"],
   "dependencies": [],

--- a/homeassistant/components/fritzbox/manifest.json
+++ b/homeassistant/components/fritzbox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fritzbox",
-  "name": "Fritzbox",
+  "name": "AVM FRITZ!Box",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox",
   "requirements": ["pyfritzhome==0.4.0"],
   "dependencies": [],

--- a/homeassistant/components/fritzbox_callmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_callmonitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fritzbox_callmonitor",
-  "name": "Fritzbox callmonitor",
+  "name": "AVM FRITZ!Box Call Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_callmonitor",
   "requirements": ["fritzconnection==0.8.4"],
   "dependencies": [],

--- a/homeassistant/components/fritzbox_netmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_netmonitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fritzbox_netmonitor",
-  "name": "Fritzbox netmonitor",
+  "name": "AVM FRITZ!Box Net Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_netmonitor",
   "requirements": ["fritzconnection==0.8.4"],
   "dependencies": [],

--- a/homeassistant/components/fritzdect/manifest.json
+++ b/homeassistant/components/fritzdect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "fritzdect",
-  "name": "Fritzdect",
+  "name": "AVM FRITZ!DECT",
   "documentation": "https://www.home-assistant.io/integrations/fritzdect",
   "requirements": ["fritzhome==1.0.4"],
   "dependencies": [],

--- a/homeassistant/components/frontier_silicon/manifest.json
+++ b/homeassistant/components/frontier_silicon/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "frontier_silicon",
-  "name": "Frontier silicon",
+  "name": "Frontier Silicon",
   "documentation": "https://www.home-assistant.io/integrations/frontier_silicon",
   "requirements": ["afsapi==0.0.4"],
   "dependencies": [],

--- a/homeassistant/components/futurenow/manifest.json
+++ b/homeassistant/components/futurenow/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "futurenow",
-  "name": "Futurenow",
+  "name": "P5 FutureNow",
   "documentation": "https://www.home-assistant.io/integrations/futurenow",
   "requirements": ["pyfnip==0.2"],
   "dependencies": [],

--- a/homeassistant/components/gc100/manifest.json
+++ b/homeassistant/components/gc100/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gc100",
-  "name": "Gc100",
+  "name": "Global Caché GC-100",
   "documentation": "https://www.home-assistant.io/integrations/gc100",
   "requirements": ["python-gc100==1.0.3a"],
   "dependencies": [],

--- a/homeassistant/components/generic_thermostat/manifest.json
+++ b/homeassistant/components/generic_thermostat/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "generic_thermostat",
-  "name": "Generic thermostat",
+  "name": "Generic Thermostat",
   "documentation": "https://www.home-assistant.io/integrations/generic_thermostat",
   "requirements": [],
   "dependencies": ["sensor", "switch"],

--- a/homeassistant/components/geo_json_events/manifest.json
+++ b/homeassistant/components/geo_json_events/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "geo_json_events",
-  "name": "Geo json events",
+  "name": "GeoJSON",
   "documentation": "https://www.home-assistant.io/integrations/geo_json_events",
   "requirements": ["geojson_client==0.4"],
   "dependencies": [],

--- a/homeassistant/components/geo_location/manifest.json
+++ b/homeassistant/components/geo_location/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "geo_location",
-  "name": "Geo location",
+  "name": "Geolocation",
   "documentation": "https://www.home-assistant.io/integrations/geo_location",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/geo_rss_events/manifest.json
+++ b/homeassistant/components/geo_rss_events/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "geo_rss_events",
-  "name": "Geo RSS events",
+  "name": "GeoRSS",
   "documentation": "https://www.home-assistant.io/integrations/geo_rss_events",
   "requirements": ["georss_generic_client==0.3"],
   "dependencies": [],

--- a/homeassistant/components/github/manifest.json
+++ b/homeassistant/components/github/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "github",
-  "name": "Github",
+  "name": "GitHub",
   "documentation": "https://www.home-assistant.io/integrations/github",
   "requirements": ["PyGithub==1.43.8"],
   "dependencies": [],

--- a/homeassistant/components/gitlab_ci/manifest.json
+++ b/homeassistant/components/gitlab_ci/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gitlab_ci",
-  "name": "Gitlab ci",
+  "name": "GitLab-CI",
   "documentation": "https://www.home-assistant.io/integrations/gitlab_ci",
   "requirements": ["python-gitlab==1.6.0"],
   "dependencies": [],

--- a/homeassistant/components/gntp/manifest.json
+++ b/homeassistant/components/gntp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gntp",
-  "name": "Gntp",
+  "name": "Growl (GnGNTP)",
   "documentation": "https://www.home-assistant.io/integrations/gntp",
   "requirements": ["gntp==1.0.3"],
   "dependencies": [],

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google",
-  "name": "Google",
+  "name": "Google Calendars",
   "documentation": "https://www.home-assistant.io/integrations/google",
   "requirements": [
     "google-api-python-client==1.6.4",

--- a/homeassistant/components/google_assistant/manifest.json
+++ b/homeassistant/components/google_assistant/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google_assistant",
-  "name": "Google assistant",
+  "name": "Google Assistant",
   "documentation": "https://www.home-assistant.io/integrations/google_assistant",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/google_domains/manifest.json
+++ b/homeassistant/components/google_domains/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google_domains",
-  "name": "Google domains",
+  "name": "Google Domains",
   "documentation": "https://www.home-assistant.io/integrations/google_domains",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/google_maps/manifest.json
+++ b/homeassistant/components/google_maps/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google_maps",
-  "name": "Google maps",
+  "name": "Google Maps",
   "documentation": "https://www.home-assistant.io/integrations/google_maps",
   "requirements": ["locationsharinglib==4.1.0"],
   "dependencies": [],

--- a/homeassistant/components/google_pubsub/manifest.json
+++ b/homeassistant/components/google_pubsub/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google_pubsub",
-  "name": "Google pubsub",
+  "name": "Google Pub/Sub",
   "documentation": "https://www.home-assistant.io/integrations/google_pubsub",
   "requirements": ["google-cloud-pubsub==0.39.1"],
   "dependencies": [],

--- a/homeassistant/components/google_translate/manifest.json
+++ b/homeassistant/components/google_translate/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google_translate",
-  "name": "Google Translate",
+  "name": "Google Translate Text-to-Speech",
   "documentation": "https://www.home-assistant.io/integrations/google_translate",
   "requirements": ["gTTS-token==1.1.3"],
   "dependencies": [],

--- a/homeassistant/components/google_travel_time/manifest.json
+++ b/homeassistant/components/google_travel_time/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google_travel_time",
-  "name": "Google travel time",
+  "name": "Google Maps Travel Time",
   "documentation": "https://www.home-assistant.io/integrations/google_travel_time",
   "requirements": ["googlemaps==2.5.1"],
   "dependencies": [],

--- a/homeassistant/components/google_wifi/manifest.json
+++ b/homeassistant/components/google_wifi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "google_wifi",
-  "name": "Google wifi",
+  "name": "Google Wifi",
   "documentation": "https://www.home-assistant.io/integrations/google_wifi",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/gpmdp/manifest.json
+++ b/homeassistant/components/gpmdp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gpmdp",
-  "name": "Gpmdp",
+  "name": "Google Play Music Desktop Player (GPMDP)",
   "documentation": "https://www.home-assistant.io/integrations/gpmdp",
   "requirements": ["websocket-client==0.54.0"],
   "dependencies": ["configurator"],

--- a/homeassistant/components/gpsd/manifest.json
+++ b/homeassistant/components/gpsd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gpsd",
-  "name": "Gpsd",
+  "name": "GPSD",
   "documentation": "https://www.home-assistant.io/integrations/gpsd",
   "requirements": ["gps3==0.33.3"],
   "dependencies": [],

--- a/homeassistant/components/gpslogger/manifest.json
+++ b/homeassistant/components/gpslogger/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gpslogger",
-  "name": "Gpslogger",
+  "name": "GPSLogger",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gpslogger",
   "requirements": [],

--- a/homeassistant/components/greeneye_monitor/manifest.json
+++ b/homeassistant/components/greeneye_monitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "greeneye_monitor",
-  "name": "Greeneye monitor",
+  "name": "GreenEye Monitor (GEM)",
   "documentation": "https://www.home-assistant.io/integrations/greeneye_monitor",
   "requirements": ["greeneye_monitor==1.0.1"],
   "dependencies": [],

--- a/homeassistant/components/greenwave/manifest.json
+++ b/homeassistant/components/greenwave/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "greenwave",
-  "name": "Greenwave",
+  "name": "Greenwave Reality",
   "documentation": "https://www.home-assistant.io/integrations/greenwave",
   "requirements": ["greenwavereality==0.5.1"],
   "dependencies": [],

--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "growatt_server",
-  "name": "Growatt Server",
+  "name": "Growatt",
   "documentation": "https://www.home-assistant.io/integrations/growatt_server/",
   "requirements": ["growattServer==0.0.1"],
   "dependencies": [],

--- a/homeassistant/components/gstreamer/manifest.json
+++ b/homeassistant/components/gstreamer/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gstreamer",
-  "name": "Gstreamer",
+  "name": "GStreamer",
   "documentation": "https://www.home-assistant.io/integrations/gstreamer",
   "requirements": ["gstreamer-player==1.1.2"],
   "dependencies": [],

--- a/homeassistant/components/gtfs/manifest.json
+++ b/homeassistant/components/gtfs/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "gtfs",
-  "name": "Gtfs",
+  "name": "General Transit Feed Specification (GTFS)",
   "documentation": "https://www.home-assistant.io/integrations/gtfs",
   "requirements": ["pygtfs==0.1.5"],
   "dependencies": [],

--- a/homeassistant/components/hangouts/manifest.json
+++ b/homeassistant/components/hangouts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hangouts",
-  "name": "Hangouts",
+  "name": "Google Hangouts",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/hangouts",
   "requirements": ["hangups==0.4.9"],

--- a/homeassistant/components/harman_kardon_avr/manifest.json
+++ b/homeassistant/components/harman_kardon_avr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "harman_kardon_avr",
-  "name": "Harman kardon avr",
+  "name": "Harman Kardon AVR",
   "documentation": "https://www.home-assistant.io/integrations/harman_kardon_avr",
   "requirements": ["hkavr==0.0.5"],
   "dependencies": [],

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "harmony",
-  "name": "Harmony",
+  "name": "Logitech Harmony Hub",
   "documentation": "https://www.home-assistant.io/integrations/harmony",
   "requirements": ["aioharmony==0.1.13"],
   "dependencies": [],

--- a/homeassistant/components/haveibeenpwned/manifest.json
+++ b/homeassistant/components/haveibeenpwned/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "haveibeenpwned",
-  "name": "Haveibeenpwned",
+  "name": "HaveIBeenPwned",
   "documentation": "https://www.home-assistant.io/integrations/haveibeenpwned",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/hddtemp/manifest.json
+++ b/homeassistant/components/hddtemp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hddtemp",
-  "name": "Hddtemp",
+  "name": "hddtemp",
   "documentation": "https://www.home-assistant.io/integrations/hddtemp",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/hdmi_cec/manifest.json
+++ b/homeassistant/components/hdmi_cec/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hdmi_cec",
-  "name": "Hdmi cec",
+  "name": "HDMI-CEC",
   "documentation": "https://www.home-assistant.io/integrations/hdmi_cec",
   "requirements": ["pyCEC==0.4.13"],
   "dependencies": [],

--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "heos",
-  "name": "HEOS",
+  "name": "Denon HEOS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/heos",
   "requirements": ["pyheos==0.6.0"],

--- a/homeassistant/components/here_travel_time/manifest.json
+++ b/homeassistant/components/here_travel_time/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "here_travel_time",
-  "name": "HERE travel time",
+  "name": "HERE Travel Time",
   "documentation": "https://www.home-assistant.io/integrations/here_travel_time",
   "requirements": ["herepy==2.0.0"],
   "dependencies": [],

--- a/homeassistant/components/hikvisioncam/manifest.json
+++ b/homeassistant/components/hikvisioncam/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hikvisioncam",
-  "name": "Hikvisioncam",
+  "name": "Hikvision",
   "documentation": "https://www.home-assistant.io/integrations/hikvisioncam",
   "requirements": ["hikvision==0.4"],
   "dependencies": [],

--- a/homeassistant/components/history_graph/manifest.json
+++ b/homeassistant/components/history_graph/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "history_graph",
-  "name": "History graph",
+  "name": "History Graph",
   "documentation": "https://www.home-assistant.io/integrations/history_graph",
   "requirements": [],
   "dependencies": ["history"],

--- a/homeassistant/components/history_stats/manifest.json
+++ b/homeassistant/components/history_stats/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "history_stats",
-  "name": "History stats",
+  "name": "History Stats",
   "documentation": "https://www.home-assistant.io/integrations/history_stats",
   "requirements": [],
   "dependencies": ["history"],

--- a/homeassistant/components/hitron_coda/manifest.json
+++ b/homeassistant/components/hitron_coda/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hitron_coda",
-  "name": "Hitron coda",
+  "name": "Rogers Hitron CODA",
   "documentation": "https://www.home-assistant.io/integrations/hitron_coda",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/hlk_sw16/manifest.json
+++ b/homeassistant/components/hlk_sw16/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hlk_sw16",
-  "name": "Hlk sw16",
+  "name": "Hi-Link HLK-SW16",
   "documentation": "https://www.home-assistant.io/integrations/hlk_sw16",
   "requirements": ["hlk-sw16==0.0.7"],
   "dependencies": [],

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "homekit",
-  "name": "Homekit",
+  "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
   "requirements": ["HAP-python==2.6.0"],
   "dependencies": [],

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "homekit_controller",
-  "name": "Homekit controller",
+  "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "requirements": ["homekit[IP]==0.15.0"],

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "homematicip_cloud",
-  "name": "Homematicip cloud",
+  "name": "HomematicIP Cloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
   "requirements": ["homematicip==0.10.15"],

--- a/homeassistant/components/homeworks/manifest.json
+++ b/homeassistant/components/homeworks/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "homeworks",
-  "name": "Homeworks",
+  "name": "Lutron Homeworks",
   "documentation": "https://www.home-assistant.io/integrations/homeworks",
   "requirements": ["pyhomeworks==0.0.6"],
   "dependencies": [],

--- a/homeassistant/components/honeywell/manifest.json
+++ b/homeassistant/components/honeywell/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "honeywell",
-  "name": "Honeywell",
+  "name": "Honeywell Total Connect Comfort (TCC)",
   "documentation": "https://www.home-assistant.io/integrations/honeywell",
   "requirements": ["somecomfort==0.5.2"],
   "dependencies": [],

--- a/homeassistant/components/horizon/manifest.json
+++ b/homeassistant/components/horizon/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "horizon",
-  "name": "Horizon",
+  "name": "Unitymedia Horizon HD Recorder",
   "documentation": "https://www.home-assistant.io/integrations/horizon",
   "requirements": ["horimote==0.4.1"],
   "dependencies": [],

--- a/homeassistant/components/hp_ilo/manifest.json
+++ b/homeassistant/components/hp_ilo/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hp_ilo",
-  "name": "Hp ilo",
+  "name": "HP Integrated Lights-Out (ILO)",
   "documentation": "https://www.home-assistant.io/integrations/hp_ilo",
   "requirements": ["python-hpilo==4.3"],
   "dependencies": [],

--- a/homeassistant/components/html5/manifest.json
+++ b/homeassistant/components/html5/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "html5",
-  "name": "HTML5 Notifications",
+  "name": "HTML5 Push Notifications",
   "documentation": "https://www.home-assistant.io/integrations/html5",
   "requirements": ["pywebpush==1.9.2"],
   "dependencies": ["http"],

--- a/homeassistant/components/htu21d/manifest.json
+++ b/homeassistant/components/htu21d/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "htu21d",
-  "name": "Htu21d",
+  "name": "HTU21D(F) Sensor",
   "documentation": "https://www.home-assistant.io/integrations/htu21d",
   "requirements": ["i2csense==0.0.4", "smbus-cffi==0.5.1"],
   "dependencies": [],

--- a/homeassistant/components/huawei_router/manifest.json
+++ b/homeassistant/components/huawei_router/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "huawei_router",
-  "name": "Huawei router",
+  "name": "Huawei Router",
   "documentation": "https://www.home-assistant.io/integrations/huawei_router",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/hunterdouglas_powerview/manifest.json
+++ b/homeassistant/components/hunterdouglas_powerview/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hunterdouglas_powerview",
-  "name": "Hunterdouglas powerview",
+  "name": "Hunter Douglas PowerView",
   "documentation": "https://www.home-assistant.io/integrations/hunterdouglas_powerview",
   "requirements": ["aiopvapi==1.6.14"],
   "dependencies": [],

--- a/homeassistant/components/hydrawise/manifest.json
+++ b/homeassistant/components/hydrawise/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "hydrawise",
-  "name": "Hydrawise",
+  "name": "Hunter Hydrawise",
   "documentation": "https://www.home-assistant.io/integrations/hydrawise",
   "requirements": ["hydrawiser==0.1.1"],
   "dependencies": [],

--- a/homeassistant/components/ialarm/manifest.json
+++ b/homeassistant/components/ialarm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ialarm",
-  "name": "Ialarm",
+  "name": "Antifurto365 iAlarm",
   "documentation": "https://www.home-assistant.io/integrations/ialarm",
   "requirements": ["pyialarm==0.3"],
   "dependencies": [],

--- a/homeassistant/components/icloud/manifest.json
+++ b/homeassistant/components/icloud/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "icloud",
-  "name": "iCloud",
+  "name": "Apple iCloud",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/components/icloud",
+  "documentation": "https://www.home-assistant.io/integrations/icloud",
   "requirements": ["pyicloud==0.9.1"],
   "dependencies": [],
   "codeowners": ["@Quentame"]

--- a/homeassistant/components/idteck_prox/manifest.json
+++ b/homeassistant/components/idteck_prox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "idteck_prox",
-  "name": "Idteck prox",
+  "name": "IDTECK Proximity Reader",
   "documentation": "https://www.home-assistant.io/integrations/idteck_prox",
   "requirements": ["rfk101py==0.0.1"],
   "dependencies": [],

--- a/homeassistant/components/ifttt/manifest.json
+++ b/homeassistant/components/ifttt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ifttt",
-  "name": "Ifttt",
+  "name": "IFTTT",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ifttt",
   "requirements": ["pyfttt==0.3"],

--- a/homeassistant/components/iglo/manifest.json
+++ b/homeassistant/components/iglo/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "iglo",
-  "name": "Iglo",
+  "name": "iGlo",
   "documentation": "https://www.home-assistant.io/integrations/iglo",
   "requirements": ["iglo==1.2.7"],
   "dependencies": [],

--- a/homeassistant/components/ign_sismologia/manifest.json
+++ b/homeassistant/components/ign_sismologia/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ign_sismologia",
-  "name": "IGN Sismologia",
+  "name": "IGN Sismología",
   "documentation": "https://www.home-assistant.io/integrations/ign_sismologia",
   "requirements": ["georss_ign_sismologia_client==0.2"],
   "dependencies": [],

--- a/homeassistant/components/ihc/manifest.json
+++ b/homeassistant/components/ihc/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ihc",
-  "name": "Ihc",
+  "name": "IHC Controller",
   "documentation": "https://www.home-assistant.io/integrations/ihc",
   "requirements": ["defusedxml==0.6.0", "ihcsdk==2.4.0"],
   "dependencies": [],

--- a/homeassistant/components/image_processing/manifest.json
+++ b/homeassistant/components/image_processing/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "image_processing",
-  "name": "Image processing",
+  "name": "Image Processing",
   "documentation": "https://www.home-assistant.io/integrations/image_processing",
   "requirements": [],
   "dependencies": ["camera"],

--- a/homeassistant/components/imap/manifest.json
+++ b/homeassistant/components/imap/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "imap",
-  "name": "Imap",
+  "name": "IMAP",
   "documentation": "https://www.home-assistant.io/integrations/imap",
   "requirements": ["aioimaplib==0.7.15"],
   "dependencies": [],

--- a/homeassistant/components/imap_email_content/manifest.json
+++ b/homeassistant/components/imap_email_content/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "imap_email_content",
-  "name": "Imap email content",
+  "name": "IMAP Email Content",
   "documentation": "https://www.home-assistant.io/integrations/imap_email_content",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/influxdb/manifest.json
+++ b/homeassistant/components/influxdb/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "influxdb",
-  "name": "Influxdb",
+  "name": "InfluxDB",
   "documentation": "https://www.home-assistant.io/integrations/influxdb",
   "requirements": ["influxdb==5.2.3"],
   "dependencies": [],

--- a/homeassistant/components/input_boolean/manifest.json
+++ b/homeassistant/components/input_boolean/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_boolean",
-  "name": "Input boolean",
+  "name": "Input Boolean",
   "documentation": "https://www.home-assistant.io/integrations/input_boolean",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/input_datetime/manifest.json
+++ b/homeassistant/components/input_datetime/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_datetime",
-  "name": "Input datetime",
+  "name": "Input Datetime",
   "documentation": "https://www.home-assistant.io/integrations/input_datetime",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/input_number/manifest.json
+++ b/homeassistant/components/input_number/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_number",
-  "name": "Input number",
+  "name": "Input Number",
   "documentation": "https://www.home-assistant.io/integrations/input_number",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/input_select/manifest.json
+++ b/homeassistant/components/input_select/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_select",
-  "name": "Input select",
+  "name": "Input Select",
   "documentation": "https://www.home-assistant.io/integrations/input_select",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/input_text/manifest.json
+++ b/homeassistant/components/input_text/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_text",
-  "name": "Input text",
+  "name": "Input Text",
   "documentation": "https://www.home-assistant.io/integrations/input_text",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/integration/manifest.json
+++ b/homeassistant/components/integration/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "integration",
-  "name": "Integration",
+  "name": "Integration - Riemann sum integral",
   "documentation": "https://www.home-assistant.io/integrations/integration",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/intent_script/manifest.json
+++ b/homeassistant/components/intent_script/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "intent_script",
-  "name": "Intent script",
+  "name": "Intent Script",
   "documentation": "https://www.home-assistant.io/integrations/intent_script",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/ios/manifest.json
+++ b/homeassistant/components/ios/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ios",
-  "name": "Ios",
+  "name": "Apple iOS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ios",
   "requirements": [],

--- a/homeassistant/components/iota/manifest.json
+++ b/homeassistant/components/iota/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "iota",
-  "name": "Iota",
+  "name": "IOTA",
   "documentation": "https://www.home-assistant.io/integrations/iota",
   "requirements": ["pyota==2.0.5"],
   "dependencies": [],

--- a/homeassistant/components/ipma/manifest.json
+++ b/homeassistant/components/ipma/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ipma",
-  "name": "Ipma",
+  "name": "Instituto Português do Mar e Atmosfera (IPMA)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ipma",
   "requirements": ["pyipma==1.2.1"],

--- a/homeassistant/components/irish_rail_transport/manifest.json
+++ b/homeassistant/components/irish_rail_transport/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "irish_rail_transport",
-  "name": "Irish rail transport",
+  "name": "Irish Rail Transport",
   "documentation": "https://www.home-assistant.io/integrations/irish_rail_transport",
   "requirements": ["pyirishrail==0.0.2"],
   "dependencies": [],

--- a/homeassistant/components/islamic_prayer_times/manifest.json
+++ b/homeassistant/components/islamic_prayer_times/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "islamic_prayer_times",
-  "name": "Islamic prayer times",
+  "name": "Islamic Prayer Times",
   "documentation": "https://www.home-assistant.io/integrations/islamic_prayer_times",
   "requirements": ["prayer_times_calculator==0.0.3"],
   "dependencies": [],

--- a/homeassistant/components/iss/manifest.json
+++ b/homeassistant/components/iss/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "iss",
-  "name": "Iss",
+  "name": "International Space Station (ISS)",
   "documentation": "https://www.home-assistant.io/integrations/iss",
   "requirements": ["pyiss==1.0.1"],
   "dependencies": [],

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "isy994",
-  "name": "Isy994",
+  "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
   "requirements": ["PyISY==1.1.2"],
   "dependencies": [],

--- a/homeassistant/components/itach/manifest.json
+++ b/homeassistant/components/itach/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "itach",
-  "name": "Itach",
+  "name": "Global Caché iTach TCP/IP to IR",
   "documentation": "https://www.home-assistant.io/integrations/itach",
   "requirements": ["pyitachip2ir==0.0.7"],
   "dependencies": [],

--- a/homeassistant/components/itunes/manifest.json
+++ b/homeassistant/components/itunes/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "itunes",
-  "name": "Itunes",
+  "name": "Apple iTunes",
   "documentation": "https://www.home-assistant.io/integrations/itunes",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/izone/manifest.json
+++ b/homeassistant/components/izone/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "izone",
-  "name": "izone",
+  "name": "iZone",
   "documentation": "https://www.home-assistant.io/integrations/izone",
   "requirements": ["python-izone==1.1.1"],
   "dependencies": [],

--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "jewish_calendar",
-  "name": "Jewish calendar",
+  "name": "Jewish Calendar",
   "documentation": "https://www.home-assistant.io/integrations/jewish_calendar",
   "requirements": ["hdate==0.9.3"],
   "dependencies": [],

--- a/homeassistant/components/joaoapps_join/manifest.json
+++ b/homeassistant/components/joaoapps_join/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "joaoapps_join",
-  "name": "Joaoapps join",
+  "name": "Joaoapps Join",
   "documentation": "https://www.home-assistant.io/integrations/joaoapps_join",
   "requirements": ["python-join-api==0.0.4"],
   "dependencies": [],

--- a/homeassistant/components/juicenet/manifest.json
+++ b/homeassistant/components/juicenet/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "juicenet",
-  "name": "Juicenet",
+  "name": "JuiceNet",
   "documentation": "https://www.home-assistant.io/integrations/juicenet",
   "requirements": ["python-juicenet==0.1.6"],
   "dependencies": [],

--- a/homeassistant/components/keenetic_ndms2/manifest.json
+++ b/homeassistant/components/keenetic_ndms2/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "keenetic_ndms2",
-  "name": "Keenetic ndms2",
+  "name": "Keenetic NDMS2 Routers",
   "documentation": "https://www.home-assistant.io/integrations/keenetic_ndms2",
   "requirements": ["ndms2_client==0.0.11"],
   "dependencies": [],

--- a/homeassistant/components/keyboard_remote/manifest.json
+++ b/homeassistant/components/keyboard_remote/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "keyboard_remote",
-  "name": "Keyboard remote",
+  "name": "Keyboard Remote",
   "documentation": "https://www.home-assistant.io/integrations/keyboard_remote",
   "requirements": ["evdev==1.1.2", "aionotify==0.2.0"],
   "dependencies": [],

--- a/homeassistant/components/kiwi/manifest.json
+++ b/homeassistant/components/kiwi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "kiwi",
-  "name": "Kiwi",
+  "name": "KIWI",
   "documentation": "https://www.home-assistant.io/integrations/kiwi",
   "requirements": ["kiwiki-client==0.1.1"],
   "dependencies": [],

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "knx",
-  "name": "Knx",
+  "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
   "requirements": ["xknx==0.11.2"],
   "dependencies": [],

--- a/homeassistant/components/kwb/manifest.json
+++ b/homeassistant/components/kwb/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "kwb",
-  "name": "Kwb",
+  "name": "KWB Easyfire",
   "documentation": "https://www.home-assistant.io/integrations/kwb",
   "requirements": ["pykwb==0.0.8"],
   "dependencies": [],

--- a/homeassistant/components/lacrosse/manifest.json
+++ b/homeassistant/components/lacrosse/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lacrosse",
-  "name": "Lacrosse",
+  "name": "LaCrosse",
   "documentation": "https://www.home-assistant.io/integrations/lacrosse",
   "requirements": ["pylacrosse==0.4.0"],
   "dependencies": [],

--- a/homeassistant/components/lametric/manifest.json
+++ b/homeassistant/components/lametric/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lametric",
-  "name": "Lametric",
+  "name": "LaMetric",
   "documentation": "https://www.home-assistant.io/integrations/lametric",
   "requirements": ["lmnotify==0.0.4"],
   "dependencies": [],

--- a/homeassistant/components/lannouncer/manifest.json
+++ b/homeassistant/components/lannouncer/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lannouncer",
-  "name": "Lannouncer",
+  "name": "LANnouncer",
   "documentation": "https://www.home-assistant.io/integrations/lannouncer",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/lastfm/manifest.json
+++ b/homeassistant/components/lastfm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lastfm",
-  "name": "Lastfm",
+  "name": "Last.fm",
   "documentation": "https://www.home-assistant.io/integrations/lastfm",
   "requirements": ["pylast==3.1.0"],
   "dependencies": [],

--- a/homeassistant/components/launch_library/manifest.json
+++ b/homeassistant/components/launch_library/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "launch_library",
-  "name": "Launch library",
+  "name": "Launch Library",
   "documentation": "https://www.home-assistant.io/integrations/launch_library",
   "requirements": ["pylaunches==0.2.0"],
   "dependencies": [],

--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lcn",
-  "name": "Lcn",
+  "name": "LCN",
   "documentation": "https://www.home-assistant.io/integrations/lcn",
   "requirements": ["pypck==0.6.3"],
   "dependencies": [],

--- a/homeassistant/components/lg_netcast/manifest.json
+++ b/homeassistant/components/lg_netcast/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lg_netcast",
-  "name": "Lg netcast",
+  "name": "LG Netcast",
   "documentation": "https://www.home-assistant.io/integrations/lg_netcast",
   "requirements": ["pylgnetcast-homeassistant==0.2.0.dev0"],
   "dependencies": [],

--- a/homeassistant/components/lg_soundbar/manifest.json
+++ b/homeassistant/components/lg_soundbar/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lg_soundbar",
-  "name": "Lg soundbar",
+  "name": "LG Soundbars",
   "documentation": "https://www.home-assistant.io/integrations/lg_soundbar",
   "requirements": ["temescal==0.1"],
   "dependencies": [],

--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lifx",
-  "name": "Lifx",
+  "name": "LIFX",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lifx",
   "requirements": ["aiolifx==0.6.7", "aiolifx_effects==0.2.2"],

--- a/homeassistant/components/lifx_cloud/manifest.json
+++ b/homeassistant/components/lifx_cloud/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lifx_cloud",
-  "name": "Lifx cloud",
+  "name": "LIFX Cloud",
   "documentation": "https://www.home-assistant.io/integrations/lifx_cloud",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/lifx_legacy/manifest.json
+++ b/homeassistant/components/lifx_legacy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lifx_legacy",
-  "name": "Lifx legacy",
+  "name": "LIFX Legacy",
   "documentation": "https://www.home-assistant.io/integrations/lifx_legacy",
   "requirements": ["liffylights==0.9.4"],
   "dependencies": [],

--- a/homeassistant/components/limitlessled/manifest.json
+++ b/homeassistant/components/limitlessled/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "limitlessled",
-  "name": "Limitlessled",
+  "name": "LimitlessLED",
   "documentation": "https://www.home-assistant.io/integrations/limitlessled",
   "requirements": ["limitlessled==1.1.3"],
   "dependencies": [],

--- a/homeassistant/components/linksys_smart/manifest.json
+++ b/homeassistant/components/linksys_smart/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "linksys_smart",
-  "name": "Linksys smart",
+  "name": "Linksys Smart Wi-Fi",
   "documentation": "https://www.home-assistant.io/integrations/linksys_smart",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/linky/manifest.json
+++ b/homeassistant/components/linky/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "linky",
-  "name": "Linky",
+  "name": "Enedis Linky",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/linky",
   "requirements": ["pylinky==0.4.0"],

--- a/homeassistant/components/linux_battery/manifest.json
+++ b/homeassistant/components/linux_battery/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "linux_battery",
-  "name": "Linux battery",
+  "name": "Linux Battery",
   "documentation": "https://www.home-assistant.io/integrations/linux_battery",
   "requirements": ["batinfo==0.4.2"],
   "dependencies": [],

--- a/homeassistant/components/lirc/manifest.json
+++ b/homeassistant/components/lirc/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lirc",
-  "name": "Lirc",
+  "name": "LIRC",
   "documentation": "https://www.home-assistant.io/integrations/lirc",
   "requirements": ["python-lirc==1.2.3"],
   "dependencies": [],

--- a/homeassistant/components/litejet/manifest.json
+++ b/homeassistant/components/litejet/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "litejet",
-  "name": "Litejet",
+  "name": "LiteJet",
   "documentation": "https://www.home-assistant.io/integrations/litejet",
   "requirements": ["pylitejet==0.1"],
   "dependencies": [],

--- a/homeassistant/components/liveboxplaytv/manifest.json
+++ b/homeassistant/components/liveboxplaytv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "liveboxplaytv",
-  "name": "Liveboxplaytv",
+  "name": "Orange Livebox Play TV",
   "documentation": "https://www.home-assistant.io/integrations/liveboxplaytv",
   "requirements": ["liveboxplaytv==2.0.3", "pyteleloisirs==3.6"],
   "dependencies": [],

--- a/homeassistant/components/llamalab_automate/manifest.json
+++ b/homeassistant/components/llamalab_automate/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "llamalab_automate",
-  "name": "Llamalab automate",
+  "name": "LlamaLab Automate",
   "documentation": "https://www.home-assistant.io/integrations/llamalab_automate",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/local_file/manifest.json
+++ b/homeassistant/components/local_file/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "local_file",
-  "name": "Local file",
+  "name": "Local File",
   "documentation": "https://www.home-assistant.io/integrations/local_file",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/london_air/manifest.json
+++ b/homeassistant/components/london_air/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "london_air",
-  "name": "London air",
+  "name": "London Air",
   "documentation": "https://www.home-assistant.io/integrations/london_air",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/london_underground/manifest.json
+++ b/homeassistant/components/london_underground/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "london_underground",
-  "name": "London underground",
+  "name": "London Underground",
   "documentation": "https://www.home-assistant.io/integrations/london_underground",
   "requirements": ["london-tube-status==0.2"],
   "dependencies": [],

--- a/homeassistant/components/loopenergy/manifest.json
+++ b/homeassistant/components/loopenergy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "loopenergy",
-  "name": "Loopenergy",
+  "name": "Loop Energy",
   "documentation": "https://www.home-assistant.io/integrations/loopenergy",
   "requirements": ["pyloopenergy==0.1.3"],
   "dependencies": [],

--- a/homeassistant/components/luci/manifest.json
+++ b/homeassistant/components/luci/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "luci",
-  "name": "Luci",
+  "name": "OpenWRT (luci)",
   "documentation": "https://www.home-assistant.io/integrations/luci",
   "requirements": ["openwrt-luci-rpc==1.1.2"],
   "dependencies": [],

--- a/homeassistant/components/lupusec/manifest.json
+++ b/homeassistant/components/lupusec/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lupusec",
-  "name": "Lupusec",
+  "name": "Lupus Electronics LUPUSEC",
   "documentation": "https://www.home-assistant.io/integrations/lupusec",
   "requirements": ["lupupy==0.0.18"],
   "dependencies": [],

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lutron_caseta",
-  "name": "Lutron caseta",
+  "name": "Lutron Caseta",
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
   "requirements": ["pylutron-caseta==0.5.1"],
   "dependencies": [],

--- a/homeassistant/components/lw12wifi/manifest.json
+++ b/homeassistant/components/lw12wifi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lw12wifi",
-  "name": "Lw12wifi",
+  "name": "LAGUTE LW-12",
   "documentation": "https://www.home-assistant.io/integrations/lw12wifi",
   "requirements": ["lw12==0.9.2"],
   "dependencies": [],


### PR DESCRIPTION
## Description:

I'm working on getting some things synced between our documentation and the codebase (making the codebase the source of truth). The title/name of the integration is a great starting point for this.

However, the product/brand/integration names are often misspelled, incorrect or incomplete. This PR corrects a bunch of those.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. 

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
