### PR TITLE
Unhide SPC binary sensors by default

### DIFF
--- a/homeassistant/components/spc/binary_sensor.py
+++ b/homeassistant/components/spc/binary_sensor.py
@@ -62,14 +62,7 @@ class SpcBinarySensor(BinarySensorDevice):
     @property
     def is_on(self):
         """Whether the device is switched on."""
-
         return self._zone.input == ZoneInput.OPEN
-
-    @property
-    def hidden(self) -> bool:
-        """Whether the device is hidden by default."""
-        # These type of sensors are probably mainly used for automations
-        return True
 
     @property
     def should_poll(self):


### PR DESCRIPTION
# Description:

Binary sensors for the Vanderbilt SPC integration were hidden by default.

Comment in the original code:

> These type of sensors are probably mainly used for automations

This is clearly from the era before Lovelace.

This PR is meant to replace a PR we've received at our documentation repository. In that PR the contributor tried to document how to customize your entities to "unhide" these.

Related PR @ Docs: home-assistant/home-assistant.io#11717

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
