### PR TITLE
WIP: Convert tplink integration to use a new asyncio-enabled backend library

### DIFF
--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Callable, List, Any, Awaitable
+from typing import Any, Awaitable, Callable, List
 
 from kasa import (
     Discover,
@@ -94,7 +94,6 @@ async def async_discover_devices(
         else:
             _LOGGER.error("Unknown smart device type: %s", type(dev))
 
-
     return SmartDevices(lights, switches)
 
 
@@ -124,7 +123,6 @@ def get_static_devices(config_data) -> SmartDevices:
 
 AsyncAddEntities = Callable[[List[Any], bool], None]
 AddEntitiesCallable = Callable[[Any, AsyncAddEntities], Awaitable[bool]]
-
 
 
 async def async_add_entities_retry(

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -11,6 +11,7 @@ from kasa import (
     SmartDevice,
     SmartDeviceException,
     SmartDimmer,
+    SmartLightStrip,
     SmartPlug,
     SmartStrip,
 )
@@ -28,6 +29,7 @@ CONF_DISCOVERY = "discovery"
 CONF_LIGHT = "light"
 CONF_STRIP = "strip"
 CONF_SWITCH = "switch"
+CONF_LIGHTSTRIP = "lightstrip"
 
 
 class SmartDevices:
@@ -83,7 +85,7 @@ async def async_discover_devices(
 
         if dev.is_strip or dev.is_plug:
             switches.append(dev)
-        elif dev.is_dimmer or dev.is_bulb:
+        elif dev.is_dimmer or dev.is_bulb or dev.is_lightstrip:
             lights.append(dev)
         else:
             _LOGGER.error("Unknown smart device type: %s", dev.device_type)
@@ -97,7 +99,7 @@ def get_static_devices(config_data) -> SmartDevices:
     lights = []
     switches = []
 
-    for type_ in [CONF_LIGHT, CONF_SWITCH, CONF_STRIP, CONF_DIMMER]:
+    for type_ in [CONF_LIGHT, CONF_SWITCH, CONF_STRIP, CONF_DIMMER, CONF_LIGHTSTRIP]:
         for entry in config_data[type_]:
             host = entry["host"]
 
@@ -109,6 +111,8 @@ def get_static_devices(config_data) -> SmartDevices:
                 switches.append(SmartStrip(host))
             elif type_ == CONF_DIMMER:
                 lights.append(SmartDimmer(host))
+            elif type_ == CONF_LIGHTSTRIP:
+                lights.append(SmartLightStrip(host))
 
     return SmartDevices(lights, switches)
 

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -2,4 +2,4 @@
 import datetime
 
 DOMAIN = "tplink"
-MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=8)
+MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=5)

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -1,8 +1,6 @@
 """Support for TPLink lights."""
 from datetime import timedelta
 import logging
-import time
-from typing import Any, Dict, NamedTuple, Tuple, cast
 
 from kasa import SmartBulb, SmartDeviceException
 
@@ -64,62 +62,38 @@ def brightness_from_percentage(percent):
     return round((percent * 255.0) / 100.0)
 
 
-LightState = NamedTuple(
-    "LightState",
-    (
-        ("state", bool),
-        ("brightness", int),
-        ("color_temp", float),
-        ("hs", Tuple[int, int]),
-        ("emeter_params", dict),
-    ),
-)
-
-
-LightFeatures = NamedTuple(
-    "LightFeatures",
-    (
-        ("sysinfo", Dict[str, Any]),
-        ("mac", str),
-        ("alias", str),
-        ("model", str),
-        ("supported_features", int),
-        ("min_mireds", float),
-        ("max_mireds", float),
-    ),
-)
-
-
 class TPLinkSmartBulb(LightEntity):
     """Representation of a TPLink Smart Bulb."""
 
     def __init__(self, smartbulb: SmartBulb) -> None:
         """Initialize the bulb."""
         self.smartbulb = smartbulb
-        self._light_features = cast(LightFeatures, None)
-        self._light_state = cast(LightState, None)
+        self._min_mireds = None
+        self._max_mireds = None
         self._is_available = True
         self._is_setting_light_state = False
+        self._supported_features = None
+        self._device_state_attributes = {}
 
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._light_features.mac
+        return self.smartbulb.mac
 
     @property
     def name(self):
         """Return the name of the Smart Bulb."""
-        return self._light_features.alias
+        return self.smartbulb.alias
 
     @property
     def device_info(self):
         """Return information about the device."""
         return {
-            "name": self._light_features.alias,
-            "model": self._light_features.model,
+            "name": self.smartbulb.alias,
+            "model": self.smartbulb.model,
             "manufacturer": "TP-Link",
-            "connections": {(dr.CONNECTION_NETWORK_MAC, self._light_features.mac)},
-            "sw_version": self._light_features.sysinfo["sw_ver"],
+            "connections": {(dr.CONNECTION_NETWORK_MAC, self.smartbulb.mac)},
+            "sw_version": self.smartbulb.sys_info["sw_ver"],
         }
 
     @property
@@ -130,76 +104,79 @@ class TPLinkSmartBulb(LightEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        return self._light_state.emeter_params
+        return self._device_state_attributes
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
-        brightness = (
-            int(kwargs[ATTR_BRIGHTNESS])
-            if ATTR_BRIGHTNESS in kwargs
-            else self._light_state.brightness
-            if self._light_state.brightness is not None
-            else 255
-        )
-        color_tmp = (
-            int(kwargs[ATTR_COLOR_TEMP])
-            if ATTR_COLOR_TEMP in kwargs
-            else self._light_state.color_temp
-        )
+        if self._is_setting_light_state:
+            return  # we are already trying to set a state
 
-        await self.async_set_light_state_retry(
-            self._light_state,
-            LightState(
-                state=True,
-                brightness=brightness,
-                color_temp=color_tmp,
-                hs=tuple(kwargs.get(ATTR_HS_COLOR, self._light_state.hs or ())),
-                emeter_params=self._light_state.emeter_params,
-            ),
-        )
+        brightness = color_temp = hsv = None
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = brightness_to_percentage(int(kwargs[ATTR_BRIGHTNESS]))
+        if ATTR_COLOR_TEMP in kwargs:
+            color_temp = int(mired_to_kelvin(int(kwargs[ATTR_COLOR_TEMP])))
+        if ATTR_HS_COLOR in kwargs:
+            hsv = kwargs[ATTR_HS_COLOR]
+
+        self._is_setting_light_state = True
+
+        for t in range(5):
+            try:
+                if brightness is not None:
+                    await self.smartbulb.set_brightness(brightness)
+                if color_temp is not None:
+                    await self.smartbulb.set_color_temp(color_temp)
+                if hsv is not None:
+                    await self.smartbulb.set_hsv(*hsv, brightness)
+
+                await self.smartbulb.turn_on()
+                # all actions on bulbs will cause an automatic update
+                await self.async_update_ha_state(force_refresh=False)
+                self._is_available = True
+                self._is_setting_light_state = False
+                return
+            except (SmartDeviceException, OSError) as ex:
+                _LOGGER.debug("Got error while setting the state, retrying: %s", ex)
+
+        _LOGGER.warning("Could not set state for %s", self.smartbulb.host)
+        self._is_setting_light_state = False
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
-        await self.async_set_light_state_retry(
-            self._light_state,
-            LightState(
-                state=False,
-                brightness=self._light_state.brightness,
-                color_temp=self._light_state.color_temp,
-                hs=self._light_state.hs,
-                emeter_params=self._light_state.emeter_params,
-            ),
-        )
+        await self.smartbulb.turn_off()
 
     @property
     def min_mireds(self):
         """Return minimum supported color temperature."""
-        return self._light_features.min_mireds
+        return self._min_mireds
 
     @property
     def max_mireds(self):
         """Return maximum supported color temperature."""
-        return self._light_features.max_mireds
+        return self._max_mireds
 
     @property
     def color_temp(self):
         """Return the color temperature of this light in mireds for HA."""
-        return self._light_state.color_temp
+        if self.smartbulb.color_temp is not None and self.smartbulb.color_temp != 0:
+            return kelvin_to_mired(self.smartbulb.color_temp)
 
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return self._light_state.brightness
+        return brightness_from_percentage(self.smartbulb.brightness)
 
     @property
     def hs_color(self):
         """Return the color."""
-        return self._light_state.hs
+        hue, sat, _ = self.smartbulb.hsv
+        return hue, sat
 
     @property
     def is_on(self):
         """Return True if device is on."""
-        return self._light_state.state
+        return self.smartbulb.is_on
 
     async def async_update(self):
         """Update the TP-Link Bulb's state."""
@@ -208,9 +185,10 @@ class TPLinkSmartBulb(LightEntity):
             return
 
         try:
-            # Update light features only once.
-            self._light_features = self._light_features or self.get_light_features()
-            self._light_state = await self.get_light_state()
+            await self.smartbulb.update()
+            self.update_emeter_state()
+
+            self._supported_features = self.get_light_features()
             self._is_available = True
         except (SmartDeviceException, OSError) as ex:
             if self._is_available:
@@ -222,127 +200,45 @@ class TPLinkSmartBulb(LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return self._light_features.supported_features
+        return self._supported_features
 
     def get_light_features(self):
         """Determine all supported features in one go."""
-        sysinfo = self.smartbulb.sys_info
         supported_features = 0
-        mac = self.smartbulb.mac
-        alias = self.smartbulb.alias
-        model = self.smartbulb.model
-        min_mireds = None
-        max_mireds = None
 
         if self.smartbulb.is_dimmable:
             supported_features += SUPPORT_BRIGHTNESS
         if self.smartbulb.is_variable_color_temp:
             supported_features += SUPPORT_COLOR_TEMP
-            min_mireds = kelvin_to_mired(self.smartbulb.valid_temperature_range[1])
-            max_mireds = kelvin_to_mired(self.smartbulb.valid_temperature_range[0])
+            self._min_mireds = kelvin_to_mired(
+                self.smartbulb.valid_temperature_range[1]
+            )
+            self._max_mireds = kelvin_to_mired(
+                self.smartbulb.valid_temperature_range[0]
+            )
         if self.smartbulb.is_color:
             supported_features += SUPPORT_COLOR
 
-        return LightFeatures(
-            sysinfo=sysinfo,
-            mac=mac,
-            alias=alias,
-            model=model,
-            supported_features=supported_features,
-            min_mireds=min_mireds,
-            max_mireds=max_mireds,
-        )
+        return supported_features
 
-    async def get_light_state(self) -> LightState:
+    def update_emeter_state(self):
         """Get the light state."""
         emeter_params = {}
-        brightness = None
-        color_temp = None
-        hue_saturation = None
-
-        await self.smartbulb.update()
-
-        state = self.smartbulb.is_on
-
-        if self._light_features.supported_features & SUPPORT_BRIGHTNESS:
-            brightness = brightness_from_percentage(self.smartbulb.brightness)
-
-        if self._light_features.supported_features & SUPPORT_COLOR_TEMP:
-            if self.smartbulb.color_temp is not None and self.smartbulb.color_temp != 0:
-                color_temp = kelvin_to_mired(self.smartbulb.color_temp)
-
-        if self._light_features.supported_features & SUPPORT_COLOR:
-            hue, sat, _ = self.smartbulb.hsv
-            hue_saturation = (hue, sat)
 
         if self.smartbulb.has_emeter:
             emeter_params[ATTR_CURRENT_POWER_W] = "{:.1f}".format(
-                await self.smartbulb.current_consumption()
+                self.smartbulb.emeter_realtime["power"]
             )
-            daily_statistics = await self.smartbulb.get_emeter_daily()
-            monthly_statistics = await self.smartbulb.get_emeter_monthly()
-            try:
+
+            consumption_today = self.smartbulb.emeter_today
+            consumption_this_month = self.smartbulb.emeter_this_month
+            if consumption_today is not None:
                 emeter_params[ATTR_DAILY_ENERGY_KWH] = "{:.3f}".format(
-                    daily_statistics[int(time.strftime("%d"))]
+                    consumption_today
                 )
+            if consumption_this_month is not None:
                 emeter_params[ATTR_MONTHLY_ENERGY_KWH] = "{:.3f}".format(
-                    monthly_statistics[int(time.strftime("%m"))]
+                    consumption_this_month
                 )
-            except KeyError:
-                # device returned no daily/monthly history
-                pass
 
-        return LightState(
-            state=state,
-            brightness=brightness,
-            color_temp=color_temp,
-            hs=hue_saturation,
-            emeter_params=emeter_params,
-        )
-
-    async def async_set_light_state_retry(
-        self, old_light_state: LightState, new_light_state: LightState
-    ) -> None:
-        """Set the light state with retry."""
-        # Optimistically setting the light state.
-        self._light_state = new_light_state
-
-        # Tell the device to set the states.
-        self._is_setting_light_state = True
-
-        # TODO: this used to be two separate calls to set_light_state and it was simply confusing..
-        for t in range(5):
-            try:
-                await self.set_light_state(old_light_state, new_light_state)
-                self._is_available = True
-                self._is_setting_light_state = False
-                return
-            except (SmartDeviceException, OSError) as ex:
-                _LOGGER.debug("Got error while setting the state, retrying: %s", ex)
-
-        _LOGGER.warning("Could not set state for %s", self.smartbulb.host)
-        self._is_setting_light_state = False
-
-    async def set_light_state(
-        self, old_light_state: LightState, new_light_state: LightState
-    ) -> None:
-        """Set the light state."""
-        # Calling the API with the new state information.
-        if new_light_state.state != old_light_state.state:
-            if new_light_state.state:
-                await self.smartbulb.turn_on()
-            else:
-                await self.smartbulb.turn_off()
-                return
-
-        if new_light_state.color_temp != old_light_state.color_temp:
-            await self.smartbulb.set_color_temp(
-                int(mired_to_kelvin(new_light_state.color_temp))
-            )
-
-        brightness_pct = brightness_to_percentage(new_light_state.brightness)
-        if new_light_state.hs != old_light_state.hs and len(new_light_state.hs) > 1:
-            hue, sat = new_light_state.hs
-            await self.smartbulb.set_hsv(int(hue), int(sat), brightness_pct)
-        elif new_light_state.brightness != old_light_state.brightness:
-            await self.smartbulb.set_brightness(brightness_pct)
+        self._device_state_attributes = emeter_params

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -35,17 +35,6 @@ ATTR_DAILY_ENERGY_KWH = "daily_energy_kwh"
 ATTR_MONTHLY_ENERGY_KWH = "monthly_energy_kwh"
 
 
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the platform.
-
-    Deprecated.
-    """
-    _LOGGER.warning(
-        "Loading as a platform is no longer supported, "
-        "convert to use the tplink component."
-    )
-
-
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up switches."""
     await async_add_entities_retry(

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -121,21 +121,22 @@ class TPLinkSmartBulb(LightEntity):
 
         self._is_setting_light_state = True
         try:
-            if brightness is not None:
+            if brightness is not None and self.supported_features & SUPPORT_BRIGHTNESS:
                 await self.smartbulb.set_brightness(brightness)
-            if color_temp is not None:
+            if color_temp is not None and self.supported_features & SUPPORT_COLOR_TEMP:
                 await self.smartbulb.set_color_temp(color_temp)
-            if hsv is not None:
+            if hsv is not None and self.supported_features & SUPPORT_COLOR:
                 await self.smartbulb.set_hsv(*hsv, brightness)
 
             await self.smartbulb.turn_on()
             # all actions on bulbs will cause an automatic update
             await self.async_update_ha_state(force_refresh=False)
             self._is_available = True
-            self._is_setting_light_state = False
             return
         except (SmartDeviceException, OSError) as ex:
             _LOGGER.debug("Got error while setting the state: %s", ex)
+        finally:
+            self._is_setting_light_state = False
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -113,7 +113,7 @@ class TPLinkSmartBulb(LightEntity):
 
         brightness = None
         if ATTR_BRIGHTNESS in kwargs:
-            brightness = brightness_to_percentage(int(kwargs[ATTR_BRIGHTNESS]))
+            brightness = int(kwargs[ATTR_BRIGHTNESS])
 
         self._is_setting_light_state = True
         try:

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -223,7 +223,7 @@ class TPLinkSmartBulb(LightEntity):
             self._light_features = (
                 self._light_features or self.get_light_features()
             )
-            self._light_state = self.get_light_state()
+            self._light_state = await self.get_light_state()
             self._is_available = True
         except (SmartDeviceException, OSError) as ex:
             if self._is_available:
@@ -332,7 +332,6 @@ class TPLinkSmartBulb(LightEntity):
                 return
             except (SmartDeviceException, OSError) as ex:
                 _LOGGER.debug("Got error while setting the state, retrying: %s", ex)
-
 
         _LOGGER.warning("Could not set state for %s", self.smartbulb.host)
         self._is_setting_light_state = False

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -117,15 +117,14 @@ class TPLinkSmartBulb(LightEntity):
 
         self._is_setting_light_state = True
         try:
-            if brightness is not None and self.supported_features & SUPPORT_BRIGHTNESS:
-                await self.smartbulb.set_brightness(brightness)
-            if (
-                ATTR_COLOR_TEMP in kwargs
-                and self.supported_features & SUPPORT_COLOR_TEMP
-            ):
+            if brightness is not None and self.smartbulb.is_dimmable:
+                await self.smartbulb.set_brightness(
+                    brightness_to_percentage(brightness)
+                )
+            if ATTR_COLOR_TEMP in kwargs and self.smartbulb.is_variable_color_temp:
                 color_temp = int(mired_to_kelvin(int(kwargs[ATTR_COLOR_TEMP])))
                 await self.smartbulb.set_color_temp(color_temp)
-            if ATTR_HS_COLOR in kwargs and self.supported_features & SUPPORT_COLOR:
+            if ATTR_HS_COLOR in kwargs and self.smartbulb.is_color:
                 hue, sat = kwargs[ATTR_HS_COLOR]
                 if brightness is None:
                     brightness = self.brightness

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Any, Dict, NamedTuple, Tuple, cast
 
-from pyHS100 import SmartBulb, SmartDeviceException
+from kasa import SmartBulb, SmartDeviceException
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -15,22 +15,18 @@ from homeassistant.components.light import (
     SUPPORT_COLOR_TEMP,
     LightEntity,
 )
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired,
     color_temperature_mired_to_kelvin as mired_to_kelvin,
 )
-import homeassistant.util.dt as dt_util
 
 from . import CONF_LIGHT, DOMAIN as TPLINK_DOMAIN
 from .common import async_add_entities_retry
 
 PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=5)
-CURRENT_POWER_UPDATE_INTERVAL = timedelta(seconds=60)
-HISTORICAL_POWER_UPDATE_INTERVAL = timedelta(minutes=60)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,21 +34,16 @@ ATTR_CURRENT_POWER_W = "current_power_w"
 ATTR_DAILY_ENERGY_KWH = "daily_energy_kwh"
 ATTR_MONTHLY_ENERGY_KWH = "monthly_energy_kwh"
 
-LIGHT_STATE_DFT_ON = "dft_on_state"
-LIGHT_STATE_ON_OFF = "on_off"
-LIGHT_STATE_RELAY_STATE = "relay_state"
-LIGHT_STATE_BRIGHTNESS = "brightness"
-LIGHT_STATE_COLOR_TEMP = "color_temp"
-LIGHT_STATE_HUE = "hue"
-LIGHT_STATE_SATURATION = "saturation"
-LIGHT_STATE_ERROR_MSG = "err_msg"
 
-LIGHT_SYSINFO_MAC = "mac"
-LIGHT_SYSINFO_ALIAS = "alias"
-LIGHT_SYSINFO_MODEL = "model"
-LIGHT_SYSINFO_IS_DIMMABLE = "is_dimmable"
-LIGHT_SYSINFO_IS_VARIABLE_COLOR_TEMP = "is_variable_color_temp"
-LIGHT_SYSINFO_IS_COLOR = "is_color"
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the platform.
+
+    Deprecated.
+    """
+    _LOGGER.warning(
+        "Loading as a platform is no longer supported, "
+        "convert to use the tplink component."
+    )
 
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
@@ -60,15 +51,16 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_ent
     await async_add_entities_retry(
         hass, async_add_entities, hass.data[TPLINK_DOMAIN][CONF_LIGHT], add_entity
     )
+
     return True
 
 
-def add_entity(device: SmartBulb, async_add_entities):
+async def add_entity(device: SmartBulb, async_add_entities):
     """Check if device is online and add the entity."""
     # Attempt to get the sysinfo. If it fails, it will raise an
     # exception that is caught by async_add_entities_retry which
     # will try again later.
-    device.get_sysinfo()
+    await device.update()
 
     async_add_entities([TPLinkSmartBulb(device)], update_before_add=True)
 
@@ -83,41 +75,30 @@ def brightness_from_percentage(percent):
     return round((percent * 255.0) / 100.0)
 
 
-class LightState(NamedTuple):
-    """Light state."""
-
-    state: bool
-    brightness: int
-    color_temp: float
-    hs: Tuple[int, int]
-
-    def to_param(self):
-        """Return a version that we can send to the bulb."""
-        if self.color_temp:
-            color_temp = mired_to_kelvin(self.color_temp)
-        else:
-            color_temp = None
-
-        return {
-            LIGHT_STATE_ON_OFF: 1 if self.state else 0,
-            LIGHT_STATE_BRIGHTNESS: brightness_to_percentage(self.brightness),
-            LIGHT_STATE_COLOR_TEMP: color_temp,
-            LIGHT_STATE_HUE: self.hs[0] if self.hs else 0,
-            LIGHT_STATE_SATURATION: self.hs[1] if self.hs else 0,
-        }
+LightState = NamedTuple(
+    "LightState",
+    (
+        ("state", bool),
+        ("brightness", int),
+        ("color_temp", float),
+        ("hs", Tuple[int, int]),
+        ("emeter_params", dict),
+    ),
+)
 
 
-class LightFeatures(NamedTuple):
-    """Light features."""
-
-    sysinfo: Dict[str, Any]
-    mac: str
-    alias: str
-    model: str
-    supported_features: int
-    min_mireds: float
-    max_mireds: float
-    has_emeter: bool
+LightFeatures = NamedTuple(
+    "LightFeatures",
+    (
+        ("sysinfo", Dict[str, Any]),
+        ("mac", str),
+        ("alias", str),
+        ("model", str),
+        ("supported_features", int),
+        ("min_mireds", float),
+        ("max_mireds", float),
+    ),
+)
 
 
 class TPLinkSmartBulb(LightEntity):
@@ -130,9 +111,6 @@ class TPLinkSmartBulb(LightEntity):
         self._light_state = cast(LightState, None)
         self._is_available = True
         self._is_setting_light_state = False
-        self._last_current_power_update = None
-        self._last_historical_power_update = None
-        self._emeter_params = {}
 
     @property
     def unique_id(self):
@@ -163,42 +141,45 @@ class TPLinkSmartBulb(LightEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        return self._emeter_params
+        return self._light_state.emeter_params
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = int(kwargs[ATTR_BRIGHTNESS])
-        elif self._light_state.brightness is not None:
-            brightness = self._light_state.brightness
-        else:
-            brightness = 255
+        brightness = (
+            int(kwargs[ATTR_BRIGHTNESS])
+            if ATTR_BRIGHTNESS in kwargs
+            else self._light_state.brightness
+            if self._light_state.brightness is not None
+            else 255
+        )
+        color_tmp = (
+            int(kwargs[ATTR_COLOR_TEMP])
+            if ATTR_COLOR_TEMP in kwargs
+            else self._light_state.color_temp
+        )
 
-        if ATTR_COLOR_TEMP in kwargs:
-            color_tmp = int(kwargs[ATTR_COLOR_TEMP])
-        else:
-            color_tmp = self._light_state.color_temp
-
-        if ATTR_HS_COLOR in kwargs:
-            # TP-Link requires integers.
-            hue_sat = tuple(int(val) for val in kwargs[ATTR_HS_COLOR])
-
-            # TP-Link cannot have both color temp and hue_sat
-            color_tmp = 0
-        else:
-            hue_sat = self._light_state.hs
-
-        await self._async_set_light_state_retry(
+        await self.async_set_light_state_retry(
             self._light_state,
-            self._light_state._replace(
-                state=True, brightness=brightness, color_temp=color_tmp, hs=hue_sat,
+            LightState(
+                state=True,
+                brightness=brightness,
+                color_temp=color_tmp,
+                hs=tuple(kwargs.get(ATTR_HS_COLOR, self._light_state.hs or ())),
+                emeter_params=self._light_state.emeter_params,
             ),
         )
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
-        await self._async_set_light_state_retry(
-            self._light_state, self._light_state._replace(state=False),
+        await self.async_set_light_state_retry(
+            self._light_state,
+            LightState(
+                state=False,
+                brightness=self._light_state.brightness,
+                color_temp=self._light_state.color_temp,
+                hs=self._light_state.hs,
+                emeter_params=self._light_state.emeter_params,
+            ),
         )
 
     @property
@@ -231,7 +212,7 @@ class TPLinkSmartBulb(LightEntity):
         """Return True if device is on."""
         return self._light_state.state
 
-    def update(self):
+    async def async_update(self):
         """Update the TP-Link Bulb's state."""
         # State is currently being set, ignore.
         if self._is_setting_light_state:
@@ -239,9 +220,10 @@ class TPLinkSmartBulb(LightEntity):
 
         try:
             # Update light features only once.
-            if not self._light_features:
-                self._light_features = self._get_light_features_retry()
-            self._light_state = self._get_light_state_retry()
+            self._light_features = (
+                self._light_features or self.get_light_features()
+            )
+            self._light_state = self.get_light_state()
             self._is_available = True
         except (SmartDeviceException, OSError) as ex:
             if self._is_available:
@@ -255,38 +237,23 @@ class TPLinkSmartBulb(LightEntity):
         """Flag supported features."""
         return self._light_features.supported_features
 
-    def _get_light_features_retry(self) -> LightFeatures:
-        """Retry the retrieval of the supported features."""
-        try:
-            return self._get_light_features()
-        except (SmartDeviceException, OSError):
-            pass
-
-        _LOGGER.debug("Retrying getting light features")
-        return self._get_light_features()
-
-    def _get_light_features(self):
+    def get_light_features(self):
         """Determine all supported features in one go."""
         sysinfo = self.smartbulb.sys_info
         supported_features = 0
-        # Calling api here as it reformats
         mac = self.smartbulb.mac
-        alias = sysinfo[LIGHT_SYSINFO_ALIAS]
-        model = sysinfo[LIGHT_SYSINFO_MODEL]
+        alias = self.smartbulb.alias
+        model = self.smartbulb.model
         min_mireds = None
         max_mireds = None
-        has_emeter = self.smartbulb.has_emeter
 
-        if sysinfo.get(LIGHT_SYSINFO_IS_DIMMABLE) or LIGHT_STATE_BRIGHTNESS in sysinfo:
+        if self.smartbulb.is_dimmable:
             supported_features += SUPPORT_BRIGHTNESS
-        if sysinfo.get(LIGHT_SYSINFO_IS_VARIABLE_COLOR_TEMP):
+        if self.smartbulb.is_variable_color_temp:
             supported_features += SUPPORT_COLOR_TEMP
-            # Have to make another api request here in
-            # order to not re-implement pyHS100 here
-            max_range, min_range = self.smartbulb.valid_temperature_range
-            min_mireds = kelvin_to_mired(min_range)
-            max_mireds = kelvin_to_mired(max_range)
-        if sysinfo.get(LIGHT_SYSINFO_IS_COLOR):
+            min_mireds = kelvin_to_mired(self.smartbulb.valid_temperature_range[1])
+            max_mireds = kelvin_to_mired(self.smartbulb.valid_temperature_range[0])
+        if self.smartbulb.is_color:
             supported_features += SUPPORT_COLOR
 
         return LightFeatures(
@@ -297,186 +264,97 @@ class TPLinkSmartBulb(LightEntity):
             supported_features=supported_features,
             min_mireds=min_mireds,
             max_mireds=max_mireds,
-            has_emeter=has_emeter,
         )
 
-    def _get_light_state_retry(self) -> LightState:
-        """Retry the retrieval of getting light states."""
-        try:
-            return self._get_light_state()
-        except (SmartDeviceException, OSError):
-            pass
-
-        _LOGGER.debug("Retrying getting light state")
-        return self._get_light_state()
-
-    def _light_state_from_params(self, light_state_params) -> LightState:
+    async def get_light_state(self) -> LightState:
+        """Get the light state."""
+        emeter_params = {}
         brightness = None
         color_temp = None
         hue_saturation = None
-        light_features = self._light_features
 
-        state = bool(light_state_params[LIGHT_STATE_ON_OFF])
+        await self.smartbulb.update()
 
-        if not state and LIGHT_STATE_DFT_ON in light_state_params:
-            light_state_params = light_state_params[LIGHT_STATE_DFT_ON]
+        state = self.smartbulb.is_on
 
-        if light_features.supported_features & SUPPORT_BRIGHTNESS:
-            brightness = brightness_from_percentage(
-                light_state_params[LIGHT_STATE_BRIGHTNESS]
+        if self._light_features.supported_features & SUPPORT_BRIGHTNESS:
+            brightness = brightness_from_percentage(self.smartbulb.brightness)
+
+        if self._light_features.supported_features & SUPPORT_COLOR_TEMP:
+            if self.smartbulb.color_temp is not None and self.smartbulb.color_temp != 0:
+                color_temp = kelvin_to_mired(self.smartbulb.color_temp)
+
+        if self._light_features.supported_features & SUPPORT_COLOR:
+            hue, sat, _ = self.smartbulb.hsv
+            hue_saturation = (hue, sat)
+
+        if self.smartbulb.has_emeter:
+            emeter_params[ATTR_CURRENT_POWER_W] = "{:.1f}".format(
+                await self.smartbulb.current_consumption()
             )
-
-        if light_features.supported_features & SUPPORT_COLOR_TEMP:
-            if (
-                light_state_params.get(LIGHT_STATE_COLOR_TEMP) is not None
-                and light_state_params[LIGHT_STATE_COLOR_TEMP] != 0
-            ):
-                color_temp = kelvin_to_mired(light_state_params[LIGHT_STATE_COLOR_TEMP])
-
-        if light_features.supported_features & SUPPORT_COLOR:
-            hue_saturation = (
-                light_state_params[LIGHT_STATE_HUE],
-                light_state_params[LIGHT_STATE_SATURATION],
-            )
-
-        return LightState(
-            state=state,
-            brightness=brightness,
-            color_temp=color_temp,
-            hs=hue_saturation,
-        )
-
-    def _get_light_state(self) -> LightState:
-        """Get the light state."""
-        self._update_emeter()
-        return self._light_state_from_params(self._get_device_state())
-
-    def _update_emeter(self):
-        if not self._light_features.has_emeter:
-            return
-
-        now = dt_util.utcnow()
-        if (
-            not self._last_current_power_update
-            or self._last_current_power_update + CURRENT_POWER_UPDATE_INTERVAL < now
-        ):
-            self._last_current_power_update = now
-            self._emeter_params[ATTR_CURRENT_POWER_W] = "{:.1f}".format(
-                self.smartbulb.current_consumption()
-            )
-
-        if (
-            not self._last_historical_power_update
-            or self._last_historical_power_update + HISTORICAL_POWER_UPDATE_INTERVAL
-            < now
-        ):
-            self._last_historical_power_update = now
-            daily_statistics = self.smartbulb.get_emeter_daily()
-            monthly_statistics = self.smartbulb.get_emeter_monthly()
+            daily_statistics = await self.smartbulb.get_emeter_daily()
+            monthly_statistics = await self.smartbulb.get_emeter_monthly()
             try:
-                self._emeter_params[ATTR_DAILY_ENERGY_KWH] = "{:.3f}".format(
+                emeter_params[ATTR_DAILY_ENERGY_KWH] = "{:.3f}".format(
                     daily_statistics[int(time.strftime("%d"))]
                 )
-                self._emeter_params[ATTR_MONTHLY_ENERGY_KWH] = "{:.3f}".format(
+                emeter_params[ATTR_MONTHLY_ENERGY_KWH] = "{:.3f}".format(
                     monthly_statistics[int(time.strftime("%m"))]
                 )
             except KeyError:
                 # device returned no daily/monthly history
                 pass
 
-    async def _async_set_light_state_retry(
+        return LightState(
+            state=state,
+            brightness=brightness,
+            color_temp=color_temp,
+            hs=hue_saturation,
+            emeter_params=emeter_params,
+        )
+
+    async def async_set_light_state_retry(
         self, old_light_state: LightState, new_light_state: LightState
     ) -> None:
         """Set the light state with retry."""
+        # Optimistically setting the light state.
+        self._light_state = new_light_state
+
         # Tell the device to set the states.
-        if not _light_state_diff(old_light_state, new_light_state):
-            # Nothing to do, avoid the executor
-            return
-
         self._is_setting_light_state = True
-        try:
-            light_state_params = await self.hass.async_add_executor_job(
-                self._set_light_state, old_light_state, new_light_state
-            )
-            self._is_available = True
-            self._is_setting_light_state = False
-            if LIGHT_STATE_ERROR_MSG in light_state_params:
-                raise HomeAssistantError(light_state_params[LIGHT_STATE_ERROR_MSG])
-            self._light_state = self._light_state_from_params(light_state_params)
-            return
-        except (SmartDeviceException, OSError):
-            pass
 
-        try:
-            _LOGGER.debug("Retrying setting light state")
-            light_state_params = await self.hass.async_add_executor_job(
-                self._set_light_state, old_light_state, new_light_state
-            )
-            self._is_available = True
-            if LIGHT_STATE_ERROR_MSG in light_state_params:
-                raise HomeAssistantError(light_state_params[LIGHT_STATE_ERROR_MSG])
-            self._light_state = self._light_state_from_params(light_state_params)
-        except (SmartDeviceException, OSError) as ex:
-            self._is_available = False
-            _LOGGER.warning("Could not set data for %s: %s", self.smartbulb.host, ex)
+        # TODO: this used to be two separate calls to set_light_state and it was simply confusing..
+        for t in range(5):
+            try:
+                await self.set_light_state(old_light_state, new_light_state)
+                self._is_available = True
+                self._is_setting_light_state = False
+                return
+            except (SmartDeviceException, OSError) as ex:
+                _LOGGER.debug("Got error while setting the state, retrying: %s", ex)
 
+
+        _LOGGER.warning("Could not set state for %s", self.smartbulb.host)
         self._is_setting_light_state = False
 
-    def _set_light_state(
+    async def set_light_state(
         self, old_light_state: LightState, new_light_state: LightState
     ) -> None:
         """Set the light state."""
-        diff = _light_state_diff(old_light_state, new_light_state)
-
-        if not diff:
-            return
-
-        return self._set_device_state(diff)
-
-    def _get_device_state(self):
-        """State of the bulb or smart dimmer switch."""
-        if isinstance(self.smartbulb, SmartBulb):
-            return self.smartbulb.get_light_state()
-
-        sysinfo = self.smartbulb.sys_info
-        # Its not really a bulb, its a dimmable SmartPlug (aka Wall Switch)
-        return {
-            LIGHT_STATE_ON_OFF: sysinfo[LIGHT_STATE_RELAY_STATE],
-            LIGHT_STATE_BRIGHTNESS: sysinfo.get(LIGHT_STATE_BRIGHTNESS, 0),
-            LIGHT_STATE_COLOR_TEMP: 0,
-            LIGHT_STATE_HUE: 0,
-            LIGHT_STATE_SATURATION: 0,
-        }
-
-    def _set_device_state(self, state):
-        """Set state of the bulb or smart dimmer switch."""
-        if isinstance(self.smartbulb, SmartBulb):
-            return self.smartbulb.set_light_state(state)
-
-        # Its not really a bulb, its a dimmable SmartPlug (aka Wall Switch)
-        if LIGHT_STATE_BRIGHTNESS in state:
-            # Brightness of 0 is accepted by the
-            # device but the underlying library rejects it
-            # so we turn off instead.
-            if state[LIGHT_STATE_BRIGHTNESS]:
-                self.smartbulb.brightness = state[LIGHT_STATE_BRIGHTNESS]
+        # Calling the API with the new state information.
+        if new_light_state.state != old_light_state.state:
+            if new_light_state.state:
+                await self.smartbulb.turn_on()
             else:
-                self.smartbulb.state = self.smartbulb.SWITCH_STATE_OFF
-        elif LIGHT_STATE_ON_OFF in state:
-            if state[LIGHT_STATE_ON_OFF]:
-                self.smartbulb.state = self.smartbulb.SWITCH_STATE_ON
-            else:
-                self.smartbulb.state = self.smartbulb.SWITCH_STATE_OFF
+                await self.smartbulb.turn_off()
+                return
 
-        return self._get_device_state()
+        if new_light_state.color_temp != old_light_state.color_temp:
+            await self.smartbulb.set_color_temp(int(mired_to_kelvin(new_light_state.color_temp)))
 
-
-def _light_state_diff(old_light_state: LightState, new_light_state: LightState):
-    old_state_param = old_light_state.to_param()
-    new_state_param = new_light_state.to_param()
-
-    return {
-        key: value
-        for key, value in new_state_param.items()
-        if new_state_param.get(key) != old_state_param.get(key)
-    }
+        brightness_pct = brightness_to_percentage(new_light_state.brightness)
+        if new_light_state.hs != old_light_state.hs and len(new_light_state.hs) > 1:
+            hue, sat = new_light_state.hs
+            await self.smartbulb.set_hsv(int(hue), int(sat), brightness_pct)
+        elif new_light_state.brightness != old_light_state.brightness:
+            await self.smartbulb.set_brightness(brightness_pct)

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -120,27 +120,22 @@ class TPLinkSmartBulb(LightEntity):
             hsv = kwargs[ATTR_HS_COLOR]
 
         self._is_setting_light_state = True
+        try:
+            if brightness is not None:
+                await self.smartbulb.set_brightness(brightness)
+            if color_temp is not None:
+                await self.smartbulb.set_color_temp(color_temp)
+            if hsv is not None:
+                await self.smartbulb.set_hsv(*hsv, brightness)
 
-        for t in range(5):
-            try:
-                if brightness is not None:
-                    await self.smartbulb.set_brightness(brightness)
-                if color_temp is not None:
-                    await self.smartbulb.set_color_temp(color_temp)
-                if hsv is not None:
-                    await self.smartbulb.set_hsv(*hsv, brightness)
-
-                await self.smartbulb.turn_on()
-                # all actions on bulbs will cause an automatic update
-                await self.async_update_ha_state(force_refresh=False)
-                self._is_available = True
-                self._is_setting_light_state = False
-                return
-            except (SmartDeviceException, OSError) as ex:
-                _LOGGER.debug("Got error while setting the state, retrying: %s", ex)
-
-        _LOGGER.warning("Could not set state for %s", self.smartbulb.host)
-        self._is_setting_light_state = False
+            await self.smartbulb.turn_on()
+            # all actions on bulbs will cause an automatic update
+            await self.async_update_ha_state(force_refresh=False)
+            self._is_available = True
+            self._is_setting_light_state = False
+            return
+        except (SmartDeviceException, OSError) as ex:
+            _LOGGER.debug("Got error while setting the state: %s", ex)
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -220,9 +220,7 @@ class TPLinkSmartBulb(LightEntity):
 
         try:
             # Update light features only once.
-            self._light_features = (
-                self._light_features or self.get_light_features()
-            )
+            self._light_features = self._light_features or self.get_light_features()
             self._light_state = await self.get_light_state()
             self._is_available = True
         except (SmartDeviceException, OSError) as ex:
@@ -349,7 +347,9 @@ class TPLinkSmartBulb(LightEntity):
                 return
 
         if new_light_state.color_temp != old_light_state.color_temp:
-            await self.smartbulb.set_color_temp(int(mired_to_kelvin(new_light_state.color_temp)))
+            await self.smartbulb.set_color_temp(
+                int(mired_to_kelvin(new_light_state.color_temp))
+            )
 
         brightness_pct = brightness_to_percentage(new_light_state.brightness)
         if new_light_state.hs != old_light_state.hs and len(new_light_state.hs) > 1:

--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -3,6 +3,6 @@
   "name": "TP-Link Kasa Smart",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tplink",
-  "requirements": ["pyHS100==0.3.5.1"],
+  "requirements": [],
   "codeowners": ["@rytilahti"]
 }

--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -3,6 +3,6 @@
   "name": "TP-Link Kasa Smart",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tplink",
-  "requirements": [],
+  "requirements": ["python-kasa==0.4.0.dev0"],
   "codeowners": ["@rytilahti"]
 }

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -1,6 +1,5 @@
 """Support for TPLink HS100/HS110/HS200 smart switch."""
 import logging
-import time
 from typing import Union
 
 from kasa import SmartDeviceException, SmartPlug, SmartStrip
@@ -128,7 +127,7 @@ class SmartPlugSwitch(SwitchEntity):
                 await self.smartplug.update()
 
             if self.smartplug.has_emeter:
-                emeter_readings = await self.smartplug.get_emeter_realtime()
+                emeter_readings = self.smartplug.emeter_realtime
 
                 self._emeter_params[ATTR_CURRENT_POWER_W] = "{:.2f}".format(
                     emeter_readings["power"]
@@ -143,14 +142,9 @@ class SmartPlugSwitch(SwitchEntity):
                     emeter_readings["current"]
                 )
 
-                emeter_statics = await self.smartplug.get_emeter_daily()
-                try:
-                    self._emeter_params[ATTR_TODAY_ENERGY_KWH] = "{:.3f}".format(
-                        emeter_statics[int(time.strftime("%e"))]
-                    )
-                except KeyError:
-                    # Device returned no daily history
-                    pass
+                consumption_today = self.smartplug.emeter_today
+                if consumption_today is not None:
+                    self._emeter_params[ATTR_TODAY_ENERGY_KWH] = consumption_today
 
             self._available = True
 

--- a/tests/components/tplink/test_common.py
+++ b/tests/components/tplink/test_common.py
@@ -1,17 +1,20 @@
 """Common code tests."""
+import asyncio
 from datetime import timedelta
 
+from asynctest import CoroutineMock
 from kasa import SmartDeviceException
 
 from homeassistant.components.tplink.common import async_add_entities_retry
 from homeassistant.helpers.typing import HomeAssistantType
+import homeassistant.util.dt as dt_util
 
-from tests.async_mock import MagicMock
+from tests.common import async_fire_time_changed
 
 
 async def test_async_add_entities_retry(hass: HomeAssistantType):
     """Test interval callback."""
-    async_add_entities_callback = MagicMock()
+    async_add_entities_callback = CoroutineMock()
 
     # The objects that will be passed to async_add_entities_callback.
     objects = ["Object 1", "Object 2", "Object 3", "Object 4"]
@@ -22,61 +25,79 @@ async def test_async_add_entities_retry(hass: HomeAssistantType):
     # To help understand what's going on, a comment exists describing what the
     # object list looks like throughout the iterations.
     callback_side_effects = [
-        # OB1, OB2, OB3, OB4
-        False,
-        False,
+        # Interval pass 1
+        False,  # Object 1
+        False,  # Object 2
         True,  # Object 3
-        False,
-        # OB1, OB2, OB4
+        False,  # Object 4
+        # Interval pass 2
         True,  # Object 1
-        SmartDeviceException("My error"),
-        False,
-        # OB2, OB4
+        SmartDeviceException("My error"),  # Object 2
+        False,  # Object 4
+        # Interval pass 3
         True,  # Object 2
         True,  # Object 4
     ]
 
-    callback = MagicMock(side_effect=callback_side_effects)
+    callback = CoroutineMock(side_effect=callback_side_effects)
+    start_time = dt_util.utcnow()
 
-    await async_add_entities_retry(
-        hass,
-        async_add_entities_callback,
-        objects,
-        callback,
-        interval=timedelta(milliseconds=100),
-    )
-    await hass.async_block_till_done()
+    await async_add_entities_retry(hass, async_add_entities_callback, objects, callback)
+    async_fire_time_changed(hass, start_time + timedelta(seconds=10))
+    await asyncio.sleep(0.1)
+    assert callback.call_count == 4
 
-    assert callback.call_count == len(callback_side_effects)
+    callback.reset_mock()
+    async_fire_time_changed(hass, start_time + timedelta(seconds=61))
+    await asyncio.sleep(0.1)
+    assert callback.call_count == 3
+
+    callback.reset_mock()
+    async_fire_time_changed(hass, start_time + timedelta(seconds=61))
+    await asyncio.sleep(0.1)
+    assert callback.call_count == 2
 
 
 async def test_async_add_entities_retry_cancel(hass: HomeAssistantType):
     """Test interval callback."""
-    async_add_entities_callback = MagicMock()
+    async_add_entities_callback = CoroutineMock()
+
+    # The objects that will be passed to async_add_entities_callback.
+    objects = ["Object 1", "Object 2", "Object 3", "Object 4"]
 
     callback_side_effects = [
-        False,
-        False,
-        True,  # Object 1
-        False,
-        True,  # Object 2
-        SmartDeviceException("My error"),
-        False,
+        # Interval pass 1
+        False,  # Object 1
+        False,  # Object 2
         True,  # Object 3
+        False,  # Object 4
+        # Interval pass 2
+        True,  # Object 1
+        SmartDeviceException("My error"),  # Object 2
+        False,  # Object 4
+        # Interval pass 3
+        True,  # Object 2
         True,  # Object 4
     ]
 
-    callback = MagicMock(side_effect=callback_side_effects)
+    callback = CoroutineMock(side_effect=callback_side_effects)
+    start_time = dt_util.utcnow()
 
-    objects = ["Object 1", "Object 2", "Object 3", "Object 4"]
     cancel = await async_add_entities_retry(
-        hass,
-        async_add_entities_callback,
-        objects,
-        callback,
-        interval=timedelta(milliseconds=100),
+        hass, async_add_entities_callback, objects, callback
     )
-    cancel()
-    await hass.async_block_till_done()
-
+    async_fire_time_changed(hass, start_time + timedelta(seconds=10))
+    await asyncio.sleep(0.1)
     assert callback.call_count == 4
+
+    callback.reset_mock()
+    async_fire_time_changed(hass, start_time + timedelta(seconds=61))
+    await asyncio.sleep(0.1)
+    assert callback.call_count == 3
+
+    cancel()
+
+    callback.reset_mock()
+    async_fire_time_changed(hass, start_time + timedelta(seconds=61))
+    await asyncio.sleep(0.1)
+    assert callback.call_count == 0

--- a/tests/components/tplink/test_common.py
+++ b/tests/components/tplink/test_common.py
@@ -1,7 +1,7 @@
 """Common code tests."""
 from datetime import timedelta
 
-from pyHS100 import SmartDeviceException
+from kasa import SmartDeviceException
 
 from homeassistant.components.tplink.common import async_add_entities_retry
 from homeassistant.helpers.typing import HomeAssistantType

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
-from pyHS100 import SmartBulb, SmartDevice, SmartDeviceException, SmartPlug
+from kasa import SmartBulb, SmartDevice, SmartDeviceException, SmartPlug
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
@@ -55,10 +55,7 @@ async def test_configuring_tplink_causes_discovery(hass):
 
 @pytest.mark.parametrize(
     "name,cls,platform",
-    [
-        ("pyHS100.SmartPlug", SmartPlug, "switch"),
-        ("pyHS100.SmartBulb", SmartBulb, "light"),
-    ],
+    [("kasa.SmartPlug", SmartPlug, "switch"), ("kasa.SmartBulb", SmartBulb, "light")],
 )
 @pytest.mark.parametrize("count", [1, 2, 3])
 async def test_configuring_device_types(hass, name, cls, platform, count):

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -1,7 +1,7 @@
 """Tests for light platform."""
 from typing import Callable, NamedTuple
 
-from pyHS100 import SmartDeviceException
+from kasa import SmartDeviceException
 import pytest
 
 from homeassistant.components import tplink


### PR DESCRIPTION
## Description:
This PR ports the tplink integration to use a maintainer-made asyncio-fork of pyhs100 called python-kasa.

The major changes which should help with the linked issues are:
* Uses asyncio to avoid blocking I/O.
* The responses are cached now, the data is fetched from devices by awaiting `update()`.
* Only the main device is polled for smartstrips, dropping number of I/O requests for multiplug devices, thanks to an anonymous donor for sending me a test device! :tada:
* All data is fetched using a single I/O operation. This will effectively drop the number of requests per cycle to 1 per device.
* Bulbs and dimmers now support defining transition periods for changes.
* Support for light strips (KL430).

This PR has been tested to work with the following devices so far:
* HS110
* KP303
* KL60
* KL130

**It would be great to get feedback from users with other devices!**
Testing this requires installing python-kasa from git: https://github.com/python-kasa/python-kasa/ .

**Related issue (if applicable):** Related to / potentially closes: #30357, closes #30693, closes #28912, closes #23045, closes #28590, closes #29169, obsoletes #35628, obsoletes #35460, obsoletes #34465, obsoletes #29941

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
