### PR TITLE
Fix hassfest allowing omitting discovery methods when using OAuth2Flow

### DIFF
--- a/script/hassfest/ssdp.py
+++ b/script/hassfest/ssdp.py
@@ -43,6 +43,7 @@ def generate_and_validate(integrations: Dict[str, Integration]):
                 content = fp.read()
                 if (
                     " async_step_ssdp" not in content
+                    and "AbstractOAuth2FlowHandler" not in content
                     and "register_discovery_flow" not in content
                 ):
                     integration.add_error("ssdp", "Config flow has no async_step_ssdp")

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -41,10 +41,12 @@ def generate_and_validate(integrations: Dict[str, Integration]):
             with open(str(integration.path / "config_flow.py")) as fp:
                 content = fp.read()
                 uses_discovery_flow = "register_discovery_flow" in content
+                uses_oauth2_flow = "AbstractOAuth2FlowHandler" in content
 
                 if (
                     service_types
                     and not uses_discovery_flow
+                    and not uses_oauth2_flow
                     and " async_step_zeroconf" not in content
                 ):
                     integration.add_error(
@@ -55,6 +57,7 @@ def generate_and_validate(integrations: Dict[str, Integration]):
                 if (
                     homekit_models
                     and not uses_discovery_flow
+                    and not uses_oauth2_flow
                     and " async_step_homekit" not in content
                 ):
                     integration.add_error(


### PR DESCRIPTION
## Description:

If an integration implements the AbstractOAuth2FlowHandler, the following steps may be omitted:

- `async_step_homekit`
- `async_step_ssdp`
- `async_step_zeroconf`

Since the AbstractOAuth2FlowHandler provides defaults for these steps.


**Related PR:** #30717

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
