### PR TITLE
Add Integration Quality Scale to manifest and hassfest

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -240,6 +240,11 @@ class Integration:
         return cast(str, self.manifest.get("documentation"))
 
     @property
+    def quality_scale(self) -> Optional[str]:
+        """Return Integration Quality Scale."""
+        return cast(str, self.manifest.get("quality_scale"))
+
+    @property
     def is_built_in(self) -> bool:
         """Test if package is a built-in integration."""
         return self.pkg_path.startswith(PACKAGE_BUILTIN)

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -6,6 +6,13 @@ from voluptuous.humanize import humanize_error
 
 from .model import Integration
 
+SUPPORTED_QUALITY_SCALES = [
+    "gold",
+    "internal",
+    "platinum",
+    "silver",
+]
+
 MANIFEST_SCHEMA = vol.Schema(
     {
         vol.Required("domain"): str,
@@ -17,6 +24,7 @@ MANIFEST_SCHEMA = vol.Schema(
         ),
         vol.Optional("homekit"): vol.Schema({vol.Optional("models"): [str]}),
         vol.Required("documentation"): str,
+        vol.Optional("quality_scale"): vol.In(SUPPORTED_QUALITY_SCALES),
         vol.Required("requirements"): [str],
         vol.Required("dependencies"): [str],
         vol.Optional("after_dependencies"): [str],


### PR DESCRIPTION
## Description:

Add the integration quality scale to the manifest and hassfest.

This merely sets the possibility to add it, and added validation to hassfest to ensure the correctness of data.

Having this data available in the backend, allows us to use it in the frontend as well. Besides, from the backend review, it is much easier to decide if an integration meets all the requirements (as the documentation team is less profound with the codebase).

I'll sync up the data available from the documentation once this is in place and from that point on setup the sync to make the codebase the source of truth for this value.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
