### PR TITLE
Some additions at xiaomi tv component

### DIFF
--- a/homeassistant/components/xiaomi_tv/manifest.json
+++ b/homeassistant/components/xiaomi_tv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "xiaomi_tv",
   "name": "Xiaomi TV",
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_tv",
-  "requirements": ["pymitv==1.4.3"],
+  "requirements": ["pymitv==1.5.0"],
   "dependencies": [],
   "codeowners": ["@simse"]
 }

--- a/homeassistant/components/xiaomi_tv/media_player.py
+++ b/homeassistant/components/xiaomi_tv/media_player.py
@@ -15,6 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
 import homeassistant.helpers.config_validation as cv
 
 DEFAULT_NAME = "Xiaomi TV"
+CONF_ASSUME_STATE = "assume_state"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_ASSUME_STATE, default=True): cv.boolean,
     }
 )
 
@@ -36,6 +38,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # If a hostname is set. Discovery is skipped.
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
+    assume_state = config.get(CONF_ASSUME_STATE)
 
     if host is not None:
         # Check if there's a valid TV at the IP address.
@@ -52,17 +55,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class XiaomiTV(MediaPlayerDevice):
     """Represent the Xiaomi TV for Home Assistant."""
 
-    def __init__(self, ip, name):
+    def __init__(self, ip, name, assume_state):
         """Receive IP address and name to construct class."""
 
         # Initialize the Xiaomi TV.
-        self._tv = pymitv.TV(ip)
+        self._tv = pymitv.TV(ip, assume_state=assume_state)
         # Default name value, only to be overridden by user.
         self._name = name
-        self._state = STATE_OFF
+        self._state = STATE_ON
         self._volume_level = None
         self._source = None
         self._source_list = ["hdmi1", "hdmi2"]
+        self._assume_state = assume_state
 
     @property
     def name(self):
@@ -72,18 +76,23 @@ class XiaomiTV(MediaPlayerDevice):
     @property
     def state(self):
         """Return _state variable, containing the appropriate constant."""
-        if self._tv.assume_state:
+        return self._state
+
+    def update(self):
+        """Update the device state."""
+        _LOGGER.debug("update: %s", self.entity_id)
+        if self._assume_state:
             return self._state
         if self._tv.is_on:
             self._state = STATE_ON
         else:
             self._state = STATE_OFF
-        self._volume_level = int(self._tv.get_volume()) / 100
+        return self._state
 
     @property
     def assumed_state(self):
         """Indicate that state is assumed."""
-        return True
+        return self._assume_state
 
     @property
     def supported_features(self):
@@ -114,16 +123,18 @@ class XiaomiTV(MediaPlayerDevice):
         would be unable to turn the TV back on, unless it's done manually.
         """
         if self._state is not STATE_OFF:
-            self._tv.sleep()
-
-            self._state = STATE_OFF
+            if self._tv.assume_state:
+                self._tv.sleep()
+                self._state = STATE_OFF
+            else:
+                self._tv.turn_off()
 
     def turn_on(self):
         """Wake the TV back up from sleep."""
         if self._state is not STATE_ON:
-            self._tv.wake()
-
-            self._state = STATE_ON
+            if self._tv.assume_state:
+                self._tv.wake()
+                self._state = STATE_ON
 
     def volume_up(self):
         """Increase volume by one."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1357,7 +1357,7 @@ pymediaroom==0.6.4
 pymfy==0.7.1
 
 # homeassistant.components.xiaomi_tv
-pymitv==1.4.3
+pymitv==1.5.0
 
 # homeassistant.components.mochad
 pymochad==0.2.0


### PR DESCRIPTION
## Description:

Some additions at xiaomi tv component.

- Use async to add devices
- Add source selection (currently only hdmi1/hdmi2 are supported)
- Add get volume support
- Add assume state option at xiaomi_tv

In some cases (for example Xiaomi Projector) switching the device to
sleep just turn off the screen but the device keep running normaly.
To avoid this an extra config attribute named `assume_state` added.
If set to False (default is True), the tv instead of going to sleep
will turn off completely.


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11698

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
- platform: xiaomi_tv
  host: x.x.x.x
  name: Xiaomi TV
  assume_state: False
```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
