### PR TITLE
Upgrade Oru to new version 0.1.11

### DIFF
--- a/homeassistant/components/oru/manifest.json
+++ b/homeassistant/components/oru/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/oru",
   "dependencies": [],
   "codeowners": ["@bvlaicu"],
-  "requirements": ["oru==0.1.9"]
+  "requirements": ["oru==0.1.11"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -953,7 +953,7 @@ openwebifpy==3.1.1
 openwrt-luci-rpc==1.1.2
 
 # homeassistant.components.oru
-oru==0.1.9
+oru==0.1.11
 
 # homeassistant.components.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
## Description:
Bumped oru py version to 0.1.11 which adds a timeout to the underlying api request.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
