### PR TITLE
Check netgear device_tracker link_rate to ensure device is connected

### DIFF
--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -31,9 +31,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_USERNAME, default=""): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PORT, default=None): vol.Any(None, cv.port),
-        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_APS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_DEVICES, default=[]): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(CONF_APS, default=[]): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
     }
 )
 
@@ -51,7 +57,14 @@ def get_scanner(hass, config):
     accesspoints = info.get(CONF_APS)
 
     scanner = NetgearDeviceScanner(
-        host, ssl, username, password, port, devices, excluded_devices, accesspoints
+        host,
+        ssl,
+        username,
+        password,
+        port,
+        devices,
+        excluded_devices,
+        accesspoints,
     )
 
     return scanner if scanner.success_init else None
@@ -110,7 +123,10 @@ class NetgearDeviceScanner(DeviceScanner):
                     or dev.name in self.excluded_devices
                 )
             )
-            if tracked:
+
+            # when link_rate is None this means the router still knows about
+            # the device, but it is not in range.
+            if tracked and dev.link_rate is not None:
                 devices.append(dev.mac)
                 if (
                     self.tracked_accesspoints

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -31,15 +31,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_USERNAME, default=""): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PORT, default=None): vol.Any(None, cv.port),
-        vol.Optional(CONF_DEVICES, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
-        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
-        vol.Optional(CONF_APS, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
+        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_APS, default=[]): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 
@@ -57,14 +51,7 @@ def get_scanner(hass, config):
     accesspoints = info.get(CONF_APS)
 
     scanner = NetgearDeviceScanner(
-        host,
-        ssl,
-        username,
-        password,
-        port,
-        devices,
-        excluded_devices,
-        accesspoints,
+        host, ssl, username, password, port, devices, excluded_devices, accesspoints
     )
 
     return scanner if scanner.success_init else None


### PR DESCRIPTION
## Description:

Allows Netgear device_tracker to show devices as offline when they recently disconnected.

A redo of PR #29434 which got totally borked due to rebase.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

Documentation Not needed.

## Example entry for `configuration.yaml` (if applicable):

Config does not change.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
