### PR TITLE
Implement TimeHoldController Interface in Alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1653,3 +1653,29 @@ class AlexaEqualizerController(AlexaCapability):
             configurations = {"modes": {"supported": supported_sound_modes}}
 
         return configurations
+
+
+class AlexaTimeHoldController(AlexaCapability):
+    """Implements Alexa.TimeHoldController.
+
+    https://developer.amazon.com/docs/device-apis/alexa-timeholdcontroller.html
+    """
+
+    supported_locales = {"en-US"}
+
+    def __init__(self, entity, allow_remote_resume=False):
+        """Initialize the entity."""
+        super().__init__(entity)
+        self._allow_remote_resume = allow_remote_resume
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa.TimeHoldController"
+
+    def configuration(self):
+        """Return configuration object.
+
+        Set allowRemoteResume to True if Alexa can restart the operation on the device.
+        When false, Alexa does not send the Resume directive.
+        """
+        return {"allowRemoteResume": self._allow_remote_resume}

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -19,6 +19,7 @@ from homeassistant.components import (
     script,
     sensor,
     switch,
+    timer,
 )
 from homeassistant.components.climate import const as climate
 from homeassistant.const import (
@@ -61,6 +62,7 @@ from .capabilities import (
     AlexaStepSpeaker,
     AlexaTemperatureSensor,
     AlexaThermostatController,
+    AlexaTimeHoldController,
     AlexaToggleController,
 )
 from .const import CONF_DESCRIPTION, CONF_DISPLAY_CATEGORIES
@@ -705,3 +707,17 @@ class InputNumberCapabilities(AlexaEntity):
         )
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.hass)
+
+
+@ENTITY_ADAPTERS.register(timer.DOMAIN)
+class TimerCapabilities(AlexaEntity):
+    """Class to represent Timer capabilities."""
+
+    def default_display_categories(self):
+        """Return the display categories for this entity."""
+        return [DisplayCategory.OTHER]
+
+    def interfaces(self):
+        """Yield the supported interfaces."""
+        yield AlexaTimeHoldController(self.entity, allow_remote_resume=True)
+        yield Alexa(self.entity)

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -10,6 +10,7 @@ from homeassistant.components import (
     input_number,
     light,
     media_player,
+    timer,
 )
 from homeassistant.components.climate import const as climate
 from homeassistant.const import (
@@ -1396,3 +1397,29 @@ async def async_api_bands_directive(hass, config, directive, context):
     # Currently bands directives are not supported.
     msg = "Entity does not support directive"
     raise AlexaInvalidDirectiveError(msg)
+
+
+@HANDLERS.register(("Alexa.TimeHoldController", "Hold"))
+async def async_api_hold(hass, config, directive, context):
+    """Process a TimeHoldController Hold request."""
+    entity = directive.entity
+    data = {ATTR_ENTITY_ID: entity.entity_id}
+
+    await hass.services.async_call(
+        entity.domain, timer.SERVICE_PAUSE, data, blocking=False, context=context
+    )
+
+    return directive.response()
+
+
+@HANDLERS.register(("Alexa.TimeHoldController", "Resume"))
+async def async_api_resume(hass, config, directive, context):
+    """Process a TimeHoldController Resume request."""
+    entity = directive.entity
+    data = {ATTR_ENTITY_ID: entity.entity_id}
+
+    await hass.services.async_call(
+        entity.domain, timer.SERVICE_START, data, blocking=False, context=context
+    )
+
+    return directive.response()

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -3064,3 +3064,17 @@ async def test_timer_hold(hass):
     await assert_request_calls_service(
         "Alexa.TimeHoldController", "Hold", "timer#laundry", "timer.pause", hass
     )
+
+
+async def test_timer_resume(hass):
+    """Test timer resume."""
+    device = (
+        "timer.laundry",
+        "paused",
+        {"friendly_name": "Laundry", "duration": "00:01:00", "remaining": "00:50:00"},
+    )
+    await discovery_test(device, hass)
+
+    await assert_request_calls_service(
+        "Alexa.TimeHoldController", "Resume", "timer#laundry", "timer.start", hass
+    )


### PR DESCRIPTION
## Description:

Implements the `Alexa.TimeHoldController` interface in Alexa. 

It's not just for microwaves!

Currently implemented with the `timer` component, but can be expanded to other devices that benefit from "pause", "hold" and "restart" voice utterances. e.g. vacuums. 

The only caveat with yielding this controller for `timer` entities is, utterances will not work if the friendly name includes the word "Timer"; as it will conflict with the native Alexa Timers. But that is for another PR.

> Alexa, pause the laundry.
> Alexa, hold the sous vide.
> Alexa, restart the microwave.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
