### PR TITLE
Correct names in manifests (Q-S)

### DIFF
--- a/homeassistant/components/aws/manifest.json
+++ b/homeassistant/components/aws/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aws",
-  "name": "Amazon Web Services",
+  "name": "Amazon Web Services (AWS)",
   "documentation": "https://www.home-assistant.io/integrations/aws",
   "requirements": ["aiobotocore==0.10.4"],
   "dependencies": [],

--- a/homeassistant/components/qbittorrent/manifest.json
+++ b/homeassistant/components/qbittorrent/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "qbittorrent",
-  "name": "Qbittorrent",
+  "name": "qBittorrent",
   "documentation": "https://www.home-assistant.io/integrations/qbittorrent",
   "requirements": ["python-qbittorrent==0.4.1"],
   "dependencies": [],

--- a/homeassistant/components/qnap/manifest.json
+++ b/homeassistant/components/qnap/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "qnap",
-  "name": "Qnap",
+  "name": "QNAP",
   "documentation": "https://www.home-assistant.io/integrations/qnap",
   "requirements": ["qnapstats==0.2.7"],
   "dependencies": [],

--- a/homeassistant/components/qrcode/manifest.json
+++ b/homeassistant/components/qrcode/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "qrcode",
-  "name": "Qrcode",
+  "name": "QR Code",
   "documentation": "https://www.home-assistant.io/integrations/qrcode",
   "requirements": ["pillow==6.2.1", "pyzbar==0.1.7"],
   "dependencies": [],

--- a/homeassistant/components/quantum_gateway/manifest.json
+++ b/homeassistant/components/quantum_gateway/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "quantum_gateway",
-  "name": "Quantum gateway",
+  "name": "Quantum Gateway",
   "documentation": "https://www.home-assistant.io/integrations/quantum_gateway",
   "requirements": ["quantum-gateway==0.0.5"],
   "dependencies": [],

--- a/homeassistant/components/qwikswitch/manifest.json
+++ b/homeassistant/components/qwikswitch/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "qwikswitch",
-  "name": "Qwikswitch",
+  "name": "QwikSwitch QSUSB",
   "documentation": "https://www.home-assistant.io/integrations/qwikswitch",
   "requirements": ["pyqwikswitch==0.93"],
   "dependencies": [],

--- a/homeassistant/components/radiotherm/manifest.json
+++ b/homeassistant/components/radiotherm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "radiotherm",
-  "name": "Radiotherm",
+  "name": "Radio Thermostat",
   "documentation": "https://www.home-assistant.io/integrations/radiotherm",
   "requirements": ["radiotherm==2.0.0"],
   "dependencies": [],

--- a/homeassistant/components/rainbird/manifest.json
+++ b/homeassistant/components/rainbird/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rainbird",
-  "name": "Rainbird",
+  "name": "Rain Bird",
   "documentation": "https://www.home-assistant.io/integrations/rainbird",
   "requirements": ["pyrainbird==0.4.1"],
   "dependencies": [],

--- a/homeassistant/components/raincloud/manifest.json
+++ b/homeassistant/components/raincloud/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "raincloud",
-  "name": "Raincloud",
+  "name": "Melnor RainCloud",
   "documentation": "https://www.home-assistant.io/integrations/raincloud",
   "requirements": ["raincloudy==0.0.7"],
   "dependencies": [],

--- a/homeassistant/components/rainmachine/manifest.json
+++ b/homeassistant/components/rainmachine/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rainmachine",
-  "name": "Rainmachine",
+  "name": "RainMachine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rainmachine",
   "requirements": ["regenmaschine==1.5.1"],

--- a/homeassistant/components/raspyrfm/manifest.json
+++ b/homeassistant/components/raspyrfm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "raspyrfm",
-  "name": "Raspyrfm",
+  "name": "RaspyRFM",
   "documentation": "https://www.home-assistant.io/integrations/raspyrfm",
   "requirements": ["raspyrfm-client==1.2.8"],
   "dependencies": [],

--- a/homeassistant/components/recollect_waste/manifest.json
+++ b/homeassistant/components/recollect_waste/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "recollect_waste",
-  "name": "Recollect waste",
+  "name": "ReCollect Waste",
   "documentation": "https://www.home-assistant.io/integrations/recollect_waste",
   "requirements": ["recollect-waste==1.0.1"],
   "dependencies": [],

--- a/homeassistant/components/recswitch/manifest.json
+++ b/homeassistant/components/recswitch/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "recswitch",
-  "name": "Recswitch",
+  "name": "Ankuoo REC Switch",
   "documentation": "https://www.home-assistant.io/integrations/recswitch",
   "requirements": ["pyrecswitch==1.0.2"],
   "dependencies": [],

--- a/homeassistant/components/remember_the_milk/manifest.json
+++ b/homeassistant/components/remember_the_milk/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "remember_the_milk",
-  "name": "Remember the milk",
+  "name": "Remember The Milk",
   "documentation": "https://www.home-assistant.io/integrations/remember_the_milk",
   "requirements": ["RtmAPI==0.7.2", "httplib2==0.10.3"],
   "dependencies": ["configurator"],

--- a/homeassistant/components/repetier/manifest.json
+++ b/homeassistant/components/repetier/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "repetier",
-  "name": "Repetier Server",
+  "name": "Repetier-Server",
   "documentation": "https://www.home-assistant.io/integrations/repetier",
   "requirements": ["pyrepetier==3.0.5"],
   "dependencies": [],

--- a/homeassistant/components/rest/manifest.json
+++ b/homeassistant/components/rest/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rest",
-  "name": "Rest",
+  "name": "RESTful",
   "documentation": "https://www.home-assistant.io/integrations/rest",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/rest_command/manifest.json
+++ b/homeassistant/components/rest_command/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rest_command",
-  "name": "Rest command",
+  "name": "RESTful Command",
   "documentation": "https://www.home-assistant.io/integrations/rest_command",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/rflink/manifest.json
+++ b/homeassistant/components/rflink/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rflink",
-  "name": "Rflink",
+  "name": "RFLink",
   "documentation": "https://www.home-assistant.io/integrations/rflink",
   "requirements": ["rflink==0.0.50"],
   "dependencies": [],

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rfxtrx",
-  "name": "Rfxtrx",
+  "name": "RFXCOM RFXtrx",
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "requirements": ["pyRFXtrx==0.24"],
   "dependencies": [],

--- a/homeassistant/components/rmvtransport/manifest.json
+++ b/homeassistant/components/rmvtransport/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rmvtransport",
-  "name": "Rmvtransport",
+  "name": "RMV",
   "documentation": "https://www.home-assistant.io/integrations/rmvtransport",
   "requirements": ["PyRMVtransport==0.2.9"],
   "dependencies": [],

--- a/homeassistant/components/rocketchat/manifest.json
+++ b/homeassistant/components/rocketchat/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rocketchat",
-  "name": "Rocketchat",
+  "name": "Rocket.Chat",
   "documentation": "https://www.home-assistant.io/integrations/rocketchat",
   "requirements": ["rocketchat-API==0.6.1"],
   "dependencies": [],

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "roomba",
-  "name": "Roomba",
+  "name": "iRobot Roomba",
   "documentation": "https://www.home-assistant.io/integrations/roomba",
   "requirements": ["roombapy==1.4.2"],
   "dependencies": [],

--- a/homeassistant/components/route53/manifest.json
+++ b/homeassistant/components/route53/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "route53",
-  "name": "Route53",
+  "name": "AWS Route53",
   "documentation": "https://www.home-assistant.io/integrations/route53",
   "requirements": ["boto3==1.9.252", "ipify==1.0.0"],
   "dependencies": [],

--- a/homeassistant/components/rova/manifest.json
+++ b/homeassistant/components/rova/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rova",
-  "name": "Rova",
+  "name": "ROVA",
   "documentation": "https://www.home-assistant.io/integrations/rova",
   "requirements": ["rova==0.1.0"],
   "dependencies": [],

--- a/homeassistant/components/rpi_camera/manifest.json
+++ b/homeassistant/components/rpi_camera/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rpi_camera",
-  "name": "Rpi camera",
+  "name": "Raspberry Pi Camera",
   "documentation": "https://www.home-assistant.io/integrations/rpi_camera",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/rpi_gpio/manifest.json
+++ b/homeassistant/components/rpi_gpio/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rpi_gpio",
-  "name": "Rpi gpio",
+  "name": "Raspberry Pi GPIO",
   "documentation": "https://www.home-assistant.io/integrations/rpi_gpio",
   "requirements": ["RPi.GPIO==0.7.0"],
   "dependencies": [],

--- a/homeassistant/components/rpi_gpio_pwm/manifest.json
+++ b/homeassistant/components/rpi_gpio_pwm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rpi_gpio_pwm",
-  "name": "Rpi gpio pwm",
+  "name": "pigpio Daemon PWM LED",
   "documentation": "https://www.home-assistant.io/integrations/rpi_gpio_pwm",
   "requirements": ["pwmled==1.4.1"],
   "dependencies": [],

--- a/homeassistant/components/rpi_pfio/manifest.json
+++ b/homeassistant/components/rpi_pfio/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rpi_pfio",
-  "name": "Rpi pfio",
+  "name": "PiFace Digital I/O (PFIO)",
   "documentation": "https://www.home-assistant.io/integrations/rpi_pfio",
   "requirements": ["pifacecommon==4.2.2", "pifacedigitalio==3.0.5"],
   "dependencies": [],

--- a/homeassistant/components/rpi_rf/manifest.json
+++ b/homeassistant/components/rpi_rf/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rpi_rf",
-  "name": "Rpi rf",
+  "name": "Raspberry Pi RF",
   "documentation": "https://www.home-assistant.io/integrations/rpi_rf",
   "requirements": ["rpi-rf==0.9.7"],
   "dependencies": [],

--- a/homeassistant/components/rss_feed_template/manifest.json
+++ b/homeassistant/components/rss_feed_template/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rss_feed_template",
-  "name": "Rss feed template",
+  "name": "RSS Feed Template",
   "documentation": "https://www.home-assistant.io/integrations/rss_feed_template",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/rtorrent/manifest.json
+++ b/homeassistant/components/rtorrent/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rtorrent",
-  "name": "Rtorrent",
+  "name": "rTorrent",
   "documentation": "https://www.home-assistant.io/integrations/rtorrent",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/russound_rio/manifest.json
+++ b/homeassistant/components/russound_rio/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "russound_rio",
-  "name": "Russound rio",
+  "name": "Russound RIO",
   "documentation": "https://www.home-assistant.io/integrations/russound_rio",
   "requirements": ["russound_rio==0.1.7"],
   "dependencies": [],

--- a/homeassistant/components/russound_rnet/manifest.json
+++ b/homeassistant/components/russound_rnet/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "russound_rnet",
-  "name": "Russound rnet",
+  "name": "Russound RNET",
   "documentation": "https://www.home-assistant.io/integrations/russound_rnet",
   "requirements": ["russound==0.1.9"],
   "dependencies": [],

--- a/homeassistant/components/sabnzbd/manifest.json
+++ b/homeassistant/components/sabnzbd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sabnzbd",
-  "name": "Sabnzbd",
+  "name": "SABnzbd",
   "documentation": "https://www.home-assistant.io/integrations/sabnzbd",
   "requirements": ["pysabnzbd==1.1.0"],
   "dependencies": ["configurator"],

--- a/homeassistant/components/saj/manifest.json
+++ b/homeassistant/components/saj/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "saj",
-  "name": "SAJ",
+  "name": "SAJ Solar Inverter",
   "documentation": "https://www.home-assistant.io/integrations/saj",
   "requirements": ["pysaj==0.0.14"],
   "dependencies": [],

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "samsungtv",
-  "name": "Samsung TV",
+  "name": "Samsung Smart TV",
   "documentation": "https://www.home-assistant.io/integrations/samsungtv",
   "requirements": ["samsungctl[websocket]==0.7.1", "wakeonlan==1.1.6"],
   "dependencies": [],

--- a/homeassistant/components/satel_integra/manifest.json
+++ b/homeassistant/components/satel_integra/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "satel_integra",
-  "name": "Satel integra",
+  "name": "Satel Integra",
   "documentation": "https://www.home-assistant.io/integrations/satel_integra",
   "requirements": ["satel_integra==0.3.4"],
   "dependencies": [],

--- a/homeassistant/components/scene/manifest.json
+++ b/homeassistant/components/scene/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "scene",
-  "name": "Scene",
+  "name": "Scenes",
   "documentation": "https://www.home-assistant.io/integrations/scene",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/script/manifest.json
+++ b/homeassistant/components/script/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "script",
-  "name": "Script",
+  "name": "Scripts",
   "documentation": "https://www.home-assistant.io/integrations/script",
   "requirements": [],
   "dependencies": ["group"],

--- a/homeassistant/components/scsgate/manifest.json
+++ b/homeassistant/components/scsgate/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "scsgate",
-  "name": "Scsgate",
+  "name": "SCSGate",
   "documentation": "https://www.home-assistant.io/integrations/scsgate",
   "requirements": ["scsgate==0.1.0"],
   "dependencies": [],

--- a/homeassistant/components/sendgrid/manifest.json
+++ b/homeassistant/components/sendgrid/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sendgrid",
-  "name": "Sendgrid",
+  "name": "SendGrid",
   "documentation": "https://www.home-assistant.io/integrations/sendgrid",
   "requirements": ["sendgrid==6.1.0"],
   "dependencies": [],

--- a/homeassistant/components/sensehat/manifest.json
+++ b/homeassistant/components/sensehat/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sensehat",
-  "name": "Sensehat",
+  "name": "Sense HAT",
   "documentation": "https://www.home-assistant.io/integrations/sensehat",
   "requirements": ["sense-hat==2.2.0"],
   "dependencies": [],

--- a/homeassistant/components/serial_pm/manifest.json
+++ b/homeassistant/components/serial_pm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "serial_pm",
-  "name": "Serial pm",
+  "name": "Serial Particulate Matter",
   "documentation": "https://www.home-assistant.io/integrations/serial_pm",
   "requirements": ["pmsensor==0.4"],
   "dependencies": [],

--- a/homeassistant/components/seven_segments/manifest.json
+++ b/homeassistant/components/seven_segments/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "seven_segments",
-  "name": "Seven segments",
+  "name": "Seven Segments OCR",
   "documentation": "https://www.home-assistant.io/integrations/seven_segments",
   "requirements": ["pillow==6.2.1"],
   "dependencies": [],

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "seventeentrack",
-  "name": "Seventeentrack",
+  "name": "17TRACK",
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
   "requirements": ["py17track==2.2.2"],
   "dependencies": [],

--- a/homeassistant/components/shell_command/manifest.json
+++ b/homeassistant/components/shell_command/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "shell_command",
-  "name": "Shell command",
+  "name": "Shell Command",
   "documentation": "https://www.home-assistant.io/integrations/shell_command",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/shiftr/manifest.json
+++ b/homeassistant/components/shiftr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "shiftr",
-  "name": "Shiftr",
+  "name": "shiftr.io",
   "documentation": "https://www.home-assistant.io/integrations/shiftr",
   "requirements": ["paho-mqtt==1.5.0"],
   "dependencies": [],

--- a/homeassistant/components/shopping_list/manifest.json
+++ b/homeassistant/components/shopping_list/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "shopping_list",
-  "name": "Shopping list",
+  "name": "Shopping List",
   "documentation": "https://www.home-assistant.io/integrations/shopping_list",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/sht31/manifest.json
+++ b/homeassistant/components/sht31/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sht31",
-  "name": "Sht31",
+  "name": "Sensirion SHT31",
   "documentation": "https://www.home-assistant.io/integrations/sht31",
   "requirements": ["Adafruit-GPIO==1.0.3", "Adafruit-SHT31==1.0.2"],
   "dependencies": [],

--- a/homeassistant/components/signal_messenger/manifest.json
+++ b/homeassistant/components/signal_messenger/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "signal_messenger",
-  "name": "signal_messenger",
+  "name": "Signal Messenger",
   "documentation": "https://www.home-assistant.io/integrations/signal_messenger",
   "dependencies": [],
   "codeowners": ["@bbernhard"],

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "simplisafe",
-  "name": "Simplisafe",
+  "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
   "requirements": ["simplisafe-python==5.3.6"],

--- a/homeassistant/components/sinch/manifest.json
+++ b/homeassistant/components/sinch/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sinch",
-  "name": "Sinch",
+  "name": "Sinch SMS",
   "documentation": "https://www.home-assistant.io/components/sinch",
   "dependencies": [],
   "codeowners": ["@bendikrb"],

--- a/homeassistant/components/sky_hub/manifest.json
+++ b/homeassistant/components/sky_hub/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sky_hub",
-  "name": "Sky hub",
+  "name": "Sky Hub",
   "documentation": "https://www.home-assistant.io/integrations/sky_hub",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/skybell/manifest.json
+++ b/homeassistant/components/skybell/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "skybell",
-  "name": "Skybell",
+  "name": "SkyBell",
   "documentation": "https://www.home-assistant.io/integrations/skybell",
   "requirements": ["skybellpy==0.4.0"],
   "dependencies": [],

--- a/homeassistant/components/sleepiq/manifest.json
+++ b/homeassistant/components/sleepiq/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sleepiq",
-  "name": "Sleepiq",
+  "name": "SleepIQ",
   "documentation": "https://www.home-assistant.io/integrations/sleepiq",
   "requirements": ["sleepyq==0.7"],
   "dependencies": [],

--- a/homeassistant/components/sma/manifest.json
+++ b/homeassistant/components/sma/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sma",
-  "name": "Sma",
+  "name": "SMA Solar",
   "documentation": "https://www.home-assistant.io/integrations/sma",
   "requirements": ["pysma==0.3.4"],
   "dependencies": [],

--- a/homeassistant/components/smarty/manifest.json
+++ b/homeassistant/components/smarty/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "smarty",
-  "name": "smarty",
+  "name": "Salda Smarty",
   "documentation": "https://www.home-assistant.io/integrations/smarty",
   "requirements": ["pysmarty==0.8"],
   "dependencies": [],

--- a/homeassistant/components/smhi/manifest.json
+++ b/homeassistant/components/smhi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "smhi",
-  "name": "Smhi",
+  "name": "SMHI",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/smhi",
   "requirements": ["smhi-pkg==1.0.10"],

--- a/homeassistant/components/smtp/manifest.json
+++ b/homeassistant/components/smtp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "smtp",
-  "name": "Smtp",
+  "name": "SMTP",
   "documentation": "https://www.home-assistant.io/integrations/smtp",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "snmp",
-  "name": "Snmp",
+  "name": "SNMP",
   "documentation": "https://www.home-assistant.io/integrations/snmp",
   "requirements": ["pysnmp==4.4.12"],
   "dependencies": [],

--- a/homeassistant/components/sochain/manifest.json
+++ b/homeassistant/components/sochain/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sochain",
-  "name": "Sochain",
+  "name": "SoChain",
   "documentation": "https://www.home-assistant.io/integrations/sochain",
   "requirements": ["python-sochain-api==0.0.2"],
   "dependencies": [],

--- a/homeassistant/components/socialblade/manifest.json
+++ b/homeassistant/components/socialblade/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "socialblade",
-  "name": "Socialblade",
+  "name": "Social Blade",
   "documentation": "https://www.home-assistant.io/integrations/socialblade",
   "requirements": ["socialbladeclient==0.2"],
   "dependencies": [],

--- a/homeassistant/components/solaredge/manifest.json
+++ b/homeassistant/components/solaredge/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "solaredge",
-  "name": "Solaredge",
+  "name": "SolarEdge",
   "documentation": "https://www.home-assistant.io/integrations/solaredge",
   "requirements": ["solaredge==0.0.2", "stringcase==1.2.0"],
   "config_flow": true,

--- a/homeassistant/components/solaredge_local/manifest.json
+++ b/homeassistant/components/solaredge_local/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "solaredge_local",
-  "name": "Solar Edge Local",
+  "name": "SolarEdge Local",
   "documentation": "https://www.home-assistant.io/integrations/solaredge_local",
   "requirements": ["solaredge-local==0.2.0"],
   "dependencies": [],

--- a/homeassistant/components/solax/manifest.json
+++ b/homeassistant/components/solax/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "solax",
-  "name": "Solax Inverter",
+  "name": "SolaX Power",
   "documentation": "https://www.home-assistant.io/integrations/solax",
   "requirements": ["solax==0.2.2"],
   "dependencies": [],

--- a/homeassistant/components/soma/manifest.json
+++ b/homeassistant/components/soma/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "soma",
-  "name": "Soma Open API",
+  "name": "Soma Connect",
   "config_flow": true,
   "documentation": "",
   "dependencies": [],

--- a/homeassistant/components/songpal/manifest.json
+++ b/homeassistant/components/songpal/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "songpal",
-  "name": "Songpal",
+  "name": "Sony Songpal",
   "documentation": "https://www.home-assistant.io/integrations/songpal",
   "requirements": ["python-songpal==0.11.2"],
   "dependencies": [],

--- a/homeassistant/components/sony_projector/manifest.json
+++ b/homeassistant/components/sony_projector/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sony_projector",
-  "name": "Sony projector",
+  "name": "Sony Projector",
   "documentation": "https://www.home-assistant.io/integrations/sony_projector",
   "requirements": ["pysdcp==1"],
   "dependencies": [],

--- a/homeassistant/components/soundtouch/manifest.json
+++ b/homeassistant/components/soundtouch/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "soundtouch",
-  "name": "Soundtouch",
+  "name": "Bose Soundtouch",
   "documentation": "https://www.home-assistant.io/integrations/soundtouch",
   "requirements": ["libsoundtouch==0.7.2"],
   "dependencies": [],

--- a/homeassistant/components/spaceapi/manifest.json
+++ b/homeassistant/components/spaceapi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "spaceapi",
-  "name": "Spaceapi",
+  "name": "Space API",
   "documentation": "https://www.home-assistant.io/integrations/spaceapi",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/spc/manifest.json
+++ b/homeassistant/components/spc/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "spc",
-  "name": "Spc",
+  "name": "Vanderbilt SPC",
   "documentation": "https://www.home-assistant.io/integrations/spc",
   "requirements": ["pyspcwebgw==0.4.0"],
   "dependencies": [],

--- a/homeassistant/components/speedtestdotnet/manifest.json
+++ b/homeassistant/components/speedtestdotnet/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "speedtestdotnet",
-  "name": "Speedtestdotnet",
+  "name": "Speedtest.net",
   "documentation": "https://www.home-assistant.io/integrations/speedtestdotnet",
   "requirements": ["speedtest-cli==2.1.2"],
   "dependencies": [],

--- a/homeassistant/components/spider/manifest.json
+++ b/homeassistant/components/spider/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "spider",
-  "name": "Spider",
+  "name": "Itho Daalderop Spider",
   "documentation": "https://www.home-assistant.io/integrations/spider",
   "requirements": ["spiderpy==1.3.1"],
   "dependencies": [],

--- a/homeassistant/components/spotcrime/manifest.json
+++ b/homeassistant/components/spotcrime/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "spotcrime",
-  "name": "Spotcrime",
+  "name": "Spot Crime",
   "documentation": "https://www.home-assistant.io/integrations/spotcrime",
   "requirements": ["spotcrime==1.0.4"],
   "dependencies": [],

--- a/homeassistant/components/sql/manifest.json
+++ b/homeassistant/components/sql/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sql",
-  "name": "Sql",
+  "name": "SQL",
   "documentation": "https://www.home-assistant.io/integrations/sql",
   "requirements": ["sqlalchemy==1.3.12"],
   "dependencies": [],

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "squeezebox",
-  "name": "Squeezebox",
+  "name": "Logitech Squeezebox",
   "documentation": "https://www.home-assistant.io/integrations/squeezebox",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ssdp",
-  "name": "SSDP",
+  "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
   "requirements": ["defusedxml==0.6.0", "netdisco==2.6.0"],
   "dependencies": [],

--- a/homeassistant/components/starlingbank/manifest.json
+++ b/homeassistant/components/starlingbank/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "starlingbank",
-  "name": "Starlingbank",
+  "name": "Starling Bank",
   "documentation": "https://www.home-assistant.io/integrations/starlingbank",
   "requirements": ["starlingbank==3.2"],
   "dependencies": [],

--- a/homeassistant/components/startca/manifest.json
+++ b/homeassistant/components/startca/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "startca",
-  "name": "Startca",
+  "name": "Start.ca",
   "documentation": "https://www.home-assistant.io/integrations/startca",
   "requirements": ["xmltodict==0.12.0"],
   "dependencies": [],

--- a/homeassistant/components/statsd/manifest.json
+++ b/homeassistant/components/statsd/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "statsd",
-  "name": "Statsd",
+  "name": "StatsD",
   "documentation": "https://www.home-assistant.io/integrations/statsd",
   "requirements": ["statsd==3.2.1"],
   "dependencies": [],

--- a/homeassistant/components/steam_online/manifest.json
+++ b/homeassistant/components/steam_online/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "steam_online",
-  "name": "Steam online",
+  "name": "Steam",
   "documentation": "https://www.home-assistant.io/integrations/steam_online",
   "requirements": ["steamodd==4.21"],
   "dependencies": [],

--- a/homeassistant/components/streamlabswater/manifest.json
+++ b/homeassistant/components/streamlabswater/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "streamlabswater",
-  "name": "Streamlabs Water",
+  "name": "StreamLabs",
   "documentation": "https://www.home-assistant.io/integrations/streamlabswater",
   "requirements": ["streamlabswater==1.0.1"],
   "dependencies": [],

--- a/homeassistant/components/stt/manifest.json
+++ b/homeassistant/components/stt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "stt",
-  "name": "Stt",
+  "name": "Speech-to-Text (STT)",
   "documentation": "https://www.home-assistant.io/integrations/stt",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/suez_water/manifest.json
+++ b/homeassistant/components/suez_water/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "suez_water",
-  "name": "Suez Water Consumption Sensor",
+  "name": "Suez Water",
   "documentation": "https://www.home-assistant.io/integrations/suez_water",
   "dependencies": [],
   "codeowners": ["@ooii"],

--- a/homeassistant/components/swiss_hydrological_data/manifest.json
+++ b/homeassistant/components/swiss_hydrological_data/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "swiss_hydrological_data",
-  "name": "Swiss hydrological data",
+  "name": "Swiss Hydrological Data",
   "documentation": "https://www.home-assistant.io/integrations/swiss_hydrological_data",
   "requirements": ["swisshydrodata==0.0.3"],
   "dependencies": [],

--- a/homeassistant/components/swisscom/manifest.json
+++ b/homeassistant/components/swisscom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "swisscom",
-  "name": "Swisscom",
+  "name": "Swisscom Internet-Box",
   "documentation": "https://www.home-assistant.io/integrations/swisscom",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "switchbot",
-  "name": "Switchbot",
+  "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
   "requirements": ["PySwitchbot==0.6.2"],
   "dependencies": [],

--- a/homeassistant/components/switchmate/manifest.json
+++ b/homeassistant/components/switchmate/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "switchmate",
-  "name": "Switchmate",
+  "name": "Switchmate SimplySmart Home",
   "documentation": "https://www.home-assistant.io/integrations/switchmate",
   "requirements": ["pySwitchmate==0.4.6"],
   "dependencies": [],

--- a/homeassistant/components/syncthru/manifest.json
+++ b/homeassistant/components/syncthru/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "syncthru",
-  "name": "Syncthru",
+  "name": "Samsung SyncThru Printer",
   "documentation": "https://www.home-assistant.io/integrations/syncthru",
   "requirements": ["pysyncthru==0.5.0"],
   "dependencies": [],

--- a/homeassistant/components/synology_chat/manifest.json
+++ b/homeassistant/components/synology_chat/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "synology_chat",
-  "name": "Synology chat",
+  "name": "Synology Chat",
   "documentation": "https://www.home-assistant.io/integrations/synology_chat",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/synologydsm/manifest.json
+++ b/homeassistant/components/synologydsm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "synologydsm",
-  "name": "Synologydsm",
+  "name": "SynologyDSM",
   "documentation": "https://www.home-assistant.io/integrations/synologydsm",
   "requirements": ["python-synology==0.3.0"],
   "dependencies": [],

--- a/homeassistant/components/system_health/manifest.json
+++ b/homeassistant/components/system_health/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "system_health",
-  "name": "System health",
+  "name": "System Health",
   "documentation": "https://www.home-assistant.io/integrations/system_health",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/system_log/manifest.json
+++ b/homeassistant/components/system_log/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "system_log",
-  "name": "System log",
+  "name": "System Log",
   "documentation": "https://www.home-assistant.io/integrations/system_log",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/systemmonitor/manifest.json
+++ b/homeassistant/components/systemmonitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "systemmonitor",
-  "name": "Systemmonitor",
+  "name": "System Monitor",
   "documentation": "https://www.home-assistant.io/integrations/systemmonitor",
   "requirements": ["psutil==5.6.7"],
   "dependencies": [],


### PR DESCRIPTION
## Description:

I'm working on getting some things synced between our documentation and the codebase (making the codebase the source of truth). The title/name of the integration is a great starting point for this.

However, the product/brand/integration names are often misspelled, incorrect or incomplete. This PR corrects a bunch of those.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. 

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
