### PR TITLE
Remove hidden property from fibaro integration

### DIFF
--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -426,11 +426,6 @@ class FibaroDevice(Entity):
             self.dont_know_message(cmd)
 
     @property
-    def hidden(self) -> bool:
-        """Return True if the entity should be hidden from UIs."""
-        return self.fibaro_device.visible is False
-
-    @property
     def current_power_w(self):
         """Return the current power usage in W."""
         if "power" in self.fibaro_device.properties:


### PR DESCRIPTION
## Breaking Change:

Entities from the Fibaro integration were hidden in Home Assistant if they were hidden in Fibaro, which is no longer the case. This could affect automations that relies on the `hidden` state attribute of entities created by this integration.

## Description:

Removes the `hidden` property from the Fibaro integration.

The hidden property dates from the pre-Lovelace era, where entities themselves determined if they were hidden or not. Besides, a device hidden in Fibaro, could be shown in the Home Assistant UI, which this change allows for now.

(recap: A device hidden in Fibaro, should not be the control on if a device is shown/hidden in Home Assistant). 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
fibaro:
  gateways:
    - url: http://192.168.1.161/api/
      username: your_username
      password: your_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
