### PR TITLE
Fix SynologyDSM sensor TypeError if network_sensors value is None

### DIFF
--- a/homeassistant/components/synologydsm/sensor.py
+++ b/homeassistant/components/synologydsm/sensor.py
@@ -231,6 +231,9 @@ class SynoNasUtilSensor(SynoNasSensor):
         if self.var_id in network_sensors or self.var_id in memory_sensors:
             attr = getattr(self._api.utilisation, self.var_id)(False)
 
+            if attr is None:
+                return None
+
             if self.var_id in network_sensors:
                 return round(attr / 1024.0, 1)
             if self.var_id in memory_sensors:


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Fix this log : 
```
2020-01-12 12:24:56 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/Users/XXX/dev/home-assistant/homeassistant/helpers/entity.py", line 284, in async_update_ha_state
    self._async_write_ha_state()
  File "/Users/XXX/dev/home-assistant/homeassistant/helpers/entity.py", line 320, in _async_write_ha_state
    state = self.state
  File "/Users/XXX/dev/home-assistant/homeassistant/components/synologydsm/sensor.py", line 237, in state
    if self.var_id in network_sensors:
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html