### PR TITLE
Log error when integration is missing platform setup

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -83,6 +83,16 @@ class EntityPlatform:
         platform = self.platform
         hass = self.hass
 
+        if not hasattr(platform, "async_setup_platform") and not hasattr(
+            platform, "setup_platform"
+        ):
+            self.logger.error(
+                "The %s platform for the %s integration does not support platform setup. Please remove it from your config.",
+                self.platform_name,
+                self.domain,
+            )
+            return
+
         @callback
         def async_create_setup_task():
             """Get task to set up platform."""

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -834,3 +834,17 @@ async def test_override_restored_entities(hass):
 
     state = hass.states.get("test_domain.world")
     assert state.state == "on"
+
+
+async def test_platform_with_no_setup(hass, caplog):
+    """Test setting up a platform that doesnt' support setup."""
+    entity_platform = MockEntityPlatform(
+        hass, domain="mock-integration", platform_name="mock-platform", platform=None
+    )
+
+    await entity_platform.async_setup(None)
+
+    assert (
+        "The mock-platform platform for the mock-integration integration does not support platform setup."
+        in caplog.text
+    )


### PR DESCRIPTION
## Description:
Print an error that platform setup no longer works instead of requiring integrations to add this warning themselves when they migrate to being loaded via a config entry. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
