### PR TITLE
Bump ZHA quirks to 0.0.31

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
     "bellows-homeassistant==0.12.0",
-    "zha-quirks==0.0.30",
+    "zha-quirks==0.0.31",
     "zigpy-deconz==0.7.0",
     "zigpy-homeassistant==0.12.0",
     "zigpy-xbee-homeassistant==0.8.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2112,7 +2112,7 @@ zengge==0.2
 zeroconf==0.24.4
 
 # homeassistant.components.zha
-zha-quirks==0.0.30
+zha-quirks==0.0.31
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -675,7 +675,7 @@ yahooweather==0.10
 zeroconf==0.24.4
 
 # homeassistant.components.zha
-zha-quirks==0.0.30
+zha-quirks==0.0.31
 
 # homeassistant.components.zha
 zigpy-deconz==0.7.0


### PR DESCRIPTION
## Description:
This PR bumps the version of the ZHA quirks lib. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]