### PR TITLE
Catch UnicodeDecodeError exceptions in 'androidtv.adb_command' service

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -528,7 +528,13 @@ class ADBDevice(MediaPlayerDevice):
             self.schedule_update_ha_state()
             return self._adb_response
 
-        response = self.aftv.adb_shell(cmd)
+        try:
+            response = self.aftv.adb_shell(cmd)
+        except UnicodeDecodeError:
+            self._adb_response = None
+            self.schedule_update_ha_state()
+            return
+
         if isinstance(response, str) and response.strip():
             self._adb_response = response.strip()
         else:

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -640,7 +640,7 @@ async def test_adb_command_unicode_decode_error(hass):
     ):
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            "adb_command",
+            SERVICE_ADB_COMMAND,
             {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: command},
             blocking=True,
         )


### PR DESCRIPTION
## Description:

Catch `UnicodeDecodeError` exceptions in `androidtv.adb_command` service

This is related to https://github.com/JeffLIrion/adb_shell/issues/63.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
