### PR TITLE
Add MELCloud integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -410,6 +410,7 @@ omit =
     homeassistant/components/mcp23017/*
     homeassistant/components/media_extractor/*
     homeassistant/components/mediaroom/media_player.py
+    homeassistant/components/melcloud/__init__.py
     homeassistant/components/melcloud/climate.py
     homeassistant/components/melcloud/sensor.py
     homeassistant/components/message_bird/notify.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -410,6 +410,8 @@ omit =
     homeassistant/components/mcp23017/*
     homeassistant/components/media_extractor/*
     homeassistant/components/mediaroom/media_player.py
+    homeassistant/components/melcloud/climate.py
+    homeassistant/components/melcloud/sensor.py
     homeassistant/components/message_bird/notify.py
     homeassistant/components/met/weather.py
     homeassistant/components/meteo_france/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -204,6 +204,7 @@ homeassistant/components/mastodon/* @fabaff
 homeassistant/components/matrix/* @tinloaf
 homeassistant/components/mcp23017/* @jardiamj
 homeassistant/components/mediaroom/* @dgomes
+homeassistant/components/melcloud/* @vilppuvuorinen
 homeassistant/components/melissa/* @kennedyshead
 homeassistant/components/met/* @danielhiversen
 homeassistant/components/meteo_france/* @victorcerutti @oncleben31 @Quentame

--- a/homeassistant/components/melcloud/.translations/en.json
+++ b/homeassistant/components/melcloud/.translations/en.json
@@ -6,7 +6,7 @@
         "title": "Connect to MELCloud",
         "description": "Connect using your MELCloud account.",
         "data": {
-          "email": "Email used to login to MELCloud.",
+          "username": "Email used to login to MELCloud.",
           "password": "MELCloud password."
         }
       }

--- a/homeassistant/components/melcloud/.translations/en.json
+++ b/homeassistant/components/melcloud/.translations/en.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "title": "MELCloud",
+    "step": {
+      "user": {
+        "title": "Connect to MELCloud",
+        "description": "Connect using your MELCloud account.",
+        "data": {
+          "email": "Email used to login to MELCloud.",
+          "password": "MELCloud password."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "MELCloud integration already configured for {email}. Existing access token has been refreshed."
+    }
+  }
+}

--- a/homeassistant/components/melcloud/.translations/en.json
+++ b/homeassistant/components/melcloud/.translations/en.json
@@ -17,7 +17,7 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "MELCloud integration already configured for {email}. Existing access token has been refreshed."
+      "already_configured": "MELCloud integration already configured for this email. Access token has been refreshed."
     }
   }
 }

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -136,7 +136,6 @@ class MelCloudDevice:
 async def mel_api_setup(hass, token) -> Optional[List[MelCloudDevice]]:
     """Create a MELCloud instance only once."""
     session = hass.helpers.aiohttp_client.async_get_clientsession()
-    print("setup")
     try:
         with timeout(10):
             client = Client(

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -70,7 +70,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
     await asyncio.gather(
-        [
+        *[
             hass.config_entries.async_forward_entry_unload(config_entry, platform)
             for platform in PLATFORMS
         ]

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -1,0 +1,161 @@
+"""The MELCloud Climate integration."""
+import asyncio
+from datetime import timedelta
+import logging
+from typing import Dict, List, Optional
+
+from aiohttp import ClientConnectionError
+from async_timeout import timeout
+from pymelcloud import Client, Device
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import (
+    CONF_EMAIL,
+    CONF_TOKEN,
+)
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.util import Throttle
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+
+PLATFORMS = ["climate", "sensor"]
+
+CONF_LANGUAGE = "language"
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: vol.Schema({vol.Required(CONF_TOKEN): str})}, extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigEntry):
+    """Establish connection with MELCloud."""
+    if DOMAIN not in config:
+        return True
+
+    email = config[DOMAIN].get(CONF_EMAIL)
+    token = config[DOMAIN].get(CONF_TOKEN)
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_EMAIL: email, CONF_TOKEN: token},
+        )
+    )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Establish connection with MELClooud."""
+    conf = entry.data
+    mel_api = await mel_api_setup(hass, conf[CONF_TOKEN])
+    if not mel_api:
+        return False
+    hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: mel_api})
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload a config entry."""
+    await asyncio.wait(
+        [
+            hass.config_entries.async_forward_entry_unload(config_entry, platform)
+            for platform in PLATFORMS
+        ]
+    )
+    hass.data[DOMAIN].pop(config_entry.entry_id)
+    if not hass.data[DOMAIN]:
+        hass.data.pop(DOMAIN)
+    return True
+
+
+class MelCloudDevice:
+    """MELCloud Device instance."""
+
+    def __init__(self, device: Device):
+        """Construct a device wrapper."""
+        self.device = device
+        self.name = device.name
+        self._available = True
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    async def async_update(self, **kwargs):
+        """Pull the latest data from MELCloud."""
+        try:
+            await self.device.update()
+            self._available = True
+        except ClientConnectionError:
+            _LOGGER.warning("Connection failed for %s", self.name)
+            self._available = False
+
+    async def async_set(self, properties: Dict[str, any]):
+        """Write state changes to the MELCloud API."""
+        try:
+            await self.device.set(properties)
+            self._available = True
+        except ClientConnectionError:
+            _LOGGER.warning("Connection failed for %s", self.name)
+            self._available = False
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
+
+    @property
+    def device_id(self):
+        """Return device ID."""
+        return self.device.device_id
+
+    @property
+    def building_id(self):
+        """Return building ID of the device."""
+        return self.device.building_id
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        _device_info = {
+            "identifiers": {(DOMAIN, f"{self.device.mac}-{self.device.serial}")},
+            "manufacturer": "Mitsubishi Electric",
+            "name": self.name,
+        }
+        unit_infos = self.device.units
+        if unit_infos is not None:
+            _device_info["model"] = ", ".join(
+                list(set(map(lambda x: x["model"], unit_infos)))
+            )
+        return _device_info
+
+
+async def mel_api_setup(hass, token) -> Optional[List[MelCloudDevice]]:
+    """Create a MELCloud instance only once."""
+    session = hass.helpers.aiohttp_client.async_get_clientsession()
+    try:
+        with timeout(10):
+            client = Client(
+                token,
+                session,
+                conf_update_interval=timedelta(minutes=5),
+                device_set_debounce=timedelta(milliseconds=500),
+            )
+            devices = await client.get_devices()
+    except asyncio.TimeoutError:
+        _LOGGER.debug("Connection timed out")
+        raise ConfigEntryNotReady
+    except ClientConnectionError:
+        _LOGGER.debug("ClientConnectionError")
+        raise ConfigEntryNotReady
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.error("Unexpected error when initializing client")
+        return None
+
+    return [MelCloudDevice(device) for device in devices]

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -136,6 +136,7 @@ class MelCloudDevice:
 async def mel_api_setup(hass, token) -> Optional[List[MelCloudDevice]]:
     """Create a MELCloud instance only once."""
     session = hass.helpers.aiohttp_client.async_get_clientsession()
+    print("setup")
     try:
         with timeout(10):
             client = Client(

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
-    await asyncio.wait(
+    await asyncio.gather(
         [
             hass.config_entries.async_forward_entry_unload(config_entry, platform)
             for platform in PLATFORMS

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -147,4 +147,7 @@ async def mel_api_setup(hass, token) -> Optional[List[MelCloudDevice]]:
     except (asyncio.TimeoutError, ClientConnectionError) as ex:
         raise ConfigEntryNotReady() from ex
 
-    return [MelCloudDevice(device) for device in devices]
+    wrapped_devices = {}
+    for k, value in devices.items():
+        wrapped_devices[k] = [MelCloudDevice(device) for device in value]
+    return wrapped_devices

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -31,9 +31,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistantType, config: ConfigEntry):
     """Establish connection with MELCloud."""
-    if DOMAIN not in config:
-        return True
-
     email = config[DOMAIN].get(CONF_EMAIL)
     token = config[DOMAIN].get(CONF_TOKEN)
     hass.async_create_task(

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -123,7 +123,7 @@ class MelCloudDevice:
         unit_infos = self.device.units
         if unit_infos is not None:
             _device_info["model"] = ", ".join(
-                [x["model"] for x in unit_infos if len(x["model"]) > 0]
+                [x["model"] for x in unit_infos if x["model"]]
             )
         return _device_info
 

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from aiohttp import ClientConnectionError
 from async_timeout import timeout
@@ -100,7 +100,7 @@ class MelCloudDevice:
             _LOGGER.warning("Connection failed for %s", self.name)
             self._available = False
 
-    async def async_set(self, properties: Dict[str, any]):
+    async def async_set(self, properties: Dict[str, Any]):
         """Write state changes to the MELCloud API."""
         try:
             await self.device.set(properties)
@@ -145,7 +145,7 @@ async def mel_devices_setup(hass, token) -> List[MelCloudDevice]:
     session = hass.helpers.aiohttp_client.async_get_clientsession()
     try:
         with timeout(10):
-            devices = await get_devices(
+            all_devices = await get_devices(
                 token,
                 session,
                 conf_update_interval=timedelta(minutes=5),
@@ -155,6 +155,6 @@ async def mel_devices_setup(hass, token) -> List[MelCloudDevice]:
         raise ConfigEntryNotReady() from ex
 
     wrapped_devices = {}
-    for k, value in devices.items():
-        wrapped_devices[k] = [MelCloudDevice(device) for device in value]
+    for device_type, devices in all_devices.items():
+        wrapped_devices[device_type] = [MelCloudDevice(device) for device in devices]
     return wrapped_devices

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from aiohttp import ClientConnectionError
 from async_timeout import timeout
@@ -46,10 +46,8 @@ async def async_setup(hass: HomeAssistantType, config: ConfigEntry):
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Establish connection with MELClooud."""
     conf = entry.data
-    mel_api = await mel_api_setup(hass, conf[CONF_TOKEN])
-    if not mel_api:
-        return False
-    hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: mel_api})
+    mel_devices = await mel_devices_setup(hass, conf[CONF_TOKEN])
+    hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: mel_devices})
     for platform in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
@@ -130,8 +128,8 @@ class MelCloudDevice:
         return _device_info
 
 
-async def mel_api_setup(hass, token) -> Optional[List[MelCloudDevice]]:
-    """Create a MELCloud instance only once."""
+async def mel_devices_setup(hass, token) -> List[MelCloudDevice]:
+    """Query connected devices from MELCloud."""
     session = hass.helpers.aiohttp_client.async_get_clientsession()
     try:
         with timeout(10):

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -10,7 +10,7 @@ from pymelcloud import Device, get_devices
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_TOKEN
+from homeassistant.const import CONF_TOKEN, CONF_USERNAME
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
@@ -28,7 +28,10 @@ CONF_LANGUAGE = "language"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {vol.Required(CONF_EMAIL): cv.string, vol.Required(CONF_TOKEN): cv.string}
+            {
+                vol.Required(CONF_USERNAME): cv.string,
+                vol.Required(CONF_TOKEN): cv.string,
+            }
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -40,13 +43,13 @@ async def async_setup(hass: HomeAssistantType, config: ConfigEntry):
     if DOMAIN not in config:
         return True
 
-    email = config[DOMAIN][CONF_EMAIL]
+    username = config[DOMAIN][CONF_USERNAME]
     token = config[DOMAIN][CONF_TOKEN]
     hass.async_create_task(
         hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_IMPORT},
-            data={CONF_EMAIL: email, CONF_TOKEN: token},
+            data={CONF_USERNAME: username, CONF_TOKEN: token},
         )
     )
     return True

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -128,7 +128,7 @@ class MelCloudDevice:
         unit_infos = self.device.units
         if unit_infos is not None:
             _device_info["model"] = ", ".join(
-                list(set(map(lambda x: x["model"], unit_infos)))
+                [x["model"] for x in unit_infos if len(x["model"]) > 0]
             )
         return _device_info
 

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -144,14 +144,7 @@ async def mel_api_setup(hass, token) -> Optional[List[MelCloudDevice]]:
                 conf_update_interval=timedelta(minutes=5),
                 device_set_debounce=timedelta(seconds=1),
             )
-    except asyncio.TimeoutError:
-        _LOGGER.debug("Connection timed out")
-        raise ConfigEntryNotReady
-    except ClientConnectionError:
-        _LOGGER.debug("ClientConnectionError")
-        raise ConfigEntryNotReady
-    except Exception:  # pylint: disable=broad-except
-        _LOGGER.error("Unexpected error when initializing client")
-        return None
+    except (asyncio.TimeoutError, ClientConnectionError) as ex:
+        raise ConfigEntryNotReady() from ex
 
     return [MelCloudDevice(device) for device in devices]

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -10,10 +10,7 @@ from pymelcloud import Client, Device
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_EMAIL,
-    CONF_TOKEN,
-)
+from homeassistant.const import CONF_EMAIL, CONF_TOKEN
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import Throttle

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 
 from aiohttp import ClientConnectionError
 from async_timeout import timeout
-from pymelcloud import Client, Device
+from pymelcloud import Device, get_devices
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -138,13 +138,12 @@ async def mel_api_setup(hass, token) -> Optional[List[MelCloudDevice]]:
     session = hass.helpers.aiohttp_client.async_get_clientsession()
     try:
         with timeout(10):
-            client = Client(
+            devices = await get_devices(
                 token,
                 session,
                 conf_update_interval=timedelta(minutes=5),
-                device_set_debounce=timedelta(milliseconds=500),
+                device_set_debounce=timedelta(seconds=1),
             )
-            devices = await client.get_devices()
     except asyncio.TimeoutError:
         _LOGGER.debug("Connection timed out")
         raise ConfigEntryNotReady

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_TOKEN
 from homeassistant.exceptions import ConfigEntryNotReady
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import Throttle
 
@@ -25,14 +26,22 @@ PLATFORMS = ["climate", "sensor"]
 
 CONF_LANGUAGE = "language"
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: vol.Schema({vol.Required(CONF_TOKEN): str})}, extra=vol.ALLOW_EXTRA,
+    {
+        DOMAIN: vol.Schema(
+            {vol.Required(CONF_EMAIL): cv.string, vol.Required(CONF_TOKEN): cv.string}
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 
 async def async_setup(hass: HomeAssistantType, config: ConfigEntry):
     """Establish connection with MELCloud."""
-    email = config[DOMAIN].get(CONF_EMAIL)
-    token = config[DOMAIN].get(CONF_TOKEN)
+    if DOMAIN not in config:
+        return True
+
+    email = config[DOMAIN][CONF_EMAIL]
+    token = config[DOMAIN][CONF_TOKEN]
     hass.async_create_task(
         hass.config_entries.flow.async_init(
             DOMAIN,

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -137,13 +137,11 @@ class AtaDeviceClimate(ClimateDevice):
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        if not self._device.power:
-            await self._device.set({"power": True})
+        await self._device.set({"power": True})
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
-        if self._device.power:
-            await self._device.set({"power": False})
+        await self._device.set({"power": False})
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -149,22 +149,16 @@ class AtaDeviceClimate(ClimateDevice):
     @property
     def fan_mode(self) -> Optional[str]:
         """Return the fan setting."""
-        speed = self._api.device.fan_speed
-        if speed is None:
-            return None
-        return speed.replace("-", " ")
+        return self._api.device.fan_speed
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        await self._api.device.set({"fan_speed": fan_mode.replace(" ", "-")})
+        await self._api.device.set({"fan_speed": fan_mode})
 
     @property
     def fan_modes(self) -> Optional[List[str]]:
         """Return the list of available fan modes."""
-        speeds = self._api.device.fan_speeds
-        if speeds is None:
-            return None
-        return list(map(lambda x: x.replace("-", " "), speeds))
+        return self._api.device.fan_speeds
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -48,6 +48,7 @@ class AtaDeviceClimate(ClimateDevice):
     def __init__(self, device: MelCloudDevice, name=None):
         """Initialize the climate."""
         self._api = device
+        self._device = self._api.device
         if name is None:
             name = device.name
         self._name = name
@@ -55,7 +56,7 @@ class AtaDeviceClimate(ClimateDevice):
     @property
     def unique_id(self) -> Optional[str]:
         """Return a unique ID."""
-        return f"{self._api.device.serial}-{self._api.device.mac}-climate"
+        return f"{self._device.serial}-{self._device.mac}-climate"
 
     @property
     def name(self):
@@ -94,20 +95,20 @@ class AtaDeviceClimate(ClimateDevice):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement used by the platform."""
-        return TEMP_UNIT_LOOKUP.get(self._api.device.temp_unit, TEMP_CELSIUS)
+        return TEMP_UNIT_LOOKUP.get(self._device.temp_unit, TEMP_CELSIUS)
 
     @property
     def hvac_mode(self) -> str:
         """Return hvac operation ie. heat, cool mode."""
-        mode = self._api.device.operation_mode
-        if not self._api.device.power or mode is None:
+        mode = self._device.operation_mode
+        if not self._device.power or mode is None:
             return HVAC_MODE_OFF
         return HVAC_MODE_LOOKUP.get(mode)
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVAC_MODE_OFF:
-            await self._api.device.set({"power": False})
+            await self._device.set({"power": False})
             return
 
         operation_mode = HVAC_MODE_REVERSE_LOOKUP.get(hvac_mode, None)
@@ -117,59 +118,59 @@ class AtaDeviceClimate(ClimateDevice):
         props = {"operation_mode": operation_mode}
         if self.hvac_mode == HVAC_MODE_OFF:
             props["power"] = True
-        await self._api.device.set(props)
+        await self._device.set(props)
 
     @property
     def hvac_modes(self) -> List[str]:
         """Return the list of available hvac operation modes."""
         return [HVAC_MODE_OFF] + list(
-            map(HVAC_MODE_LOOKUP.get, self._api.device.operation_modes)
+            map(HVAC_MODE_LOOKUP.get, self._device.operation_modes)
         )
 
     @property
     def current_temperature(self) -> Optional[float]:
         """Return the current temperature."""
-        return self._api.device.room_temperature
+        return self._device.room_temperature
 
     @property
     def target_temperature(self) -> Optional[float]:
         """Return the temperature we try to reach."""
-        return self._api.device.target_temperature
+        return self._device.target_temperature
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
-        await self._api.device.set(
+        await self._device.set(
             {"target_temperature": kwargs.get("temperature", self.target_temperature)}
         )
 
     @property
     def target_temperature_step(self) -> Optional[float]:
         """Return the supported step of target temperature."""
-        return self._api.device.target_temperature_step
+        return self._device.target_temperature_step
 
     @property
     def fan_mode(self) -> Optional[str]:
         """Return the fan setting."""
-        return self._api.device.fan_speed
+        return self._device.fan_speed
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        await self._api.device.set({"fan_speed": fan_mode})
+        await self._device.set({"fan_speed": fan_mode})
 
     @property
     def fan_modes(self) -> Optional[List[str]]:
         """Return the list of available fan modes."""
-        return self._api.device.fan_speeds
+        return self._device.fan_speeds
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        if not self._api.device.power:
-            await self._api.device.set({"power": True})
+        if not self._device.power:
+            await self._device.set({"power": True})
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
-        if self._api.device.power:
-            await self._api.device.set({"power": False})
+        if self._device.power:
+            await self._device.set({"power": False})
 
     @property
     def supported_features(self) -> int:
@@ -179,7 +180,7 @@ class AtaDeviceClimate(ClimateDevice):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        min_value = self._api.device.target_temperature_min
+        min_value = self._device.target_temperature_min
         if min_value is not None:
             return min_value
 
@@ -190,7 +191,7 @@ class AtaDeviceClimate(ClimateDevice):
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        max_value = self._api.device.target_temperature_max
+        max_value = self._device.target_temperature_max
         if max_value is not None:
             return max_value
 

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -13,12 +13,12 @@ from homeassistant.components.climate.const import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
-from homeassistant.components.melcloud import MelCloudDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.temperature import convert as convert_temperature
 
+from . import MelCloudDevice
 from .const import DOMAIN, HVAC_MODE_LOOKUP, HVAC_MODE_REVERSE_LOOKUP, TEMP_UNIT_LOOKUP
 
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -20,7 +20,7 @@ from homeassistant.util.temperature import convert as convert_temperature
 
 from .const import DOMAIN, HVAC_MODE_LOOKUP, HVAC_MODE_REVERSE_LOOKUP, TEMP_UNIT_LOOKUP
 
-ENTITY_ID_FORMAT = DOMAIN + ".{}"
+ENTITY_ID_FORMAT = f"{DOMAIN}.{{}}"
 SCAN_INTERVAL = timedelta(seconds=60)
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,8 +49,7 @@ class AtaDeviceClimate(ClimateDevice):
         self._api = device
         if name is None:
             name = device.name
-
-        self._name = "{} {}".format(name, "HVAC")
+        self._name = name
 
     @property
     def unique_id(self) -> Optional[str]:

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -7,27 +7,18 @@ from pymelcloud import Device
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    DEFAULT_MIN_TEMP,
     DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
     HVAC_MODE_OFF,
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
-from homeassistant.const import (
-    PRECISION_TENTHS,
-    PRECISION_WHOLE,
-    TEMP_CELSIUS,
-)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PRECISION_TENTHS, PRECISION_WHOLE, TEMP_CELSIUS
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.temperature import convert as convert_temperature
 
-from .const import (
-    DOMAIN,
-    HVAC_MODE_LOOKUP,
-    HVAC_MODE_REVERSE_LOOKUP,
-    TEMP_UNIT_LOOKUP,
-)
+from .const import DOMAIN, HVAC_MODE_LOOKUP, HVAC_MODE_REVERSE_LOOKUP, TEMP_UNIT_LOOKUP
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -1,0 +1,199 @@
+"""Platform for climate integration."""
+from datetime import timedelta
+import logging
+from typing import List, Optional
+
+from pymelcloud import Device
+
+from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate.const import (
+    DEFAULT_MIN_TEMP,
+    DEFAULT_MAX_TEMP,
+    HVAC_MODE_OFF,
+    SUPPORT_FAN_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.const import (
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    TEMP_CELSIUS,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.util.temperature import convert as convert_temperature
+
+from .const import (
+    DOMAIN,
+    HVAC_MODE_LOOKUP,
+    HVAC_MODE_REVERSE_LOOKUP,
+    TEMP_UNIT_LOOKUP,
+)
+
+ENTITY_ID_FORMAT = DOMAIN + ".{}"
+SCAN_INTERVAL = timedelta(seconds=60)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+):
+    """Set up MelCloud device climate based on config_entry."""
+    mel_devices = hass.data[DOMAIN].get(entry.entry_id)
+    async_add_entities(
+        [MelCloudClimate(mel_device) for mel_device in mel_devices], True
+    )
+
+
+class MelCloudClimate(ClimateDevice):
+    """MELCloud device."""
+
+    def __init__(self, device: Device, name=None):
+        """Initialize the climate."""
+        self._api = device
+        if name is None:
+            name = device.name
+
+        self._name = "{} {}".format(name, "HVAC")
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID."""
+        return f"{self._api.device.serial}-{self._api.device.mac}-climate"
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def should_poll(self) -> bool:
+        """Return True if entity has to be polled for state.
+
+        False if entity pushes its state to HA.
+        """
+        return True
+
+    async def async_update(self):
+        """Update state from MELCloud."""
+        await self._api.async_update()
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return self._api.device_info
+
+    @property
+    def state(self) -> str:
+        """Return the current state."""
+        return self.hvac_mode
+
+    @property
+    def precision(self) -> float:
+        """Return the precision of the system."""
+        if self.hass.config.units.temperature_unit == TEMP_CELSIUS:
+            return PRECISION_TENTHS
+        return PRECISION_WHOLE
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the unit of measurement used by the platform."""
+        return TEMP_UNIT_LOOKUP.get(self._api.device.temp_unit, TEMP_CELSIUS)
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+        mode = self._api.device.operation_mode
+        if mode is None:
+            return HVAC_MODE_OFF
+        return HVAC_MODE_LOOKUP.get(mode)
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        operation_mode = HVAC_MODE_REVERSE_LOOKUP.get(hvac_mode, None)
+        if operation_mode is None:
+            raise ValueError(f"Invalid hvac_mode [{hvac_mode}]")
+        await self._api.device.set({"operation_mode": operation_mode})
+
+    @property
+    def hvac_modes(self) -> List[str]:
+        """Return the list of available hvac operation modes."""
+        return list(map(HVAC_MODE_LOOKUP.get, self._api.device.operation_modes()))
+
+    @property
+    def current_temperature(self) -> Optional[float]:
+        """Return the current temperature."""
+        return self._api.device.temperature
+
+    @property
+    def target_temperature(self) -> Optional[float]:
+        """Return the temperature we try to reach."""
+        return self._api.device.target_temperature
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set new target temperature."""
+        await self._api.device.set(
+            {"target_temperature": kwargs.get("temperature", self.target_temperature)}
+        )
+
+    @property
+    def target_temperature_step(self) -> Optional[float]:
+        """Return the supported step of target temperature."""
+        return self._api.device.target_temperature_step
+
+    @property
+    def fan_mode(self) -> Optional[str]:
+        """Return the fan setting."""
+        speed = self._api.device.fan_speed
+        if speed is None:
+            return None
+        return speed.replace("-", " ")
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set new target fan mode."""
+        await self._api.device.set({"fan_speed": fan_mode.replace(" ", "-")})
+
+    @property
+    def fan_modes(self) -> Optional[List[str]]:
+        """Return the list of available fan modes."""
+        speeds = self._api.device.fan_speeds()
+        if speeds is None:
+            return None
+        return list(map(lambda x: x.replace("-", " "), speeds))
+
+    async def async_turn_on(self) -> None:
+        """Turn the entity on."""
+        if not self._api.device.power:
+            await self._api.device.set({"power": True})
+
+    async def async_turn_off(self) -> None:
+        """Turn the entity off."""
+        if self._api.device.power:
+            await self._api.device.set({"power": False})
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+        return SUPPORT_FAN_MODE | SUPPORT_TARGET_TEMPERATURE
+
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum temperature."""
+        min_value = self._api.device.target_temperature_min
+        if min_value is not None:
+            return min_value
+
+        return convert_temperature(
+            DEFAULT_MIN_TEMP, TEMP_CELSIUS, self.temperature_unit
+        )
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum temperature."""
+        max_value = self._api.device.target_temperature_max
+        if max_value is not None:
+            return max_value
+
+        return convert_temperature(
+            DEFAULT_MAX_TEMP, TEMP_CELSIUS, self.temperature_unit
+        )

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -123,9 +123,9 @@ class AtaDeviceClimate(ClimateDevice):
     @property
     def hvac_modes(self) -> List[str]:
         """Return the list of available hvac operation modes."""
-        return [HVAC_MODE_OFF] + list(
-            map(HVAC_MODE_LOOKUP.get, self._device.operation_modes)
-        )
+        return [HVAC_MODE_OFF] + [
+            HVAC_MODE_LOOKUP.get(mode) for mode in self._device.operation_modes
+        ]
 
     @property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import logging
 from typing import List, Optional
 
-from pymelcloud import AtaDevice
+from pymelcloud import DEVICE_TYPE_ATA
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
@@ -33,11 +33,7 @@ async def async_setup_entry(
     """Set up MelCloud device climate based on config_entry."""
     mel_devices = hass.data[DOMAIN].get(entry.entry_id)
     async_add_entities(
-        [
-            AtaDeviceClimate(mel_device)
-            for mel_device in mel_devices
-            if isinstance(mel_device.device, AtaDevice)
-        ],
+        [AtaDeviceClimate(mel_device) for mel_device in mel_devices[DEVICE_TYPE_ATA]],
         True,
     )
 

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -59,14 +59,6 @@ class AtaDeviceClimate(ClimateDevice):
         """Return the display name of this light."""
         return self._name
 
-    @property
-    def should_poll(self) -> bool:
-        """Return True if entity has to be polled for state.
-
-        False if entity pushes its state to HA.
-        """
-        return True
-
     async def async_update(self):
         """Update state from MELCloud."""
         await self._api.async_update()

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -13,6 +13,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
+from homeassistant.components.melcloud import MelCloudDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PRECISION_TENTHS, PRECISION_WHOLE, TEMP_CELSIUS
 from homeassistant.helpers.typing import HomeAssistantType
@@ -44,7 +45,7 @@ async def async_setup_entry(
 class AtaDeviceClimate(ClimateDevice):
     """Air-to-Air climate device."""
 
-    def __init__(self, device: AtaDevice, name=None):
+    def __init__(self, device: MelCloudDevice, name=None):
         """Initialize the climate."""
         self._api = device
         if name is None:

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -9,13 +9,13 @@ import pymelcloud
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.melcloud.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@config_entries.HANDLERS.register("melcloud")
-class FlowHandler(config_entries.ConfigFlow):
+class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 1

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -9,11 +9,7 @@ import pymelcloud
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_EMAIL,
-    CONF_PASSWORD,
-    CONF_TOKEN,
-)
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TOKEN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -1,0 +1,101 @@
+"""Config flow for the MELCloud platform."""
+import asyncio
+import logging
+from typing import Callable
+
+from aiohttp import ClientError, ClientResponseError
+from async_timeout import timeout
+import pymelcloud
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_EMAIL,
+    CONF_PASSWORD,
+    CONF_TOKEN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@config_entries.HANDLERS.register("melcloud")
+class FlowHandler(config_entries.ConfigFlow):
+    """Handle a config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def _create_entry(self, email: str, token: str):
+        """Register new entry."""
+        for entry in self._async_current_entries():
+            if entry.data.get(CONF_EMAIL, entry.title) == email:
+                entry.connection_class = self.CONNECTION_CLASS
+                self.hass.config_entries.async_update_entry(
+                    entry, data={CONF_EMAIL: email, CONF_TOKEN: token}
+                )
+                return self.async_abort(
+                    reason="already_configured",
+                    description_placeholders={"email": email},
+                )
+
+        return self.async_create_entry(
+            title=email, data={CONF_EMAIL: email, CONF_TOKEN: token}
+        )
+
+    async def _init_client(self, email: str, password: str) -> pymelcloud.Client:
+        return await pymelcloud.login(
+            email, password, self.hass.helpers.aiohttp_client.async_get_clientsession(),
+        )
+
+    async def _init_client_with_token(self, token: str) -> pymelcloud.Client:
+        return pymelcloud.Client(
+            token, self.hass.helpers.aiohttp_client.async_get_clientsession(),
+        )
+
+    async def _create_client(
+        self, email: str, client_creator: Callable[[], pymelcloud.Client],
+    ):
+        """Create client."""
+        try:
+            client = await client_creator()
+            with timeout(10):
+                await client.update_confs()
+        except asyncio.TimeoutError:
+            return self.async_abort(reason="cannot_connect")
+        except ClientResponseError as err:
+            if err.status == 401 or err.status == 403:
+                return self.async_abort(reason="invalid_auth")
+            else:
+                return self.async_abort(reason="cannot_connect")
+        except ClientError:
+            _LOGGER.exception("ClientError")
+            return self.async_abort(reason="cannot_connect")
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected error creating device")
+            return self.async_abort(reason="unknown")
+
+        return await self._create_entry(email, client.token)
+
+    async def async_step_user(self, user_input=None):
+        """User initiated config flow."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
+                ),
+            )
+        email = user_input[CONF_EMAIL]
+        return await self._create_client(
+            email, lambda: self._init_client(email, user_input[CONF_PASSWORD])
+        )
+
+    async def async_step_import(self, user_input):
+        """Import a config entry."""
+        email = user_input.get(CONF_EMAIL)
+        token = user_input.get(CONF_TOKEN)
+        if not token:
+            return await self.async_step_user()
+        return await self._create_client(
+            email, lambda: self._init_client_with_token(token)
+        )

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -23,17 +23,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _create_entry(self, username: str, token: str):
         """Register new entry."""
-        for entry in self._async_current_entries():
-            if entry.data[CONF_USERNAME] == username:
-                entry.connection_class = self.CONNECTION_CLASS
-                self.hass.config_entries.async_update_entry(
-                    entry, data={CONF_USERNAME: username, CONF_TOKEN: token}
-                )
-                return self.async_abort(
-                    reason="already_configured",
-                    description_placeholders={"email": username},
-                )
-
+        await self.async_set_unique_id(username)
+        self._abort_if_unique_id_configured({CONF_TOKEN: token})
         return self.async_create_entry(
             title=username, data={CONF_USERNAME: username, CONF_TOKEN: token},
         )

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -74,7 +74,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
             )
         username = user_input[CONF_USERNAME]
-        return await self._create_client(username, password=user_input[CONF_PASSWORD],)
+        return await self._create_client(username, password=user_input[CONF_PASSWORD])
 
     async def async_step_import(self, user_input):
         """Import a config entry."""

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 
-from .const import DOMAIN
+from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -9,8 +9,9 @@ import pymelcloud
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.melcloud.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -61,8 +61,7 @@ class FlowHandler(config_entries.ConfigFlow):
         except ClientResponseError as err:
             if err.status == 401 or err.status == 403:
                 return self.async_abort(reason="invalid_auth")
-            else:
-                return self.async_abort(reason="cannot_connect")
+            return self.async_abort(reason="cannot_connect")
         except ClientError:
             _LOGGER.exception("ClientError")
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -64,18 +64,12 @@ class FlowHandler(config_entries.ConfigFlow):
                     acquired_token,
                     self.hass.helpers.aiohttp_client.async_get_clientsession(),
                 )
-        except asyncio.TimeoutError:
-            return self.async_abort(reason="cannot_connect")
         except ClientResponseError as err:
             if err.status == 401 or err.status == 403:
                 return self.async_abort(reason="invalid_auth")
             return self.async_abort(reason="cannot_connect")
-        except ClientError:
-            _LOGGER.exception("ClientError")
+        except (asyncio.TimeoutError, ClientError):
             return self.async_abort(reason="cannot_connect")
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected error creating device")
-            return self.async_abort(reason="unknown")
 
         return await self._create_entry(email, acquired_token)
 

--- a/homeassistant/components/melcloud/const.py
+++ b/homeassistant/components/melcloud/const.py
@@ -1,0 +1,31 @@
+"""Constants for the MELCloud Climate integration."""
+import pymelcloud
+
+from homeassistant.const import (
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
+from homeassistant.components.climate.const import (
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
+)
+
+DOMAIN = "melcloud"
+
+HVAC_MODE_LOOKUP = {
+    pymelcloud.OPERATION_MODE_HEAT: HVAC_MODE_HEAT,
+    pymelcloud.OPERATION_MODE_DRY: HVAC_MODE_DRY,
+    pymelcloud.OPERATION_MODE_COOL: HVAC_MODE_COOL,
+    pymelcloud.OPERATION_MODE_FAN_ONLY: HVAC_MODE_FAN_ONLY,
+    pymelcloud.OPERATION_MODE_HEAT_COOL: HVAC_MODE_HEAT_COOL,
+}
+HVAC_MODE_REVERSE_LOOKUP = {v: k for k, v in HVAC_MODE_LOOKUP.items()}
+
+TEMP_UNIT_LOOKUP = {
+    pymelcloud.UNIT_TEMP_CELSIUS: TEMP_CELSIUS,
+    pymelcloud.UNIT_TEMP_FAHRENHEIT: TEMP_FAHRENHEIT,
+}
+TEMP_UNIT_REVERSE_LOOKUP = {v: k for k, v in TEMP_UNIT_LOOKUP.items()}

--- a/homeassistant/components/melcloud/const.py
+++ b/homeassistant/components/melcloud/const.py
@@ -1,17 +1,14 @@
 """Constants for the MELCloud Climate integration."""
 import pymelcloud
 
-from homeassistant.const import (
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
-)
 from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_DRY,
     HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
 )
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 
 DOMAIN = "melcloud"
 

--- a/homeassistant/components/melcloud/const.py
+++ b/homeassistant/components/melcloud/const.py
@@ -1,5 +1,6 @@
 """Constants for the MELCloud Climate integration."""
-import pymelcloud
+import pymelcloud.ata_device as ata_device
+from pymelcloud.const import UNIT_TEMP_CELSIUS, UNIT_TEMP_FAHRENHEIT
 
 from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
@@ -13,16 +14,16 @@ from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 DOMAIN = "melcloud"
 
 HVAC_MODE_LOOKUP = {
-    pymelcloud.OPERATION_MODE_HEAT: HVAC_MODE_HEAT,
-    pymelcloud.OPERATION_MODE_DRY: HVAC_MODE_DRY,
-    pymelcloud.OPERATION_MODE_COOL: HVAC_MODE_COOL,
-    pymelcloud.OPERATION_MODE_FAN_ONLY: HVAC_MODE_FAN_ONLY,
-    pymelcloud.OPERATION_MODE_HEAT_COOL: HVAC_MODE_HEAT_COOL,
+    ata_device.OPERATION_MODE_HEAT: HVAC_MODE_HEAT,
+    ata_device.OPERATION_MODE_DRY: HVAC_MODE_DRY,
+    ata_device.OPERATION_MODE_COOL: HVAC_MODE_COOL,
+    ata_device.OPERATION_MODE_FAN_ONLY: HVAC_MODE_FAN_ONLY,
+    ata_device.OPERATION_MODE_HEAT_COOL: HVAC_MODE_HEAT_COOL,
 }
 HVAC_MODE_REVERSE_LOOKUP = {v: k for k, v in HVAC_MODE_LOOKUP.items()}
 
 TEMP_UNIT_LOOKUP = {
-    pymelcloud.UNIT_TEMP_CELSIUS: TEMP_CELSIUS,
-    pymelcloud.UNIT_TEMP_FAHRENHEIT: TEMP_FAHRENHEIT,
+    UNIT_TEMP_CELSIUS: TEMP_CELSIUS,
+    UNIT_TEMP_FAHRENHEIT: TEMP_FAHRENHEIT,
 }
 TEMP_UNIT_REVERSE_LOOKUP = {v: k for k, v in TEMP_UNIT_LOOKUP.items()}

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "MELCloud",
   "config_flow": true,
   "documentation": "",
-  "requirements": ["pymelcloud==0.7.0"],
+  "requirements": ["pymelcloud==0.7.1"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "MELCloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/melcloud",
-  "requirements": ["pymelcloud==1.0.1"],
+  "requirements": ["pymelcloud==1.2.0"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -2,13 +2,11 @@
   "domain": "melcloud",
   "name": "MELCloud",
   "config_flow": true,
-  "documentation": "",
+  "documentation": "https://www.home-assistant.io/integrations/melcloud",
   "requirements": ["pymelcloud==1.0.1"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "codeowners": [
-    "@vilppuvuorinen"
-  ]
+  "codeowners": ["@vilppuvuorinen"]
 }

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "MELCloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/melcloud",
-  "requirements": ["pymelcloud==1.2.0"],
+  "requirements": ["pymelcloud==2.0.0"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "melcloud",
+  "name": "MELCloud",
+  "config_flow": true,
+  "documentation": "",
+  "requirements": ["pymelcloud==0.7.0"],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@vilppuvuorinen"
+  ]
+}

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -4,9 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/melcloud",
   "requirements": ["pymelcloud==2.0.0"],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
   "dependencies": [],
   "codeowners": ["@vilppuvuorinen"]
 }

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "MELCloud",
   "config_flow": true,
   "documentation": "",
-  "requirements": ["pymelcloud==0.7.1"],
+  "requirements": ["pymelcloud==1.0.1"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -1,7 +1,7 @@
 """Support for MelCloud device sensors."""
 import logging
 
-from pymelcloud import Device
+from pymelcloud import AtaDevice
 
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
@@ -17,11 +17,11 @@ ATTR_VALUE_FN = "value_fn"
 
 SENSORS = [
     {
-        ATTR_MEASUREMENT: "Inside Temperature",
+        ATTR_MEASUREMENT: "Room Temperature",
         ATTR_ICON: "mdi:thermometer",
         ATTR_UNIT_FN: lambda x: TEMP_UNIT_LOOKUP.get(x.device.temp_unit, TEMP_CELSIUS),
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
-        ATTR_VALUE_FN: lambda x: x.device.temperature,
+        ATTR_VALUE_FN: lambda x: x.device.room_temperature,
     },
     {
         ATTR_MEASUREMENT: "Energy",
@@ -43,6 +43,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             MelCloudSensor(mel_device, definition, hass.config.units)
             for definition in SENSORS
             for mel_device in mel_devices
+            if isinstance(mel_device.device, AtaDevice)
         ],
         True,
     )
@@ -51,7 +52,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class MelCloudSensor(Entity):
     """Representation of a Sensor."""
 
-    def __init__(self, device: Device, definition, units: UnitSystem, name=None):
+    def __init__(self, device: AtaDevice, definition, units: UnitSystem, name=None):
         """Initialize the sensor."""
         self._api = device
         if name is None:

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -19,9 +19,7 @@ SENSORS = [
     {
         ATTR_MEASUREMENT: "Inside Temperature",
         ATTR_ICON: "mdi:thermometer",
-        ATTR_UNIT_FN: lambda x: TEMP_UNIT_LOOKUP.get(
-            x.device.temp_unit, TEMP_CELSIUS
-        ),
+        ATTR_UNIT_FN: lambda x: TEMP_UNIT_LOOKUP.get(x.device.temp_unit, TEMP_CELSIUS),
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_VALUE_FN: lambda x: x.device.temperature,
     },

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -9,28 +9,25 @@ from homeassistant.util.unit_system import UnitSystem
 
 from .const import DOMAIN, TEMP_UNIT_LOOKUP
 
-ATTR_MEASUREMENT = "measurement"
 ATTR_ICON = "icon"
 ATTR_UNIT_FN = "unit_fn"
 ATTR_DEVICE_CLASS = "device_class"
 ATTR_VALUE_FN = "value_fn"
 
-SENSORS = [
-    {
-        ATTR_MEASUREMENT: "Room Temperature",
+SENSORS = {
+    "Room Temperature": {
         ATTR_ICON: "mdi:thermometer",
         ATTR_UNIT_FN: lambda x: TEMP_UNIT_LOOKUP.get(x.device.temp_unit, TEMP_CELSIUS),
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_VALUE_FN: lambda x: x.device.room_temperature,
     },
-    {
-        ATTR_MEASUREMENT: "Energy",
+    "Energy": {
         ATTR_ICON: "mdi:factory",
         ATTR_UNIT_FN: lambda x: "kWh",
         ATTR_DEVICE_CLASS: None,
         ATTR_VALUE_FN: lambda x: x.device.total_energy_consumed,
     },
-]
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,8 +37,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     mel_devices = hass.data[DOMAIN].get(entry.entry_id)
     async_add_entities(
         [
-            MelCloudSensor(mel_device, definition, hass.config.units)
-            for definition in SENSORS
+            MelCloudSensor(mel_device, measurement, definition, hass.config.units)
+            for measurement, definition in SENSORS.items()
             for mel_device in mel_devices[DEVICE_TYPE_ATA]
         ],
         True,
@@ -51,20 +48,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class MelCloudSensor(Entity):
     """Representation of a Sensor."""
 
-    def __init__(self, device: AtaDevice, definition, units: UnitSystem, name=None):
+    def __init__(self, device: AtaDevice, measurement, definition, units: UnitSystem):
         """Initialize the sensor."""
         self._api = device
-        if name is None:
-            self._name_slug = device.name
-        else:
-            self._name_slug = name
-
+        self._name_slug = device.name
+        self._measurement = measurement
         self._def = definition
 
     @property
     def unique_id(self):
         """Return a unique ID."""
-        normalized = self._def[ATTR_MEASUREMENT].lower().replace(" ", "_")
+        normalized = self._measurement.lower().replace(" ", "_")
         return f"{self._api.device.serial}-{self._api.device.mac}-{normalized}"
 
     @property
@@ -75,7 +69,7 @@ class MelCloudSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{self._name_slug} {self._def[ATTR_MEASUREMENT]}"
+        return f"{self._name_slug} {self._measurement}"
 
     @property
     def state(self):

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -1,7 +1,7 @@
 """Support for MelCloud device sensors."""
 import logging
 
-from pymelcloud import AtaDevice
+from pymelcloud import DEVICE_TYPE_ATA, AtaDevice
 
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
@@ -42,8 +42,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         [
             MelCloudSensor(mel_device, definition, hass.config.units)
             for definition in SENSORS
-            for mel_device in mel_devices
-            if isinstance(mel_device.device, AtaDevice)
+            for mel_device in mel_devices[DEVICE_TYPE_ATA]
         ],
         True,
     )

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -20,17 +20,17 @@ SENSORS = [
         ATTR_MEASUREMENT: "Inside Temperature",
         ATTR_ICON: "mdi:thermometer",
         ATTR_UNIT_FN: lambda x: TEMP_UNIT_LOOKUP.get(
-            x._api.device.temp_unit, TEMP_CELSIUS
+            x.device.temp_unit, TEMP_CELSIUS
         ),
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
-        ATTR_VALUE_FN: lambda x: x._api.device.temperature,
+        ATTR_VALUE_FN: lambda x: x.device.temperature,
     },
     {
         ATTR_MEASUREMENT: "Energy",
         ATTR_ICON: "mdi:factory",
         ATTR_UNIT_FN: lambda x: "kWh",
         ATTR_DEVICE_CLASS: None,
-        ATTR_VALUE_FN: lambda x: x._api.device.total_energy_consumed,
+        ATTR_VALUE_FN: lambda x: x.device.total_energy_consumed,
     },
 ]
 
@@ -82,12 +82,12 @@ class MelCloudSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._def[ATTR_VALUE_FN](self)
+        return self._def[ATTR_VALUE_FN](self._api)
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return self._def[ATTR_UNIT_FN](self)
+        return self._def[ATTR_UNIT_FN](self._api)
 
     @property
     def device_class(self):

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -1,0 +1,111 @@
+"""Support for MelCloud device sensors."""
+import logging
+
+from pymelcloud import Device
+
+from homeassistant.const import (
+    DEVICE_CLASS_TEMPERATURE,
+    TEMP_CELSIUS,
+)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util.unit_system import UnitSystem
+
+from .const import (
+    DOMAIN,
+    TEMP_UNIT_LOOKUP,
+)
+
+
+ATTR_MEASUREMENT = "measurement"
+ATTR_ICON = "icon"
+ATTR_UNIT_FN = "unit_fn"
+ATTR_DEVICE_CLASS = "device_class"
+ATTR_VALUE_FN = "value_fn"
+
+SENSORS = [
+    {
+        ATTR_MEASUREMENT: "Inside Temperature",
+        ATTR_ICON: "mdi:thermometer",
+        ATTR_UNIT_FN: lambda x: TEMP_UNIT_LOOKUP.get(
+            x._api.device.temp_unit, TEMP_CELSIUS
+        ),
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        ATTR_VALUE_FN: lambda x: x._api.device.temperature,
+    },
+    {
+        ATTR_MEASUREMENT: "Energy",
+        ATTR_ICON: "mdi:factory",
+        ATTR_UNIT_FN: lambda x: "kWh",
+        ATTR_DEVICE_CLASS: None,
+        ATTR_VALUE_FN: lambda x: x._api.device.total_energy_consumed,
+    },
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up MELCloud device sensors based on config_entry."""
+    mel_devices = hass.data[DOMAIN].get(entry.entry_id)
+    async_add_entities(
+        [
+            MelCloudSensor(mel_device, definition, hass.config.units)
+            for definition in SENSORS
+            for mel_device in mel_devices
+        ],
+        True,
+    )
+
+
+class MelCloudSensor(Entity):
+    """Representation of a Sensor."""
+
+    def __init__(self, device: Device, definition, units: UnitSystem, name=None):
+        """Initialize the sensor."""
+        self._api = device
+        if name is None:
+            self._name_slug = device.name
+        else:
+            self._name_slug = name
+
+        self._def = definition
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        normalized = self._def[ATTR_MEASUREMENT].lower().replace(" ", "_")
+        return f"{self._api.device.serial}-{self._api.device.mac}-{normalized}"
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._def[ATTR_ICON]
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self._name_slug} {self._def[ATTR_MEASUREMENT]}"
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._def[ATTR_VALUE_FN](self)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._def[ATTR_UNIT_FN](self)
+
+    @property
+    def device_class(self):
+        """Return device class."""
+        return self._def[ATTR_DEVICE_CLASS]
+
+    async def async_update(self):
+        """Retrieve latest state."""
+        await self._api.async_update()
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return self._api.device_info

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -3,18 +3,11 @@ import logging
 
 from pymelcloud import Device
 
-from homeassistant.const import (
-    DEVICE_CLASS_TEMPERATURE,
-    TEMP_CELSIUS,
-)
+from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.unit_system import UnitSystem
 
-from .const import (
-    DOMAIN,
-    TEMP_UNIT_LOOKUP,
-)
-
+from .const import DOMAIN, TEMP_UNIT_LOOKUP
 
 ATTR_MEASUREMENT = "measurement"
 ATTR_ICON = "icon"

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -9,19 +9,22 @@ from homeassistant.util.unit_system import UnitSystem
 
 from .const import DOMAIN, TEMP_UNIT_LOOKUP
 
+ATTR_MEASUREMENT_NAME = "measurement_name"
 ATTR_ICON = "icon"
 ATTR_UNIT_FN = "unit_fn"
 ATTR_DEVICE_CLASS = "device_class"
 ATTR_VALUE_FN = "value_fn"
 
 SENSORS = {
-    "Room Temperature": {
+    "room_temperature": {
+        ATTR_MEASUREMENT_NAME: "Room Temperature",
         ATTR_ICON: "mdi:thermometer",
         ATTR_UNIT_FN: lambda x: TEMP_UNIT_LOOKUP.get(x.device.temp_unit, TEMP_CELSIUS),
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_VALUE_FN: lambda x: x.device.room_temperature,
     },
-    "Energy": {
+    "energy": {
+        ATTR_MEASUREMENT_NAME: "Energy",
         ATTR_ICON: "mdi:factory",
         ATTR_UNIT_FN: lambda x: "kWh",
         ATTR_DEVICE_CLASS: None,
@@ -58,8 +61,7 @@ class MelCloudSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        normalized = self._measurement.lower().replace(" ", "_")
-        return f"{self._api.device.serial}-{self._api.device.mac}-{normalized}"
+        return f"{self._api.device.serial}-{self._api.device.mac}-{self._measurement}"
 
     @property
     def icon(self):
@@ -69,7 +71,7 @@ class MelCloudSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{self._name_slug} {self._measurement}"
+        return f"{self._name_slug} {self._def[ATTR_MEASUREMENT_NAME]}"
 
     @property
     def state(self):

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -6,7 +6,7 @@
         "title": "Connect to MELCloud",
         "description": "Connect using your MELCloud account.",
         "data": {
-          "email": "Email used to login to MELCloud.",
+          "username": "Email used to login to MELCloud.",
           "password": "MELCloud password."
         }
       }

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "title": "MELCloud",
+    "step": {
+      "user": {
+        "title": "Connect to MELCloud",
+        "description": "Connect using your MELCloud account.",
+        "data": {
+          "email": "Email used to login to MELCloud.",
+          "password": "MELCloud password."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "MELCloud integration already configured for {email}. Existing access token has been refreshed."
+    }
+  }
+}

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -17,7 +17,7 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "MELCloud integration already configured for {email}. Existing access token has been refreshed."
+      "already_configured": "MELCloud integration already configured for this email. Access token has been refreshed."
     }
   }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -54,6 +54,7 @@ FLOWS = [
     "logi_circle",
     "luftdaten",
     "mailgun",
+    "melcloud",
     "met",
     "meteo_france",
     "mikrotik",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1355,7 +1355,7 @@ pymailgunner==1.4
 pymediaroom==0.6.4
 
 # homeassistant.components.melcloud
-pymelcloud==0.7.1
+pymelcloud==1.0.1
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1355,7 +1355,7 @@ pymailgunner==1.4
 pymediaroom==0.6.4
 
 # homeassistant.components.melcloud
-pymelcloud==1.2.0
+pymelcloud==2.0.0
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1355,7 +1355,7 @@ pymailgunner==1.4
 pymediaroom==0.6.4
 
 # homeassistant.components.melcloud
-pymelcloud==0.7.0
+pymelcloud==0.7.1
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1355,7 +1355,7 @@ pymailgunner==1.4
 pymediaroom==0.6.4
 
 # homeassistant.components.melcloud
-pymelcloud==1.0.1
+pymelcloud==1.2.0
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1354,6 +1354,9 @@ pymailgunner==1.4
 # homeassistant.components.mediaroom
 pymediaroom==0.6.4
 
+# homeassistant.components.melcloud
+pymelcloud==0.7.0
+
 # homeassistant.components.somfy
 pymfy==0.7.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -485,7 +485,7 @@ pylitejet==0.1
 pymailgunner==1.4
 
 # homeassistant.components.melcloud
-pymelcloud==1.2.0
+pymelcloud==2.0.0
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -485,7 +485,7 @@ pylitejet==0.1
 pymailgunner==1.4
 
 # homeassistant.components.melcloud
-pymelcloud==0.7.0
+pymelcloud==0.7.1
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -485,7 +485,7 @@ pylitejet==0.1
 pymailgunner==1.4
 
 # homeassistant.components.melcloud
-pymelcloud==0.7.1
+pymelcloud==1.0.1
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -484,6 +484,9 @@ pylitejet==0.1
 # homeassistant.components.mailgun
 pymailgunner==1.4
 
+# homeassistant.components.melcloud
+pymelcloud==0.7.0
+
 # homeassistant.components.somfy
 pymfy==0.7.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -485,7 +485,7 @@ pylitejet==0.1
 pymailgunner==1.4
 
 # homeassistant.components.melcloud
-pymelcloud==1.0.1
+pymelcloud==1.2.0
 
 # homeassistant.components.somfy
 pymfy==0.7.1

--- a/tests/components/melcloud/__init__.py
+++ b/tests/components/melcloud/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the MELCloud integration."""

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -67,11 +67,7 @@ async def test_form(hass, mock_login, mock_get_devices):
 
 @pytest.mark.parametrize(
     "error,reason",
-    [
-        (ClientError(), "cannot_connect"),
-        (asyncio.TimeoutError(), "cannot_connect"),
-        (Exception(), "unknown"),
-    ],
+    [(ClientError(), "cannot_connect"), (asyncio.TimeoutError(), "cannot_connect")],
 )
 async def test_form_errors(hass, mock_login, mock_get_devices, error, reason):
     """Test we handle cannot connect error."""

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -1,0 +1,171 @@
+"""Test the MELCloud config flow."""
+from aiohttp import ClientError, ClientResponseError
+import asyncio
+from asynctest import patch as async_patch
+from unittest.mock import PropertyMock
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.melcloud import config_flow
+from homeassistant.components.melcloud.const import DOMAIN
+
+from tests.common import mock_coro
+
+
+def init_config_flow(hass):
+    """Init flow."""
+    flow = config_flow.FlowHandler()
+    flow.hass = hass
+    return flow
+
+
+@pytest.fixture
+def mock_login():
+    """Mock Client in pymelcloud."""
+    with async_patch("pymelcloud.Client") as mock, async_patch(
+        "pymelcloud.login"
+    ) as login_mock:
+        type(mock()).token = PropertyMock(return_value="test-token")
+        mock().update_confs.return_value = mock_coro()
+        mock().get_devices.return_value = mock_coro([])
+
+        login_mock.return_value = mock_coro(mock())
+        yield login_mock
+
+
+@pytest.fixture
+def mock_request_info():
+    """Mock RequestInfo to create ClientResposenErrors."""
+    with async_patch("aiohttp.RequestInfo") as mock_ri:
+        mock_ri.return_value.real_url.return_value = ""
+        yield mock_ri
+
+
+async def test_form(hass, mock_login):
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with async_patch(
+        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, async_patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"email": "test-email@test-domain.com", "password": "test-password"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "test-email@test-domain.com"
+    assert result2["data"] == {
+        "email": "test-email@test-domain.com",
+        "token": "test-token",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("error", [(ClientError()), (asyncio.TimeoutError())])
+async def test_form_errors(hass, mock_login, error):
+    """Test we handle cannot connect error."""
+    mock_login.return_value = mock_coro(exception=error)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with async_patch(
+        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
+    ), async_patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=mock_coro(True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"email": "test-email@test-domain.com", "password": "test-password"},
+        )
+
+    assert len(mock_login.mock_calls) == 1
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "cannot_connect"
+
+
+@pytest.mark.parametrize(
+    "error,message",
+    [(401, "invalid_auth"), (403, "invalid_auth"), (500, "cannot_connect")],
+)
+async def test_form_response_errors(
+    hass, mock_login, mock_request_info, error, message
+):
+    """Test we handle response errors."""
+    mock_login.return_value = mock_coro(
+        exception=ClientResponseError(mock_request_info(), (), status=error),
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with async_patch(
+        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
+    ), async_patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=mock_coro(True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"email": "test-email@test-domain.com", "password": "test-password"},
+        )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == message
+
+
+async def test_token_refresh(hass, mock_login):
+    """Re-configuration with existing email should refresh token."""
+    await hass.config_entries.async_add(
+        config_entries.ConfigEntry(
+            1,
+            DOMAIN,
+            "",
+            {"email": "test-email@test-domain.com", "token": "test-original-token"},
+            config_entries.SOURCE_USER,
+            config_entries.CONN_CLASS_CLOUD_POLL,
+            {},
+        )
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with async_patch(
+        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
+    ) as mock_setup, async_patch(
+        "homeassistant.components.melcloud.async_setup_entry",
+        return_value=mock_coro(True),
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"email": "test-email@test-domain.com", "password": "test-password"},
+        )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "already_configured"
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 0
+    assert len(mock_setup_entry.mock_calls) == 0
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    entry = entries[0]
+    assert entry.data["email"] == "test-email@test-domain.com"
+    assert entry.data["token"] == "test-token"

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -3,6 +3,7 @@ import asyncio
 
 from aiohttp import ClientError, ClientResponseError
 from asynctest import patch as async_patch
+import pymelcloud
 import pytest
 
 from homeassistant import config_entries
@@ -23,7 +24,9 @@ def mock_login():
 def mock_get_devices():
     """Mock pymelcloud get_devices."""
     with async_patch("pymelcloud.get_devices") as mock:
-        mock.return_value = mock_coro([])
+        mock.return_value = mock_coro(
+            {pymelcloud.DEVICE_TYPE_ATA: [], pymelcloud.DEVICE_TYPE_ATW: []}
+        )
         yield mock
 
 

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -54,13 +54,13 @@ async def test_form(hass, mock_login, mock_get_devices):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"email": "test-email@test-domain.com", "password": "test-password"},
+            {"username": "test-email@test-domain.com", "password": "test-password"},
         )
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-email@test-domain.com"
     assert result2["data"] == {
-        "email": "test-email@test-domain.com",
+        "username": "test-email@test-domain.com",
         "token": "test-token",
     }
     await hass.async_block_till_done()
@@ -88,7 +88,7 @@ async def test_form_errors(hass, mock_login, mock_get_devices, error, reason):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"email": "test-email@test-domain.com", "password": "test-password"},
+            {"username": "test-email@test-domain.com", "password": "test-password"},
         )
 
     assert len(mock_login.mock_calls) == 1
@@ -120,20 +120,11 @@ async def test_form_response_errors(
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"email": "test-email@test-domain.com", "password": "test-password"},
+            {"username": "test-email@test-domain.com", "password": "test-password"},
         )
 
     assert result2["type"] == "abort"
     assert result2["reason"] == message
-
-
-async def test_failed_import_form(hass, mock_login, mock_get_devices):
-    """Test we get the form if imported without token."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data={},
-    )
-    assert result["type"] == "form"
-    assert result["errors"] is None
 
 
 async def test_import_with_token(hass, mock_login, mock_get_devices):
@@ -147,13 +138,13 @@ async def test_import_with_token(hass, mock_login, mock_get_devices):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={"email": "test-email@test-domain.com", "token": "test-token"},
+            data={"username": "test-email@test-domain.com", "token": "test-token"},
         )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "test-email@test-domain.com"
     assert result["data"] == {
-        "email": "test-email@test-domain.com",
+        "username": "test-email@test-domain.com",
         "token": "test-token",
     }
     await hass.async_block_till_done()
@@ -162,13 +153,13 @@ async def test_import_with_token(hass, mock_login, mock_get_devices):
 
 
 async def test_token_refresh(hass, mock_login, mock_get_devices):
-    """Re-configuration with existing email should refresh token."""
+    """Re-configuration with existing username should refresh token."""
     await hass.config_entries.async_add(
         config_entries.ConfigEntry(
             1,
             DOMAIN,
             "",
-            {"email": "test-email@test-domain.com", "token": "test-original-token"},
+            {"username": "test-email@test-domain.com", "token": "test-original-token"},
             config_entries.SOURCE_USER,
             config_entries.CONN_CLASS_CLOUD_POLL,
             {},
@@ -187,7 +178,7 @@ async def test_token_refresh(hass, mock_login, mock_get_devices):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"email": "test-email@test-domain.com", "password": "test-password"},
+            {"username": "test-email@test-domain.com", "password": "test-password"},
         )
 
     assert result2["type"] == "abort"
@@ -200,5 +191,5 @@ async def test_token_refresh(hass, mock_login, mock_get_devices):
     assert len(entries) == 1
 
     entry = entries[0]
-    assert entry.data["email"] == "test-email@test-domain.com"
+    assert entry.data["username"] == "test-email@test-domain.com"
     assert entry.data["token"] == "test-token"

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the MELCloud config flow."""
-from aiohttp import ClientError, ClientResponseError
 import asyncio
-from asynctest import patch as async_patch
 from unittest.mock import PropertyMock
 
+from aiohttp import ClientError, ClientResponseError
+from asynctest import patch as async_patch
 import pytest
 
 from homeassistant import config_entries

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -133,16 +133,15 @@ async def test_import_with_token(hass, mock_login, mock_get_devices):
 
 async def test_token_refresh(hass, mock_login, mock_get_devices):
     """Re-configuration with existing username should refresh token."""
-    await hass.config_entries.async_add(
-        MockConfigEntry(
-            domain=DOMAIN,
-            data={
-                "username": "test-email@test-domain.com",
-                "token": "test-original-token",
-            },
-            unique_id="test-email@test-domain.com",
-        )
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "username": "test-email@test-domain.com",
+            "token": "test-original-token",
+        },
+        unique_id="test-email@test-domain.com",
     )
+    mock_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.melcloud.async_setup", return_value=True

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -2,38 +2,39 @@
 import asyncio
 
 from aiohttp import ClientError, ClientResponseError
-from asynctest import patch as async_patch
+from asynctest import patch
 import pymelcloud
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.melcloud.const import DOMAIN
 
-from tests.common import mock_coro
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
 def mock_login():
     """Mock pymelcloud login."""
-    with async_patch("pymelcloud.login") as mock:
-        mock.return_value = mock_coro("test-token")
+    with patch("pymelcloud.login") as mock:
+        mock.return_value = "test-token"
         yield mock
 
 
 @pytest.fixture
 def mock_get_devices():
     """Mock pymelcloud get_devices."""
-    with async_patch("pymelcloud.get_devices") as mock:
-        mock.return_value = mock_coro(
-            {pymelcloud.DEVICE_TYPE_ATA: [], pymelcloud.DEVICE_TYPE_ATW: []}
-        )
+    with patch("pymelcloud.get_devices") as mock:
+        mock.return_value = {
+            pymelcloud.DEVICE_TYPE_ATA: [],
+            pymelcloud.DEVICE_TYPE_ATW: [],
+        }
         yield mock
 
 
 @pytest.fixture
 def mock_request_info():
-    """Mock RequestInfo to create ClientResposenErrors."""
-    with async_patch("aiohttp.RequestInfo") as mock_ri:
+    """Mock RequestInfo to create ClientResponseErrors."""
+    with patch("aiohttp.RequestInfo") as mock_ri:
         mock_ri.return_value.real_url.return_value = ""
         yield mock_ri
 
@@ -46,11 +47,10 @@ async def test_form(hass, mock_login, mock_get_devices):
     assert result["type"] == "form"
     assert result["errors"] is None
 
-    with async_patch(
-        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
-    ) as mock_setup, async_patch(
-        "homeassistant.components.melcloud.async_setup_entry",
-        return_value=mock_coro(True),
+    with patch(
+        "homeassistant.components.melcloud.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.melcloud.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -74,26 +74,17 @@ async def test_form(hass, mock_login, mock_get_devices):
 )
 async def test_form_errors(hass, mock_login, mock_get_devices, error, reason):
     """Test we handle cannot connect error."""
-    mock_login.return_value = mock_coro(exception=error)
+    mock_login.side_effect = error
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={"username": "test-email@test-domain.com", "password": "test-password"},
     )
 
-    with async_patch(
-        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
-    ), async_patch(
-        "homeassistant.components.melcloud.async_setup_entry",
-        return_value=mock_coro(True),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "test-email@test-domain.com", "password": "test-password"},
-        )
-
     assert len(mock_login.mock_calls) == 1
-    assert result2["type"] == "abort"
-    assert result2["reason"] == reason
+    assert result["type"] == "abort"
+    assert result["reason"] == reason
 
 
 @pytest.mark.parametrize(
@@ -104,36 +95,24 @@ async def test_form_response_errors(
     hass, mock_login, mock_get_devices, mock_request_info, error, message
 ):
     """Test we handle response errors."""
-    mock_login.return_value = mock_coro(
-        exception=ClientResponseError(mock_request_info(), (), status=error),
-    )
+    mock_login.side_effect = ClientResponseError(mock_request_info(), (), status=error)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={"username": "test-email@test-domain.com", "password": "test-password"},
     )
 
-    with async_patch(
-        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
-    ), async_patch(
-        "homeassistant.components.melcloud.async_setup_entry",
-        return_value=mock_coro(True),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "test-email@test-domain.com", "password": "test-password"},
-        )
-
-    assert result2["type"] == "abort"
-    assert result2["reason"] == message
+    assert result["type"] == "abort"
+    assert result["reason"] == message
 
 
 async def test_import_with_token(hass, mock_login, mock_get_devices):
     """Test successful import."""
-    with async_patch(
-        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
-    ) as mock_setup, async_patch(
-        "homeassistant.components.melcloud.async_setup_entry",
-        return_value=mock_coro(True),
+    with patch(
+        "homeassistant.components.melcloud.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.melcloud.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -155,34 +134,32 @@ async def test_import_with_token(hass, mock_login, mock_get_devices):
 async def test_token_refresh(hass, mock_login, mock_get_devices):
     """Re-configuration with existing username should refresh token."""
     await hass.config_entries.async_add(
-        config_entries.ConfigEntry(
-            1,
-            DOMAIN,
-            "",
-            {"username": "test-email@test-domain.com", "token": "test-original-token"},
-            config_entries.SOURCE_USER,
-            config_entries.CONN_CLASS_CLOUD_POLL,
-            {},
+        MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "username": "test-email@test-domain.com",
+                "token": "test-original-token",
+            },
+            unique_id="test-email@test-domain.com",
         )
     )
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with async_patch(
-        "homeassistant.components.melcloud.async_setup", return_value=mock_coro(True)
-    ) as mock_setup, async_patch(
-        "homeassistant.components.melcloud.async_setup_entry",
-        return_value=mock_coro(True),
+    with patch(
+        "homeassistant.components.melcloud.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.melcloud.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "test-email@test-domain.com", "password": "test-password"},
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                "username": "test-email@test-domain.com",
+                "password": "test-password",
+            },
         )
 
-    assert result2["type"] == "abort"
-    assert result2["reason"] == "already_configured"
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 0


### PR DESCRIPTION
## Description:

*This stuff is not supported nor in any way affiliated with Mitsubishi Electric.*

Provides climate and sensor platforms for Mitsubishi Electric heat pumps connected to MELCloud service. Multiple platforms on one go is not the best option, but it does not make sense to remove them and commit them later either. This thing started as a `custom_component`.

Email and access token are stored to the ConfigEntry. The token can be updated by adding the integration again with the same email address. The config flow is aborted and the update is performed on the background. This is a bit unorthodox, but at least I like it better than storing the plain-text password.

## Additional information

Link to documentation pull request: home-assistant/home-assistant.io#11930

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
