### PR TITLE
Migrate Integration Quality Scale from docs to manifest: internal

### DIFF
--- a/homeassistant/components/alarm_control_panel/manifest.json
+++ b/homeassistant/components/alarm_control_panel/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/alarm_control_panel",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/alert/manifest.json
+++ b/homeassistant/components/alert/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "dependencies": [],
   "after_dependencies": ["notify"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/api/manifest.json
+++ b/homeassistant/components/api/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/api",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/auth/manifest.json
+++ b/homeassistant/components/auth/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "dependencies": ["http"],
   "after_dependencies": ["onboarding"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/automation/manifest.json
+++ b/homeassistant/components/automation/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/automation",
   "requirements": [],
   "dependencies": ["device_automation", "group", "webhook"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/bayesian/manifest.json
+++ b/homeassistant/components/bayesian/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/bayesian",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/binary_sensor/manifest.json
+++ b/homeassistant/components/binary_sensor/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/binary_sensor",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/browser/manifest.json
+++ b/homeassistant/components/browser/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/browser",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/camera/manifest.json
+++ b/homeassistant/components/camera/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "dependencies": ["http"],
   "after_dependencies": ["media_player"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/climate/manifest.json
+++ b/homeassistant/components/climate/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/climate",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/config/manifest.json
+++ b/homeassistant/components/config/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/config",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/configurator/manifest.json
+++ b/homeassistant/components/configurator/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/configurator",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/counter/manifest.json
+++ b/homeassistant/components/counter/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/counter",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/cover/manifest.json
+++ b/homeassistant/components/cover/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/cover",
   "requirements": [],
   "dependencies": ["group"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/demo/manifest.json
+++ b/homeassistant/components/demo/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/demo",
   "requirements": [],
   "dependencies": ["conversation", "zone", "group", "configurator"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/device_automation/manifest.json
+++ b/homeassistant/components/device_automation/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/device_automation",
   "requirements": [],
   "dependencies": ["webhook"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/device_sun_light_trigger/manifest.json
+++ b/homeassistant/components/device_sun_light_trigger/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/device_sun_light_trigger",
   "requirements": [],
   "dependencies": ["device_tracker", "group", "light", "person"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/device_tracker/manifest.json
+++ b/homeassistant/components/device_tracker/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/device_tracker",
   "requirements": [],
   "dependencies": ["group", "zone"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/discovery/manifest.json
+++ b/homeassistant/components/discovery/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/discovery",
   "requirements": ["netdisco==2.6.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/downloader/manifest.json
+++ b/homeassistant/components/downloader/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/downloader",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/emulated_hue/manifest.json
+++ b/homeassistant/components/emulated_hue/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/emulated_hue",
   "requirements": ["aiohttp_cors==0.7.0"],
   "dependencies": [],
-  "codeowners": ["@NobleKangaroo"]
+  "codeowners": ["@NobleKangaroo"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/fan/manifest.json
+++ b/homeassistant/components/fan/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/fan",
   "requirements": [],
   "dependencies": ["group"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/filter/manifest.json
+++ b/homeassistant/components/filter/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/filter",
   "requirements": [],
   "dependencies": ["history"],
-  "codeowners": ["@dgomes"]
+  "codeowners": ["@dgomes"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/flux/manifest.json
+++ b/homeassistant/components/flux/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "dependencies": [],
   "after_dependencies": ["light"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/folder_watcher/manifest.json
+++ b/homeassistant/components/folder_watcher/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/folder_watcher",
   "requirements": ["watchdog==0.8.3"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -12,5 +12,6 @@
     "system_log",
     "websocket_api"
   ],
-  "codeowners": ["@home-assistant/frontend"]
+  "codeowners": ["@home-assistant/frontend"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/group/manifest.json
+++ b/homeassistant/components/group/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/group",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/history/manifest.json
+++ b/homeassistant/components/history/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/history",
   "requirements": [],
   "dependencies": ["http", "recorder"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/history_graph/manifest.json
+++ b/homeassistant/components/history_graph/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/history_graph",
   "requirements": [],
   "dependencies": ["history"],
-  "codeowners": ["@andrey-git"]
+  "codeowners": ["@andrey-git"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/history_stats/manifest.json
+++ b/homeassistant/components/history_stats/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/history_stats",
   "requirements": [],
   "dependencies": ["history"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/homeassistant/manifest.json
+++ b/homeassistant/components/homeassistant/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homeassistant",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/http",
   "requirements": ["aiohttp_cors==0.7.0"],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/input_boolean/manifest.json
+++ b/homeassistant/components/input_boolean/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/input_boolean",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/input_datetime/manifest.json
+++ b/homeassistant/components/input_datetime/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/input_datetime",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/input_number/manifest.json
+++ b/homeassistant/components/input_number/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/input_number",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/input_select/manifest.json
+++ b/homeassistant/components/input_select/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/input_select",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/input_text/manifest.json
+++ b/homeassistant/components/input_text/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/input_text",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/integration/manifest.json
+++ b/homeassistant/components/integration/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/integration",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@dgomes"]
+  "codeowners": ["@dgomes"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/intent_script/manifest.json
+++ b/homeassistant/components/intent_script/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/intent_script",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/light/manifest.json
+++ b/homeassistant/components/light/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/light",
   "requirements": [],
   "dependencies": ["group"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/lock/manifest.json
+++ b/homeassistant/components/lock/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/lock",
   "requirements": [],
   "dependencies": ["group"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/logger/manifest.json
+++ b/homeassistant/components/logger/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/logger",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/manual/manifest.json
+++ b/homeassistant/components/manual/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/manual",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/map/manifest.json
+++ b/homeassistant/components/map/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/map",
   "requirements": [],
   "dependencies": ["frontend"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/media_extractor/manifest.json
+++ b/homeassistant/components/media_extractor/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/media_extractor",
   "requirements": ["youtube_dl==2020.01.01"],
   "dependencies": ["media_player"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/media_player/manifest.json
+++ b/homeassistant/components/media_player/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/media_player",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/min_max/manifest.json
+++ b/homeassistant/components/min_max/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/min_max",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -6,5 +6,6 @@
   "requirements": ["PyNaCl==1.3.0"],
   "dependencies": ["http", "webhook", "person"],
   "after_dependencies": ["cloud"],
-  "codeowners": ["@robbiet480"]
+  "codeowners": ["@robbiet480"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/mold_indicator/manifest.json
+++ b/homeassistant/components/mold_indicator/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/mold_indicator",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/moon/manifest.json
+++ b/homeassistant/components/moon/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/moon",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/notify/manifest.json
+++ b/homeassistant/components/notify/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/notify",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/onboarding/manifest.json
+++ b/homeassistant/components/onboarding/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/onboarding",
   "requirements": [],
   "dependencies": ["auth", "http", "person"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/otp/manifest.json
+++ b/homeassistant/components/otp/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/otp",
   "requirements": ["pyotp==2.3.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/panel_custom/manifest.json
+++ b/homeassistant/components/panel_custom/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/panel_custom",
   "requirements": [],
   "dependencies": ["frontend"],
-  "codeowners": ["@home-assistant/frontend"]
+  "codeowners": ["@home-assistant/frontend"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/panel_iframe/manifest.json
+++ b/homeassistant/components/panel_iframe/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/panel_iframe",
   "requirements": [],
   "dependencies": ["frontend"],
-  "codeowners": ["@home-assistant/frontend"]
+  "codeowners": ["@home-assistant/frontend"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/persistent_notification/manifest.json
+++ b/homeassistant/components/persistent_notification/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/persistent_notification",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/person/manifest.json
+++ b/homeassistant/components/person/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "dependencies": [],
   "after_dependencies": ["device_tracker"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/ping/manifest.json
+++ b/homeassistant/components/ping/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/ping",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/plant/manifest.json
+++ b/homeassistant/components/plant/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "dependencies": ["group", "zone"],
   "after_dependencies": ["recorder"],
-  "codeowners": ["@ChristianKuehnel"]
+  "codeowners": ["@ChristianKuehnel"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/proximity/manifest.json
+++ b/homeassistant/components/proximity/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/proximity",
   "requirements": [],
   "dependencies": ["device_tracker", "zone"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/python_script/manifest.json
+++ b/homeassistant/components/python_script/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/python_script",
   "requirements": ["restrictedpython==5.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/random/manifest.json
+++ b/homeassistant/components/random/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/random",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/recorder/manifest.json
+++ b/homeassistant/components/recorder/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/recorder",
   "requirements": ["sqlalchemy==1.3.12"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/rss_feed_template/manifest.json
+++ b/homeassistant/components/rss_feed_template/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/rss_feed_template",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/scene/manifest.json
+++ b/homeassistant/components/scene/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/scene",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/script/manifest.json
+++ b/homeassistant/components/script/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/script",
   "requirements": [],
   "dependencies": ["group"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/season/manifest.json
+++ b/homeassistant/components/season/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/season",
   "requirements": ["ephem==3.7.7.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/sensor/manifest.json
+++ b/homeassistant/components/sensor/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/sensor",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/shell_command/manifest.json
+++ b/homeassistant/components/shell_command/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/shell_command",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/shopping_list/manifest.json
+++ b/homeassistant/components/shopping_list/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/shopping_list",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/simulated/manifest.json
+++ b/homeassistant/components/simulated/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/simulated",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/statistics/manifest.json
+++ b/homeassistant/components/statistics/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "dependencies": [],
   "after_dependencies": ["recorder"],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/stream",
   "requirements": ["av==6.1.2"],
   "dependencies": ["http"],
-  "codeowners": ["@hunterjm"]
+  "codeowners": ["@hunterjm"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/sun/manifest.json
+++ b/homeassistant/components/sun/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/sun",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@Swamp-Ig"]
+  "codeowners": ["@Swamp-Ig"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/switch/manifest.json
+++ b/homeassistant/components/switch/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/switch",
   "requirements": [],
   "dependencies": ["group"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/system_health/manifest.json
+++ b/homeassistant/components/system_health/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/system_health",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/system_log/manifest.json
+++ b/homeassistant/components/system_log/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/system_log",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/template/manifest.json
+++ b/homeassistant/components/template/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/template",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@PhracturedBlue", "@tetienne"]
+  "codeowners": ["@PhracturedBlue", "@tetienne"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/threshold/manifest.json
+++ b/homeassistant/components/threshold/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/threshold",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/time_date/manifest.json
+++ b/homeassistant/components/time_date/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/time_date",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/timer/manifest.json
+++ b/homeassistant/components/timer/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/timer",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/tod/manifest.json
+++ b/homeassistant/components/tod/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/tod",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/trend/manifest.json
+++ b/homeassistant/components/trend/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/trend",
   "requirements": ["numpy==1.17.4"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/universal/manifest.json
+++ b/homeassistant/components/universal/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/universal",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/updater/manifest.json
+++ b/homeassistant/components/updater/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/updater",
   "requirements": ["distro==1.4.0"],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/uptime/manifest.json
+++ b/homeassistant/components/uptime/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/uptime",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/utility_meter/manifest.json
+++ b/homeassistant/components/utility_meter/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/utility_meter",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@dgomes"]
+  "codeowners": ["@dgomes"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/version/manifest.json
+++ b/homeassistant/components/version/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/version",
   "requirements": ["pyhaversion==3.1.0"],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/weather/manifest.json
+++ b/homeassistant/components/weather/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/weather",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/weblink/manifest.json
+++ b/homeassistant/components/weblink/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/weblink",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/websocket_api/manifest.json
+++ b/homeassistant/components/websocket_api/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/websocket_api",
   "requirements": [],
   "dependencies": ["http"],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/workday",
   "requirements": ["holidays==0.9.12"],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/worldclock/manifest.json
+++ b/homeassistant/components/worldclock/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/worldclock",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
   "requirements": ["zeroconf==0.24.4"],
   "dependencies": ["api"],
-  "codeowners": ["@robbiet480", "@Kane610"]
+  "codeowners": ["@robbiet480", "@Kane610"],
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/zone/manifest.json
+++ b/homeassistant/components/zone/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/zone",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@home-assistant/core"]
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
 }


### PR DESCRIPTION
## Description:

Migrates Quality Scale from docs to the manifest.
This only migrates integrations with the "internal" scale set.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
