### PR TITLE
Change nomenclature for Roborock fan speeds - tests

### DIFF
--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -204,12 +204,12 @@ async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-80"
     assert state.attributes.get(ATTR_CLEANING_TIME) == 155
     assert state.attributes.get(ATTR_CLEANED_AREA) == 123
-    assert state.attributes.get(ATTR_FAN_SPEED) == "Quiet"
+    assert state.attributes.get(ATTR_FAN_SPEED) == "Silent"
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == [
-        "Quiet",
-        "Balanced",
+        "Silent",
+        "Standard",
+        "Medium",
         "Turbo",
-        "Max",
         "Gentle",
     ]
     assert state.attributes.get(ATTR_MAIN_BRUSH_LEFT) == 12
@@ -348,10 +348,10 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     assert state.attributes.get(ATTR_CLEANED_AREA) == 133
     assert state.attributes.get(ATTR_FAN_SPEED) == 99
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == [
-        "Quiet",
-        "Balanced",
+        "Silent",
+        "Standard",
+        "Medium",
         "Turbo",
-        "Max",
         "Gentle",
     ]
     assert state.attributes.get(ATTR_MAIN_BRUSH_LEFT) == 11


### PR DESCRIPTION
## Description:

Regarding PR #30164.

## Breaking Change:

May break some automations using the string/names from the current implementation.

> Users will need to update any automations that utilize fan speed values – specifically:
> 
>     * `Quiet -> Silent`
> 
>     * `Balanced -> Standard`
> 
>     * `Turbo -> Medium`
> 
>     * `Max -> Turbo`

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
