### PR TITLE
Bump pyRFXtrx to 0.25

### DIFF
--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rfxtrx",
   "name": "RFXCOM RFXtrx",
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
-  "requirements": ["pyRFXtrx==0.24"],
+  "requirements": ["pyRFXtrx==0.25"],
   "dependencies": [],
   "codeowners": ["@danielhiversen"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1098,7 +1098,7 @@ pyHS100==0.3.5
 pyMetno==0.4.6
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.24
+pyRFXtrx==0.25
 
 # homeassistant.components.switchmate
 # pySwitchmate==0.4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -384,7 +384,7 @@ pyHS100==0.3.5
 pyMetno==0.4.6
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.24
+pyRFXtrx==0.25
 
 # homeassistant.components.nextbus
 py_nextbusnext==0.1.4


### PR DESCRIPTION
## Breaking Change:
The update switches the commands for 'open' and 'close' for rfxtrx covers of the 'Rollertrol' type, as they were switched (clicking open resulted in closing of the cover and vice versa). Existing automations should be updated. 

## Description:
PR updates pyRFXtrx to 0.25.
- Reverts "Update Rollertrol"

**Related issue (if applicable):** fixes #16788

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
