### PR TITLE
Add support for displaying Daf Yomi

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -21,6 +21,7 @@ SENSOR_TYPES = {
         "weekly_portion": ["Parshat Hashavua", "mdi:book-open-variant"],
         "holiday": ["Holiday", "mdi:calendar-star"],
         "omer_count": ["Day of the Omer", "mdi:counter"],
+        "daf_yomi": ["Daf Yomi", "mdi:book-open-variant"],
     },
     "time": {
         "first_light": ["Alot Hashachar", "mdi:weather-sunset-up"],

--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -2,7 +2,7 @@
   "domain": "jewish_calendar",
   "name": "Jewish Calendar",
   "documentation": "https://www.home-assistant.io/integrations/jewish_calendar",
-  "requirements": ["hdate==0.9.3"],
+  "requirements": ["hdate==0.9.5"],
   "dependencies": [],
   "codeowners": ["@tsvi"]
 }

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -30,51 +30,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities(sensors)
 
 
-# Define fixed values:
-DAF_YOMI_CYCLE_11_START = dt_util.dt.date(1997, 9, 29)
-DAF_YOMI_MESECHTOS = [
-    {"en_name": "Berachos", "heb_name": "ברכות", "pages": 63},
-    {"en_name": "Shabbos", "heb_name": "שבת", "pages": 156},
-    {"en_name": "Eruvin", "heb_name": "עירובין", "pages": 104},
-    {"en_name": "Pesachim", "heb_name": "פסחים", "pages": 120},
-    {"en_name": "Shekalim", "heb_name": "שקלים", "pages": 21},
-    {"en_name": "Yoma", "heb_name": "יומא", "pages": 87},
-    {"en_name": "Succah", "heb_name": "סוכה", "pages": 55},
-    {"en_name": "Beitzah", "heb_name": "ביצה", "pages": 39},
-    {"en_name": "Rosh Hashanah", "heb_name": "ראש השנה", "pages": 34},
-    {"en_name": "Taanis", "heb_name": "תענית", "pages": 30},
-    {"en_name": "Megillah", "heb_name": "מגילה", "pages": 31},
-    {"en_name": "Moed Katan", "heb_name": "מועד קטן", "pages": 28},
-    {"en_name": "Chagigah", "heb_name": "חגיגה", "pages": 26},
-    {"en_name": "Yevamos", "heb_name": "יבמות", "pages": 121},
-    {"en_name": "Kesubos", "heb_name": "כתובות", "pages": 111},
-    {"en_name": "Nedarim", "heb_name": "נדרים", "pages": 90},
-    {"en_name": "Nazir", "heb_name": "נזיר", "pages": 65},
-    {"en_name": "Sotah", "heb_name": "סוטה", "pages": 48},
-    {"en_name": "Gittin", "heb_name": "גיטין", "pages": 89},
-    {"en_name": "Kiddushin", "heb_name": "קידושין", "pages": 81},
-    {"en_name": "Bava Kamma", "heb_name": "בבא קמא", "pages": 118},
-    {"en_name": "Bava Metzia", "heb_name": "בבא מציעא", "pages": 118},
-    {"en_name": "Bava Basra", "heb_name": "בבא בתרא", "pages": 175},
-    {"en_name": "Sanhedrin", "heb_name": "סנהדרין", "pages": 112},
-    {"en_name": "Makkos", "heb_name": "מכות", "pages": 23},
-    {"en_name": "Shevuos", "heb_name": "שבועות", "pages": 48},
-    {"en_name": "Avodah Zarah", "heb_name": "עבודה זרה", "pages": 75},
-    {"en_name": "Horayos", "heb_name": "הוריות", "pages": 13},
-    {"en_name": "Zevachim", "heb_name": "זבחים", "pages": 119},
-    {"en_name": "Menachos", "heb_name": "מנחות", "pages": 109},
-    {"en_name": "Chullin", "heb_name": "חולין", "pages": 141},
-    {"en_name": "Bechoros", "heb_name": "בכורות", "pages": 60},
-    {"en_name": "Arachin", "heb_name": "ערכין", "pages": 33},
-    {"en_name": "Temurah", "heb_name": "תמורה", "pages": 33},
-    {"en_name": "Kereisos", "heb_name": "כריתות", "pages": 27},
-    {"en_name": "Meilah", "heb_name": "מעילה", "pages": 36},
-    {"en_name": "Niddah", "heb_name": "נדה", "pages": 72},
-]
-
-DAF_YOMI_TOTAL_PAGES = sum(mesechta["pages"] for mesechta in DAF_YOMI_MESECHTOS)
-
-
 class JewishCalendarSensor(Entity):
     """Representation of an Jewish calendar sensor."""
 
@@ -157,29 +112,6 @@ class JewishCalendarSensor(Entity):
 
         return {}
 
-    def get_daf(self, date):
-        """Return a string representing the day's daf."""
-        # The first few cycles were only 2702 blatt. After that it became 2711. Even with
-        # that, the math doesn't play nicely with the dates before the 11th cycle :(
-        # From Cycle 11 onwards, it was simple and sequential
-        days_since_start_cycle_11 = (date - DAF_YOMI_CYCLE_11_START).days
-        daf_number = days_since_start_cycle_11 % (DAF_YOMI_TOTAL_PAGES)
-
-        for entry in DAF_YOMI_MESECHTOS:
-            if daf_number >= entry["pages"]:
-                daf_number -= entry["pages"]
-            else:
-                break
-
-        if self._hebrew:
-            heb_number = hdate.date.hebrew_number(daf_number + 2)
-            heb_number = heb_number.replace("'", "").replace('"', "")
-            dafstring = f"{entry['heb_name']} {heb_number}"
-        else:
-            dafstring = f"{entry['en_name']} {daf_number + 2}"
-
-        return dafstring
-
     def get_state(self, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         # Terminology note: by convention in py-libhdate library, "upcoming"
@@ -197,7 +129,7 @@ class JewishCalendarSensor(Entity):
         if self._type == "omer_count":
             return after_shkia_date.omer_day
         if self._type == "daf_yomi":
-            return self.get_daf(dt_util.now().date())
+            return hdate.HDate(today, diaspora=self._diaspora, hebrew=self._hebrew).daf_yomi
 
         return None
 

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -129,7 +129,7 @@ class JewishCalendarSensor(Entity):
         if self._type == "omer_count":
             return after_shkia_date.omer_day
         if self._type == "daf_yomi":
-            return hdate.HDate(today, diaspora=self._diaspora, hebrew=self._hebrew).daf_yomi
+            return hdate.HDate(dt_util.now().date(), diaspora=self._diaspora, hebrew=self._hebrew).daf_yomi
 
         return None
 

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -174,9 +174,9 @@ class JewishCalendarSensor(Entity):
         if self._hebrew:
             heb_number = hdate.date.hebrew_number(daf_number + 2)
             heb_number = heb_number.replace("'", "").replace('"', "")
-            dafstring = "%s %s" % (entry["heb_name"], heb_number)
+            dafstring = f"{entry['heb_name']} {heb_number}"
         else:
-            dafstring = "%s %s" % (entry["en_name"], daf_number + 2)
+            dafstring = f"{entry['en_name']} {daf_number + 2}"
 
         return dafstring
 

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -173,8 +173,7 @@ class JewishCalendarSensor(Entity):
                     heb_number = hdate.date.hebrew_number(daf_number + 2)
                     heb_number = heb_number.replace("'", "").replace('"', "")
                     return "%s %s" % (entry["heb_name"], heb_number)
-                else:
-                    return "%s %s" % (entry["en_name"], daf_number + 2)
+                return "%s %s" % (entry["en_name"], daf_number + 2)
 
     def get_state(self, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -91,7 +91,7 @@ class JewishCalendarSensor(Entity):
         if today_times.havdalah and now > today_times.havdalah:
             after_tzais_date = date.next_day
 
-        self._state = self.get_state(after_shkia_date, after_tzais_date)
+        self._state = self.get_state(date, after_shkia_date, after_tzais_date)
         _LOGGER.debug("New value for %s: %s", self._type, self._state)
 
     def make_zmanim(self, date):
@@ -112,7 +112,7 @@ class JewishCalendarSensor(Entity):
 
         return {}
 
-    def get_state(self, after_shkia_date, after_tzais_date):
+    def get_state(self, date, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         # Terminology note: by convention in py-libhdate library, "upcoming"
         # refers to "current" or "upcoming" dates.
@@ -129,7 +129,7 @@ class JewishCalendarSensor(Entity):
         if self._type == "omer_count":
             return after_shkia_date.omer_day
         if self._type == "daf_yomi":
-            return hdate.HDate(dt_util.now().date(), diaspora=self._diaspora, hebrew=self._hebrew).daf_yomi
+            return date.daf_yomi
 
         return None
 
@@ -159,7 +159,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
 
         return attrs
 
-    def get_state(self, after_shkia_date, after_tzais_date):
+    def get_state(self, date, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         if self._type == "upcoming_shabbat_candle_lighting":
             times = self.make_zmanim(

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -158,6 +158,7 @@ class JewishCalendarSensor(Entity):
         return {}
 
     def get_daf(self, date):
+        """Returns a string representing the day's daf"""
         # The first few cycles were only 2702 blatt. After that it became 2711. Even with
         # that, the math doesn't play nicely with the dates before the 11th cycle :(
         # From Cycle 11 onwards, it was simple and sequential

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -158,7 +158,7 @@ class JewishCalendarSensor(Entity):
         return {}
 
     def get_daf(self, date):
-        """Returns a string representing the day's daf"""
+        """Return a string representing the day's daf."""
         # The first few cycles were only 2702 blatt. After that it became 2711. Even with
         # that, the math doesn't play nicely with the dates before the 11th cycle :(
         # From Cycle 11 onwards, it was simple and sequential

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -29,6 +29,49 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     async_add_entities(sensors)
 
+# Define fixed values:
+DAF_YOMI_CYCLE_11_START = dt_util.dt.date(1997, 9, 29)
+DAF_YOMI_MESECHTOS = [
+    {"en_name":"Berachos", "heb_name":"ברכות", "pages":63},
+    {"en_name":"Shabbos", "heb_name":"שבת", "pages":156},
+    {"en_name":"Eruvin", "heb_name":"עירובין", "pages":104},
+    {"en_name":"Pesachim", "heb_name":"פסחים", "pages":120},
+    {"en_name":"Shekalim", "heb_name":"שקלים", "pages":21},
+    {"en_name":"Yoma", "heb_name":"יומא", "pages":87},
+    {"en_name":"Succah", "heb_name":"סוכה", "pages":55},
+    {"en_name":"Beitzah", "heb_name":"ביצה", "pages":39},
+    {"en_name":"Rosh Hashanah", "heb_name":"ראש השנה", "pages":34},
+    {"en_name":"Taanis", "heb_name":"תענית", "pages":30},
+    {"en_name":"Megillah", "heb_name":"מגילה", "pages":31},
+    {"en_name":"Moed Katan", "heb_name":"מועד קטן", "pages":28},
+    {"en_name":"Chagigah", "heb_name":"חגיגה", "pages":26},
+    {"en_name":"Yevamos", "heb_name":"יבמות", "pages":121},
+    {"en_name":"Kesubos", "heb_name":"כתובות", "pages":111},
+    {"en_name":"Nedarim", "heb_name":"נדרים", "pages":90},
+    {"en_name":"Nazir", "heb_name":"נזיר", "pages":65},
+    {"en_name":"Sotah", "heb_name":"סוטה", "pages":48},
+    {"en_name":"Gittin", "heb_name":"גיטין", "pages":89},
+    {"en_name":"Kiddushin", "heb_name":"קידושין", "pages":81},
+    {"en_name":"Bava Kamma", "heb_name":"בבא קמא", "pages":118},
+    {"en_name":"Bava Metzia", "heb_name":"בבא מציעא", "pages":118},
+    {"en_name":"Bava Basra", "heb_name":"בבא בתרא", "pages":175},
+    {"en_name":"Sanhedrin", "heb_name":"סנהדרין", "pages":112},
+    {"en_name":"Makkos", "heb_name":"מכות", "pages":23},
+    {"en_name":"Shevuos", "heb_name":"שבועות", "pages":48},
+    {"en_name":"Avodah Zarah", "heb_name":"עבודה זרה", "pages":75},
+    {"en_name":"Horayos", "heb_name":"הוריות", "pages":13},
+    {"en_name":"Zevachim", "heb_name":"זבחים", "pages":119},
+    {"en_name":"Menachos", "heb_name":"מנחות", "pages":109},
+    {"en_name":"Chullin", "heb_name":"חולין", "pages":141},
+    {"en_name":"Bechoros", "heb_name":"בכורות", "pages":60},
+    {"en_name":"Arachin", "heb_name":"ערכין", "pages":33},
+    {"en_name":"Temurah", "heb_name":"תמורה", "pages":33},
+    {"en_name":"Kereisos", "heb_name":"כריתות", "pages":27},
+    {"en_name":"Meilah", "heb_name":"מעילה", "pages":36},
+    {"en_name":"Niddah", "heb_name":"נדה", "pages":72}
+    ]
+
+DAF_YOMI_TOTAL_PAGES = sum(mesechta['pages'] for mesechta in DAF_YOMI_MESECHTOS)
 
 class JewishCalendarSensor(Entity):
     """Representation of an Jewish calendar sensor."""
@@ -112,6 +155,24 @@ class JewishCalendarSensor(Entity):
 
         return {}
 
+    def get_daf(self, date):
+        # The first few cycles were only 2702 blatt. After that it became 2711. Even with
+        # that, the math doesn't play nicely with the dates before the 11th cycle :(
+        # From Cycle 11 onwards, it was simple and sequential
+        days_since_start_cycle_11 = (date - DAF_YOMI_CYCLE_11_START).days
+        daf_number = days_since_start_cycle_11 % (DAF_YOMI_TOTAL_PAGES)
+
+        for entry in DAF_YOMI_MESECHTOS:
+            if daf_number >= entry["pages"]:
+                daf_number -= entry["pages"]
+            else:
+                if self._hebrew:
+                    heb_number = hdate.date.hebrew_number(daf_number + 2)
+                    heb_number = heb_number.replace("'", "").replace('"', '')
+                    return "%s %s" % (entry["heb_name"], heb_number)
+                else:
+                    return "%s %s" % (entry["en_name"], daf_number + 2)
+
     def get_state(self, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         # Terminology note: by convention in py-libhdate library, "upcoming"
@@ -128,6 +189,8 @@ class JewishCalendarSensor(Entity):
             return after_shkia_date.holiday_description
         if self._type == "omer_count":
             return after_shkia_date.omer_day
+        if self._type == "daf_yomi":
+            return self.get_daf(dt_util.now().date())
 
         return None
 

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -29,49 +29,51 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     async_add_entities(sensors)
 
+
 # Define fixed values:
 DAF_YOMI_CYCLE_11_START = dt_util.dt.date(1997, 9, 29)
 DAF_YOMI_MESECHTOS = [
-    {"en_name":"Berachos", "heb_name":"ברכות", "pages":63},
-    {"en_name":"Shabbos", "heb_name":"שבת", "pages":156},
-    {"en_name":"Eruvin", "heb_name":"עירובין", "pages":104},
-    {"en_name":"Pesachim", "heb_name":"פסחים", "pages":120},
-    {"en_name":"Shekalim", "heb_name":"שקלים", "pages":21},
-    {"en_name":"Yoma", "heb_name":"יומא", "pages":87},
-    {"en_name":"Succah", "heb_name":"סוכה", "pages":55},
-    {"en_name":"Beitzah", "heb_name":"ביצה", "pages":39},
-    {"en_name":"Rosh Hashanah", "heb_name":"ראש השנה", "pages":34},
-    {"en_name":"Taanis", "heb_name":"תענית", "pages":30},
-    {"en_name":"Megillah", "heb_name":"מגילה", "pages":31},
-    {"en_name":"Moed Katan", "heb_name":"מועד קטן", "pages":28},
-    {"en_name":"Chagigah", "heb_name":"חגיגה", "pages":26},
-    {"en_name":"Yevamos", "heb_name":"יבמות", "pages":121},
-    {"en_name":"Kesubos", "heb_name":"כתובות", "pages":111},
-    {"en_name":"Nedarim", "heb_name":"נדרים", "pages":90},
-    {"en_name":"Nazir", "heb_name":"נזיר", "pages":65},
-    {"en_name":"Sotah", "heb_name":"סוטה", "pages":48},
-    {"en_name":"Gittin", "heb_name":"גיטין", "pages":89},
-    {"en_name":"Kiddushin", "heb_name":"קידושין", "pages":81},
-    {"en_name":"Bava Kamma", "heb_name":"בבא קמא", "pages":118},
-    {"en_name":"Bava Metzia", "heb_name":"בבא מציעא", "pages":118},
-    {"en_name":"Bava Basra", "heb_name":"בבא בתרא", "pages":175},
-    {"en_name":"Sanhedrin", "heb_name":"סנהדרין", "pages":112},
-    {"en_name":"Makkos", "heb_name":"מכות", "pages":23},
-    {"en_name":"Shevuos", "heb_name":"שבועות", "pages":48},
-    {"en_name":"Avodah Zarah", "heb_name":"עבודה זרה", "pages":75},
-    {"en_name":"Horayos", "heb_name":"הוריות", "pages":13},
-    {"en_name":"Zevachim", "heb_name":"זבחים", "pages":119},
-    {"en_name":"Menachos", "heb_name":"מנחות", "pages":109},
-    {"en_name":"Chullin", "heb_name":"חולין", "pages":141},
-    {"en_name":"Bechoros", "heb_name":"בכורות", "pages":60},
-    {"en_name":"Arachin", "heb_name":"ערכין", "pages":33},
-    {"en_name":"Temurah", "heb_name":"תמורה", "pages":33},
-    {"en_name":"Kereisos", "heb_name":"כריתות", "pages":27},
-    {"en_name":"Meilah", "heb_name":"מעילה", "pages":36},
-    {"en_name":"Niddah", "heb_name":"נדה", "pages":72}
-    ]
+    {"en_name": "Berachos", "heb_name": "ברכות", "pages": 63},
+    {"en_name": "Shabbos", "heb_name": "שבת", "pages": 156},
+    {"en_name": "Eruvin", "heb_name": "עירובין", "pages": 104},
+    {"en_name": "Pesachim", "heb_name": "פסחים", "pages": 120},
+    {"en_name": "Shekalim", "heb_name": "שקלים", "pages": 21},
+    {"en_name": "Yoma", "heb_name": "יומא", "pages": 87},
+    {"en_name": "Succah", "heb_name": "סוכה", "pages": 55},
+    {"en_name": "Beitzah", "heb_name": "ביצה", "pages": 39},
+    {"en_name": "Rosh Hashanah", "heb_name": "ראש השנה", "pages": 34},
+    {"en_name": "Taanis", "heb_name": "תענית", "pages": 30},
+    {"en_name": "Megillah", "heb_name": "מגילה", "pages": 31},
+    {"en_name": "Moed Katan", "heb_name": "מועד קטן", "pages": 28},
+    {"en_name": "Chagigah", "heb_name": "חגיגה", "pages": 26},
+    {"en_name": "Yevamos", "heb_name": "יבמות", "pages": 121},
+    {"en_name": "Kesubos", "heb_name": "כתובות", "pages": 111},
+    {"en_name": "Nedarim", "heb_name": "נדרים", "pages": 90},
+    {"en_name": "Nazir", "heb_name": "נזיר", "pages": 65},
+    {"en_name": "Sotah", "heb_name": "סוטה", "pages": 48},
+    {"en_name": "Gittin", "heb_name": "גיטין", "pages": 89},
+    {"en_name": "Kiddushin", "heb_name": "קידושין", "pages": 81},
+    {"en_name": "Bava Kamma", "heb_name": "בבא קמא", "pages": 118},
+    {"en_name": "Bava Metzia", "heb_name": "בבא מציעא", "pages": 118},
+    {"en_name": "Bava Basra", "heb_name": "בבא בתרא", "pages": 175},
+    {"en_name": "Sanhedrin", "heb_name": "סנהדרין", "pages": 112},
+    {"en_name": "Makkos", "heb_name": "מכות", "pages": 23},
+    {"en_name": "Shevuos", "heb_name": "שבועות", "pages": 48},
+    {"en_name": "Avodah Zarah", "heb_name": "עבודה זרה", "pages": 75},
+    {"en_name": "Horayos", "heb_name": "הוריות", "pages": 13},
+    {"en_name": "Zevachim", "heb_name": "זבחים", "pages": 119},
+    {"en_name": "Menachos", "heb_name": "מנחות", "pages": 109},
+    {"en_name": "Chullin", "heb_name": "חולין", "pages": 141},
+    {"en_name": "Bechoros", "heb_name": "בכורות", "pages": 60},
+    {"en_name": "Arachin", "heb_name": "ערכין", "pages": 33},
+    {"en_name": "Temurah", "heb_name": "תמורה", "pages": 33},
+    {"en_name": "Kereisos", "heb_name": "כריתות", "pages": 27},
+    {"en_name": "Meilah", "heb_name": "מעילה", "pages": 36},
+    {"en_name": "Niddah", "heb_name": "נדה", "pages": 72},
+]
 
-DAF_YOMI_TOTAL_PAGES = sum(mesechta['pages'] for mesechta in DAF_YOMI_MESECHTOS)
+DAF_YOMI_TOTAL_PAGES = sum(mesechta["pages"] for mesechta in DAF_YOMI_MESECHTOS)
+
 
 class JewishCalendarSensor(Entity):
     """Representation of an Jewish calendar sensor."""
@@ -168,7 +170,7 @@ class JewishCalendarSensor(Entity):
             else:
                 if self._hebrew:
                     heb_number = hdate.date.hebrew_number(daf_number + 2)
-                    heb_number = heb_number.replace("'", "").replace('"', '')
+                    heb_number = heb_number.replace("'", "").replace('"', "")
                     return "%s %s" % (entry["heb_name"], heb_number)
                 else:
                     return "%s %s" % (entry["en_name"], daf_number + 2)

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -169,11 +169,16 @@ class JewishCalendarSensor(Entity):
             if daf_number >= entry["pages"]:
                 daf_number -= entry["pages"]
             else:
-                if self._hebrew:
-                    heb_number = hdate.date.hebrew_number(daf_number + 2)
-                    heb_number = heb_number.replace("'", "").replace('"', "")
-                    return "%s %s" % (entry["heb_name"], heb_number)
-                return "%s %s" % (entry["en_name"], daf_number + 2)
+                break
+
+        if self._hebrew:
+            heb_number = hdate.date.hebrew_number(daf_number + 2)
+            heb_number = heb_number.replace("'", "").replace('"', "")
+            dafstring = "%s %s" % (entry["heb_name"], heb_number)
+        else:
+            dafstring = "%s %s" % (entry["en_name"], daf_number + 2)
+
+        return dafstring
 
     def get_state(self, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -73,7 +73,7 @@ class JewishCalendarSensor(Entity):
 
         _LOGGER.debug("Now: %s Sunset: %s", now, sunset)
 
-        date = hdate.HDate(today, diaspora=self._diaspora, hebrew=self._hebrew)
+        daytime_date = hdate.HDate(today, diaspora=self._diaspora, hebrew=self._hebrew)
 
         # The Jewish day starts after darkness (called "tzais") and finishes at
         # sunset ("shkia"). The time in between is a gray area (aka "Bein
@@ -82,16 +82,16 @@ class JewishCalendarSensor(Entity):
         # For some sensors, it is more interesting to consider the date to be
         # tomorrow based on sunset ("shkia"), for others based on "tzais".
         # Hence the following variables.
-        after_tzais_date = after_shkia_date = date
+        after_tzais_date = after_shkia_date = daytime_date
         today_times = self.make_zmanim(today)
 
         if now > sunset:
-            after_shkia_date = date.next_day
+            after_shkia_date = daytime_date.next_day
 
         if today_times.havdalah and now > today_times.havdalah:
-            after_tzais_date = date.next_day
+            after_tzais_date = daytime_date.next_day
 
-        self._state = self.get_state(date, after_shkia_date, after_tzais_date)
+        self._state = self.get_state(daytime_date, after_shkia_date, after_tzais_date)
         _LOGGER.debug("New value for %s: %s", self._type, self._state)
 
     def make_zmanim(self, date):
@@ -112,7 +112,7 @@ class JewishCalendarSensor(Entity):
 
         return {}
 
-    def get_state(self, date, after_shkia_date, after_tzais_date):
+    def get_state(self, daytime_date, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         # Terminology note: by convention in py-libhdate library, "upcoming"
         # refers to "current" or "upcoming" dates.
@@ -129,7 +129,7 @@ class JewishCalendarSensor(Entity):
         if self._type == "omer_count":
             return after_shkia_date.omer_day
         if self._type == "daf_yomi":
-            return date.daf_yomi
+            return daytime_date.daf_yomi
 
         return None
 
@@ -159,7 +159,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
 
         return attrs
 
-    def get_state(self, date, after_shkia_date, after_tzais_date):
+    def get_state(self, daytime_date, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         if self._type == "upcoming_shabbat_candle_lighting":
             times = self.make_zmanim(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -655,7 +655,7 @@ hass-nabucasa==0.31
 hbmqtt==0.9.5
 
 # homeassistant.components.jewish_calendar
-hdate==0.9.3
+hdate==0.9.5
 
 # homeassistant.components.heatmiser
 heatmiserV3==1.1.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -232,7 +232,7 @@ hass-nabucasa==0.31
 hbmqtt==0.9.5
 
 # homeassistant.components.jewish_calendar
-hdate==0.9.3
+hdate==0.9.5
 
 # homeassistant.components.here_travel_time
 herepy==2.0.0

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -568,3 +568,37 @@ async def test_omer_sensor(hass, test_time, result):
         await hass.async_block_till_done()
 
     assert hass.states.get("sensor.test_day_of_the_omer").state == result
+
+
+DAFYOMI_PARAMS = [
+    (dt(2014, 4, 28, 0), "Beitzah 29"),
+    (dt(2020, 1, 4, 0), "Niddah 73"),
+    (dt(2020, 1, 5, 0), "Berachos 2"),
+    (dt(2020, 3, 7, 0), "Berachos 64"),
+    (dt(2020, 3, 8, 0), "Shabbos 2"),
+]
+DAFYOMI_TEST_IDS = [
+    "randomly_picked_date",
+    "end_of_cycle13",
+    "start_of_cycle14",
+    "last_day_of_omer",
+    "shavuot_no_omer",
+]
+
+
+@pytest.mark.parametrize(["test_time", "result"], DAFYOMI_PARAMS, ids=DAFYOMI_TEST_IDS)
+async def test_dafyomi_sensor(hass, test_time, result):
+    """Test Daf Yomi sensor output."""
+    test_time = hass.config.time_zone.localize(test_time)
+
+    with alter_time(test_time):
+        assert await async_setup_component(
+            hass, jewish_calendar.DOMAIN, {"jewish_calendar": {"name": "test"}}
+        )
+        await hass.async_block_till_done()
+
+        future = dt_util.utcnow() + timedelta(seconds=30)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.test_daf_yomi").state == result

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -581,8 +581,8 @@ DAFYOMI_TEST_IDS = [
     "randomly_picked_date",
     "end_of_cycle13",
     "start_of_cycle14",
-    "last_day_of_omer",
-    "shavuot_no_omer",
+    "cycle14_end_of_berachos",
+    "cycle14_start_of_shabbos",
 ]
 
 


### PR DESCRIPTION
## Description:
Add support for displaying the day's Daf Yomi to the jewish_calendar component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
