### PR TITLE
UniFi - Fix problem with restoring POE control

### DIFF
--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -42,12 +42,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             _, mac = entity.unique_id.split("-", 1)
 
-            if mac in controller.api.clients or mac not in controller.api.clients_all:
+            if mac in controller.api.clients:
+                switches_off.append(entity.unique_id)
                 continue
 
-            client = controller.api.clients_all[mac]
-            controller.api.clients.process_raw([client.raw])
-            switches_off.append(entity.unique_id)
+            if mac in controller.api.clients_all:
+                client = controller.api.clients_all[mac]
+                controller.api.clients.process_raw([client.raw])
+                switches_off.append(entity.unique_id)
+                continue
 
     @callback
     def update_controller():


### PR DESCRIPTION
## Description:
Changed how to identify a device with POE off which was reported broken

**Related issue (if applicable):** fixes #27720

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]