### PR TITLE
Make met config flow tests robust

### DIFF
--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -41,13 +41,6 @@ async def test_flow_with_home_location(hass):
     assert default_data["longitude"] == 2
     assert default_data["elevation"] == 3
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=default_data
-    )
-
-    assert result["type"] == "create_entry"
-    assert result["data"] == default_data
-
 
 async def test_create_entry(hass):
     """Test create entry from user input."""

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -18,20 +18,6 @@ async def test_show_config_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_show_config_form_default_values():
-    """Test show configuration form."""
-    hass = Mock()
-    flow = config_flow.MetFlowHandler()
-    flow.hass = hass
-
-    result = await flow._show_config_form(
-        name="test", latitude="0", longitude="0", elevation="0"
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "user"
-
-
 async def test_flow_with_home_location(hass):
     """Test config flow.
 

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -2,18 +2,17 @@
 from unittest.mock import Mock, patch
 
 from homeassistant.components.met import config_flow
+from homeassistant.components.met.const import DOMAIN
 from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
 
 from tests.common import MockConfigEntry, mock_coro
 
 
-async def test_show_config_form():
+async def test_show_config_form(hass):
     """Test show configuration form."""
-    hass = Mock()
-    flow = config_flow.MetFlowHandler()
-    flow.hass = hass
-
-    result = await flow._show_config_form()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -49,35 +49,21 @@ async def test_flow_with_home_location(hass):
     assert result["data"] == default_data
 
 
-async def test_flow_entry_created_from_user_input():
-    """Test that create data from user input.
-
-    Test when the form should show when no configurations exists
-    """
-    hass = Mock()
-    flow = config_flow.MetFlowHandler()
-    flow.hass = hass
-
+async def test_create_entry(hass):
+    """Test create entry from user input."""
     test_data = {
         "name": "home",
-        CONF_LONGITUDE: "0",
-        CONF_LATITUDE: "0",
-        CONF_ELEVATION: "0",
+        CONF_LONGITUDE: 0,
+        CONF_LATITUDE: 0,
+        CONF_ELEVATION: 0,
     }
 
-    # Test that entry created when user_input name not exists
-    with patch.object(
-        flow, "_show_config_form", return_value=mock_coro()
-    ) as config_form, patch.object(
-        flow.hass.config_entries, "async_entries", return_value=mock_coro()
-    ) as config_entries:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}, data=test_data
+    )
 
-        result = await flow.async_step_user(user_input=test_data)
-
-        assert result["type"] == "create_entry"
-        assert result["data"] == test_data
-        assert len(config_entries.mock_calls) == 1
-        assert not config_form.mock_calls
+    assert result["type"] == "create_entry"
+    assert result["data"] == test_data
 
 
 async def test_flow_entry_config_entry_already_exists():

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_flow_with_home_location(hass):
     """Test config flow.
 
     Test the flow when a default location is configured.
-    Then it should return a form with default values
+    Then it should return a form with default values.
     """
     hass.config.latitude = 1
     hass.config.longitude = 2


### PR DESCRIPTION
## Breaking Change:
N/A
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- Make met config flow tests robust, by using core interface.
- Remove not needed duplicate tests.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
