### PR TITLE
Update pyhomematic to 0.1.63

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -173,6 +173,7 @@ HM_DEVICE_TYPES = {
         "IPMultiIO",
         "TiltIP",
         "IPShutterContactSabotage",
+        "IPContact",
     ],
     DISCOVER_COVER: ["Blind", "KeyBlind", "IPKeyBlind", "IPKeyBlindTilt"],
     DISCOVER_LOCKS: ["KeyMatic"],

--- a/homeassistant/components/homematic/binary_sensor.py
+++ b/homeassistant/components/homematic/binary_sensor.py
@@ -29,6 +29,7 @@ SENSOR_TYPES_CLASS = {
     "SmokeV2": DEVICE_CLASS_SMOKE,
     "TiltSensor": None,
     "WeatherSensor": None,
+    "IPContact": DEVICE_CLASS_OPENING,
 }
 
 

--- a/homeassistant/components/homematic/manifest.json
+++ b/homeassistant/components/homematic/manifest.json
@@ -2,7 +2,7 @@
   "domain": "homematic",
   "name": "Homematic",
   "documentation": "https://www.home-assistant.io/integrations/homematic",
-  "requirements": ["pyhomematic==0.1.62"],
+  "requirements": ["pyhomematic==0.1.63"],
   "dependencies": [],
   "codeowners": ["@pvizeli", "@danielperna84"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1288,7 +1288,7 @@ pyhik==0.2.5
 pyhiveapi==0.2.19.3
 
 # homeassistant.components.homematic
-pyhomematic==0.1.62
+pyhomematic==0.1.63
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -442,7 +442,7 @@ pyhaversion==3.1.0
 pyheos==0.6.0
 
 # homeassistant.components.homematic
-pyhomematic==0.1.62
+pyhomematic==0.1.63
 
 # homeassistant.components.icloud
 pyicloud==0.9.1


### PR DESCRIPTION
## Description:
Update pyhomematic to 0.1.63

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
