### PR TITLE
Correct names in manifests (M-P)

### DIFF
--- a/homeassistant/components/manual_mqtt/manifest.json
+++ b/homeassistant/components/manual_mqtt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "manual_mqtt",
-  "name": "Manual mqtt",
+  "name": "Manual MQTT",
   "documentation": "https://www.home-assistant.io/integrations/manual_mqtt",
   "requirements": [],
   "dependencies": ["mqtt"],

--- a/homeassistant/components/marytts/manifest.json
+++ b/homeassistant/components/marytts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "marytts",
-  "name": "Marytts",
+  "name": "MaryTTS",
   "documentation": "https://www.home-assistant.io/integrations/marytts",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/maxcube/manifest.json
+++ b/homeassistant/components/maxcube/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "maxcube",
-  "name": "Maxcube",
+  "name": "eQ-3 MAX!",
   "documentation": "https://www.home-assistant.io/integrations/maxcube",
   "requirements": ["maxcube-api==0.1.0"],
   "dependencies": [],

--- a/homeassistant/components/media_extractor/manifest.json
+++ b/homeassistant/components/media_extractor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "media_extractor",
-  "name": "Media extractor",
+  "name": "Media Extractor",
   "documentation": "https://www.home-assistant.io/integrations/media_extractor",
   "requirements": ["youtube_dl==2020.01.01"],
   "dependencies": ["media_player"],

--- a/homeassistant/components/media_player/manifest.json
+++ b/homeassistant/components/media_player/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "media_player",
-  "name": "Media player",
+  "name": "Media Player",
   "documentation": "https://www.home-assistant.io/integrations/media_player",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/message_bird/manifest.json
+++ b/homeassistant/components/message_bird/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "message_bird",
-  "name": "Message bird",
+  "name": "MessageBird",
   "documentation": "https://www.home-assistant.io/integrations/message_bird",
   "requirements": ["messagebird==1.2.0"],
   "dependencies": [],

--- a/homeassistant/components/met/manifest.json
+++ b/homeassistant/components/met/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "met",
-  "name": "Met",
+  "name": "Meteorologisk institutt (Met.no)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/met",
   "requirements": ["pyMetno==0.4.6"],

--- a/homeassistant/components/meteo_france/manifest.json
+++ b/homeassistant/components/meteo_france/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "meteo_france",
-  "name": "Meteo france",
+  "name": "Météo-France",
   "documentation": "https://www.home-assistant.io/integrations/meteo_france",
   "requirements": ["meteofrance==0.3.7", "vigilancemeteo==3.0.0"],
   "dependencies": [],

--- a/homeassistant/components/meteoalarm/manifest.json
+++ b/homeassistant/components/meteoalarm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "meteoalarm",
-  "name": "meteoalarm",
+  "name": "MeteoAlarm",
   "documentation": "https://www.home-assistant.io/integrations/meteoalarm",
   "requirements": ["meteoalertapi==0.1.6"],
   "dependencies": [],

--- a/homeassistant/components/metoffice/manifest.json
+++ b/homeassistant/components/metoffice/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "metoffice",
-  "name": "Metoffice",
+  "name": "Met Office",
   "documentation": "https://www.home-assistant.io/integrations/metoffice",
   "requirements": ["datapoint==0.9.5"],
   "dependencies": [],

--- a/homeassistant/components/mfi/manifest.json
+++ b/homeassistant/components/mfi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mfi",
-  "name": "Mfi",
+  "name": "Ubiquiti mFi mPort",
   "documentation": "https://www.home-assistant.io/integrations/mfi",
   "requirements": ["mficlient==0.3.0"],
   "dependencies": [],

--- a/homeassistant/components/mhz19/manifest.json
+++ b/homeassistant/components/mhz19/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mhz19",
-  "name": "Mhz19",
+  "name": "MH-Z19 CO2 Sensor",
   "documentation": "https://www.home-assistant.io/integrations/mhz19",
   "requirements": ["pmsensor==0.4"],
   "dependencies": [],

--- a/homeassistant/components/microsoft/manifest.json
+++ b/homeassistant/components/microsoft/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "microsoft",
-  "name": "Microsoft",
+  "name": "Microsoft Text-to-Speech (TTS)",
   "documentation": "https://www.home-assistant.io/integrations/microsoft",
   "requirements": ["pycsspeechtts==1.0.3"],
   "dependencies": [],

--- a/homeassistant/components/microsoft_face/manifest.json
+++ b/homeassistant/components/microsoft_face/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "microsoft_face",
-  "name": "Microsoft face",
+  "name": "Microsoft Face",
   "documentation": "https://www.home-assistant.io/integrations/microsoft_face",
   "requirements": [],
   "dependencies": ["camera"],

--- a/homeassistant/components/microsoft_face_detect/manifest.json
+++ b/homeassistant/components/microsoft_face_detect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "microsoft_face_detect",
-  "name": "Microsoft face detect",
+  "name": "Microsoft Face Detect",
   "documentation": "https://www.home-assistant.io/integrations/microsoft_face_detect",
   "requirements": [],
   "dependencies": ["microsoft_face"],

--- a/homeassistant/components/microsoft_face_identify/manifest.json
+++ b/homeassistant/components/microsoft_face_identify/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "microsoft_face_identify",
-  "name": "Microsoft face identify",
+  "name": "Microsoft Face Identify",
   "documentation": "https://www.home-assistant.io/integrations/microsoft_face_identify",
   "requirements": [],
   "dependencies": ["microsoft_face"],

--- a/homeassistant/components/miflora/manifest.json
+++ b/homeassistant/components/miflora/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "miflora",
-  "name": "Miflora",
+  "name": "Mi Flora",
   "documentation": "https://www.home-assistant.io/integrations/miflora",
   "requirements": ["bluepy==1.3.0", "miflora==0.6.0"],
   "dependencies": [],

--- a/homeassistant/components/mikrotik/manifest.json
+++ b/homeassistant/components/mikrotik/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mikrotik",
-  "name": "Mikrotik",
+  "name": "MikroTik",
   "documentation": "https://www.home-assistant.io/integrations/mikrotik",
   "requirements": ["librouteros==2.3.0"],
   "dependencies": [],

--- a/homeassistant/components/min_max/manifest.json
+++ b/homeassistant/components/min_max/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "min_max",
-  "name": "Min max",
+  "name": "Min/Max",
   "documentation": "https://www.home-assistant.io/integrations/min_max",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/mitemp_bt/manifest.json
+++ b/homeassistant/components/mitemp_bt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mitemp_bt",
-  "name": "Mitemp bt",
+  "name": "Xiaomi Mijia BLE Temperature and Humidity Sensor",
   "documentation": "https://www.home-assistant.io/integrations/mitemp_bt",
   "requirements": ["mitemp_bt==0.0.3"],
   "dependencies": [],

--- a/homeassistant/components/mjpeg/manifest.json
+++ b/homeassistant/components/mjpeg/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mjpeg",
-  "name": "Mjpeg",
+  "name": "MJPEG IP Camera",
   "documentation": "https://www.home-assistant.io/integrations/mjpeg",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/modem_callerid/manifest.json
+++ b/homeassistant/components/modem_callerid/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "modem_callerid",
-  "name": "Modem callerid",
+  "name": "Modem Caller ID",
   "documentation": "https://www.home-assistant.io/integrations/modem_callerid",
   "requirements": ["basicmodem==0.7"],
   "dependencies": [],

--- a/homeassistant/components/mold_indicator/manifest.json
+++ b/homeassistant/components/mold_indicator/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mold_indicator",
-  "name": "Mold indicator",
+  "name": "Mold Indicator",
   "documentation": "https://www.home-assistant.io/integrations/mold_indicator",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/monoprice/manifest.json
+++ b/homeassistant/components/monoprice/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "monoprice",
-  "name": "Monoprice",
+  "name": "Monoprice 6-Zone Amplifier",
   "documentation": "https://www.home-assistant.io/integrations/monoprice",
   "requirements": ["pymonoprice==0.3"],
   "dependencies": [],

--- a/homeassistant/components/mpchc/manifest.json
+++ b/homeassistant/components/mpchc/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mpchc",
-  "name": "Mpchc",
+  "name": "Media Player Classic Home Cinema (MPC-HC)",
   "documentation": "https://www.home-assistant.io/integrations/mpchc",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/mpd/manifest.json
+++ b/homeassistant/components/mpd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mpd",
-  "name": "Mpd",
+  "name": "Music Player Daemon (MPD)",
   "documentation": "https://www.home-assistant.io/integrations/mpd",
   "requirements": ["python-mpd2==1.0.0"],
   "dependencies": [],

--- a/homeassistant/components/mqtt_eventstream/manifest.json
+++ b/homeassistant/components/mqtt_eventstream/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mqtt_eventstream",
-  "name": "Mqtt eventstream",
+  "name": "MQTT Eventstream",
   "documentation": "https://www.home-assistant.io/integrations/mqtt_eventstream",
   "requirements": [],
   "dependencies": ["mqtt"],

--- a/homeassistant/components/mqtt_json/manifest.json
+++ b/homeassistant/components/mqtt_json/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mqtt_json",
-  "name": "Mqtt json",
+  "name": "MQTT JSON",
   "documentation": "https://www.home-assistant.io/integrations/mqtt_json",
   "requirements": [],
   "dependencies": ["mqtt"],

--- a/homeassistant/components/mqtt_room/manifest.json
+++ b/homeassistant/components/mqtt_room/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mqtt_room",
-  "name": "Mqtt room",
+  "name": "MQTT Room Presence",
   "documentation": "https://www.home-assistant.io/integrations/mqtt_room",
   "requirements": [],
   "dependencies": ["mqtt"],

--- a/homeassistant/components/mqtt_statestream/manifest.json
+++ b/homeassistant/components/mqtt_statestream/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mqtt_statestream",
-  "name": "Mqtt statestream",
+  "name": "MQTT Statestream",
   "documentation": "https://www.home-assistant.io/integrations/mqtt_statestream",
   "requirements": [],
   "dependencies": ["mqtt"],

--- a/homeassistant/components/mvglive/manifest.json
+++ b/homeassistant/components/mvglive/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mvglive",
-  "name": "Mvglive",
+  "name": "MVG",
   "documentation": "https://www.home-assistant.io/integrations/mvglive",
   "requirements": ["PyMVGLive==1.1.4"],
   "dependencies": [],

--- a/homeassistant/components/mychevy/manifest.json
+++ b/homeassistant/components/mychevy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mychevy",
-  "name": "Mychevy",
+  "name": "myChevrolet",
   "documentation": "https://www.home-assistant.io/integrations/mychevy",
   "requirements": ["mychevy==1.2.0"],
   "dependencies": [],

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "myq",
-  "name": "Myq",
+  "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
   "requirements": ["pymyq==2.0.1"],
   "dependencies": [],

--- a/homeassistant/components/mysensors/manifest.json
+++ b/homeassistant/components/mysensors/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mysensors",
-  "name": "Mysensors",
+  "name": "MySensors",
   "documentation": "https://www.home-assistant.io/integrations/mysensors",
   "requirements": ["pymysensors==0.18.0"],
   "dependencies": [],

--- a/homeassistant/components/mystrom/manifest.json
+++ b/homeassistant/components/mystrom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mystrom",
-  "name": "Mystrom",
+  "name": "myStrom",
   "documentation": "https://www.home-assistant.io/integrations/mystrom",
   "requirements": ["python-mystrom==0.5.0"],
   "dependencies": ["http"],

--- a/homeassistant/components/mythicbeastsdns/manifest.json
+++ b/homeassistant/components/mythicbeastsdns/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mythicbeastsdns",
-  "name": "Mythicbeastsdns",
+  "name": "Mythic Beasts DNS",
   "documentation": "https://www.home-assistant.io/integrations/mythicbeastsdns",
   "requirements": ["mbddns==0.1.2"],
   "dependencies": [],

--- a/homeassistant/components/nad/manifest.json
+++ b/homeassistant/components/nad/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nad",
-  "name": "Nad",
+  "name": "NAD",
   "documentation": "https://www.home-assistant.io/integrations/nad",
   "requirements": ["nad_receiver==0.0.11"],
   "dependencies": [],

--- a/homeassistant/components/namecheapdns/manifest.json
+++ b/homeassistant/components/namecheapdns/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "namecheapdns",
-  "name": "Namecheapdns",
+  "name": "Namecheap FreeDNS",
   "documentation": "https://www.home-assistant.io/integrations/namecheapdns",
   "requirements": ["defusedxml==0.6.0"],
   "dependencies": [],

--- a/homeassistant/components/neato/manifest.json
+++ b/homeassistant/components/neato/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "neato",
-  "name": "Neato",
+  "name": "Neato Botvac",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/neato",
   "requirements": ["pybotvac==0.0.17"],

--- a/homeassistant/components/nederlandse_spoorwegen/manifest.json
+++ b/homeassistant/components/nederlandse_spoorwegen/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nederlandse_spoorwegen",
-  "name": "Nederlandse spoorwegen",
+  "name": "Nederlandse Spoorwegen (NS)",
   "documentation": "https://www.home-assistant.io/integrations/nederlandse_spoorwegen",
   "requirements": ["nsapi==2.7.4"],
   "dependencies": [],

--- a/homeassistant/components/ness_alarm/manifest.json
+++ b/homeassistant/components/ness_alarm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ness_alarm",
-  "name": "Ness alarm",
+  "name": "Ness Alarm",
   "documentation": "https://www.home-assistant.io/integrations/ness_alarm",
   "requirements": ["nessclient==0.9.15"],
   "dependencies": [],

--- a/homeassistant/components/netgear_lte/manifest.json
+++ b/homeassistant/components/netgear_lte/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "netgear_lte",
-  "name": "Netgear lte",
+  "name": "Netgear LTE",
   "documentation": "https://www.home-assistant.io/integrations/netgear_lte",
   "requirements": ["eternalegypt==0.0.11"],
   "dependencies": [],

--- a/homeassistant/components/nfandroidtv/manifest.json
+++ b/homeassistant/components/nfandroidtv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nfandroidtv",
-  "name": "Nfandroidtv",
+  "name": "Notifications for Android TV / FireTV",
   "documentation": "https://www.home-assistant.io/integrations/nfandroidtv",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/niko_home_control/manifest.json
+++ b/homeassistant/components/niko_home_control/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "niko_home_control",
-  "name": "Niko home control",
+  "name": "Niko Home Control",
   "documentation": "https://www.home-assistant.io/integrations/niko_home_control",
   "requirements": ["niko-home-control==0.2.1"],
   "dependencies": [],

--- a/homeassistant/components/nilu/manifest.json
+++ b/homeassistant/components/nilu/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nilu",
-  "name": "Nilu",
+  "name": "Norwegian Institute for Air Research (NILU)",
   "documentation": "https://www.home-assistant.io/integrations/nilu",
   "requirements": ["niluclient==0.1.2"],
   "dependencies": [],

--- a/homeassistant/components/nissan_leaf/manifest.json
+++ b/homeassistant/components/nissan_leaf/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nissan_leaf",
-  "name": "Nissan leaf",
+  "name": "Nissan Leaf",
   "documentation": "https://www.home-assistant.io/integrations/nissan_leaf",
   "requirements": ["pycarwings2==2.9"],
   "dependencies": [],

--- a/homeassistant/components/nmap_tracker/manifest.json
+++ b/homeassistant/components/nmap_tracker/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nmap_tracker",
-  "name": "Nmap tracker",
+  "name": "Nmap Tracker",
   "documentation": "https://www.home-assistant.io/integrations/nmap_tracker",
   "requirements": ["python-nmap==0.6.1", "getmac==0.8.1"],
   "dependencies": [],

--- a/homeassistant/components/nmbs/manifest.json
+++ b/homeassistant/components/nmbs/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nmbs",
-  "name": "Nmbs",
+  "name": "NMBS",
   "documentation": "https://www.home-assistant.io/integrations/nmbs",
   "requirements": ["pyrail==0.0.3"],
   "dependencies": [],

--- a/homeassistant/components/no_ip/manifest.json
+++ b/homeassistant/components/no_ip/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "no_ip",
-  "name": "No ip",
+  "name": "No-IP.com",
   "documentation": "https://www.home-assistant.io/integrations/no_ip",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/noaa_tides/manifest.json
+++ b/homeassistant/components/noaa_tides/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "noaa_tides",
-  "name": "Noaa tides",
+  "name": "NOAA Tides",
   "documentation": "https://www.home-assistant.io/integrations/noaa_tides",
   "requirements": ["py_noaa==0.3.0"],
   "dependencies": [],

--- a/homeassistant/components/norway_air/manifest.json
+++ b/homeassistant/components/norway_air/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "norway_air",
-  "name": "Norway air",
+  "name": "Om Luftkvalitet i Norge (Norway Air)",
   "documentation": "https://www.home-assistant.io/integrations/norway_air",
   "requirements": ["pyMetno==0.4.6"],
   "dependencies": [],

--- a/homeassistant/components/notify/manifest.json
+++ b/homeassistant/components/notify/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "notify",
-  "name": "Notify",
+  "name": "Notifications",
   "documentation": "https://www.home-assistant.io/integrations/notify",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/nsw_fuel_station/manifest.json
+++ b/homeassistant/components/nsw_fuel_station/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nsw_fuel_station",
-  "name": "Nsw fuel station",
+  "name": "NSW Fuel Station Price",
   "documentation": "https://www.home-assistant.io/integrations/nsw_fuel_station",
   "requirements": ["nsw-fuel-api-client==1.0.10"],
   "dependencies": [],

--- a/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
+++ b/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nsw_rural_fire_service_feed",
-  "name": "Nsw rural fire service feed",
+  "name": "NSW Rural Fire Service Incidents",
   "documentation": "https://www.home-assistant.io/integrations/nsw_rural_fire_service_feed",
   "requirements": ["aio_geojson_nsw_rfs_incidents==0.1"],
   "dependencies": [],

--- a/homeassistant/components/nuheat/manifest.json
+++ b/homeassistant/components/nuheat/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nuheat",
-  "name": "Nuheat",
+  "name": "NuHeat",
   "documentation": "https://www.home-assistant.io/integrations/nuheat",
   "requirements": ["nuheat==0.3.0"],
   "dependencies": [],

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nut",
-  "name": "Nut",
+  "name": "Network UPS Tools (NUT)",
   "documentation": "https://www.home-assistant.io/integrations/nut",
   "requirements": ["pynut2==2.1.2"],
   "dependencies": [],

--- a/homeassistant/components/nws/manifest.json
+++ b/homeassistant/components/nws/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nws",
-  "name": "National Weather Service",
+  "name": "National Weather Service (NWS)",
   "documentation": "https://www.home-assistant.io/integrations/nws",
   "dependencies": [],
   "codeowners": ["@MatthewFlamm"],

--- a/homeassistant/components/nx584/manifest.json
+++ b/homeassistant/components/nx584/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nx584",
-  "name": "Nx584",
+  "name": "NX584",
   "documentation": "https://www.home-assistant.io/integrations/nx584",
   "requirements": ["pynx584==0.4"],
   "dependencies": [],

--- a/homeassistant/components/nzbget/manifest.json
+++ b/homeassistant/components/nzbget/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "nzbget",
-  "name": "Nzbget",
+  "name": "NZBGet",
   "documentation": "https://www.home-assistant.io/integrations/nzbget",
   "requirements": ["pynzbgetapi==0.2.0"],
   "dependencies": [],

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "octoprint",
-  "name": "Octoprint",
+  "name": "OctoPrint",
   "documentation": "https://www.home-assistant.io/integrations/octoprint",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/oem/manifest.json
+++ b/homeassistant/components/oem/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "oem",
-  "name": "Oem",
+  "name": "OpenEnergyMonitor WiFi Thermostat",
   "documentation": "https://www.home-assistant.io/integrations/oem",
   "requirements": ["oemthermostat==1.1"],
   "dependencies": [],

--- a/homeassistant/components/ohmconnect/manifest.json
+++ b/homeassistant/components/ohmconnect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ohmconnect",
-  "name": "Ohmconnect",
+  "name": "OhmConnect",
   "documentation": "https://www.home-assistant.io/integrations/ohmconnect",
   "requirements": ["defusedxml==0.6.0"],
   "dependencies": [],

--- a/homeassistant/components/onboarding/manifest.json
+++ b/homeassistant/components/onboarding/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "onboarding",
-  "name": "Onboarding",
+  "name": "Home Assistant Onboarding",
   "documentation": "https://www.home-assistant.io/integrations/onboarding",
   "requirements": [],
   "dependencies": ["auth", "http", "person"],

--- a/homeassistant/components/onewire/manifest.json
+++ b/homeassistant/components/onewire/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "onewire",
-  "name": "Onewire",
+  "name": "1-Wire",
   "documentation": "https://www.home-assistant.io/integrations/onewire",
   "requirements": ["pyownet==0.10.0.post1"],
   "dependencies": [],

--- a/homeassistant/components/onvif/manifest.json
+++ b/homeassistant/components/onvif/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "onvif",
-  "name": "Onvif",
+  "name": "ONVIF",
   "documentation": "https://www.home-assistant.io/integrations/onvif",
   "requirements": ["onvif-zeep-async==0.2.0"],
   "dependencies": ["ffmpeg"],

--- a/homeassistant/components/openalpr_cloud/manifest.json
+++ b/homeassistant/components/openalpr_cloud/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "openalpr_cloud",
-  "name": "Openalpr cloud",
+  "name": "OpenALPR Cloud",
   "documentation": "https://www.home-assistant.io/integrations/openalpr_cloud",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/openalpr_local/manifest.json
+++ b/homeassistant/components/openalpr_local/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "openalpr_local",
-  "name": "Openalpr local",
+  "name": "OpenALPR Local",
   "documentation": "https://www.home-assistant.io/integrations/openalpr_local",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/opencv/manifest.json
+++ b/homeassistant/components/opencv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "opencv",
-  "name": "Opencv",
+  "name": "OpenCV",
   "documentation": "https://www.home-assistant.io/integrations/opencv",
   "requirements": ["numpy==1.17.4", "opencv-python-headless==4.1.2.30"],
   "dependencies": [],

--- a/homeassistant/components/openevse/manifest.json
+++ b/homeassistant/components/openevse/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "openevse",
-  "name": "Openevse",
+  "name": "OpenEVSE",
   "documentation": "https://www.home-assistant.io/integrations/openevse",
   "requirements": ["openevsewifi==0.4"],
   "dependencies": [],

--- a/homeassistant/components/openexchangerates/manifest.json
+++ b/homeassistant/components/openexchangerates/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "openexchangerates",
-  "name": "Openexchangerates",
+  "name": "Open Exchange Rates",
   "documentation": "https://www.home-assistant.io/integrations/openexchangerates",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/opengarage/manifest.json
+++ b/homeassistant/components/opengarage/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "opengarage",
-  "name": "Opengarage",
+  "name": "OpenGarage",
   "documentation": "https://www.home-assistant.io/integrations/opengarage",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/openhardwaremonitor/manifest.json
+++ b/homeassistant/components/openhardwaremonitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "openhardwaremonitor",
-  "name": "Openhardwaremonitor",
+  "name": "Open Hardware Monitor",
   "documentation": "https://www.home-assistant.io/integrations/openhardwaremonitor",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "openhome",
-  "name": "Openhome",
+  "name": "Linn / OpenHome",
   "documentation": "https://www.home-assistant.io/integrations/openhome",
   "requirements": ["openhomedevice==0.6.3"],
   "dependencies": [],

--- a/homeassistant/components/opensensemap/manifest.json
+++ b/homeassistant/components/opensensemap/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "opensensemap",
-  "name": "Opensensemap",
+  "name": "openSenseMap",
   "documentation": "https://www.home-assistant.io/integrations/opensensemap",
   "requirements": ["opensensemap-api==0.1.5"],
   "dependencies": [],

--- a/homeassistant/components/opensky/manifest.json
+++ b/homeassistant/components/opensky/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "opensky",
-  "name": "Opensky",
+  "name": "OpenSky Network",
   "documentation": "https://www.home-assistant.io/integrations/opensky",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/opentherm_gw/manifest.json
+++ b/homeassistant/components/opentherm_gw/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "opentherm_gw",
-  "name": "Opentherm Gateway",
+  "name": "OpenTherm Gateway",
   "documentation": "https://www.home-assistant.io/integrations/opentherm_gw",
   "requirements": ["pyotgw==0.5b1"],
   "dependencies": [],

--- a/homeassistant/components/oru/manifest.json
+++ b/homeassistant/components/oru/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "oru",
-  "name": "Orange and Rockland Utility Smart Energy Meter Sensor",
+  "name": "Orange and Rockland Utility (ORU)",
   "documentation": "https://www.home-assistant.io/integrations/oru",
   "dependencies": [],
   "codeowners": ["@bvlaicu"],

--- a/homeassistant/components/otp/manifest.json
+++ b/homeassistant/components/otp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "otp",
-  "name": "Otp",
+  "name": "One-Time Password (OTP)",
   "documentation": "https://www.home-assistant.io/integrations/otp",
   "requirements": ["pyotp==2.3.0"],
   "dependencies": [],

--- a/homeassistant/components/owntracks/manifest.json
+++ b/homeassistant/components/owntracks/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "owntracks",
-  "name": "Owntracks",
+  "name": "OwnTracks",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/owntracks",
   "requirements": ["PyNaCl==1.3.0"],

--- a/homeassistant/components/panasonic_bluray/manifest.json
+++ b/homeassistant/components/panasonic_bluray/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "panasonic_bluray",
-  "name": "Panasonic bluray",
+  "name": "Panasonic Blu-Ray Player",
   "documentation": "https://www.home-assistant.io/integrations/panasonic_bluray",
   "requirements": ["panacotta==0.1"],
   "dependencies": [],

--- a/homeassistant/components/panasonic_viera/manifest.json
+++ b/homeassistant/components/panasonic_viera/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "panasonic_viera",
-  "name": "Panasonic viera",
+  "name": "Panasonic Viera TV",
   "documentation": "https://www.home-assistant.io/integrations/panasonic_viera",
   "requirements": ["panasonic_viera==0.3.2", "wakeonlan==1.1.6"],
   "dependencies": [],

--- a/homeassistant/components/panel_custom/manifest.json
+++ b/homeassistant/components/panel_custom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "panel_custom",
-  "name": "Panel custom",
+  "name": "Custom Panel",
   "documentation": "https://www.home-assistant.io/integrations/panel_custom",
   "requirements": [],
   "dependencies": ["frontend"],

--- a/homeassistant/components/panel_iframe/manifest.json
+++ b/homeassistant/components/panel_iframe/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "panel_iframe",
-  "name": "Panel iframe",
+  "name": "iframe Panel",
   "documentation": "https://www.home-assistant.io/integrations/panel_iframe",
   "requirements": [],
   "dependencies": ["frontend"],

--- a/homeassistant/components/persistent_notification/manifest.json
+++ b/homeassistant/components/persistent_notification/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "persistent_notification",
-  "name": "Persistent notification",
+  "name": "Persistent Notification",
   "documentation": "https://www.home-assistant.io/integrations/persistent_notification",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/philips_js/manifest.json
+++ b/homeassistant/components/philips_js/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "philips_js",
-  "name": "Philips js",
+  "name": "Philips TV",
   "documentation": "https://www.home-assistant.io/integrations/philips_js",
   "requirements": ["ha-philipsjs==0.0.8"],
   "dependencies": [],

--- a/homeassistant/components/pi_hole/manifest.json
+++ b/homeassistant/components/pi_hole/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "pi_hole",
-  "name": "Pi hole",
+  "name": "Pi-hole",
   "documentation": "https://www.home-assistant.io/integrations/pi_hole",
   "requirements": ["hole==0.5.0"],
   "dependencies": [],

--- a/homeassistant/components/picotts/manifest.json
+++ b/homeassistant/components/picotts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "picotts",
-  "name": "Picotts",
+  "name": "Pico TTS",
   "documentation": "https://www.home-assistant.io/integrations/picotts",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/ping/manifest.json
+++ b/homeassistant/components/ping/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ping",
-  "name": "Ping",
+  "name": "Ping (ICMP)",
   "documentation": "https://www.home-assistant.io/integrations/ping",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/pjlink/manifest.json
+++ b/homeassistant/components/pjlink/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "pjlink",
-  "name": "Pjlink",
+  "name": "PJLink",
   "documentation": "https://www.home-assistant.io/integrations/pjlink",
   "requirements": ["pypjlink2==1.2.0"],
   "dependencies": [],

--- a/homeassistant/components/plant/manifest.json
+++ b/homeassistant/components/plant/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "plant",
-  "name": "Plant",
+  "name": "Plant Monitor",
   "documentation": "https://www.home-assistant.io/integrations/plant",
   "requirements": [],
   "dependencies": ["group", "zone"],

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "plex",
-  "name": "Plex",
+  "name": "Plex Media Server",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/plex",
   "requirements": ["plexapi==3.3.0", "plexauth==0.0.5", "plexwebsocket==0.0.6"],

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "plugwise",
-  "name": "Plugwise",
+  "name": "Plugwise Anna",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
   "dependencies": [],
   "codeowners": ["@laetificat", "@CoMPaTech", "@bouwew"],

--- a/homeassistant/components/plum_lightpad/manifest.json
+++ b/homeassistant/components/plum_lightpad/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "plum_lightpad",
-  "name": "Plum lightpad",
+  "name": "Plum Lightpad",
   "documentation": "https://www.home-assistant.io/integrations/plum_lightpad",
   "requirements": ["plumlightpad==0.0.11"],
   "dependencies": [],

--- a/homeassistant/components/pocketcasts/manifest.json
+++ b/homeassistant/components/pocketcasts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "pocketcasts",
-  "name": "Pocketcasts",
+  "name": "Pocket Casts",
   "documentation": "https://www.home-assistant.io/integrations/pocketcasts",
   "requirements": ["pocketcasts==0.1"],
   "dependencies": [],

--- a/homeassistant/components/point/manifest.json
+++ b/homeassistant/components/point/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "point",
-  "name": "Point",
+  "name": "Minut Point",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/point",
   "requirements": ["pypoint==1.1.2"],

--- a/homeassistant/components/postnl/manifest.json
+++ b/homeassistant/components/postnl/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "postnl",
-  "name": "Postnl",
+  "name": "PostNL",
   "documentation": "https://www.home-assistant.io/integrations/postnl",
   "requirements": ["postnl_api==1.2.2"],
   "dependencies": [],

--- a/homeassistant/components/prezzibenzina/manifest.json
+++ b/homeassistant/components/prezzibenzina/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "prezzibenzina",
-  "name": "Prezzibenzina",
+  "name": "Prezzi Benzina",
   "documentation": "https://www.home-assistant.io/integrations/prezzibenzina",
   "requirements": ["prezzibenzina-py==1.1.4"],
   "dependencies": [],

--- a/homeassistant/components/proxy/manifest.json
+++ b/homeassistant/components/proxy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "proxy",
-  "name": "Proxy",
+  "name": "Camera Proxy",
   "documentation": "https://www.home-assistant.io/integrations/proxy",
   "requirements": ["pillow==6.2.1"],
   "dependencies": [],

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ps4",
-  "name": "Ps4",
+  "name": "Sony PlayStation 4",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ps4",
   "requirements": ["pyps4-2ndscreen==1.0.4"],

--- a/homeassistant/components/ptvsd/manifest.json
+++ b/homeassistant/components/ptvsd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ptvsd",
-  "name": "ptvsd",
+  "name": "PTVSD - Python Tools for Visual Studio Debug Server",
   "documentation": "https://www.home-assistant.io/integrations/ptvsd",
   "requirements": ["ptvsd==4.2.8"],
   "dependencies": [],

--- a/homeassistant/components/pulseaudio_loopback/manifest.json
+++ b/homeassistant/components/pulseaudio_loopback/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "pulseaudio_loopback",
-  "name": "Pulseaudio loopback",
+  "name": "PulseAudio Loopback",
   "documentation": "https://www.home-assistant.io/integrations/pulseaudio_loopback",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/pvoutput/manifest.json
+++ b/homeassistant/components/pvoutput/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "pvoutput",
-  "name": "Pvoutput",
+  "name": "PVOutput",
   "documentation": "https://www.home-assistant.io/integrations/pvoutput",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/pyload/manifest.json
+++ b/homeassistant/components/pyload/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "pyload",
-  "name": "Pyload",
+  "name": "pyLoad",
   "documentation": "https://www.home-assistant.io/integrations/pyload",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/python_script/manifest.json
+++ b/homeassistant/components/python_script/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "python_script",
-  "name": "Python script",
+  "name": "Python Scripts",
   "documentation": "https://www.home-assistant.io/integrations/python_script",
   "requirements": ["restrictedpython==5.0"],
   "dependencies": [],


### PR DESCRIPTION
## Description:

I'm working on getting some things synced between our documentation and the codebase (making the codebase the source of truth). The title/name of the integration is a great starting point for this.

However, the product/brand/integration names are often misspelled, incorrect or incomplete. This PR corrects a bunch of those.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. 

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
