### PR TITLE
Update Hue SSDP discovery

### DIFF
--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -6,7 +6,12 @@
   "requirements": ["aiohue==1.10.1"],
   "ssdp": [
     {
-      "manufacturer": "Royal Philips Electronics"
+      "manufacturer": "Royal Philips Electronics",
+      "modelName": "Philips hue bridge 2012"
+    },
+    {
+      "manufacturer": "Royal Philips Electronics",
+      "modelName": "Philips hue bridge 2015"
     }
   ],
   "homekit": {

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -24,7 +24,12 @@ SSDP = {
     ],
     "hue": [
         {
-            "manufacturer": "Royal Philips Electronics"
+            "manufacturer": "Royal Philips Electronics",
+            "modelName": "Philips hue bridge 2012"
+        },
+        {
+            "manufacturer": "Royal Philips Electronics",
+            "modelName": "Philips hue bridge 2015"
         }
     ],
     "samsungtv": [


### PR DESCRIPTION
## Description:
Narrow Hue SSDP discovery instead of matching all Philips SSDP stuff.

**Related issue (if applicable):** fixes #30623

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

