### PR TITLE
Add missing string for already_configured in GIOS integration

### DIFF
--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -15,6 +15,9 @@
       "wrong_station_id": "ID of the measuring station is not correct.",
       "invalid_sensors_data": "Invalid sensors' data for this measuring station.",
       "cannot_connect": "Cannot connect to the GIOŚ server."
+    },
+    "abort": {
+      "already_configured": "GIOŚ integration for this measuring station is already configured."
     }
   }
 }


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Once again, I forgot to add string for `abort` -> `already_configured` in initial PR. This fix that mistake. It's only change in `strings.json` file. This PR should be merged, if possible, before 0.104 release.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
