### PR TITLE
Remove hidden property from emby integration

### DIFF
--- a/homeassistant/components/emby/media_player.py
+++ b/homeassistant/components/emby/media_player.py
@@ -36,8 +36,6 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_AUTO_HIDE = "auto_hide"
-
 MEDIA_TYPE_TRAILER = "trailer"
 MEDIA_TYPE_GENERIC_VIDEO = "video"
 
@@ -45,7 +43,6 @@ DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8096
 DEFAULT_SSL_PORT = 8920
 DEFAULT_SSL = False
-DEFAULT_AUTO_HIDE = False
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +58,6 @@ SUPPORT_EMBY = (
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_API_KEY): cv.string,
-        vol.Optional(CONF_AUTO_HIDE, default=DEFAULT_AUTO_HIDE): cv.boolean,
         vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
         vol.Optional(CONF_PORT): cv.port,
         vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
@@ -76,7 +72,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     key = config.get(CONF_API_KEY)
     port = config.get(CONF_PORT)
     ssl = config.get(CONF_SSL)
-    auto_hide = config.get(CONF_AUTO_HIDE)
 
     if port is None:
         port = DEFAULT_SSL_PORT if ssl else DEFAULT_PORT
@@ -109,7 +104,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                     active_emby_devices[dev_id] = add
                     _LOGGER.debug("Showing %s, item: %s", dev_id, add)
                     add.set_available(True)
-                    add.set_hidden(False)
 
         if new_devices:
             _LOGGER.debug("Adding new devices: %s", new_devices)
@@ -123,8 +117,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             inactive_emby_devices[data] = rem
             _LOGGER.debug("Inactive %s, item: %s", data, rem)
             rem.set_available(False)
-            if auto_hide:
-                rem.set_hidden(True)
 
     @callback
     def start_emby(event):
@@ -152,7 +144,6 @@ class EmbyDevice(MediaPlayerDevice):
         self.device_id = device_id
         self.device = self.emby.devices[self.device_id]
 
-        self._hidden = False
         self._available = True
 
         self.media_status_last_position = None
@@ -176,15 +167,6 @@ class EmbyDevice(MediaPlayerDevice):
             self.media_status_received = None
 
         self.async_schedule_update_ha_state()
-
-    @property
-    def hidden(self):
-        """Return True if entity should be hidden from UI."""
-        return self._hidden
-
-    def set_hidden(self, value):
-        """Set hidden property."""
-        self._hidden = value
 
     @property
     def available(self):


### PR DESCRIPTION
## Breaking Change:

The `auto_hide` configuration option has been removed from the Emby platform. Please be sure to remove it from your configuration.

## Description:

This removes the `auto_hide` configuration option from the Emby media player platform, as a result the `hidden` property is removed.

This is from a pre-Lovelace era. It now results in a player to be unavailable, which is expected behavior. Showing it or not, is not up to the integration/platform, but to the frontend/UI.


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11728

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: emby
    host: YOUR_IP_ADDRESS
    api_key: YOUR_API_KEY
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
