### PR TITLE
Fix discovery for oauth2 flow implementations

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -270,7 +270,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
 
         return await self.async_step_pick_implementation()
 
-    async_step_user = async_step_discovery
+    async_step_user = async_step_pick_implementation
     async_step_ssdp = async_step_discovery
     async_step_zeroconf = async_step_discovery
     async_step_homekit = async_step_discovery

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -259,10 +259,21 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
         """
         return self.async_create_entry(title=self.flow_impl.name, data=data)
 
-    async_step_user = async_step_pick_implementation
-    async_step_ssdp = async_step_pick_implementation
-    async_step_zeroconf = async_step_pick_implementation
-    async_step_homekit = async_step_pick_implementation
+    async def async_step_discovery(self, user_input: dict = None) -> dict:
+        """Handle a flow initialized by discovery."""
+        await self.async_set_unique_id(self.DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        assert self.hass is not None
+        if self.hass.config_entries.async_entries(self.DOMAIN):
+            return self.async_abort(reason="already_configured")
+
+        return await self.async_step_pick_implementation()
+
+    async_step_user = async_step_discovery
+    async_step_ssdp = async_step_discovery
+    async_step_zeroconf = async_step_discovery
+    async_step_homekit = async_step_discovery
 
     @classmethod
     def async_register_implementation(

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -122,6 +122,64 @@ async def test_abort_if_authorization_timeout(hass, flow_handler, local_impl):
     assert result["reason"] == "authorize_url_timeout"
 
 
+async def test_step_discovery(hass, flow_handler, local_impl):
+    """Check flow triggers from discovery."""
+    hass.config.api.base_url = "https://example.com"
+    flow_handler.async_register_implementation(hass, local_impl)
+    config_entry_oauth2_flow.async_register_implementation(
+        hass, TEST_DOMAIN, MockOAuth2Implementation()
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pick_implementation"
+
+
+async def test_abort_discovered_multiple(hass, flow_handler, local_impl):
+    """Test if aborts when discovered multiple times."""
+    hass.config.api.base_url = "https://example.com"
+    flow_handler.async_register_implementation(hass, local_impl)
+    config_entry_oauth2_flow.async_register_implementation(
+        hass, TEST_DOMAIN, MockOAuth2Implementation()
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": config_entries.SOURCE_SSDP}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pick_implementation"
+
+    result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_in_progress"
+
+
+async def test_abort_discovered_existing_entries(hass, flow_handler, local_impl):
+    """Test if abort discovery when entries exists."""
+    hass.config.api.base_url = "https://example.com"
+    flow_handler.async_register_implementation(hass, local_impl)
+    config_entry_oauth2_flow.async_register_implementation(
+        hass, TEST_DOMAIN, MockOAuth2Implementation()
+    )
+
+    entry = MockConfigEntry(domain=TEST_DOMAIN, data={},)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": config_entries.SOURCE_SSDP}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
 async def test_full_flow(
     hass, flow_handler, local_impl, aiohttp_client, aioclient_mock
 ):


### PR DESCRIPTION
## Description:

Fixes enabling discovery on an integration that implements the oauth2 helpers.
Discovery data is sent as user_input, triggering the configuration flow incorrectly.

Furthermore, since this is about OAuth accounts (and not devices), I've set the DOMAIN as the unique ID, this allows the user to ignore the discovery. This also prevents multiple discoveries to pop up.

Lastly, once a config entry for the integration domain has been set up, we stop using discovery.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
