### PR TITLE
Fix  determination of supported_features by HomematicIP Cloud Cover

### DIFF
--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -58,7 +58,9 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
     @property
     def current_cover_position(self) -> int:
         """Return current position of cover."""
-        return int((1 - self._device.shutterLevel) * 100)
+        if self._device.shutterLevel is not None:
+            return int((1 - self._device.shutterLevel) * 100)
+        return None
 
     async def async_set_cover_position(self, **kwargs) -> None:
         """Move the cover to a specific position."""
@@ -93,7 +95,9 @@ class HomematicipCoverSlats(HomematicipCoverShutter, CoverDevice):
     @property
     def current_cover_tilt_position(self) -> int:
         """Return current tilt position of cover."""
-        return int((1 - self._device.slatsLevel) * 100)
+        if self._device.slatsLevel is not None:
+            return int((1 - self._device.slatsLevel) * 100)
+        return None
 
     async def async_set_cover_tilt_position(self, **kwargs) -> None:
         """Move the cover to a specific tilt position."""

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -7,7 +7,7 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
 )
 from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
-from homeassistant.const import STATE_CLOSED, STATE_OPEN
+from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNKNOWN
 from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
@@ -87,7 +87,7 @@ async def test_hmip_cover_shutter(hass, default_mock_hap):
 
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", None)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == STATE_UNKNOWN
 
 
 async def test_hmip_cover_slats(hass, default_mock_hap):
@@ -154,7 +154,7 @@ async def test_hmip_cover_slats(hass, default_mock_hap):
 
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", None)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == STATE_UNKNOWN
 
 
 async def test_hmip_garage_door_tormatic(hass, default_mock_hap):


### PR DESCRIPTION
## Description:
Fix Error with HomematicIP Cloud Cover.
The current code fails, if slatsLevel or shutterLevel of the HomematicIP Device is None.
In this case the supported features (cover/__init__.py) could not be determined.

**This fix should be added to 0.104.0 milestone.**

## Checklist:
  - [x]The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
