### PR TITLE
Bump Adafruit_BBIO to 1.1.1

### DIFF
--- a/homeassistant/components/bbb_gpio/manifest.json
+++ b/homeassistant/components/bbb_gpio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "bbb_gpio",
   "name": "BeagleBone Black GPIO",
   "documentation": "https://www.home-assistant.io/integrations/bbb_gpio",
-  "requirements": ["Adafruit_BBIO==1.0.0"],
+  "requirements": ["Adafruit_BBIO==1.1.1"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -31,7 +31,7 @@ Adafruit-GPIO==1.0.3
 Adafruit-SHT31==1.0.2
 
 # homeassistant.components.bbb_gpio
-# Adafruit_BBIO==1.0.0
+# Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
 HAP-python==2.6.0


### PR DESCRIPTION
## Description:
- bump Adafruit_BBIO to the latest version to fix the incorrect behaviour of not updating the sensors state

**Related issue (if applicable):** fixes #30509<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally. (Tested by https://github.com/home-assistant/home-assistant/issues/30509#issue-545468183)
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
