### PR TITLE
Add support for Dyson TP06 fan

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -82,6 +82,7 @@ homeassistant/components/discogs/* @thibmaek
 homeassistant/components/doorbird/* @oblogic7
 homeassistant/components/dsmr_reader/* @depl0y
 homeassistant/components/dweet/* @fabaff
+homeassistant/components/dyson/* @etheralm
 homeassistant/components/ecobee/* @marthoc
 homeassistant/components/ecovacs/* @OverloadUT
 homeassistant/components/egardia/* @jeroenterheerdt

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -530,7 +530,10 @@ class DysonPureCoolDevice(FanEntity):
     @property
     def carbon_filter(self):
         """Return the carbon filter state."""
-        return int(self._device.state.carbon_filter_state)
+        if self._device.state.carbon_filter_state == "INV":
+            return self._device.state.carbon_filter_state
+        else:
+            return int(self._device.state.carbon_filter_state)
 
     @property
     def speed_list(self) -> list:

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -532,8 +532,7 @@ class DysonPureCoolDevice(FanEntity):
         """Return the carbon filter state."""
         if self._device.state.carbon_filter_state == "INV":
             return self._device.state.carbon_filter_state
-        else:
-            return int(self._device.state.carbon_filter_state)
+        return int(self._device.state.carbon_filter_state)
 
     @property
     def speed_list(self) -> list:

--- a/homeassistant/components/dyson/manifest.json
+++ b/homeassistant/components/dyson/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/dyson",
   "requirements": ["libpurecool==0.6.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@etheralm"]
 }

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -834,11 +834,11 @@ async def test_purecool_update_state_filter_inv(devices, login, hass):
         "msg": "CURRENT-STATE",
         "product-state": {
             "fpwr": "OFF",
-            "fdir": "OFF",
-            "auto": "OFF",
+            "fdir": "ON",
+            "auto": "ON",
             "oscs": "ON",
             "oson": "ON",
-            "nmod": "OFF",
+            "nmod": "ON",
             "rhtm": "ON",
             "fnst": "FAN",
             "ercd": "11E1",
@@ -848,10 +848,10 @@ async def test_purecool_update_state_filter_inv(devices, login, hass):
             "bril": "0002",
             "corf": "ON",
             "cflr": "INV",
-            "hflr": "0095",
+            "hflr": "0075",
             "sltm": "OFF",
-            "osal": "0045",
-            "osau": "0095",
+            "osal": "0055",
+            "osau": "0105",
             "ancp": "CUST",
         },
     }
@@ -866,7 +866,19 @@ async def test_purecool_update_state_filter_inv(devices, login, hass):
     fan_state = hass.states.get("fan.living_room")
     attributes = fan_state.attributes
 
+    assert fan_state.state == "off"
+    assert attributes[dyson.ATTR_NIGHT_MODE] is True
+    assert attributes[dyson.ATTR_AUTO_MODE] is True
+    assert attributes[dyson.ATTR_ANGLE_LOW] == 55
+    assert attributes[dyson.ATTR_ANGLE_HIGH] == 105
+    assert attributes[dyson.ATTR_FLOW_DIRECTION_FRONT] is True
+    assert attributes[dyson.ATTR_TIMER] == "OFF"
+    assert attributes[dyson.ATTR_HEPA_FILTER] == 75
     assert attributes[dyson.ATTR_CARBON_FILTER] == "INV"
+    assert attributes[dyson.ATTR_DYSON_SPEED] == int(FanSpeed.FAN_SPEED_2.value)
+    assert attributes[ATTR_SPEED] is SPEED_LOW
+    assert attributes[ATTR_OSCILLATING] is False
+    assert attributes[dyson.ATTR_DYSON_SPEED_LIST] == _get_supported_speeds()
 
 
 @asynctest.patch("libpurecool.dyson.DysonAccount.login", return_value=True)


### PR DESCRIPTION
## Description:

The new dyson fan with model TP06  uses the same product number as TP04, but it has a combined filter and reports "INV" as carbon filter state instead of a numerical value. This PR fixes this issue.

**Related issue (if applicable):** fixes https://github.com/etheralm/libpurecool/issues/8 fixes #30340

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11689
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
