### PR TITLE
update aiopylgtv to 0.2.5

### DIFF
--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "webostv",
   "name": "LG webOS Smart TV",
   "documentation": "https://www.home-assistant.io/integrations/webostv",
-  "requirements": ["aiopylgtv==0.2.4"],
+  "requirements": ["aiopylgtv==0.2.5"],
   "dependencies": ["configurator"],
   "codeowners": ["@bendavid"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -190,7 +190,7 @@ aionotion==1.1.0
 aiopvapi==1.6.14
 
 # homeassistant.components.webostv
-aiopylgtv==0.2.4
+aiopylgtv==0.2.5
 
 # homeassistant.components.switcher_kis
 aioswitcher==2019.4.26

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -69,7 +69,7 @@ aiohue==1.10.1
 aionotion==1.1.0
 
 # homeassistant.components.webostv
-aiopylgtv==0.2.4
+aiopylgtv==0.2.5
 
 # homeassistant.components.switcher_kis
 aioswitcher==2019.4.26


### PR DESCRIPTION
This version of aiopylgtv properly specifies minimal version numbers for dependencies to avoid issues when upgrading from an older home assistant version.

Fixes https://github.com/home-assistant/home-assistant/issues/30698
