### PR TITLE
Add available property to vizio component and bumped pyvizio version

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -32,12 +32,12 @@ def validate_auth(config: ConfigType) -> ConfigType:
 
 
 VIZIO_SCHEMA = {
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
         cv.string, vol.Lower, vol.In(["tv", "soundbar"])
     ),
-    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
     vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
         vol.Coerce(int), vol.Range(min=1, max=10)
     ),

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -32,12 +32,12 @@ def validate_auth(config: ConfigType) -> ConfigType:
 
 
 VIZIO_SCHEMA = {
-    vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
         cv.string, vol.Lower, vol.In(["tv", "soundbar"])
     ),
+    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
     vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
         vol.Coerce(int), vol.Range(min=1, max=10)
     ),

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "Vizio SmartCast TV",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.0.15"],
+  "requirements": ["pyvizio==0.0.16"],
   "dependencies": [],
   "codeowners": ["@raman325"]
 }

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -96,7 +96,6 @@ class VizioDevice(MediaPlayerDevice):
     ) -> None:
         """Initialize Vizio device."""
 
-        self._hass = hass
         self._name = name
         self._state = None
         self._volume_level = None

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -72,7 +72,7 @@ async def async_setup_platform(
     device_type = config[CONF_DEVICE_CLASS]
 
     device = VizioAsync(
-        DEVICE_ID, host, name, token, device_type, async_get_clientsession(hass, False)
+        DEVICE_ID, name, device_type, async_get_clientsession(hass, False)
     )
     if not await device.can_connect():
         fail_auth_msg = ""
@@ -96,7 +96,6 @@ class VizioDevice(MediaPlayerDevice):
     ) -> None:
         """Initialize Vizio device."""
 
-        self._hass = hass
         self._name = name
         self._state = None
         self._volume_level = None

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -83,7 +83,7 @@ async def async_setup_platform(
             "is valid and available, device type is correct%s",
             fail_auth_msg,
         )
-        return
+        return False
 
     async_add_entities([VizioDevice(device, name, volume_step, device_type)], True)
 
@@ -96,6 +96,7 @@ class VizioDevice(MediaPlayerDevice):
     ) -> None:
         """Initialize Vizio device."""
 
+        self._hass = hass
         self._name = name
         self._state = None
         self._volume_level = None

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -96,6 +96,7 @@ class VizioDevice(MediaPlayerDevice):
     ) -> None:
         """Initialize Vizio device."""
 
+        self._hass = hass
         self._name = name
         self._state = None
         self._volume_level = None

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -120,11 +120,9 @@ class VizioDevice(MediaPlayerDevice):
             self._available = False
         else:
             self._available = True
+
             if not self._unique_id:
                 self._unique_id = await self._device.get_esn()
-                if not self._unique_id:
-                    self._available = False
-                    return
 
             if is_on:
                 self._state = STATE_ON

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -83,7 +83,7 @@ async def async_setup_platform(
             "is valid and available, device type is correct%s",
             fail_auth_msg,
         )
-        return False
+        return
 
     async_add_entities([VizioDevice(device, name, volume_step, device_type)], True)
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -72,7 +72,7 @@ async def async_setup_platform(
     device_type = config[CONF_DEVICE_CLASS]
 
     device = VizioAsync(
-        DEVICE_ID, host, name, token, device_type, async_get_clientsession(hass, False)
+        DEVICE_ID, name, device_type, async_get_clientsession(hass, False)
     )
     if not await device.can_connect():
         fail_auth_msg = ""

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -116,9 +116,7 @@ class VizioDevice(MediaPlayerDevice):
 
         is_on = await self._device.get_power_state()
 
-        if is_on is None:
-            self._available = False
-        else:
+        if is_on is not None:
             self._available = True
 
             if not self._unique_id:
@@ -144,6 +142,8 @@ class VizioDevice(MediaPlayerDevice):
                 self._volume_level = None
                 self._current_input = None
                 self._available_inputs = None
+        else:
+            self._available = False
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -83,7 +83,7 @@ async def async_setup_platform(
             "is valid and available, device type is correct%s",
             fail_auth_msg,
         )
-        return
+        return False
 
     async_add_entities([VizioDevice(device, name, volume_step, device_type)], True)
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -72,7 +72,7 @@ async def async_setup_platform(
     device_type = config[CONF_DEVICE_CLASS]
 
     device = VizioAsync(
-        DEVICE_ID, name, device_type, async_get_clientsession(hass, False)
+        DEVICE_ID, host, name, token, device_type, async_get_clientsession(hass, False)
     )
     if not await device.can_connect():
         fail_auth_msg = ""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,11 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
+<<<<<<< HEAD
 pyvizio==0.0.15
+=======
+pyvizio==0.0.14
+>>>>>>> update requirements_all
 
 # homeassistant.components.velux
 pyvlx==0.2.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.15
+pyvizio==0.0.16
 
 # homeassistant.components.velux
 pyvlx==0.2.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,11 +1696,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-<<<<<<< HEAD
 pyvizio==0.0.15
-=======
-pyvizio==0.0.14
->>>>>>> update requirements_all
 
 # homeassistant.components.velux
 pyvlx==0.2.12


### PR DESCRIPTION
## Description:
Added the `available` property to the `vizio` component so it will fail more gracefully and bumped `pyvizio` version to detect failures better

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
