### PR TITLE
Remove hidden property from egardia integration

### DIFF
--- a/homeassistant/components/egardia/binary_sensor.py
+++ b/homeassistant/components/egardia/binary_sensor.py
@@ -65,12 +65,6 @@ class EgardiaBinarySensor(BinarySensorDevice):
         return self._state == STATE_ON
 
     @property
-    def hidden(self):
-        """Whether the device is hidden by default."""
-        # these type of sensors are probably mainly used for automations
-        return True
-
-    @property
     def device_class(self):
         """Return the device class."""
         return self._device_class


### PR DESCRIPTION
## Breaking Change:

Binary sensors for the Egardia integration were hidden by default, which is no longer the case. This could affect automations that relies on the `hidden` state attribute of entities created by this integration.

## Description:

Binary sensors for the Egardia integration were hidden by default.

Comment in the original code:

> these type of sensors are probably mainly used for automations

This is clearly from the era before Lovelace.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
