### PR TITLE
Remove `suppress_warning` from config options for vizio component

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
-    CONF_SUPPRESS_WARNING,
     CONF_VOLUME_STEP,
     DEFAULT_DEVICE_CLASS,
     DEFAULT_NAME,
@@ -33,7 +32,6 @@ VIZIO_SCHEMA = {
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_ACCESS_TOKEN): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SUPPRESS_WARNING, default=False): cv.boolean,
     vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
         cv.string, vol.Lower, vol.In(["tv", "soundbar"])
     ),

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -1,6 +1,5 @@
 """Constants used by vizio component."""
 
-CONF_SUPPRESS_WARNING = "suppress_warning"
 CONF_VOLUME_STEP = "volume_step"
 
 DEFAULT_NAME = "Vizio SmartCast"

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -6,6 +6,5 @@
     "pyvizio==0.0.12"
   ],
   "dependencies": [],
-  "config_flow": true,
   "codeowners": ["@raman325"]
 }

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -3,8 +3,9 @@
   "name": "Vizio",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
   "requirements": [
-    "pyvizio==0.0.11"
+    "pyvizio==0.0.12"
   ],
   "dependencies": [],
+  "config_flow": true,
   "codeowners": ["@raman325"]
 }

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -49,15 +49,7 @@ SUPPORTED_COMMANDS = {
 }
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA), validate_auth)
-=======
-PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA, validate_auth))
->>>>>>> update .coveragerc, move validate_auth to __init__, only attempt to get ESN if device setup is validated
-=======
-PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA), validate_auth)
->>>>>>> fix schema validation
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -4,7 +4,7 @@ import logging
 
 from pyvizio import Vizio
 from requests.packages import urllib3
-import voluptous as vol
+import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
@@ -56,7 +56,11 @@ SUPPORTED_COMMANDS = {
 }
 
 
+<<<<<<< HEAD
 PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA), validate_auth)
+=======
+PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA, validate_auth))
+>>>>>>> update .coveragerc, move validate_auth to __init__, only attempt to get ESN if device setup is validated
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -57,10 +57,14 @@ SUPPORTED_COMMANDS = {
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA), validate_auth)
 =======
 PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA, validate_auth))
 >>>>>>> update .coveragerc, move validate_auth to __init__, only attempt to get ESN if device setup is validated
+=======
+PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA), validate_auth)
+>>>>>>> fix schema validation
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -4,9 +4,10 @@ import logging
 
 from pyvizio import Vizio
 from requests.packages import urllib3
+import voluptous as vol
 
 from homeassistant import util
-from homeassistant.components.media_player import MediaPlayerDevice
+from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PREVIOUS_TRACK,

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -4,10 +4,9 @@ import logging
 
 from pyvizio import Vizio
 from requests.packages import urllib3
-import voluptuous as vol
 
 from homeassistant import util
-from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
+from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PREVIOUS_TRACK,

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 import logging
 
 from pyvizio import Vizio
-from requests.packages import urllib3
 import voluptuous as vol
 
 from homeassistant import util
@@ -28,13 +27,7 @@ from homeassistant.const import (
 )
 
 from . import VIZIO_SCHEMA, validate_auth
-from .const import (
-    CONF_SUPPRESS_WARNING,
-    CONF_VOLUME_STEP,
-    DEFAULT_NAME,
-    DEVICE_ID,
-    ICON,
-)
+from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEVICE_ID, ICON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,12 +79,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         )
         return
 
-    if config[CONF_SUPPRESS_WARNING]:
-        _LOGGER.warning(
-            "InsecureRequestWarning is disabled "
-            "because of Vizio platform configuration"
-        )
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     add_entities([device], True)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.11
+pyvizio==0.0.12
 
 # homeassistant.components.velux
 pyvlx==0.2.12


### PR DESCRIPTION
## Breaking Change:
Removed `suppress_warning` as a config option for the `vizio` component.

## Description:
The `pyvizio` component now suppresses insecure HTTPS request warnings in a way that doesn't affect global `requests` from other components, HA, etc. There is no need to globally suppress insecure warnings now.

NOTE: Should follow merge of #30522 since it incorporates those changes

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11650

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: vizio
    host: '<IP>:<PORT>'
    access_token: '<AUTH_TOKEN>'
    device_class: tv
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
