### PR TITLE
Update NSAPI to version 3.0.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -219,6 +219,7 @@ homeassistant/components/msteams/* @peroyvind
 homeassistant/components/mysensors/* @MartinHjelmare
 homeassistant/components/mystrom/* @fabaff
 homeassistant/components/neato/* @dshokouhi @Santobert
+homeassistant/components/nederlandse_spoorwegen/* @YarmoM
 homeassistant/components/nello/* @pschmitt
 homeassistant/components/ness_alarm/* @nickw444
 homeassistant/components/nest/* @awarecan

--- a/homeassistant/components/nederlandse_spoorwegen/manifest.json
+++ b/homeassistant/components/nederlandse_spoorwegen/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nederlandse_spoorwegen",
   "name": "Nederlandse Spoorwegen (NS)",
   "documentation": "https://www.home-assistant.io/integrations/nederlandse_spoorwegen",
-  "requirements": ["nsapi==2.7.4"],
+  "requirements": ["nsapi==3.0.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/nederlandse_spoorwegen/manifest.json
+++ b/homeassistant/components/nederlandse_spoorwegen/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nederlandse_spoorwegen",
   "requirements": ["nsapi==3.0.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@YarmoM"]
 }

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -131,34 +131,26 @@ class NSDepartureSensor(Entity):
                 "%H:%M"
             ),
             "departure_time_actual": None,
-            "departure_delay": None,
+            "departure_delay": False,
             "departure_platform_planned": self._trips[0].departure_platform_planned,
             "departure_platform_actual": None,
             "arrival_time_planned": self._trips[0].arrival_time_planned.strftime(
                 "%H:%M"
             ),
             "arrival_time_actual": None,
-            "arrival_delay": None,
+            "arrival_delay": False,
             "arrival_platform_platform": self._trips[0].arrival_platform_planned,
-            "arrival_platform_actual": self._trips[0].arrival_platform_actual,
-            "direction": self._trips[0].destination,
+            "arrival_platform_actual": None,
             "next": None,
             "status": self._trips[0].status.lower(),
             "transfers": self._trips[0].nr_transfers,
             "route": route,
+            "remarks": None,
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 
         # Departure attributes
-        if self._trips[0].departure_time_actual is None:
-            attributes["departure_time_actual"] = self._trips[
-                0
-            ].departure_time_planned.strftime("%H:%M")
-            attributes["departure_delay"] = False
-            attributes["departure_platform_actual"] = self._trips[
-                0
-            ].departure_platform_planned
-        else:
+        if self._trips[0].departure_time_actual is not None:
             attributes["departure_time_actual"] = self._trips[
                 0
             ].departure_time_actual.strftime("%H:%M")
@@ -168,15 +160,7 @@ class NSDepartureSensor(Entity):
             ].departure_platform_actual
 
         # Arrival attributes
-        if self._trips[0].arrival_time_actual is None:
-            attributes["arrival_time_actual"] = self._trips[
-                0
-            ].arrival_time_planned.strftime("%H:%M")
-            attributes["arrival_delay"] = False
-            attributes["arrival_platform_actual"] = self._trips[
-                0
-            ].arrival_platform_planned
-        else:
+        if self._trips[0].arrival_time_actual is not None:
             attributes["arrival_time_actual"] = self._trips[
                 0
             ].arrival_time_actual.strftime("%H:%M")
@@ -188,7 +172,7 @@ class NSDepartureSensor(Entity):
         # Next attributes
         if self._trips[1].departure_time_actual is not None:
             attributes["next"] = self._trips[1].departure_time_actual.strftime("%H:%M")
-        else:
+        elif self._trips[1].departure_time_planned is not None:
             attributes["next"] = self._trips[1].departure_time_planned.strftime("%H:%M")
 
         return attributes
@@ -207,7 +191,7 @@ class NSDepartureSensor(Entity):
                 2,
             )
             if self._trips:
-                if self._trips[0].departure_time_actual is not None:
+                if self._trips[0].departure_delay:
                     actual_time = self._trips[0].departure_time_actual
                     self._state = actual_time.strftime("%H:%M")
                 else:

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -7,7 +7,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_EMAIL, CONF_NAME, CONF_PASSWORD
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -37,18 +37,14 @@ ROUTE_SCHEMA = vol.Schema(
 ROUTES_SCHEMA = vol.All(cv.ensure_list, [ROUTE_SCHEMA])
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_EMAIL): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_ROUTES): ROUTES_SCHEMA,
-    }
+    {vol.Required(CONF_API_KEY): cv.string, vol.Optional(CONF_ROUTES): ROUTES_SCHEMA}
 )
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the departure sensor."""
 
-    nsapi = ns_api.NSAPI(config.get(CONF_PASSWORD))
+    nsapi = ns_api.NSAPI(config[CONF_API_KEY])
     try:
         stations = nsapi.get_stations()
     except (

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -135,7 +135,9 @@ class NSDepartureSensor(Entity):
             ),
             "departure_time_actual": self._trips[0].departure_time_actual.strftime(
                 "%H:%M"
-            ) if self._trips[0].departure_time_actual is not None else None,
+            )
+            if self._trips[0].departure_time_actual is not None
+            else None,
             "departure_delay": self._trips[0].departure_time_planned
             != self._trips[0].departure_time_actual,
             "departure_platform": self._trips[0].departure_platform_planned,
@@ -144,7 +146,8 @@ class NSDepartureSensor(Entity):
                 "%H:%M"
             ),
             "arrival_time_actual": self._trips[0].arrival_time_actual.strftime("%H:%M")
-            if self._trips[0].arrival_time_actual is not None else None,
+            if self._trips[0].arrival_time_actual is not None
+            else None,
             "arrival_delay": self._trips[0].arrival_time_planned
             != self._trips[0].arrival_time_actual,
             "arrival_platform": self._trips[0].arrival_platform_planned,

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -141,12 +141,11 @@ class NSDepartureSensor(Entity):
             "arrival_delay": None,
             "arrival_platform_platform": self._trips[0].arrival_platform_planned,
             "arrival_platform_actual": self._trips[0].arrival_platform_actual,
-            "direction": self._trips[0].direction,
+            "direction": self._trips[0].destination,
             "next": None,
             "status": self._trips[0].status.lower(),
             "transfers": self._trips[0].nr_transfers,
             "route": route,
-            "remarks": self._trips[0].trip_remarks,
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -191,7 +191,7 @@ class NSDepartureSensor(Entity):
                 2,
             )
             if self._trips:
-                if self._trips[0].departure_delay:
+                if self._trips[0].departure_time_actual is not None:
                     actual_time = self._trips[0].departure_time_actual
                     self._state = actual_time.strftime("%H:%M")
                 else:

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -191,12 +191,12 @@ class NSDepartureSensor(Entity):
                 2,
             )
             if self._trips:
-                if self._trips[0].departure_time_actual is not None:
-                    actual_time = self._trips[0].departure_time_actual
-                    self._state = actual_time.strftime("%H:%M")
-                else:
+                if self._trips[0].departure_time_actual is None:
                     planned_time = self._trips[0].departure_time_planned
                     self._state = planned_time.strftime("%H:%M")
+                else:
+                    actual_time = self._trips[0].departure_time_actual
+                    self._state = actual_time.strftime("%H:%M")
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.HTTPError,

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -124,38 +124,75 @@ class NSDepartureSensor(Entity):
             for k in self._trips[0].trip_parts:
                 route.append(k.destination)
 
-        return {
+        # Static attributes
+        attributes = {
             "going": self._trips[0].going,
             "departure_time_planned": self._trips[0].departure_time_planned.strftime(
                 "%H:%M"
             ),
-            "departure_time_actual": self._trips[0].departure_time_actual.strftime(
-                "%H:%M"
-            )
-            if self._trips[0].departure_time_actual is not None
-            else None,
-            "departure_delay": self._trips[0].departure_time_planned
-            != self._trips[0].departure_time_actual,
-            "departure_platform": self._trips[0].departure_platform_planned,
-            "departure_platform_changed": self._trips[0].departure_platform_actual,
+            "departure_time_actual": None,
+            "departure_delay": None,
+            "departure_platform_planned": self._trips[0].departure_platform_planned,
+            "departure_platform_actual": None,
             "arrival_time_planned": self._trips[0].arrival_time_planned.strftime(
                 "%H:%M"
             ),
-            "arrival_time_actual": self._trips[0].arrival_time_actual.strftime("%H:%M")
-            if self._trips[0].arrival_time_actual is not None
-            else None,
-            "arrival_delay": self._trips[0].arrival_time_planned
-            != self._trips[0].arrival_time_actual,
-            "arrival_platform": self._trips[0].arrival_platform_planned,
-            "arrival_platform_changed": self._trips[0].arrival_platform_actual,
-            "next": self._trips[1].departure_time_actual.strftime("%H:%M")
-            if self._trips[1].departure_time_actual is not None
-            else self._trips[1].departure_time_planned.strftime("%H:%M"),
+            "arrival_time_actual": None,
+            "arrival_delay": None,
+            "arrival_platform_platform": self._trips[0].arrival_platform_planned,
+            "arrival_platform_actual": self._trips[0].arrival_platform_actual,
+            "direction": self._trips[0].direction,
+            "next": None,
             "status": self._trips[0].status.lower(),
             "transfers": self._trips[0].nr_transfers,
             "route": route,
+            "remarks": self._trips[0].trip_remarks,
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
+
+        # Departure attributes
+        if self._trips[0].departure_time_actual is None:
+            attributes["departure_time_actual"] = self._trips[
+                0
+            ].departure_time_planned.strftime("%H:%M")
+            attributes["departure_delay"] = False
+            attributes["departure_platform_actual"] = self._trips[
+                0
+            ].departure_platform_planned
+        else:
+            attributes["departure_time_actual"] = self._trips[
+                0
+            ].departure_time_actual.strftime("%H:%M")
+            attributes["departure_delay"] = True
+            attributes["departure_platform_actual"] = self._trips[
+                0
+            ].departure_platform_actual
+
+        # Arrival attributes
+        if self._trips[0].arrival_time_actual is None:
+            attributes["arrival_time_actual"] = self._trips[
+                0
+            ].arrival_time_planned.strftime("%H:%M")
+            attributes["arrival_delay"] = False
+            attributes["arrival_platform_actual"] = self._trips[
+                0
+            ].arrival_platform_planned
+        else:
+            attributes["arrival_time_actual"] = self._trips[
+                0
+            ].arrival_time_actual.strftime("%H:%M")
+            attributes["arrival_delay"] = True
+            attributes["arrival_platform_actual"] = self._trips[
+                0
+            ].arrival_platform_actual
+
+        # Next attributes
+        if self._trips[1].departure_time_actual is not None:
+            attributes["next"] = self._trips[1].departure_time_actual.strftime("%H:%M")
+        else:
+            attributes["next"] = self._trips[1].departure_time_planned.strftime("%H:%M")
+
+        return attributes
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -905,7 +905,7 @@ niko-home-control==0.2.1
 niluclient==0.1.2
 
 # homeassistant.components.nederlandse_spoorwegen
-nsapi==2.7.4
+nsapi==3.0.0
 
 # homeassistant.components.nsw_fuel_station
 nsw-fuel-api-client==1.0.10


### PR DESCRIPTION
## Breaking Changes:

The `nederlandse_spoorwegen` sensor now requires a single API token instead of username and password credentials.

The following `platform` attributes are renamed for consistency with `time` naming:
- `departure_platform` becomes `departure_platform_planned`
- `departure_platform_changed` becomes `departure_platform_actual`
- `arrival_platform` becomes `arrival_platform_planned`
- `arrival_platform_changed` becomes `arrival_platform_actual`

## Description:
The Nederlandse Spoorwegen API has recently changed and so has nsapi, the dependency home-assistant uses to communice with said API. This PR bumps the nsapi version to 3.0.0 and fixes some of its breaking changes.

**Related issue (if applicable):** fixes #26622

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11700

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: nederlandse_spoorwegen
  password: !secret ns_api_key
  routes:
  - name: Rijswijk-Rotterdam
    from: Rsw
    to: Rtd
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
