### PR TITLE
Make event data read only

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -470,7 +470,7 @@ class Event:
     ) -> None:
         """Initialize a new event."""
         self.event_type = event_type
-        self.data = data or {}
+        self.data = MappingProxyType(data or {})
         self.origin = origin
         self.time_fired = time_fired or dt_util.utcnow()
         self.context: Context = context or Context()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -281,48 +281,65 @@ class TestHomeAssistant(unittest.TestCase):
             self.hass.add_job(None, "test_arg")
 
 
-class TestEvent(unittest.TestCase):
-    """A Test Event class."""
+def test_event_fields():
+    """Test event fields."""
+    now = dt_util.utcnow()
+    context = ha.Context()
 
-    def test_eq(self):
-        """Test events."""
-        now = dt_util.utcnow()
-        data = {"some": "attr"}
-        context = ha.Context()
-        event1, event2 = [
-            ha.Event("some_type", data, time_fired=now, context=context)
-            for _ in range(2)
-        ]
+    event = ha.Event(
+        "test-event-type", {"data": "read-only"}, ha.EventOrigin.remote, now, context
+    )
+    assert event.event_type == "test-event-type"
+    assert event.data == {"data": "read-only"}
 
-        assert event1 == event2
+    with pytest.raises(TypeError):
+        event.data["write"] = "not-allowed"
 
-    def test_repr(self):
-        """Test that repr method works."""
-        assert "<Event TestEvent[L]>" == str(ha.Event("TestEvent"))
+    assert event.origin == ha.EventOrigin.remote
+    assert event.time_fired == now
+    assert event.context is context
 
-        assert "<Event TestEvent[R]: beer=nice>" == str(
-            ha.Event("TestEvent", {"beer": "nice"}, ha.EventOrigin.remote)
-        )
 
-    def test_as_dict(self):
-        """Test as dictionary."""
-        event_type = "some_type"
-        now = dt_util.utcnow()
-        data = {"some": "attr"}
+def test_event_eq():
+    """Test events."""
+    now = dt_util.utcnow()
+    data = {"some": "attr"}
+    context = ha.Context()
+    event1, event2 = [
+        ha.Event("some_type", data, time_fired=now, context=context) for _ in range(2)
+    ]
 
-        event = ha.Event(event_type, data, ha.EventOrigin.local, now)
-        expected = {
-            "event_type": event_type,
-            "data": data,
-            "origin": "LOCAL",
-            "time_fired": now,
-            "context": {
-                "id": event.context.id,
-                "parent_id": None,
-                "user_id": event.context.user_id,
-            },
-        }
-        assert expected == event.as_dict()
+    assert event1 == event2
+
+
+def test_event_repr():
+    """Test that repr method works."""
+    assert "<Event TestEvent[L]>" == str(ha.Event("TestEvent"))
+
+    assert "<Event TestEvent[R]: beer=nice>" == str(
+        ha.Event("TestEvent", {"beer": "nice"}, ha.EventOrigin.remote)
+    )
+
+
+def test_event_as_dict():
+    """Test as dictionary."""
+    event_type = "some_type"
+    now = dt_util.utcnow()
+    data = {"some": "attr"}
+
+    event = ha.Event(event_type, data, ha.EventOrigin.local, now)
+    expected = {
+        "event_type": event_type,
+        "data": data,
+        "origin": "LOCAL",
+        "time_fired": now,
+        "context": {
+            "id": event.context.id,
+            "parent_id": None,
+            "user_id": event.context.user_id,
+        },
+    }
+    assert expected == event.as_dict()
 
 
 class TestEventBus(unittest.TestCase):


### PR DESCRIPTION
## Description:
In #30292 I saw a stack trace where `event.data` was not a dictionary, breaking other parts of the system that relied on it. This PR will guard against that by making the data read-only in the constructor, which will blow up any event that tries to be fired with event data not being a dict.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
