### PR TITLE
Removes unneeded abort if unique id in Oauth2 discovery flow

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -262,7 +262,6 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
     async def async_step_discovery(self, user_input: dict = None) -> dict:
         """Handle a flow initialized by discovery."""
         await self.async_set_unique_id(self.DOMAIN)
-        self._abort_if_unique_id_configured()
 
         assert self.hass is not None
         if self.hass.config_entries.async_entries(self.DOMAIN):


### PR DESCRIPTION
## Description:

Addresses a comment made in #30700 after merge.

Comment <https://github.com/home-assistant/home-assistant/pull/30700#discussion_r365618654>

Removes unneeded call to `_abort_if_unique_id_configured`.

CC @MartinHjelmare 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
