### PR TITLE
Allow bi-directional Insteon device links

### DIFF
--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -88,6 +88,7 @@ SRV_ALL_LINK_MODE = "mode"
 SRV_LOAD_DB_RELOAD = "reload"
 SRV_CONTROLLER = "controller"
 SRV_RESPONDER = "responder"
+SRV_BOTH = "both"
 SRV_HOUSECODE = "housecode"
 SRV_SCENE_ON = "scene_on"
 SRV_SCENE_OFF = "scene_off"
@@ -201,7 +202,9 @@ CONFIG_SCHEMA = vol.Schema(
 ADD_ALL_LINK_SCHEMA = vol.Schema(
     {
         vol.Required(SRV_ALL_LINK_GROUP): vol.Range(min=0, max=255),
-        vol.Required(SRV_ALL_LINK_MODE): vol.In([SRV_CONTROLLER, SRV_RESPONDER]),
+        vol.Required(SRV_ALL_LINK_MODE): vol.In(
+            [SRV_CONTROLLER, SRV_RESPONDER, SRV_BOTH]
+        ),
     }
 )
 
@@ -324,7 +327,15 @@ async def async_setup(hass, config):
         """Add an INSTEON All-Link between two devices."""
         group = service.data.get(SRV_ALL_LINK_GROUP)
         mode = service.data.get(SRV_ALL_LINK_MODE)
-        link_mode = 1 if mode.lower() == SRV_CONTROLLER else 0
+        if mode.lower() == SRV_CONTROLLER:
+            link_mode = 1
+        elif mode.lower() == SRV_BOTH:
+            link_mode = 3
+        # link_mode = 2 is undefined
+        else:
+            # this module defaults to mode 0 (SRV_RESPONDER)
+            # insteon_modem defaults to 1 (SRV_CONTROLLER)
+            link_mode = 0
         insteon_modem.start_all_linking(link_mode, group)
 
     def del_all_link(service):

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -327,9 +327,9 @@ async def async_setup(hass, config):
         """Add an INSTEON All-Link between two devices."""
         group = service.data.get(SRV_ALL_LINK_GROUP)
         mode = service.data.get(SRV_ALL_LINK_MODE)
-        if mode.lower() == SRV_CONTROLLER:
+        if mode == SRV_CONTROLLER:
             link_mode = 1
-        elif mode.lower() == SRV_BOTH:
+        elif mode == SRV_BOTH:
             link_mode = 3
         # link_mode = 2 is undefined
         else:

--- a/homeassistant/components/insteon/services.yaml
+++ b/homeassistant/components/insteon/services.yaml
@@ -5,7 +5,7 @@ add_all_link:
       description: All-Link group number (0-255).
       example: 1
     mode:
-      description: "Linking mode:  controller - IM is controller   responder - IM is responder    both - IM is both controller and responder"
+      description: 'Linking mode. "controller" - IM is controller; "responder" - IM is responder; "both" - IM is both controller and responder'
       example: 'controller'
 delete_all_link:
   description: Tells the Insteon Modem (IM) to remove an All-Link record from the All-Link Database of the IM and a device. Once the IM is set to delete the link, press the link button on the corresponding device to complete the process.

--- a/homeassistant/components/insteon/services.yaml
+++ b/homeassistant/components/insteon/services.yaml
@@ -5,7 +5,7 @@ add_all_link:
       description: All-Link group number (0-255).
       example: 1
     mode:
-      description: Linking mode:   controller - IM is controller   responder - IM is responder    both - IM is both controller and responder
+      description: "Linking mode:  controller - IM is controller   responder - IM is responder    both - IM is both controller and responder"
       example: 'controller'
 delete_all_link:
   description: Tells the Insteon Modem (IM) to remove an All-Link record from the All-Link Database of the IM and a device. Once the IM is set to delete the link, press the link button on the corresponding device to complete the process.

--- a/homeassistant/components/insteon/services.yaml
+++ b/homeassistant/components/insteon/services.yaml
@@ -3,7 +3,7 @@ add_all_link:
   fields:
     group:
       description: All-Link group number (0-255).
-      example: 1
+      example: 0
     mode:
       description: 'Linking mode. "controller" - IM is controller; "responder" - IM is responder; "both" - IM is both controller and responder'
       example: 'controller'

--- a/homeassistant/components/insteon/services.yaml
+++ b/homeassistant/components/insteon/services.yaml
@@ -2,16 +2,16 @@ add_all_link:
   description: Tells the Insteom Modem (IM) start All-Linking mode. Once the the IM is in All-Linking mode, press the link button on the device to complete All-Linking.
   fields:
     group:
-      description: All-Link group number.
+      description: All-Link group number (0-255).
       example: 1
     mode:
-      description: Linking mode   controller - IM is controller   responder - IM is responder
+      description: Linking mode:   controller - IM is controller   responder - IM is responder    both - IM is both controller and responder
       example: 'controller'
 delete_all_link:
   description: Tells the Insteon Modem (IM) to remove an All-Link record from the All-Link Database of the IM and a device. Once the IM is set to delete the link, press the link button on the corresponding device to complete the process.
   fields:
     group:
-      description: All-Link group number.
+      description: All-Link group number (0-255).
       example: 1
 load_all_link_database:
   description: Load the All-Link Database for a device. WARNING - Loading a device All-LInk database is very time consuming and inconsistent. This may take a LONG time and may need to be repeated to obtain all records.


### PR DESCRIPTION
The underlying insteonplm module supports adding devices with
bidirectional communication between the PLM and the device (linking mode
3). This change exposes that functionality.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
