### PR TITLE
Fix Alexa ChangeReports Filter non-proactively_reported_properties

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -503,6 +503,10 @@ class AlexaColorController(AlexaCapability):
         """Return what properties this entity supports."""
         return [{"name": "color"}]
 
+    def properties_proactively_reported(self):
+        """Return True if properties asynchronously reported."""
+        return True
+
     def properties_retrievable(self):
         """Return True if properties can be retrieved."""
         return True
@@ -548,6 +552,10 @@ class AlexaColorTemperatureController(AlexaCapability):
         """Return what properties this entity supports."""
         return [{"name": "colorTemperatureInKelvin"}]
 
+    def properties_proactively_reported(self):
+        """Return True if properties asynchronously reported."""
+        return True
+
     def properties_retrievable(self):
         """Return True if properties can be retrieved."""
         return True
@@ -589,6 +597,10 @@ class AlexaPercentageController(AlexaCapability):
     def properties_supported(self):
         """Return what properties this entity supports."""
         return [{"name": "percentage"}]
+
+    def properties_proactively_reported(self):
+        """Return True if properties asynchronously reported."""
+        return True
 
     def properties_retrievable(self):
         """Return True if properties can be retrieved."""

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -255,6 +255,8 @@ class AlexaEntity:
     def serialize_properties(self):
         """Yield each supported property in API format."""
         for interface in self.interfaces():
+            if not interface.properties_proactively_reported():
+                continue
             for prop in interface.serialize_properties():
                 yield prop
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -257,6 +257,7 @@ class AlexaEntity:
         for interface in self.interfaces():
             if not interface.properties_proactively_reported():
                 continue
+
             for prop in interface.serialize_properties():
                 yield prop
 


### PR DESCRIPTION
## Description:
Filter properties of interfaces that do not support `properties_proactively_reported` from being included in the `ChangeReports`.

This PR also properly sets `properties_proactively_reported` to `True` on a few interfaces that were inadvertently benefiting from the bug.

**Related issue (if applicable):** fixes #30603

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
