### PR TITLE
WIP, PoC: format JSON in pre-commit

### DIFF
--- a/.pre-commit-config-all.yaml
+++ b/.pre-commit-config-all.yaml
@@ -57,3 +57,10 @@ repos:
         types: [python]
         require_serial: true
         files: ^homeassistant/.+\.py$
+    -   id: format_json
+        name: format_json
+        entry: script/format_json
+        language: script
+        types: [json]
+        files: ^(homeassistant|script|tests)/.+\.json$
+        exclude: /(\.translations/|strings(\.\w+)?\.json$)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,15 @@ repos:
     rev: v4.3.21
     hooks:
     -   id: isort
+-   repo: local
+    hooks:
+    -   id: format_json
+        name: format_json
+        entry: script/format_json
+        language: script
+        types: [json]
+        files: ^(homeassistant|script|tests)/.+\.json$
+        exclude: /(\.translations/|strings(\.\w+)?\.json$)
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:

--- a/script/format_json
+++ b/script/format_json
@@ -1,0 +1,7 @@
+#!/bin/sh -eu
+
+for srcfile in "$@"; do
+    destfile=$(mktemp)
+    python3 -m json.tool "$srcfile" "$destfile"
+    mv "$destfile" "$srcfile"
+done


### PR DESCRIPTION
## Description:

Per discussion started in #30521 

WIP, TODO:
- [ ] decide exact set of files we want to format
- [ ] actually format matching files
- [ ] hook up in CI
- [ ] remove redundant `check-json` for files we run through this

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
