### PR TITLE
Fix SynologyDSM sensor unknown for 15 min

### DIFF
--- a/homeassistant/components/synologydsm/sensor.py
+++ b/homeassistant/components/synologydsm/sensor.py
@@ -112,6 +112,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
 
         api = SynoApi(host, port, username, password, unit, use_ssl)
+        api.update()
 
         sensors = [
             SynoNasUtilSensor(api, name, variable, _UTILISATION_MON_COND[variable])


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Removing the need to wait 15 min to get SynologyDSM sensors.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) :** home-assistant/home-assistant.io#11724

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html