### PR TITLE
Revert "Forget auth token when going offline so we can reconnect (#26630)

### DIFF
--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -132,8 +132,6 @@ class AmcrestChecker(Http):
                 offline = not self.available
             if offline and was_online:
                 _LOGGER.error("%s camera offline: Too many errors", self._wrap_name)
-                with self._token_lock:
-                    self._token = None
                 dispatcher_send(
                     self._hass, service_signal(SERVICE_UPDATE, self._wrap_name)
                 )


### PR DESCRIPTION
## Description:
#26630 broke previously working Amcrest cameras.

**Related issue (if applicable):** fixes #28539

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
