### PR TITLE
Rewrite of Spotify integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -662,7 +662,6 @@ omit =
     homeassistant/components/speedtestdotnet/*
     homeassistant/components/spider/*
     homeassistant/components/spotcrime/sensor.py
-    homeassistant/components/spotify/media_player.py
     homeassistant/components/squeezebox/*
     homeassistant/components/starline/*
     homeassistant/components/starlingbank/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -662,6 +662,8 @@ omit =
     homeassistant/components/speedtestdotnet/*
     homeassistant/components/spider/*
     homeassistant/components/spotcrime/sensor.py
+    homeassistant/components/spotify/__init__.py
+    homeassistant/components/spotify/media_player.py
     homeassistant/components/squeezebox/*
     homeassistant/components/starline/*
     homeassistant/components/starlingbank/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -315,6 +315,7 @@ homeassistant/components/songpal/* @rytilahti
 homeassistant/components/spaceapi/* @fabaff
 homeassistant/components/speedtestdotnet/* @rohankapoorcom
 homeassistant/components/spider/* @peternijssen
+homeassistant/components/spotify/* @frenck
 homeassistant/components/sql/* @dgomes
 homeassistant/components/starline/* @anonym-tsk
 homeassistant/components/statistics/* @fabaff

--- a/homeassistant/components/spotify/.translations/en.json
+++ b/homeassistant/components/spotify/.translations/en.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "step": {
+      "pick_implementation": {
+        "title": "Pick Authentication Method"
+      }
+    },
+    "abort": {
+      "already_setup": "You can only configure one Spotify account.",
+      "authorize_url_timeout": "Timeout generating authorize url.",
+      "missing_configuration": "The Spotify integration is not configured. Please follow the documentation."
+    },
+    "create_entry": {
+      "default": "Successfully authenticated with Spotify."
+    },
+    "title": "Spotify"
+  }
+}

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -67,14 +67,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     spotify = Spotify(auth=session.token["access_token"])
 
     try:
-        me = await hass.async_add_executor_job(spotify.me)
+        current_user = await hass.async_add_executor_job(spotify.me)
     except SpotifyException:
         raise ConfigEntryNotReady
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_SPOTIFY_CLIENT: spotify,
-        DATA_SPOTIFY_ME: me,
+        DATA_SPOTIFY_ME: current_user,
         DATA_SPOTIFY_SESSION: session,
     }
 

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -5,6 +5,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.spotify import config_flow
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_CREDENTIALS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -15,8 +16,8 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
-                vol.Optional(CONF_CLIENT_ID): cv.string,
-                vol.Optional(CONF_CLIENT_SECRET): cv.string,
+                vol.Inclusive(CONF_CLIENT_ID, ATTR_CREDENTIALS): cv.string,
+                vol.Inclusive(CONF_CLIENT_SECRET, ATTR_CREDENTIALS): cv.string,
                 vol.Optional(CONF_ALIASES, default={}): {cv.string: cv.string},
             }
         )
@@ -33,7 +34,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][CONF_ALIASES] = config[DOMAIN].get(CONF_ALIASES)
 
-    if all(conf in config[DOMAIN] for conf in (CONF_CLIENT_ID, CONF_CLIENT_SECRET)):
+    if CONF_CLIENT_ID in config[DOMAIN]:
         config_flow.SpotifyFlowHandler.async_register_implementation(
             hass,
             config_entry_oauth2_flow.LocalOAuth2Implementation(

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -18,7 +18,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Inclusive(CONF_CLIENT_ID, ATTR_CREDENTIALS): cv.string,
                 vol.Inclusive(CONF_CLIENT_SECRET, ATTR_CREDENTIALS): cv.string,
-                vol.Optional(CONF_ALIASES, default={}): {cv.string: cv.string},
+                vol.Optional(CONF_ALIASES): {cv.string: cv.string},
             }
         )
     },
@@ -32,7 +32,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return True
 
     hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][CONF_ALIASES] = config[DOMAIN].get(CONF_ALIASES)
+
+    if CONF_ALIASES in config[DOMAIN]:
+        hass.data[DOMAIN][CONF_ALIASES] = config[DOMAIN][CONF_ALIASES]
 
     if CONF_CLIENT_ID in config[DOMAIN]:
         config_flow.SpotifyFlowHandler.async_register_implementation(

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_ALIASES, CONF_CLIENT_ID, CONF_CLIENT_SECRET, DOMAIN
+from .const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, DOMAIN
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -18,7 +18,6 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Inclusive(CONF_CLIENT_ID, ATTR_CREDENTIALS): cv.string,
                 vol.Inclusive(CONF_CLIENT_SECRET, ATTR_CREDENTIALS): cv.string,
-                vol.Optional(CONF_ALIASES): {cv.string: cv.string},
             }
         )
     },
@@ -30,11 +29,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Spotify integration."""
     if DOMAIN not in config:
         return True
-
-    hass.data[DOMAIN] = {}
-
-    if CONF_ALIASES in config[DOMAIN]:
-        hass.data[DOMAIN][CONF_ALIASES] = config[DOMAIN][CONF_ALIASES]
 
     if CONF_CLIENT_ID in config[DOMAIN]:
         config_flow.SpotifyFlowHandler.async_register_implementation(

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -1,1 +1,70 @@
-"""The spotify component."""
+"""The spotify integration."""
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.components.spotify import config_flow
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from .const import CONF_ALIASES, CONF_CLIENT_ID, CONF_CLIENT_SECRET, DOMAIN
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(CONF_CLIENT_ID): cv.string,
+                vol.Optional(CONF_CLIENT_SECRET): cv.string,
+                vol.Optional(CONF_ALIASES, default={}): {cv.string: cv.string},
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Spotify integration."""
+    if DOMAIN not in config:
+        return True
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][CONF_ALIASES] = config[DOMAIN].get(CONF_ALIASES)
+
+    if all(conf in config[DOMAIN] for conf in (CONF_CLIENT_ID, CONF_CLIENT_SECRET)):
+        config_flow.SpotifyFlowHandler.async_register_implementation(
+            hass,
+            config_entry_oauth2_flow.LocalOAuth2Implementation(
+                hass,
+                DOMAIN,
+                config[DOMAIN][CONF_CLIENT_ID],
+                config[DOMAIN][CONF_CLIENT_SECRET],
+                "https://accounts.spotify.com/authorize",
+                "https://accounts.spotify.com/api/token",
+            ),
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Spotify from a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, MEDIA_PLAYER_DOMAIN)
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Spotify config entry."""
+    # Unload entities for this entry/device.
+    await hass.config_entries.async_forward_entry_unload(entry, MEDIA_PLAYER_DOMAIN)
+
+    # Cleanup
+    del hass.data[DOMAIN][entry.entry_id]
+    if not hass.data[DOMAIN]:
+        del hass.data[DOMAIN]
+
+    return True

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -51,6 +51,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Spotify from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, MEDIA_PLAYER_DOMAIN)
     )

--- a/homeassistant/components/spotify/config_flow.py
+++ b/homeassistant/components/spotify/config_flow.py
@@ -32,7 +32,7 @@ class SpotifyFlowHandler(
             "user-modify-playback-state",
             # Needed in order to read available devices
             "user-read-playback-state",
-            # Needed to determin if the user has Spotify Premium
+            # Needed to determine if the user has Spotify Premium
             "user-read-private",
         ]
         return {"scope": ",".join(scopes)}

--- a/homeassistant/components/spotify/config_flow.py
+++ b/homeassistant/components/spotify/config_flow.py
@@ -1,0 +1,53 @@
+"""Config flow for Spotify."""
+import logging
+
+from spotipy import Spotify
+
+from homeassistant import config_entries
+from homeassistant.helpers import config_entry_oauth2_flow
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SpotifyFlowHandler(
+    config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
+):
+    """Config flow to handle Spotify OAuth2 authentication."""
+
+    DOMAIN = DOMAIN
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Return logger."""
+        return logging.getLogger(__name__)
+
+    @property
+    def extra_authorize_data(self) -> dict:
+        """Extra data that needs to be appended to the authorize url."""
+        scopes = [
+            # Needed to be able to control playback
+            "user-modify-playback-state",
+            # Needed in order to read available devices
+            "user-read-playback-state",
+            # Needed to determin if the user has Spotify Premium
+            "user-read-private",
+        ]
+        return {"scope": ",".join(scopes)}
+
+    async def async_oauth_create_entry(self, data: dict) -> dict:
+        """Create an entry for Spotify."""
+        spotify = Spotify(auth=data["token"]["access_token"])
+        current_user = await self.hass.async_add_executor_job(spotify.current_user)
+
+        name = data["id"] = current_user["id"]
+
+        if current_user.get("display_name"):
+            name = current_user["display_name"]
+        data["name"] = name
+
+        await self.async_set_unique_id(current_user["id"])
+
+        return self.async_create_entry(title=name, data=data)

--- a/homeassistant/components/spotify/config_flow.py
+++ b/homeassistant/components/spotify/config_flow.py
@@ -40,7 +40,11 @@ class SpotifyFlowHandler(
     async def async_oauth_create_entry(self, data: dict) -> dict:
         """Create an entry for Spotify."""
         spotify = Spotify(auth=data["token"]["access_token"])
-        current_user = await self.hass.async_add_executor_job(spotify.current_user)
+
+        try:
+            current_user = await self.hass.async_add_executor_job(spotify.current_user)
+        except Exception:  # pylint: disable=broad-except
+            return self.async_abort(reason="connection_error")
 
         name = data["id"] = current_user["id"]
 

--- a/homeassistant/components/spotify/const.py
+++ b/homeassistant/components/spotify/const.py
@@ -2,6 +2,5 @@
 
 DOMAIN = "spotify"
 
-CONF_ALIASES = "aliases"
 CONF_CLIENT_ID = "client_id"
 CONF_CLIENT_SECRET = "client_secret"

--- a/homeassistant/components/spotify/const.py
+++ b/homeassistant/components/spotify/const.py
@@ -1,0 +1,7 @@
+"""Define constants for the Spotify integration."""
+
+DOMAIN = "spotify"
+
+CONF_ALIASES = "aliases"
+CONF_CLIENT_ID = "client_id"
+CONF_CLIENT_SECRET = "client_secret"

--- a/homeassistant/components/spotify/const.py
+++ b/homeassistant/components/spotify/const.py
@@ -4,3 +4,7 @@ DOMAIN = "spotify"
 
 CONF_CLIENT_ID = "client_id"
 CONF_CLIENT_SECRET = "client_secret"
+
+DATA_SPOTIFY_CLIENT = "spotify_client"
+DATA_SPOTIFY_ME = "spotify_me"
+DATA_SPOTIFY_SESSION = "spotify_session"

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -2,7 +2,9 @@
   "domain": "spotify",
   "name": "Spotify",
   "documentation": "https://www.home-assistant.io/integrations/spotify",
-  "requirements": ["spotipy-homeassistant==2.4.4.dev1"],
+  "requirements": ["spotipy==2.5.0"],
+  "zeroconf": ["_spotify-connect._tcp.local."],
   "dependencies": ["configurator", "http"],
-  "codeowners": []
+  "codeowners": ["@frenck"],
+  "config_flow": true
 }

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -6,5 +6,6 @@
   "zeroconf": ["_spotify-connect._tcp.local."],
   "dependencies": ["http"],
   "codeowners": ["@frenck"],
-  "config_flow": true
+  "config_flow": true,
+  "quality_scale": "silver"
 }

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -2,7 +2,7 @@
   "domain": "spotify",
   "name": "Spotify",
   "documentation": "https://www.home-assistant.io/integrations/spotify",
-  "requirements": ["spotipy==2.6.3"],
+  "requirements": ["spotipy==2.7.1"],
   "zeroconf": ["_spotify-connect._tcp.local."],
   "dependencies": ["http"],
   "codeowners": ["@frenck"],

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/spotify",
   "requirements": ["spotipy==2.5.0"],
   "zeroconf": ["_spotify-connect._tcp.local."],
-  "dependencies": ["configurator", "http"],
+  "dependencies": ["http"],
   "codeowners": ["@frenck"],
   "config_flow": true
 }

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -2,7 +2,7 @@
   "domain": "spotify",
   "name": "Spotify",
   "documentation": "https://www.home-assistant.io/integrations/spotify",
-  "requirements": ["spotipy==2.5.0"],
+  "requirements": ["spotipy==2.6.3"],
   "zeroconf": ["_spotify-connect._tcp.local."],
   "dependencies": ["http"],
   "codeowners": ["@frenck"],

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -305,10 +305,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         """Play media."""
         kwargs = {}
 
-        if not media_id.startswith("spotify:"):
-            _LOGGER.error("Media ID must be Spotify URI ('spotify:')")
-            return
-
         if media_type == MEDIA_TYPE_MUSIC:
             kwargs["uris"] = [media_id]
         elif media_type == MEDIA_TYPE_PLAYLIST:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -314,7 +314,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         """Return the media player features that are supported."""
         if self._user is not None and self._user["product"] == "premium":
             return SUPPORT_SPOTIFY
-        return None
+        return 0
 
     @property
     def media_content_type(self) -> str:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -311,8 +311,9 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         self._currently_playing = current or {}
 
         self._playlist = None
-        if current.get("context", {}).get("type") == MEDIA_TYPE_PLAYLIST:
+        context = self._currently_playing.get("context")
+        if context is not None and context["type"] == MEDIA_TYPE_PLAYLIST:
             self._playlist = self._spotify.playlist(current["context"]["uri"])
 
-        devices = self._spotify.devices()
-        self._devices = devices["devices"] if devices is not None else []
+        devices = self._spotify.devices() or {}
+        self._devices = devices.get("devices", [])

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -313,7 +313,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             self._me = self._spotify.me()
 
         current = self._spotify.current_playback()
-        self._currently_playing = current if current is not None else {}
+        self._currently_playing = current or {}
 
         self._playlist = None
         if current.get("context", {}).get("type") == MEDIA_TYPE_PLAYLIST:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -307,9 +307,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             run_coroutine_threadsafe(
                 self._session.async_ensure_token_valid(), self.hass.loop
             ).result()
-
             self._spotify = Spotify(auth=self._session.token["access_token"])
-            self._me = self._spotify.me()
 
         current = self._spotify.current_playback()
         self._currently_playing = current or {}

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -301,6 +301,9 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
 
     def update(self) -> None:
         """Update state and attributes."""
+        if not self.enabled:
+            return
+
         if not self._session.valid_token or self._spotify is None:
             run_coroutine_threadsafe(
                 self._session.async_ensure_token_valid(), self.hass.loop

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -229,17 +229,17 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         elif media_type == MEDIA_TYPE_PLAYLIST:
             kwargs["context_uri"] = media_id
         else:
-            _LOGGER.error("media type %s is not supported", media_type)
+            _LOGGER.error("Media type %s is not supported", media_type)
             return
         if not media_id.startswith("spotify:"):
-            _LOGGER.error("media id must be spotify uri")
+            _LOGGER.error("Media ID must be Spotify URI ('spotify:')")
             return
         self._player.start_playback(**kwargs)
 
     def play_playlist(self, media_id, random_song) -> None:
         """Play random music in a playlist."""
         if not media_id.startswith("spotify:"):
-            _LOGGER.error("media id must be spotify playlist uri")
+            _LOGGER.error("Media ID must be Spotify URI ('spotify:')")
             return
         kwargs = {"context_uri": media_id}
         if random_song:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -148,6 +148,8 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
     @property
     def media_content_type(self) -> Optional[str]:
         """Return the media type."""
+        if self._playlist is not None:
+            return MEDIA_TYPE_PLAYLIST
         return MEDIA_TYPE_MUSIC
 
     @property

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -336,6 +336,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         return {
             "identifiers": {(DOMAIN, self._id)},
             "manufacturer": "Spotify AB",
-            "model": f"Spotify {model}",
+            "model": f"Spotify {model}".rstrip(),
             "name": self._name,
         }

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -97,7 +97,7 @@ async def async_setup_entry(
         session,
         entry.data[CONF_ID],
         entry.data[CONF_NAME],
-        hass.data[DOMAIN][CONF_ALIASES],
+        hass.data[DOMAIN].get(CONF_ALIASES, {}),
     )
 
     async_add_entities([player], True)

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -7,11 +7,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 from aiohttp import ClientError
 from spotipy import Spotify, SpotifyException
-import voluptuous as vol
 
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
-    ATTR_MEDIA_CONTENT_ID,
     MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_PLAYLIST,
     SUPPORT_NEXT_TRACK,
@@ -33,23 +31,12 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.dt import utc_from_timestamp
 
 from .const import DATA_SPOTIFY_CLIENT, DATA_SPOTIFY_ME, DATA_SPOTIFY_SESSION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-SERVICE_PLAY_PLAYLIST = "play_playlist"
-ATTR_RANDOM_SONG = "random_song"
-
-PLAY_PLAYLIST_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_MEDIA_CONTENT_ID): cv.string,
-        vol.Optional(ATTR_RANDOM_SONG, default=False): cv.boolean,
-    }
-)
 
 ICON = "mdi:spotify"
 

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -149,8 +149,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
     @property
     def media_content_type(self) -> Optional[str]:
         """Return the media type."""
-        if self._playlist is not None:
-            return MEDIA_TYPE_PLAYLIST
         return MEDIA_TYPE_MUSIC
 
     @property

--- a/homeassistant/components/spotify/strings.json
+++ b/homeassistant/components/spotify/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "step": {
+      "pick_implementation": {
+        "title": "Pick Authentication Method"
+      }
+    },
+    "abort": {
+      "already_setup": "You can only configure one Spotify account.",
+      "authorize_url_timeout": "Timeout generating authorize url.",
+      "missing_configuration": "The Spotify integration is not configured. Please follow the documentation."
+    },
+    "create_entry": {
+      "default": "Successfully authenticated with Spotify."
+    },
+    "title": "Spotify"
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -78,6 +78,7 @@ FLOWS = [
     "soma",
     "somfy",
     "sonos",
+    "spotify",
     "starline",
     "tellduslive",
     "tesla",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -27,6 +27,9 @@ ZEROCONF = {
     "_printer._tcp.local.": [
         "brother"
     ],
+    "_spotify-connect._tcp.local.": [
+        "spotify"
+    ],
     "_viziocast._tcp.local.": [
         "vizio"
     ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1884,7 +1884,7 @@ spiderpy==1.3.1
 spotcrime==1.0.4
 
 # homeassistant.components.spotify
-spotipy-homeassistant==2.4.4.dev1
+spotipy==2.5.0
 
 # homeassistant.components.recorder
 # homeassistant.components.sql

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1884,7 +1884,7 @@ spiderpy==1.3.1
 spotcrime==1.0.4
 
 # homeassistant.components.spotify
-spotipy==2.6.3
+spotipy==2.7.1
 
 # homeassistant.components.recorder
 # homeassistant.components.sql

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1884,7 +1884,7 @@ spiderpy==1.3.1
 spotcrime==1.0.4
 
 # homeassistant.components.spotify
-spotipy==2.5.0
+spotipy==2.6.3
 
 # homeassistant.components.recorder
 # homeassistant.components.sql

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -606,7 +606,7 @@ somecomfort==0.5.2
 speak2mary==1.4.0
 
 # homeassistant.components.spotify
-spotipy==2.5.0
+spotipy==2.6.3
 
 # homeassistant.components.recorder
 # homeassistant.components.sql

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -605,6 +605,9 @@ somecomfort==0.5.2
 # homeassistant.components.marytts
 speak2mary==1.4.0
 
+# homeassistant.components.spotify
+spotipy==2.5.0
+
 # homeassistant.components.recorder
 # homeassistant.components.sql
 sqlalchemy==1.3.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -606,7 +606,7 @@ somecomfort==0.5.2
 speak2mary==1.4.0
 
 # homeassistant.components.spotify
-spotipy==2.6.3
+spotipy==2.7.1
 
 # homeassistant.components.recorder
 # homeassistant.components.sql

--- a/tests/components/spotify/__init__.py
+++ b/tests/components/spotify/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spotify integration."""

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -1,0 +1,139 @@
+"""Tests for the Spotify config flow."""
+from unittest.mock import patch
+
+from spotipy import SpotifyException
+
+from homeassistant import data_entry_flow, setup
+from homeassistant.components.spotify.const import (
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.helpers import config_entry_oauth2_flow
+
+from tests.common import MockConfigEntry
+
+
+async def test_abort_if_no_configuration(hass):
+    """Check flow aborts when no configuration is present."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "missing_configuration"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "missing_configuration"
+
+
+async def test_zeroconf_abort_if_existing_entry(hass):
+    """Check zeroconf flow aborts when an entry already exist."""
+    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_full_flow(hass, aiohttp_client, aioclient_mock):
+    """Check a full flow."""
+    assert await setup.async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {CONF_CLIENT_ID: "client", CONF_CLIENT_SECRET: "secret"},
+            "http": {"base_url": "https://example.com"},
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    # pylint: disable=protected-access
+    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["url"] == (
+        "https://accounts.spotify.com/authorize"
+        "?response_type=code&client_id=client"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}"
+        "&scope=user-modify-playback-state,user-read-playback-state,user-read-private"
+    )
+
+    client = await aiohttp_client(hass.http.app)
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        "https://accounts.spotify.com/api/token",
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch("homeassistant.components.spotify.config_flow.Spotify"):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["data"]["auth_implementation"] == DOMAIN
+    result["data"]["token"].pop("expires_at")
+    assert result["data"]["token"] == {
+        "refresh_token": "mock-refresh-token",
+        "access_token": "mock-access-token",
+        "type": "Bearer",
+        "expires_in": 60,
+    }
+
+
+async def test_abort_if_spotify_error(hass, aiohttp_client, aioclient_mock):
+    """Check Spotify errors causes flow to abort."""
+    await setup.async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {CONF_CLIENT_ID: "client", CONF_CLIENT_SECRET: "secret"},
+            "http": {"base_url": "https://example.com"},
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    # pylint: disable=protected-access
+    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
+    client = await aiohttp_client(hass.http.app)
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        "https://accounts.spotify.com/api/token",
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.spotify.config_flow.Spotify.current_user",
+        side_effect=SpotifyException(400, -1, "message"),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "connection_error"


### PR DESCRIPTION
## Breaking Change:

The Spotify platform has been rewritten to an integration. The configuration has been changed. Removing the current Spotify platform and setting up the integration from scratch is recommended.

The device aliases and the `spotify.play_playlist` service, have been removed. Be sure to remove calls to that service from your automations.

If you use the Spotify platform at this moment:

- Remove the current configuration from your `configuration.yaml` file.
- Remove the `.spotify-token-cache` file from your configuration directory. It is no longer used, however, it does contain security credentials.
- Follow the documentation on how to set up the new Spotify integration from scratch.

## Description:

I figured Spotify is probably something people use a lot. It works but could be better. A good excuse for me to play with OAuth2 in Home Assistant 😉

![2020-01-12 22 25 26](https://user-images.githubusercontent.com/195327/72258967-a9d5ec80-360f-11ea-826a-4ae58f567604.gif)

![image](https://user-images.githubusercontent.com/195327/72596440-4f3cd900-390c-11ea-9e3f-25ec16ec2fcc.png)


Changes:

- Rewrites platform to an integration
- Adds config flow
- Implements OAuth 2 helpers/flow
- Discovery of an active Spotify Connect on the network
- Uses the original (newer) Spotify package, instead of a fork.
- Removes the old configurator
- Support for Spotify Free & Open accounts
- Added SEEK capabilities (including current media position)
- Added support for the playlist title attribute
- Added support for track number attribute
- Removed device alias support
- Removed `spotify.play_playlist_service`, use `media_player.play_media` (using `media_content_type` = `playlist`) instead.

Still to work on:
  - [x] Write tests
    - [x] `config_flow` 🥇
    - ~~`__init__` 🥇~~
    - ~~`media_player` 🥇~~
  - [x] Resolution of architectural proposal home-assistant/architecture#338
  - [x] Raise PlatformNotReady if unable to connect during platform setup 🥈
  - [x] Handle being offline/unavailable correctly 🥈
  - [x] Set available property to False if appropriate 🥈
  - [x] Supports entities being disabled 🥇
  - [x] Remove some minor log spam
  - [x] Test to find out if we can make it useable for non-premium users somewhat
  - [x] General cleanup and prettify everything 😉
  - [x] Fix hassfest to know this flow is actual valid (#30732)
  - [x] Extend Breaking change description
  - [x] Update documentation

**Related issue (if applicable):** fixes #27139

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11858

## Example entry for `configuration.yaml` (if applicable):
```yaml
spotify:
  client_id: CLIENT_ID
  client_secret: CLIENT_SECRET
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
