### PR TITLE
Fix WLED transition time unit

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -146,7 +146,8 @@ class WLEDLight(Light, WLEDDeviceEntity):
         data = {ATTR_ON: False, ATTR_SEGMENT_ID: self._segment}
 
         if ATTR_TRANSITION in kwargs:
-            data[ATTR_TRANSITION] = kwargs[ATTR_TRANSITION] * 1000
+            # WLED uses 100ms per unit, so 10 = 1 second.
+            data[ATTR_TRANSITION] = round(kwargs[ATTR_TRANSITION] * 10)
 
         try:
             await self.wled.light(**data)
@@ -173,7 +174,8 @@ class WLEDLight(Light, WLEDDeviceEntity):
             data[ATTR_COLOR_PRIMARY] = color_util.color_hsv_to_RGB(hue, sat, 100)
 
         if ATTR_TRANSITION in kwargs:
-            data[ATTR_TRANSITION] = kwargs[ATTR_TRANSITION] * 1000
+            # WLED uses 100ms per unit, so 10 = 1 second.
+            data[ATTR_TRANSITION] = round(kwargs[ATTR_TRANSITION] * 10)
 
         if ATTR_BRIGHTNESS in kwargs:
             data[ATTR_BRIGHTNESS] = kwargs[ATTR_BRIGHTNESS]


### PR DESCRIPTION
## Description:

Fixes transition times for a WLED light again, this time it corrects the unit used to match WLED itself.

Home Assistant uses seconds for transition time, while WLED uses units of 100ms. So 10 = 1 second. 

See comment by WLED author @Aircoookie: <https://github.com/home-assistant/home-assistant/issues/30489#issuecomment-570946246>

Furthermore, I realized that a float was also a valid transition time, added rounding to deal with that.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
