### PR TITLE
Migrate Integration Quality Scale from docs to manifest

### DIFF
--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/daikin",
   "requirements": ["pydaikin==1.6.1"],
   "dependencies": [],
-  "codeowners": ["@fredrike", "@rofrantz"]
+  "codeowners": ["@fredrike", "@rofrantz"],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -10,5 +10,6 @@
     }
   ],
   "dependencies": [],
-  "codeowners": ["@kane610"]
+  "codeowners": ["@kane610"],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/elgato/manifest.json
+++ b/homeassistant/components/elgato/manifest.json
@@ -6,5 +6,6 @@
   "requirements": ["elgato==0.2.0"],
   "dependencies": [],
   "zeroconf": ["_elg._tcp.local."],
-  "codeowners": ["@frenck"]
+  "codeowners": ["@frenck"],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -13,5 +13,6 @@
     "models": ["BSB002"]
   },
   "dependencies": [],
-  "codeowners": ["@balloob"]
+  "codeowners": ["@balloob"],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/luftdaten/manifest.json
+++ b/homeassistant/components/luftdaten/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/luftdaten",
   "requirements": ["luftdaten==0.6.3"],
   "dependencies": [],
-  "codeowners": ["@fabaff"]
+  "codeowners": ["@fabaff"],
+  "quality_scale": "gold"
 }

--- a/homeassistant/components/point/manifest.json
+++ b/homeassistant/components/point/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/point",
   "requirements": ["pypoint==1.1.2"],
   "dependencies": ["webhook", "http"],
-  "codeowners": ["@fredrike"]
+  "codeowners": ["@fredrike"],
+  "quality_scale": "gold"
 }

--- a/homeassistant/components/tellduslive/manifest.json
+++ b/homeassistant/components/tellduslive/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/tellduslive",
   "requirements": ["tellduslive==0.10.10"],
   "dependencies": [],
-  "codeowners": ["@fredrike"]
+  "codeowners": ["@fredrike"],
+  "quality_scale": "gold"
 }

--- a/homeassistant/components/tibber/manifest.json
+++ b/homeassistant/components/tibber/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/tibber",
   "requirements": ["pyTibber==0.12.0"],
   "dependencies": [],
-  "codeowners": ["@danielhiversen"]
+  "codeowners": ["@danielhiversen"],
+  "quality_scale": "silver"
 }

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/unifi",
   "requirements": ["aiounifi==11"],
   "dependencies": [],
-  "codeowners": ["@kane610"]
+  "codeowners": ["@kane610"],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -6,5 +6,6 @@
   "requirements": ["wled==0.2.1"],
   "dependencies": [],
   "zeroconf": ["_wled._tcp.local."],
-  "codeowners": ["@frenck"]
+  "codeowners": ["@frenck"],
+  "quality_scale": "platinum"
 }


### PR DESCRIPTION
## Description:

This PR takes the current known Integration Quality Scales from the documentation and adds them to the manifests.

After this PR is merged, the manifest will be seen as the source of truth for this value. (The docs will sync it from the codebase).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
