### PR TITLE
Bump adguardhome to 0.4.1

### DIFF
--- a/homeassistant/components/adguard/manifest.json
+++ b/homeassistant/components/adguard/manifest.json
@@ -3,7 +3,7 @@
   "name": "AdGuard Home",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/adguard",
-  "requirements": ["adguardhome==0.4.0"],
+  "requirements": ["adguardhome==0.4.1"],
   "dependencies": [],
   "codeowners": ["@frenck"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -117,7 +117,7 @@ adafruit-circuitpython-mcp230xx==1.1.2
 adb-shell==0.1.1
 
 # homeassistant.components.adguard
-adguardhome==0.4.0
+adguardhome==0.4.1
 
 # homeassistant.components.frontier_silicon
 afsapi==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -32,7 +32,7 @@ abodepy==0.16.7
 adb-shell==0.1.1
 
 # homeassistant.components.adguard
-adguardhome==0.4.0
+adguardhome==0.4.1
 
 # homeassistant.components.geonetnz_quakes
 aio_geojson_geonetnz_quakes==0.11


### PR DESCRIPTION
## Description:

AdGuard Home had a small API change in the latest releases, causing the master control switch not to work.

This PR bumps `adguardhome` to v0.4.1, which addresses this issue.

Changelog: <https://github.com/frenck/python-adguardhome/releases/tag/v0.4.1>

**Related issue (if applicable):** fixes #30519

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
