### PR TITLE
Change nomenclature for Roborock fan speeds

### DIFF
--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     extra=vol.ALLOW_EXTRA,
 )
 
-FAN_SPEEDS = {"Quiet": 38, "Balanced": 60, "Turbo": 77, "Max": 90, "Gentle": 105}
+FAN_SPEEDS = {"Silent": 38, "Standard": 60, "Medium": 77, "Turbo": 90, "Gentle": 105}
 
 ATTR_CLEAN_START = "clean_start"
 ATTR_CLEAN_STOP = "clean_stop"

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -273,7 +273,7 @@ async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_FAN_SPEED,
-        {"entity_id": entity_id, "fan_speed": "turbo"},
+        {"entity_id": entity_id, "fan_speed": "Medium"},
         blocking=True,
     )
     mock_mirobo_is_got_error.assert_has_calls(

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -204,12 +204,12 @@ async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-80"
     assert state.attributes.get(ATTR_CLEANING_TIME) == 155
     assert state.attributes.get(ATTR_CLEANED_AREA) == 123
-    assert state.attributes.get(ATTR_FAN_SPEED) == "Quiet"
+    assert state.attributes.get(ATTR_FAN_SPEED) == "Silent"
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == [
-        "Quiet",
-        "Balanced",
+        "Silent",
+        "Standard",
+        "Medium",
         "Turbo",
-        "Max",
         "Gentle",
     ]
     assert state.attributes.get(ATTR_MAIN_BRUSH_LEFT) == 12
@@ -348,10 +348,10 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     assert state.attributes.get(ATTR_CLEANED_AREA) == 133
     assert state.attributes.get(ATTR_FAN_SPEED) == 99
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == [
-        "Quiet",
-        "Balanced",
+        "Silent",
+        "Standard",
+        "Medium",
         "Turbo",
-        "Max",
         "Gentle",
     ]
     assert state.attributes.get(ATTR_MAIN_BRUSH_LEFT) == 11


### PR DESCRIPTION
Replacing the previous PR #30164, because some weird errors rebasing my repo.

## Breaking Change:

This change adjusts some fan speed values according to the Xiaomi app version 5.6.34. and therefore users will need to update anything that utilizes the following fan speed values:
- `Quiet` -> `Silent`
- `Balanced` -> `Standard`
- `Turbo` -> `Medium`
- `Max` -> `Turbo`


## Description:
Those are the new fan speed nomenclatures on the Xiaomi app vs 5.6.34.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
https://github.com/home-assistant/home-assistant.io/pull/11523

## Example entry for `configuration.yaml` (if applicable):
Not applicable.

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html

