### PR TITLE
Bump env_canada to 0.0.34

### DIFF
--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -2,7 +2,7 @@
   "domain": "environment_canada",
   "name": "Environment Canada",
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
-  "requirements": ["env_canada==0.0.31"],
+  "requirements": ["env_canada==0.0.34"],
   "dependencies": [],
   "codeowners": ["@michaeldavie"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -486,7 +486,7 @@ enocean==0.50
 enturclient==0.2.1
 
 # homeassistant.components.environment_canada
-env_canada==0.0.31
+env_canada==0.0.34
 
 # homeassistant.components.envirophat
 # envirophat==0.0.6


### PR DESCRIPTION
## Breaking Change:

Replaces radar station `XMB` with `CASMB` to keep up with data source changes.

## Description:

List of radar sites in underlying library updated.

**Related issue (if applicable): Reported by user at https://community.home-assistant.io/t/support-for-environment-canada-platforms/126241/153

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: environment_canada
    station: CASMB
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
