### PR TITLE
Add Doorbird events to logbook

### DIFF
--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -6,6 +6,7 @@ from doorbirdpy import DoorBird
 import voluptuous as vol
 
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.logbook import log_entry
 from homeassistant.const import (
     CONF_DEVICES,
     CONF_HOST,
@@ -295,5 +296,7 @@ class DoorBirdRequestView(HomeAssistantView):
             return web.Response(status=200, text=message)
 
         hass.bus.async_fire(f"{DOMAIN}_{event}", event_data)
+
+        log_entry(hass, "Doorbird {}".format(event), "event was fired.", DOMAIN)
 
         return web.Response(status=200, text="OK")

--- a/homeassistant/components/doorbird/manifest.json
+++ b/homeassistant/components/doorbird/manifest.json
@@ -3,6 +3,6 @@
   "name": "DoorBird",
   "documentation": "https://www.home-assistant.io/integrations/doorbird",
   "requirements": ["doorbirdpy==2.0.8"],
-  "dependencies": ["http"],
+  "dependencies": ["http", "logbook"],
   "codeowners": ["@oblogic7"]
 }


### PR DESCRIPTION
## Description:
Doorbird integration does not use entities since there is not any persistent state to be tracked on the devices.  Instead, HA events are fired from webhooks received from each device.  This PR adds entries to the logbook when these events are received.

![image](https://user-images.githubusercontent.com/453840/71989896-1740e200-31f8-11ea-8a49-52a5a75a81e2.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
