### PR TITLE
Remove hidden property from xiaomi_miio.remote integration

### DIFF
--- a/homeassistant/components/xiaomi_miio/remote.py
+++ b/homeassistant/components/xiaomi_miio/remote.py
@@ -16,7 +16,6 @@ from homeassistant.components.remote import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_HIDDEN,
     CONF_COMMAND,
     CONF_HOST,
     CONF_NAME,
@@ -61,7 +60,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_SLOT, default=DEFAULT_SLOT): vol.All(
             int, vol.Range(min=1, max=1000000)
         ),
-        vol.Optional(ATTR_HIDDEN, default=True): cv.boolean,
         vol.Required(CONF_TOKEN): vol.All(str, vol.Length(min=32, max=32)),
         vol.Optional(CONF_COMMANDS, default={}): cv.schema_with_slug_keys(
             COMMAND_SCHEMA
@@ -106,16 +104,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     slot = config.get(CONF_SLOT)
     timeout = config.get(CONF_TIMEOUT)
 
-    hidden = config.get(ATTR_HIDDEN)
-
     xiaomi_miio_remote = XiaomiMiioRemote(
-        friendly_name,
-        device,
-        unique_id,
-        slot,
-        timeout,
-        hidden,
-        config.get(CONF_COMMANDS),
+        friendly_name, device, unique_id, slot, timeout, config.get(CONF_COMMANDS),
     )
 
     hass.data[DATA_KEY][host] = xiaomi_miio_remote
@@ -178,14 +168,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class XiaomiMiioRemote(RemoteDevice):
     """Representation of a Xiaomi Miio Remote device."""
 
-    def __init__(
-        self, friendly_name, device, unique_id, slot, timeout, hidden, commands
-    ):
+    def __init__(self, friendly_name, device, unique_id, slot, timeout, commands):
         """Initialize the remote."""
         self._name = friendly_name
         self._device = device
         self._unique_id = unique_id
-        self._is_hidden = hidden
         self._slot = slot
         self._timeout = timeout
         self._state = False
@@ -205,11 +192,6 @@ class XiaomiMiioRemote(RemoteDevice):
     def device(self):
         """Return the remote object."""
         return self._device
-
-    @property
-    def hidden(self):
-        """Return if we should hide entity."""
-        return self._is_hidden
 
     @property
     def slot(self):
@@ -234,13 +216,6 @@ class XiaomiMiioRemote(RemoteDevice):
     def should_poll(self):
         """We should not be polled for device up state."""
         return False
-
-    @property
-    def device_state_attributes(self):
-        """Hide remote by default."""
-        if self._is_hidden:
-            return {"hidden": "true"}
-        return
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""


### PR DESCRIPTION
## Breaking Change:

The `hidden` configuration option for the `xiaomi_miio` integration (effects remotes only) has been removed.

## Description:

Removes the `hidden` property from the `xiaomi_miio` integration. This hidden property was relevant in the era before Lovelace.

Documentation PR: home-assistant/home-assistant.io#11727

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
