### PR TITLE
Set default locale for cloud Alexa config

### DIFF
--- a/homeassistant/components/alexa/config.py
+++ b/homeassistant/components/alexa/config.py
@@ -1,10 +1,12 @@
 """Config helpers for Alexa."""
+from abc import ABC, abstractmethod
+
 from homeassistant.core import callback
 
 from .state_report import async_enable_proactive_mode
 
 
-class AbstractConfig:
+class AbstractConfig(ABC):
     """Hold the configuration for Alexa."""
 
     _unsub_proactive_report = None
@@ -29,9 +31,9 @@ class AbstractConfig:
         return None
 
     @property
+    @abstractmethod
     def locale(self):
         """Return config locale."""
-        return None
 
     @property
     def entity_config(self):

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -79,6 +79,12 @@ class AlexaConfig(alexa_config.AbstractConfig):
         return self._endpoint
 
     @property
+    def locale(self):
+        """Return config locale."""
+        # Not clear how to determine locale atm.
+        return "en-US"
+
+    @property
     def entity_config(self):
         """Return entity config."""
         return self._config.get(CONF_ENTITY_CONFIG) or {}


### PR DESCRIPTION
## Description:
Set a default locale of `en-US` for the Cloud Alexa config.  Also marked the Alexa config as an abstract class so we can easier find this in the future. 

It's not clear to me how to determine the locale for smart home requests. I was scanning the docs but could only find examples of locale being passed in `LaunchIntentRequest`, which we don't get. 

Thanks to @ochlocracy for finding it.

**Related issue (if applicable):** fixes #30673

