### PR TITLE
Correct names in manifests (T-Z)

### DIFF
--- a/homeassistant/components/tank_utility/manifest.json
+++ b/homeassistant/components/tank_utility/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tank_utility",
-  "name": "Tank utility",
+  "name": "Tank Utility",
   "documentation": "https://www.home-assistant.io/integrations/tank_utility",
   "requirements": ["tank_utility==1.4.0"],
   "dependencies": [],

--- a/homeassistant/components/tapsaff/manifest.json
+++ b/homeassistant/components/tapsaff/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tapsaff",
-  "name": "Tapsaff",
+  "name": "Taps Aff",
   "documentation": "https://www.home-assistant.io/integrations/tapsaff",
   "requirements": ["tapsaff==0.2.1"],
   "dependencies": [],

--- a/homeassistant/components/tcp/manifest.json
+++ b/homeassistant/components/tcp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tcp",
-  "name": "Tcp",
+  "name": "TCP",
   "documentation": "https://www.home-assistant.io/integrations/tcp",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/ted5000/manifest.json
+++ b/homeassistant/components/ted5000/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ted5000",
-  "name": "Ted5000",
+  "name": "The Energy Detective TED5000",
   "documentation": "https://www.home-assistant.io/integrations/ted5000",
   "requirements": ["xmltodict==0.12.0"],
   "dependencies": [],

--- a/homeassistant/components/teksavvy/manifest.json
+++ b/homeassistant/components/teksavvy/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "teksavvy",
-  "name": "Teksavvy",
+  "name": "TekSavvy",
   "documentation": "https://www.home-assistant.io/integrations/teksavvy",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/tellduslive/manifest.json
+++ b/homeassistant/components/tellduslive/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tellduslive",
-  "name": "Tellduslive",
+  "name": "Telldus Live",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tellduslive",
   "requirements": ["tellduslive==0.10.10"],

--- a/homeassistant/components/tellstick/manifest.json
+++ b/homeassistant/components/tellstick/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tellstick",
-  "name": "Tellstick",
+  "name": "TellStick",
   "documentation": "https://www.home-assistant.io/integrations/tellstick",
   "requirements": ["tellcore-net==0.4", "tellcore-py==1.1.2"],
   "dependencies": [],

--- a/homeassistant/components/temper/manifest.json
+++ b/homeassistant/components/temper/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "temper",
-  "name": "Temper",
+  "name": "TEMPer",
   "documentation": "https://www.home-assistant.io/integrations/temper",
   "requirements": ["temperusb==1.5.3"],
   "dependencies": [],

--- a/homeassistant/components/tensorflow/manifest.json
+++ b/homeassistant/components/tensorflow/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tensorflow",
-  "name": "Tensorflow",
+  "name": "TensorFlow",
   "documentation": "https://www.home-assistant.io/integrations/tensorflow",
   "requirements": [
     "tensorflow==1.13.2",

--- a/homeassistant/components/thermoworks_smoke/manifest.json
+++ b/homeassistant/components/thermoworks_smoke/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "thermoworks_smoke",
-  "name": "Thermoworks smoke",
+  "name": "ThermoWorks Smoke",
   "documentation": "https://www.home-assistant.io/integrations/thermoworks_smoke",
   "requirements": ["stringcase==1.2.0", "thermoworks_smoke==0.1.8"],
   "dependencies": [],

--- a/homeassistant/components/thethingsnetwork/manifest.json
+++ b/homeassistant/components/thethingsnetwork/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "thethingsnetwork",
-  "name": "Thethingsnetwork",
+  "name": "The Things Network",
   "documentation": "https://www.home-assistant.io/integrations/thethingsnetwork",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/thingspeak/manifest.json
+++ b/homeassistant/components/thingspeak/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "thingspeak",
-  "name": "Thingspeak",
+  "name": "ThingSpeak",
   "documentation": "https://www.home-assistant.io/integrations/thingspeak",
   "requirements": ["thingspeak==1.0.0"],
   "dependencies": [],

--- a/homeassistant/components/thinkingcleaner/manifest.json
+++ b/homeassistant/components/thinkingcleaner/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "thinkingcleaner",
-  "name": "Thinkingcleaner",
+  "name": "Thinking Cleaner",
   "documentation": "https://www.home-assistant.io/integrations/thinkingcleaner",
   "requirements": ["pythinkingcleaner==0.0.3"],
   "dependencies": [],

--- a/homeassistant/components/time_date/manifest.json
+++ b/homeassistant/components/time_date/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "time_date",
-  "name": "Time date",
+  "name": "Time & Date",
   "documentation": "https://www.home-assistant.io/integrations/time_date",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/tod/manifest.json
+++ b/homeassistant/components/tod/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tod",
-  "name": "Tod",
+  "name": "Times of the Day",
   "documentation": "https://www.home-assistant.io/integrations/tod",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/tof/manifest.json
+++ b/homeassistant/components/tof/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tof",
-  "name": "Tof",
+  "name": "Time of Flight",
   "documentation": "https://www.home-assistant.io/integrations/tof",
   "requirements": ["VL53L1X2==0.1.5"],
   "dependencies": ["rpi_gpio"],

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "totalconnect",
-  "name": "Totalconnect",
+  "name": "Honeywell Total Connect Alarm",
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
   "requirements": ["total_connect_client==0.28"],
   "dependencies": [],

--- a/homeassistant/components/touchline/manifest.json
+++ b/homeassistant/components/touchline/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "touchline",
-  "name": "Touchline",
+  "name": "Roth Touchline",
   "documentation": "https://www.home-assistant.io/integrations/touchline",
   "requirements": ["pytouchline==0.7"],
   "dependencies": [],

--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tplink",
-  "name": "Tplink",
+  "name": "TP-Link Kasa Smart",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tplink",
   "requirements": ["pyHS100==0.3.5"],

--- a/homeassistant/components/tplink_lte/manifest.json
+++ b/homeassistant/components/tplink_lte/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tplink_lte",
-  "name": "Tplink lte",
+  "name": "TP-Link LTE",
   "documentation": "https://www.home-assistant.io/integrations/tplink_lte",
   "requirements": ["tp-connected==0.0.4"],
   "dependencies": [],

--- a/homeassistant/components/trackr/manifest.json
+++ b/homeassistant/components/trackr/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "trackr",
-  "name": "Trackr",
+  "name": "TrackR",
   "documentation": "https://www.home-assistant.io/integrations/trackr",
   "requirements": ["pytrackr==0.0.5"],
   "dependencies": [],

--- a/homeassistant/components/tradfri/manifest.json
+++ b/homeassistant/components/tradfri/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tradfri",
-  "name": "Tradfri",
+  "name": "IKEA TRÅDFRI (TRADFRI)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tradfri",
   "requirements": ["pytradfri[async]==6.4.0"],

--- a/homeassistant/components/trafikverket_train/manifest.json
+++ b/homeassistant/components/trafikverket_train/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "trafikverket_train",
-  "name": "Trafikverket train information",
+  "name": "Trafikverket Train",
   "documentation": "https://www.home-assistant.io/integrations/trafikverket_train",
   "requirements": ["pytrafikverket==0.1.5.9"],
   "dependencies": [],

--- a/homeassistant/components/trafikverket_weatherstation/manifest.json
+++ b/homeassistant/components/trafikverket_weatherstation/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "trafikverket_weatherstation",
-  "name": "Trafikverket weatherstation",
+  "name": "Trafikverket Weather Station",
   "documentation": "https://www.home-assistant.io/integrations/trafikverket_weatherstation",
   "requirements": ["pytrafikverket==0.1.5.9"],
   "dependencies": [],

--- a/homeassistant/components/transport_nsw/manifest.json
+++ b/homeassistant/components/transport_nsw/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "transport_nsw",
-  "name": "Transport nsw",
+  "name": "Transport NSW",
   "documentation": "https://www.home-assistant.io/integrations/transport_nsw",
   "requirements": ["PyTransportNSW==0.1.1"],
   "dependencies": [],

--- a/homeassistant/components/travisci/manifest.json
+++ b/homeassistant/components/travisci/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "travisci",
-  "name": "Travisci",
+  "name": "Travis-CI",
   "documentation": "https://www.home-assistant.io/integrations/travisci",
   "requirements": ["TravisPy==0.3.5"],
   "dependencies": [],

--- a/homeassistant/components/tts/manifest.json
+++ b/homeassistant/components/tts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tts",
-  "name": "Tts",
+  "name": "Text-to-Speech (TTS)",
   "documentation": "https://www.home-assistant.io/integrations/tts",
   "requirements": ["mutagen==1.43.0"],
   "dependencies": ["http"],

--- a/homeassistant/components/twilio_call/manifest.json
+++ b/homeassistant/components/twilio_call/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "twilio_call",
-  "name": "Twilio call",
+  "name": "Twilio Call",
   "documentation": "https://www.home-assistant.io/integrations/twilio_call",
   "requirements": [],
   "dependencies": ["twilio"],

--- a/homeassistant/components/twilio_sms/manifest.json
+++ b/homeassistant/components/twilio_sms/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "twilio_sms",
-  "name": "Twilio sms",
+  "name": "Twilio SMS",
   "documentation": "https://www.home-assistant.io/integrations/twilio_sms",
   "requirements": [],
   "dependencies": ["twilio"],

--- a/homeassistant/components/ubee/manifest.json
+++ b/homeassistant/components/ubee/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ubee",
-  "name": "Ubee",
+  "name": "Ubee Router",
   "documentation": "https://www.home-assistant.io/integrations/ubee",
   "requirements": ["pyubee==0.7"],
   "dependencies": [],

--- a/homeassistant/components/ubus/manifest.json
+++ b/homeassistant/components/ubus/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ubus",
-  "name": "Ubus",
+  "name": "OpenWrt (ubus)",
   "documentation": "https://www.home-assistant.io/integrations/ubus",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/ue_smart_radio/manifest.json
+++ b/homeassistant/components/ue_smart_radio/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ue_smart_radio",
-  "name": "Ue smart radio",
+  "name": "Logitech UE Smart Radio",
   "documentation": "https://www.home-assistant.io/integrations/ue_smart_radio",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/uk_transport/manifest.json
+++ b/homeassistant/components/uk_transport/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "uk_transport",
-  "name": "Uk transport",
+  "name": "UK Transport",
   "documentation": "https://www.home-assistant.io/integrations/uk_transport",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "unifi",
-  "name": "Unifi",
+  "name": "Ubiquiti UniFi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
   "requirements": ["aiounifi==11"],

--- a/homeassistant/components/unifi_direct/manifest.json
+++ b/homeassistant/components/unifi_direct/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "unifi_direct",
-  "name": "Unifi direct",
+  "name": "Ubiquiti UniFi AP",
   "documentation": "https://www.home-assistant.io/integrations/unifi_direct",
   "requirements": ["pexpect==4.6.0"],
   "dependencies": [],

--- a/homeassistant/components/unifiled/manifest.json
+++ b/homeassistant/components/unifiled/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "unifiled",
-  "name": "Unifi LED",
+  "name": "Ubiquiti UniFi LED",
   "documentation": "https://www.home-assistant.io/integrations/unifiled",
   "dependencies": [],
   "codeowners": ["@florisvdk"],

--- a/homeassistant/components/universal/manifest.json
+++ b/homeassistant/components/universal/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "universal",
-  "name": "Universal",
+  "name": "Universal Media Player",
   "documentation": "https://www.home-assistant.io/integrations/universal",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/upc_connect/manifest.json
+++ b/homeassistant/components/upc_connect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "upc_connect",
-  "name": "Upc connect",
+  "name": "UPC Connect Box",
   "documentation": "https://www.home-assistant.io/integrations/upc_connect",
   "requirements": ["connect-box==0.2.5"],
   "dependencies": [],

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "upnp",
-  "name": "Upnp",
+  "name": "UPnP",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
   "requirements": ["async-upnp-client==0.14.12"],

--- a/homeassistant/components/uptimerobot/manifest.json
+++ b/homeassistant/components/uptimerobot/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "uptimerobot",
-  "name": "Uptimerobot",
+  "name": "Uptime Robot",
   "documentation": "https://www.home-assistant.io/integrations/uptimerobot",
   "requirements": ["pyuptimerobot==0.0.5"],
   "dependencies": [],

--- a/homeassistant/components/uscis/manifest.json
+++ b/homeassistant/components/uscis/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "uscis",
-  "name": "Uscis",
+  "name": "U.S. Citizenship and Immigration Services (USCIS)",
   "documentation": "https://www.home-assistant.io/integrations/uscis",
   "requirements": ["uscisstatus==0.1.1"],
   "dependencies": [],

--- a/homeassistant/components/usgs_earthquakes_feed/manifest.json
+++ b/homeassistant/components/usgs_earthquakes_feed/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "usgs_earthquakes_feed",
-  "name": "Usgs earthquakes feed",
+  "name": "U.S. Geological Survey Earthquake Hazards (USGS)",
   "documentation": "https://www.home-assistant.io/integrations/usgs_earthquakes_feed",
   "requirements": ["geojson_client==0.4"],
   "dependencies": [],

--- a/homeassistant/components/utility_meter/manifest.json
+++ b/homeassistant/components/utility_meter/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "utility_meter",
-  "name": "Utility meter",
+  "name": "Utility Meter",
   "documentation": "https://www.home-assistant.io/integrations/utility_meter",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/uvc/manifest.json
+++ b/homeassistant/components/uvc/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "uvc",
-  "name": "Uvc",
+  "name": "Ubiquiti UniFi Video",
   "documentation": "https://www.home-assistant.io/integrations/uvc",
   "requirements": ["uvcclient==0.11.0"],
   "dependencies": [],

--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "vallox",
-  "name": "Vallox",
+  "name": "Valloxs",
   "documentation": "https://www.home-assistant.io/integrations/vallox",
   "requirements": ["vallox-websocket-api==2.2.0"],
   "dependencies": [],

--- a/homeassistant/components/vasttrafik/manifest.json
+++ b/homeassistant/components/vasttrafik/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "vasttrafik",
-  "name": "Vasttrafik",
+  "name": "Västtrafik",
   "documentation": "https://www.home-assistant.io/integrations/vasttrafik",
   "requirements": ["vtjp==0.1.14"],
   "dependencies": [],

--- a/homeassistant/components/vesync/manifest.json
+++ b/homeassistant/components/vesync/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "vesync",
-  "name": "VeSync",
+  "name": "Etekcity VeSync",
   "documentation": "https://www.home-assistant.io/integrations/vesync",
   "dependencies": [],
   "codeowners": ["@markperdue", "@webdjoe"],

--- a/homeassistant/components/viaggiatreno/manifest.json
+++ b/homeassistant/components/viaggiatreno/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "viaggiatreno",
-  "name": "Viaggiatreno",
+  "name": "Trenitalia ViaggiaTreno",
   "documentation": "https://www.home-assistant.io/integrations/viaggiatreno",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -1,10 +1,8 @@
 {
   "domain": "vizio",
-  "name": "Vizio",
+  "name": "Vizio SmartCast TV",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": [
-    "pyvizio==0.0.12"
-  ],
+  "requirements": ["pyvizio==0.0.12"],
   "dependencies": [],
   "codeowners": ["@raman325"]
 }

--- a/homeassistant/components/vlc/manifest.json
+++ b/homeassistant/components/vlc/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "vlc",
-  "name": "Vlc",
+  "name": "VLC media player",
   "documentation": "https://www.home-assistant.io/integrations/vlc",
   "requirements": ["python-vlc==1.1.2"],
   "dependencies": [],

--- a/homeassistant/components/vlc_telnet/manifest.json
+++ b/homeassistant/components/vlc_telnet/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "vlc_telnet",
-  "name": "VLC telnet",
+  "name": "VLC media player Telnet",
   "documentation": "https://www.home-assistant.io/integrations/vlc-telnet",
   "requirements": ["python-telnet-vlc==1.0.4"],
   "dependencies": [],

--- a/homeassistant/components/voicerss/manifest.json
+++ b/homeassistant/components/voicerss/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "voicerss",
-  "name": "Voicerss",
+  "name": "VoiceRSS",
   "documentation": "https://www.home-assistant.io/integrations/voicerss",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/volvooncall/manifest.json
+++ b/homeassistant/components/volvooncall/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "volvooncall",
-  "name": "Volvooncall",
+  "name": "Volvo On Call",
   "documentation": "https://www.home-assistant.io/integrations/volvooncall",
   "requirements": ["volvooncall==0.8.7"],
   "dependencies": [],

--- a/homeassistant/components/w800rf32/manifest.json
+++ b/homeassistant/components/w800rf32/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "w800rf32",
-  "name": "W800rf32",
+  "name": "WGL Designs W800RF32",
   "documentation": "https://www.home-assistant.io/integrations/w800rf32",
   "requirements": ["pyW800rf32==0.1"],
   "dependencies": [],

--- a/homeassistant/components/wake_on_lan/manifest.json
+++ b/homeassistant/components/wake_on_lan/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "wake_on_lan",
-  "name": "Wake on lan",
+  "name": "Wake on LAN",
   "documentation": "https://www.home-assistant.io/integrations/wake_on_lan",
   "requirements": ["wakeonlan==1.1.6"],
   "dependencies": [],

--- a/homeassistant/components/waqi/manifest.json
+++ b/homeassistant/components/waqi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "waqi",
-  "name": "Waqi",
+  "name": "World Air Quality Index (WAQI)",
   "documentation": "https://www.home-assistant.io/integrations/waqi",
   "requirements": ["waqiasync==1.0.0"],
   "dependencies": [],

--- a/homeassistant/components/water_heater/manifest.json
+++ b/homeassistant/components/water_heater/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "water_heater",
-  "name": "Water heater",
+  "name": "Water Heater",
   "documentation": "https://www.home-assistant.io/integrations/water_heater",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/waterfurnace/manifest.json
+++ b/homeassistant/components/waterfurnace/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "waterfurnace",
-  "name": "Waterfurnace",
+  "name": "WaterFurnace",
   "documentation": "https://www.home-assistant.io/integrations/waterfurnace",
   "requirements": ["waterfurnace==1.1.0"],
   "dependencies": [],

--- a/homeassistant/components/watson_iot/manifest.json
+++ b/homeassistant/components/watson_iot/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "watson_iot",
-  "name": "Watson iot",
+  "name": "IBM Watson IoT Platform",
   "documentation": "https://www.home-assistant.io/integrations/watson_iot",
   "requirements": ["ibmiotf==0.3.4"],
   "dependencies": [],

--- a/homeassistant/components/waze_travel_time/manifest.json
+++ b/homeassistant/components/waze_travel_time/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "waze_travel_time",
-  "name": "Waze travel time",
+  "name": "Waze Travel Time",
   "documentation": "https://www.home-assistant.io/integrations/waze_travel_time",
   "requirements": ["WazeRouteCalculator==0.12"],
   "dependencies": [],

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "webostv",
-  "name": "Webostv",
+  "name": "LG webOS Smart TV",
   "documentation": "https://www.home-assistant.io/integrations/webostv",
   "requirements": ["aiopylgtv==0.2.4"],
   "dependencies": ["configurator"],

--- a/homeassistant/components/websocket_api/manifest.json
+++ b/homeassistant/components/websocket_api/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "websocket_api",
-  "name": "Websocket api",
+  "name": "Home Asssitant WebSocket API",
   "documentation": "https://www.home-assistant.io/integrations/websocket_api",
   "requirements": [],
   "dependencies": ["http"],

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "wemo",
-  "name": "Wemo",
+  "name": "Belkin WeMo",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wemo",
   "requirements": ["pywemo==0.4.34"],

--- a/homeassistant/components/wirelesstag/manifest.json
+++ b/homeassistant/components/wirelesstag/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "wirelesstag",
-  "name": "Wirelesstag",
+  "name": "Wireless Sensor Tags",
   "documentation": "https://www.home-assistant.io/integrations/wirelesstag",
   "requirements": ["wirelesstagpy==0.4.0"],
   "dependencies": [],

--- a/homeassistant/components/worldtidesinfo/manifest.json
+++ b/homeassistant/components/worldtidesinfo/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "worldtidesinfo",
-  "name": "Worldtidesinfo",
+  "name": "World Tides",
   "documentation": "https://www.home-assistant.io/integrations/worldtidesinfo",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/worxlandroid/manifest.json
+++ b/homeassistant/components/worxlandroid/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "worxlandroid",
-  "name": "Worxlandroid",
+  "name": "Worx Landroid",
   "documentation": "https://www.home-assistant.io/integrations/worxlandroid",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/wsdot/manifest.json
+++ b/homeassistant/components/wsdot/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "wsdot",
-  "name": "Wsdot",
+  "name": "Washington State Department of Transportation (WSDOT)",
   "documentation": "https://www.home-assistant.io/integrations/wsdot",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/wunderground/manifest.json
+++ b/homeassistant/components/wunderground/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "wunderground",
-  "name": "Wunderground",
+  "name": "Weather Underground (WUnderground)",
   "documentation": "https://www.home-assistant.io/integrations/wunderground",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/wwlln/manifest.json
+++ b/homeassistant/components/wwlln/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "wwlln",
-  "name": "World Wide Lightning Location Network",
+  "name": "World Wide Lightning Location Network (WWLLN)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wwlln",
   "requirements": ["aiowwlln==2.0.2"],

--- a/homeassistant/components/x10/manifest.json
+++ b/homeassistant/components/x10/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "x10",
-  "name": "X10",
+  "name": "Heyu X10",
   "documentation": "https://www.home-assistant.io/integrations/x10",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/xbox_live/manifest.json
+++ b/homeassistant/components/xbox_live/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "xbox_live",
-  "name": "Xbox live",
+  "name": "Xbox Live",
   "documentation": "https://www.home-assistant.io/integrations/xbox_live",
   "requirements": ["xboxapi==0.1.1"],
   "dependencies": [],

--- a/homeassistant/components/xfinity/manifest.json
+++ b/homeassistant/components/xfinity/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "xfinity",
-  "name": "Xfinity",
+  "name": "Xfinity Gateway",
   "documentation": "https://www.home-assistant.io/integrations/xfinity",
   "requirements": ["xfinity-gateway==0.0.4"],
   "dependencies": [],

--- a/homeassistant/components/xiaomi_aqara/manifest.json
+++ b/homeassistant/components/xiaomi_aqara/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "xiaomi_aqara",
-  "name": "Xiaomi aqara",
+  "name": "Xiaomi Gateway (Aqara)",
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_aqara",
   "requirements": ["PyXiaomiGateway==0.12.4"],
   "dependencies": [],

--- a/homeassistant/components/xiaomi_tv/manifest.json
+++ b/homeassistant/components/xiaomi_tv/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "xiaomi_tv",
-  "name": "Xiaomi tv",
+  "name": "Xiaomi TV",
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_tv",
   "requirements": ["pymitv==1.4.3"],
   "dependencies": [],

--- a/homeassistant/components/xmpp/manifest.json
+++ b/homeassistant/components/xmpp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "xmpp",
-  "name": "Xmpp",
+  "name": "Jabber (XMPP)",
   "documentation": "https://www.home-assistant.io/integrations/xmpp",
   "requirements": ["slixmpp==1.4.2"],
   "dependencies": [],

--- a/homeassistant/components/xs1/manifest.json
+++ b/homeassistant/components/xs1/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "xs1",
-  "name": "Xs1",
+  "name": "EZcontrol XS1",
   "documentation": "https://www.home-assistant.io/integrations/xs1",
   "requirements": ["xs1-api-client==2.3.5"],
   "dependencies": [],

--- a/homeassistant/components/yale_smart_alarm/manifest.json
+++ b/homeassistant/components/yale_smart_alarm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yale_smart_alarm",
-  "name": "Yale smart alarm",
+  "name": "Yale Smart Living",
   "documentation": "https://www.home-assistant.io/integrations/yale_smart_alarm",
   "requirements": ["yalesmartalarmclient==0.1.6"],
   "dependencies": [],

--- a/homeassistant/components/yamaha/manifest.json
+++ b/homeassistant/components/yamaha/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yamaha",
-  "name": "Yamaha",
+  "name": "Yamaha Network Receivers",
   "documentation": "https://www.home-assistant.io/integrations/yamaha",
   "requirements": ["rxv==0.6.0"],
   "dependencies": [],

--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yamaha_musiccast",
-  "name": "Yamaha musiccast",
+  "name": "Yamaha MusicCast",
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "requirements": ["pymusiccast==0.1.6"],
   "dependencies": [],

--- a/homeassistant/components/yandextts/manifest.json
+++ b/homeassistant/components/yandextts/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yandextts",
-  "name": "Yandextts",
+  "name": "Yandex TTS",
   "documentation": "https://www.home-assistant.io/integrations/yandextts",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/yeelightsunflower/manifest.json
+++ b/homeassistant/components/yeelightsunflower/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yeelightsunflower",
-  "name": "Yeelightsunflower",
+  "name": "Yeelight Sunflower",
   "documentation": "https://www.home-assistant.io/integrations/yeelightsunflower",
   "requirements": ["yeelightsunflower==0.0.10"],
   "dependencies": [],

--- a/homeassistant/components/yessssms/manifest.json
+++ b/homeassistant/components/yessssms/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yessssms",
-  "name": "Yessssms",
+  "name": "yesss! SMS",
   "documentation": "https://www.home-assistant.io/integrations/yessssms",
   "requirements": ["YesssSMS==0.4.1"],
   "dependencies": [],

--- a/homeassistant/components/yi/manifest.json
+++ b/homeassistant/components/yi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yi",
-  "name": "Yi",
+  "name": "Yi Home Cameras",
   "documentation": "https://www.home-assistant.io/integrations/yi",
   "requirements": ["aioftp==0.12.0"],
   "dependencies": ["ffmpeg"],

--- a/homeassistant/components/yweather/manifest.json
+++ b/homeassistant/components/yweather/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "yweather",
-  "name": "Yweather",
+  "name": "Yahoo Weather",
   "documentation": "https://www.home-assistant.io/integrations/yweather",
   "requirements": ["yahooweather==0.10"],
   "dependencies": [],

--- a/homeassistant/components/zamg/manifest.json
+++ b/homeassistant/components/zamg/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "zamg",
-  "name": "Zamg",
+  "name": "Zentralanstalt für Meteorologie und Geodynamik (ZAMG)",
   "documentation": "https://www.home-assistant.io/integrations/zamg",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "zeroconf",
-  "name": "Zeroconf",
+  "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
   "requirements": ["zeroconf==0.24.4"],
   "dependencies": ["api"],

--- a/homeassistant/components/zhong_hong/manifest.json
+++ b/homeassistant/components/zhong_hong/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "zhong_hong",
-  "name": "Zhong hong",
+  "name": "ZhongHong",
   "documentation": "https://www.home-assistant.io/integrations/zhong_hong",
   "requirements": ["zhong_hong_hvac==1.0.9"],
   "dependencies": [],

--- a/homeassistant/components/ziggo_mediabox_xl/manifest.json
+++ b/homeassistant/components/ziggo_mediabox_xl/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ziggo_mediabox_xl",
-  "name": "Ziggo mediabox xl",
+  "name": "Ziggo Mediabox XL",
   "documentation": "https://www.home-assistant.io/integrations/ziggo_mediabox_xl",
   "requirements": ["ziggo-mediabox-xl==1.1.0"],
   "dependencies": [],

--- a/homeassistant/components/zoneminder/manifest.json
+++ b/homeassistant/components/zoneminder/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "zoneminder",
-  "name": "Zoneminder",
+  "name": "ZoneMinder",
   "documentation": "https://www.home-assistant.io/integrations/zoneminder",
   "requirements": ["zm-py==0.4.0"],
   "dependencies": [],


### PR DESCRIPTION
## Description:

I'm working on getting some things synced between our documentation and the codebase (making the codebase the source of truth). The title/name of the integration is a great starting point for this.

However, the product/brand/integration names are often misspelled, incorrect or incomplete. This PR corrects a bunch of those.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. 

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
