### PR TITLE
Add config flow support, move to async, add device registry support for vizio component

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -1,4 +1,5 @@
 """The vizio component."""
+
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -51,7 +51,8 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
-    """Platform setup, do nothing."""
+    """Platform setup, run import config flow for each entry in config."""
+
     if DOMAIN in config:
         for entry in config[DOMAIN]:
             hass.async_create_task(

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -1,6 +1,7 @@
 """The vizio component."""
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_DEVICE_CLASS,
@@ -8,17 +9,20 @@ from homeassistant.const import (
     CONF_NAME,
 )
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import (
     CONF_VOLUME_STEP,
     DEFAULT_DEVICE_CLASS,
     DEFAULT_NAME,
     DEFAULT_VOLUME_STEP,
+    DOMAIN,
 )
 
 
-def validate_auth(config):
+def validate_auth(config: ConfigType) -> ConfigType:
     """Validate presence of CONF_ACCESS_TOKEN when CONF_DEVICE_CLASS=tv."""
+
     token = config.get(CONF_ACCESS_TOKEN)
     if config[CONF_DEVICE_CLASS] == "tv" and not token:
         raise vol.Invalid(
@@ -29,13 +33,50 @@ def validate_auth(config):
 
 
 VIZIO_SCHEMA = {
-    vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
         cv.string, vol.Lower, vol.In(["tv", "soundbar"])
     ),
+    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
     vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
         vol.Coerce(int), vol.Range(min=1, max=10)
     ),
 }
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: [vol.All(vol.Schema(VIZIO_SCHEMA), validate_auth)]}, extra=vol.ALLOW_EXTRA
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Platform setup, do nothing."""
+    if DOMAIN in config:
+        for entry in config[DOMAIN]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
+                )
+            )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Load the saved entities."""
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "media_player")
+    )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_unload(entry, "media_player")
+    )
+
+    return True

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Vizio."""
+
 import logging
 from typing import Any, Dict, Optional
 

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -105,10 +105,10 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         title="configuration.yaml - " + user_input[CONF_NAME],
                         data=user_input,
                     )
-                else:
-                    return self.async_create_entry(
-                        title=user_input[CONF_NAME], data=user_input
-                    )
+
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
 
         return self.async_show_form(
             step_id="user", data_schema=vizio_schema(defaults), errors=errors

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -65,7 +65,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
         defaults = None
-        no_ctx = user_input.get(CONF_CONTEXT) is None
+        no_ctx = user_input and user_input.get(CONF_CONTEXT) is None
 
         if user_input is not None:
             defaults = user_input

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -60,7 +60,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    async def async_step_user(self, user_input: Dict[str, Any] = None):
+    async def async_step_user(
+        self, user_input: Dict[str, Any] = None
+    ) -> Dict[str, Any]:
         """Handle a flow initialized by the user."""
 
         errors = {}
@@ -108,7 +110,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=vizio_schema(defaults), errors=errors
         )
 
-    async def async_step_import(self, import_config: Dict[str, Any]):
+    async def async_step_import(self, import_config: Dict[str, Any]) -> Dict[str, Any]:
         """Import a config entry from configuration.yaml."""
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -76,17 +76,18 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Check if new config entry matches any existing config entries
             for entry in self.hass.config_entries.async_entries(DOMAIN):
                 if entry.data[CONF_HOST] == user_input[CONF_HOST]:
-                    if user_input.get(CONF_CONTEXT) == "config":
-                        return self.async_abort(reason="host_exists")
-                    else:
+                    if not user_input.get(CONF_CONTEXT):
                         errors[CONF_HOST] = "host_exists"
                         break
+
+                    return self.async_abort(reason="host_exists")
+
                 if entry.data[CONF_NAME] == user_input[CONF_NAME]:
-                    if user_input.get(CONF_CONTEXT) == "config":
-                        return self.async_abort(reason="name_exists")
-                    else:
+                    if not user_input.get(CONF_CONTEXT):
                         errors[CONF_NAME] = "name_exists"
                         break
+
+                    return self.async_abort(reason="name_exists")
 
             if not errors:
                 try:
@@ -107,7 +108,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 if user_input.get(CONF_CONTEXT) == "config":
                     return self.async_create_entry(
-                        title=f"configuration.yaml - {user_input[CONF_NAME]}",
+                        title=f"{user_input[CONF_NAME]} (configuration.yaml)",
                         data=user_input,
                     )
 

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Vizio."""
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pyvizio import Vizio
 import voluptuous as vol
@@ -25,7 +25,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def vizio_schema(self, defaults) -> vol.Schema:
+def vizio_schema(self, defaults: Optional[Dict[str, any]] = None) -> vol.Schema:
     """Return vol schema with expected defaults for blank form or retain what was previously filled in."""
 
     if not defaults:
@@ -66,9 +66,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
 
         errors = {}
-
         defaults = None
-
         validate = True
 
         if user_input is not None:

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -31,7 +31,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def vizio_schema(self, defaults: dict) -> vol.Schema:
-        """Return vol schema with expected defaults or defaults of what was previously filled in."""
+        """Return vol schema with expected defaults for blank form or retain what was previously filled in."""
 
         if not defaults:
             defaults = {

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -60,7 +60,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input: Dict[str, Any] = None):
         """Handle a flow initialized by the user."""
 
         errors = {}
@@ -108,7 +108,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=vizio_schema(defaults), errors=errors
         )
 
-    async def async_step_import(self, import_config):
+    async def async_step_import(self, import_config: Dict[str, Any]):
         """Import a config entry from configuration.yaml."""
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -65,7 +65,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
         defaults = None
-        no_ctx = self.context.get("source") is None
+        no_ctx = user_input.get(CONF_CONTEXT) is None
 
         if user_input is not None:
             defaults = user_input
@@ -119,5 +119,8 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config: Dict[str, Any]) -> Dict[str, Any]:
         """Import a config entry from configuration.yaml."""
+
+        # Insert record into dict to indicate data came from config import
+        import_config[CONF_CONTEXT] = "import"
 
         return await self.async_step_user(user_input=import_config)

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -1,0 +1,118 @@
+"""Config flow for Vizio."""
+import logging
+
+from pyvizio import Vizio
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_DEVICE_CLASS,
+    CONF_HOST,
+    CONF_NAME,
+)
+
+from . import validate_auth
+from .const import (
+    CONF_VOLUME_STEP,
+    DEFAULT_DEVICE_CLASS,
+    DEFAULT_NAME,
+    DEFAULT_VOLUME_STEP,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Vizio config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def vizio_schema(self, defaults: dict) -> vol.Schema:
+        """Return vol schema with expected defaults or defaults of what was previously filled in."""
+
+        if not defaults:
+            defaults = {
+                CONF_NAME: DEFAULT_NAME,
+                CONF_HOST: "",
+                CONF_DEVICE_CLASS: DEFAULT_DEVICE_CLASS,
+                CONF_ACCESS_TOKEN: "",
+                CONF_VOLUME_STEP: DEFAULT_VOLUME_STEP,
+            }
+
+        return vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=defaults[CONF_NAME]): str,
+                vol.Required(CONF_HOST, default=defaults.get(CONF_HOST)): str,
+                vol.Optional(
+                    CONF_DEVICE_CLASS, default=defaults[CONF_DEVICE_CLASS]
+                ): vol.All(str, vol.Lower, vol.In(["tv", "soundbar"])),
+                vol.Optional(
+                    CONF_ACCESS_TOKEN, default=defaults.get(CONF_ACCESS_TOKEN)
+                ): str,
+                vol.Optional(
+                    CONF_VOLUME_STEP, default=defaults[CONF_VOLUME_STEP]
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+            }
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+
+        errors = {}
+
+        defaults = None
+
+        validate = True
+
+        if user_input is not None:
+            defaults = user_input
+
+            # Check if new config entry matches any existing config entries
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.data[CONF_HOST] == user_input[CONF_HOST]:
+                    errors[CONF_HOST] = "host_exists"
+                    validate = False
+                    break
+                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                    errors[CONF_NAME] = "name_exists"
+                    validate = False
+                    break
+
+            if validate:
+                try:
+                    # Ensure schema passes custom validation, otherwise catch exception and add error
+                    validate_auth(user_input)
+
+                    # Ensure config is valid for a device
+                    if not await self.hass.async_add_executor_job(
+                        Vizio.validate_config,
+                        user_input[CONF_HOST],
+                        user_input.get(CONF_ACCESS_TOKEN),
+                        user_input[CONF_DEVICE_CLASS],
+                    ):
+                        errors["base"] = "invalid_setup"
+                except vol.Invalid:
+                    errors["base"] = "tv_needs_token"
+
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user", data_schema=self.vizio_schema(defaults), errors=errors
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data[CONF_HOST] == import_config[CONF_HOST]:
+                return self.async_abort(reason="host_exists")
+            if entry.data[CONF_NAME] == import_config[CONF_NAME]:
+                return self.async_abort(reason="name_exists")
+
+        return await self.async_step_user(user_input=import_config)

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -24,39 +24,40 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def vizio_schema(self, defaults: dict) -> vol.Schema:
+    """Return vol schema with expected defaults for blank form or retain what was previously filled in."""
+
+    if not defaults:
+        defaults = {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_HOST: "",
+            CONF_DEVICE_CLASS: DEFAULT_DEVICE_CLASS,
+            CONF_ACCESS_TOKEN: "",
+            CONF_VOLUME_STEP: DEFAULT_VOLUME_STEP,
+        }
+
+    return vol.Schema(
+        {
+            vol.Optional(CONF_NAME, default=defaults[CONF_NAME]): str,
+            vol.Required(CONF_HOST, default=defaults.get(CONF_HOST)): str,
+            vol.Optional(
+                CONF_DEVICE_CLASS, default=defaults[CONF_DEVICE_CLASS]
+            ): vol.All(str, vol.Lower, vol.In(["tv", "soundbar"])),
+            vol.Optional(
+                CONF_ACCESS_TOKEN, default=defaults.get(CONF_ACCESS_TOKEN)
+            ): str,
+            vol.Optional(CONF_VOLUME_STEP, default=defaults[CONF_VOLUME_STEP]): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=10)
+            ),
+        }
+    )
+
+
 class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Vizio config flow."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-
-    def vizio_schema(self, defaults: dict) -> vol.Schema:
-        """Return vol schema with expected defaults for blank form or retain what was previously filled in."""
-
-        if not defaults:
-            defaults = {
-                CONF_NAME: DEFAULT_NAME,
-                CONF_HOST: "",
-                CONF_DEVICE_CLASS: DEFAULT_DEVICE_CLASS,
-                CONF_ACCESS_TOKEN: "",
-                CONF_VOLUME_STEP: DEFAULT_VOLUME_STEP,
-            }
-
-        return vol.Schema(
-            {
-                vol.Optional(CONF_NAME, default=defaults[CONF_NAME]): str,
-                vol.Required(CONF_HOST, default=defaults.get(CONF_HOST)): str,
-                vol.Optional(
-                    CONF_DEVICE_CLASS, default=defaults[CONF_DEVICE_CLASS]
-                ): vol.All(str, vol.Lower, vol.In(["tv", "soundbar"])),
-                vol.Optional(
-                    CONF_ACCESS_TOKEN, default=defaults.get(CONF_ACCESS_TOKEN)
-                ): str,
-                vol.Optional(
-                    CONF_VOLUME_STEP, default=defaults[CONF_VOLUME_STEP]
-                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
-            }
-        )
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -103,7 +104,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="user", data_schema=self.vizio_schema(defaults), errors=errors
+            step_id="user", data_schema=vizio_schema(defaults), errors=errors
         )
 
     async def async_step_import(self, import_config):

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -25,7 +25,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def vizio_schema(self, defaults: Dict[str, Any]) -> vol.Schema:
+def vizio_schema(self, defaults) -> vol.Schema:
     """Return vol schema with expected defaults for blank form or retain what was previously filled in."""
 
     if not defaults:

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Vizio."""
 import logging
+from typing import Any, Dict
 
 from pyvizio import Vizio
 import voluptuous as vol
@@ -24,7 +25,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def vizio_schema(self, defaults: dict) -> vol.Schema:
+def vizio_schema(self, defaults: Dict[str, Any]) -> vol.Schema:
     """Return vol schema with expected defaults for blank form or retain what was previously filled in."""
 
     if not defaults:

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -102,7 +102,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 if user_input.get("configuration.yaml"):
                     return self.async_create_entry(
-                        title="configuration.yaml - " + user_input[CONF_NAME],
+                        title=f"configuration.yaml - {user_input[CONF_NAME]}",
                         data=user_input,
                     )
 

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -100,9 +100,15 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors["base"] = "tv_needs_token"
 
             if not errors:
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
-                )
+                if user_input.get("configuration.yaml"):
+                    return self.async_create_entry(
+                        title="configuration.yaml - " + user_input[CONF_NAME],
+                        data=user_input,
+                    )
+                else:
+                    return self.async_create_entry(
+                        title=user_input[CONF_NAME], data=user_input
+                    )
 
         return self.async_show_form(
             step_id="user", data_schema=vizio_schema(defaults), errors=errors
@@ -116,5 +122,8 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="host_exists")
             if entry.data[CONF_NAME] == import_config[CONF_NAME]:
                 return self.async_abort(reason="name_exists")
+
+        # add key to track entities coming from config
+        import_config["configuration.yaml"] = True
 
         return await self.async_step_user(user_input=import_config)

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -1,5 +1,6 @@
 """Constants used by vizio component."""
 
+CONF_CONTEXT = "context"
 CONF_VOLUME_STEP = "volume_step"
 
 DEFAULT_NAME = "Vizio SmartCast"

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,8 @@
   "domain": "vizio",
   "name": "Vizio SmartCast TV",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.0.12"],
+  "requirements": ["pyvizio==0.0.13"],
   "dependencies": [],
+  "config_flow": true,
   "codeowners": ["@raman325"]
 }

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -202,7 +202,7 @@ class VizioDevice(MediaPlayerDevice):
         return {
             "identifiers": {(DOMAIN, self._unique_id)},
             "name": self.name,
-            "manufacturer": "vizio",
+            "manufacturer": "Vizio",
             "model": self._model,
         }
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -1,12 +1,12 @@
 """Vizio SmartCast Device support."""
+
 from datetime import timedelta
 import logging
 
 from pyvizio import Vizio
-import voluptuous as vol
 
 from homeassistant import util
-from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerDevice
+from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PREVIOUS_TRACK,
@@ -17,6 +17,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_DEVICE_CLASS,
@@ -25,8 +26,8 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers.typing import HomeAssistantType
 
-from . import VIZIO_SCHEMA, validate_auth
 from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEVICE_ID, ICON
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,37 +50,48 @@ SUPPORTED_COMMANDS = {
 }
 
 
-PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend(VIZIO_SCHEMA), validate_auth)
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+) -> bool:
+    """Set up a Vizio media player entry."""
 
+    host = entry.data[CONF_HOST]
+    token = entry.data.get(CONF_ACCESS_TOKEN)
+    name = entry.data[CONF_NAME]
+    volume_step = entry.data[CONF_VOLUME_STEP]
+    device_type = entry.data[CONF_DEVICE_CLASS]
+    device = VizioDevice(hass, host, token, name, volume_step, device_type)
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Vizio media player platform."""
-    host = config[CONF_HOST]
-    token = config.get(CONF_ACCESS_TOKEN)
-    name = config[CONF_NAME]
-    volume_step = config[CONF_VOLUME_STEP]
-    device_type = config[CONF_DEVICE_CLASS]
-    device = VizioDevice(host, token, name, volume_step, device_type)
-    if not device.validate_setup():
+    if not await hass.async_add_executor_job(device.validate_setup):
         fail_auth_msg = ""
         if token:
             fail_auth_msg = " and auth token is correct"
         _LOGGER.error(
             "Failed to set up Vizio platform, please check if host "
-            "is valid and available%s",
+            "is valid and available, device type is correct, %s",
             fail_auth_msg,
         )
-        return
 
-    add_entities([device], True)
+        return False
+
+    return async_add_entities([device], True)
 
 
 class VizioDevice(MediaPlayerDevice):
     """Media Player implementation which performs REST requests to device."""
 
-    def __init__(self, host, token, name, volume_step, device_type):
+    def __init__(
+        self,
+        hass: HomeAssistantType,
+        host: str,
+        token: str,
+        name: str,
+        volume_step: int,
+        device_type: str,
+    ) -> None:
         """Initialize Vizio device."""
 
+        self._hass = hass
         self._name = name
         self._state = None
         self._volume_level = None
@@ -94,25 +106,32 @@ class VizioDevice(MediaPlayerDevice):
         self._icon = ICON[device_type]
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
-    def update(self):
+    async def async_update(self) -> None:
         """Retrieve latest state of the device."""
-        is_on = self._device.get_power_state()
 
         if not self._unique_id:
-            self._unique_id = self._device.get_esn()
+            self._unique_id = await self._hass.async_add_executor_job(
+                self._device.get_esn
+            )
+
+        is_on = await self._hass.async_add_executor_job(self._device.get_power_state)
 
         if is_on:
             self._state = STATE_ON
 
-            volume = self._device.get_current_volume()
+            volume = await self._hass.async_add_executor_job(
+                self._device.get_current_volume
+            )
             if volume is not None:
                 self._volume_level = float(volume) / self._max_volume
 
-            input_ = self._device.get_current_input()
+            input_ = await self._hass.async_add_executor_job(
+                self._device.get_current_input
+            )
             if input_ is not None:
                 self._current_input = input_.meta_name
 
-            inputs = self._device.get_inputs()
+            inputs = await self._hass.async_add_executor_job(self._device.get_inputs)
             if inputs is not None:
                 self._available_inputs = [input_.name for input_ in inputs]
 
@@ -127,100 +146,120 @@ class VizioDevice(MediaPlayerDevice):
             self._available_inputs = None
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the device."""
+
         return self._state
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the device."""
+
         return self._name
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon of the device."""
+
         return self._icon
 
     @property
-    def volume_level(self):
+    def volume_level(self) -> float:
         """Return the volume level of the device."""
+
         return self._volume_level
 
     @property
-    def source(self):
+    def source(self) -> str:
         """Return current input of the device."""
+
         return self._current_input
 
     @property
-    def source_list(self):
+    def source_list(self) -> list:
         """Return list of available inputs of the device."""
+
         return self._available_inputs
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> int:
         """Flag device features that are supported."""
+
         return self._supported_commands
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return the unique id of the device."""
+
         return self._unique_id
 
-    def turn_on(self):
+    async def async_turn_on(self) -> None:
         """Turn the device on."""
-        self._device.pow_on()
 
-    def turn_off(self):
+        await self._hass.async_add_executor_job(self._device.pow_on)
+
+    async def async_turn_off(self) -> None:
         """Turn the device off."""
-        self._device.pow_off()
 
-    def mute_volume(self, mute):
+        await self._hass.async_add_executor_job(self._device.pow_off)
+
+    async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
+
         if mute:
-            self._device.mute_on()
+            await self._hass.async_add_executor_job(self._device.mute_on)
         else:
-            self._device.mute_off()
+            await self._hass.async_add_executor_job(self._device.mute_off)
 
-    def media_previous_track(self):
+    async def async_media_previous_track(self) -> None:
         """Send previous channel command."""
-        self._device.ch_down()
 
-    def media_next_track(self):
+        await self._hass.async_add_executor_job(self._device.ch_down)
+
+    async def async_media_next_track(self) -> None:
         """Send next channel command."""
-        self._device.ch_up()
 
-    def select_source(self, source):
+        await self._hass.async_add_executor_job(self._device.ch_up)
+
+    async def async_select_source(self, source: str) -> None:
         """Select input source."""
-        self._device.input_switch(source)
 
-    def volume_up(self):
+        await self._hass.async_add_executor_job(self._device.input_switch, source)
+
+    async def async_volume_up(self) -> None:
         """Increasing volume of the device."""
-        self._device.vol_up(num=self._volume_step)
+
+        await self._hass.async_add_executor_job(self._device.vol_up, self._volume_step)
         if self._volume_level is not None:
             self._volume_level = min(
                 1.0, self._volume_level + self._volume_step / self._max_volume
             )
 
-    def volume_down(self):
+    async def async_volume_down(self) -> None:
         """Decreasing volume of the device."""
-        self._device.vol_down(num=self._volume_step)
+
+        await self._hass.async_add_executor_job(
+            self._device.vol_down, self._volume_step
+        )
         if self._volume_level is not None:
             self._volume_level = max(
                 0.0, self._volume_level - self._volume_step / self._max_volume
             )
 
-    def validate_setup(self):
+    def validate_setup(self) -> bool:
         """Validate if host is available and auth token is correct."""
+
         return self._device.can_connect()
 
-    def set_volume_level(self, volume):
+    async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level."""
+
         if self._volume_level is not None:
             if volume > self._volume_level:
                 num = int(self._max_volume * (volume - self._volume_level))
                 self._volume_level = volume
-                self._device.vol_up(num=num)
+                await self._hass.async_add_executor_job(self._device.vol_up, num)
             elif volume < self._volume_level:
                 num = int(self._max_volume * (self._volume_level - volume))
                 self._volume_level = volume
-                self._device.vol_down(num=num)
+                await self._hass.async_add_executor_job(self._device.vol_down, num)

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEVICE_ID, ICON
+from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEVICE_ID, DOMAIN, ICON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,6 +88,7 @@ class VizioDevice(MediaPlayerDevice):
         name: str,
         volume_step: int,
         device_type: str,
+        model: str = None,
     ) -> None:
         """Initialize Vizio device."""
 
@@ -103,6 +104,7 @@ class VizioDevice(MediaPlayerDevice):
         self._device = Vizio(DEVICE_ID, host, DEFAULT_NAME, token, device_type)
         self._max_volume = float(self._device.get_max_volume())
         self._unique_id = None
+        self._model = model
         self._icon = ICON[device_type]
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
@@ -192,6 +194,17 @@ class VizioDevice(MediaPlayerDevice):
         """Return the unique id of the device."""
 
         return self._unique_id
+
+    @property
+    def device_info(self):
+        """Return device registry information."""
+
+        return {
+            "identifiers": {(DOMAIN, self._unique_id)},
+            "name": self.name,
+            "manufacturer": "vizio",
+            "model": self._model,
+        }
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -21,8 +21,7 @@
         },
         "abort": {
             "name_exists": "Vizio component with name already configured.",
-            "host_exists": "Vizio component with host already configured.",
-            "cant_connect": "Vizio component could not be connected to."
+            "host_exists": "Vizio component with host already configured."
         }
     }
 }

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -1,0 +1,28 @@
+{
+    "config": {
+        "title": "Vizio SmartCast",
+        "step": {
+            "user": {
+                "title": "Setup Vizio SmartCast Client",
+                "data": {
+                    "name": "Name",
+                    "host": "<Host/IP>:<Port>",
+                    "device_class": "Device Type",
+                    "access_token": "Access Token",
+                    "volume_step": "Volume Step Size"
+                }
+            }
+        },
+        "error": {
+            "name_exists": "Name already configured.",
+            "host_exists": "Host already configured.",
+            "tv_needs_token": "When Device Type is `tv` then a valid Access Token is needed.",
+            "invalid_setup": "The configuration was unable to be validated succcessfully. [Review the docs](https://www.home-assistant.io/integrations/vizio/) and reverify that:\n- The device is powered on\n- The device is connected to the network\n- The values you filled in are accurate\nbefore attempting to resubmit."
+        },
+        "abort": {
+            "name_exists": "Vizio component with name already configured.",
+            "host_exists": "Vizio component with host already configured.",
+            "cant_connect": "Vizio component could not be connected to."
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -89,6 +89,7 @@ FLOWS = [
     "upnp",
     "velbus",
     "vesync",
+    "vizio",
     "wemo",
     "withings",
     "wled",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.12
+pyvizio==0.0.13
 
 # homeassistant.components.velux
 pyvlx==0.2.12


### PR DESCRIPTION
## Breaking Change:
`vizio` component has moved from a platform entry to a config entry. This will break existing configs for those who use this component but was necessary to ensure that users could define `vizio` entities via `configuration.yaml` and via config flow.

## Description:
As part of this change, I:
- Moved `vizio` from a platform entry to a top level config entry
- Made `vizio` async by wrapping all synchronous calls with an `await hass.async_add_executor_job`
- Added support for config flow
- Added a device registry entry

I plan to add `zeroconf` discovery support next once this is reviewed and approved

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11665

## Example entry for `configuration.yaml` (if applicable):
```yaml
vizio:
  - host: IP_ADDRESS
    access_token: AUTH_TOKEN
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
