### PR TITLE
Fix translation from HA playlist to UPnP playlistItem

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -77,7 +77,7 @@ HOME_ASSISTANT_UPNP_CLASS_MAPPING = {
     MEDIA_TYPE_EPISODE: "object.item.videoItem",
     MEDIA_TYPE_CHANNEL: "object.item.videoItem",
     MEDIA_TYPE_IMAGE: "object.item.imageItem",
-    MEDIA_TYPE_PLAYLIST: "object.item.playlist",
+    MEDIA_TYPE_PLAYLIST: "object.item.playlistItem",
 }
 UPNP_CLASS_DEFAULT = "object.item"
 HOME_ASSISTANT_UPNP_MIME_TYPE_MAPPING = {


### PR DESCRIPTION
## Description:

Upon playing a playlist from the DLNA-DMR component, an error is raised. This error happens due to an invalid translation of HomeAssitant media types to UPnP type.

Command issued:
```
media_content_type: "playlist"
media_content_id: "http://x.x.x.x:port/local/media/playlist.m3u"
entity_id: media_player.dlna_dmr
```

Traceback:
```
Unknown DIDL-lite type
Traceback (most recent call last):
  File "/home/pi/homeassistant/lib/python3.7/site-packages/homeassistant/components/websocket_api/commands.py", line 133, in handle_call_service
    connection.context(msg),
  File "/home/pi/homeassistant/lib/python3.7/site-packages/homeassistant/core.py", line 1235, in async_call
    await asyncio.shield(self._execute_service(handler, service_call))
  File "/home/pi/homeassistant/lib/python3.7/site-packages/homeassistant/core.py", line 1260, in _execute_service
    await handler.func(service_call)
  File "/home/pi/homeassistant/lib/python3.7/site-packages/homeassistant/helpers/entity_component.py", line 205, in handle_service
    self._platforms.values(), func, call, service_name, required_features
  File "/home/pi/homeassistant/lib/python3.7/site-packages/homeassistant/helpers/service.py", line 336, in entity_service_call
    future.result()  # pop exception if have
  File "/home/pi/homeassistant/lib/python3.7/site-packages/homeassistant/helpers/service.py", line 360, in _handle_service_platform_call
    await func(entity, data)
  File "/home/pi/homeassistant/lib/python3.7/site-packages/homeassistant/components/dlna_dmr/media_player.py", line 354, in async_play_media
    media_id, title, mime_type, upnp_class
  File "/home/pi/homeassistant/lib/python3.7/site-packages/async_upnp_client/profiles/dlna.py", line 632, in async_set_transport_uri
    override_dlna_features=override_dlna_features)
  File "/home/pi/homeassistant/lib/python3.7/site-packages/async_upnp_client/profiles/dlna.py", line 731, in _construct_play_media_metadata
    raise UpnpError('Unknown DIDL-lite type')
```

**Related issue (if applicable):** fixes issue reported by mail.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
