### PR TITLE
Fix test_scenes_with_entity

### DIFF
--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -229,7 +229,7 @@ async def test_scenes_with_entity(hass):
         },
     )
 
-    assert ha_scene.scenes_with_entity(hass, "light.kitchen") == [
+    assert sorted(ha_scene.scenes_with_entity(hass, "light.kitchen")) == [
         "scene.scene_1",
         "scene.scene_3",
     ]


### PR DESCRIPTION

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Should fix this failure I just ran into:

```
E       AssertionError: assert ['scene.scene...cene.scene_1'] == ['scene.scene...cene.scene_3']
E         At index 0 diff: 'scene.scene_3' != 'scene.scene_1'
E         Full diff:
E         - ['scene.scene_3', 'scene.scene_1']
E         + ['scene.scene_1', 'scene.scene_3']
tests/components/homeassistant/test_scene.py:232: AssertionError
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
