### PR TITLE
Update to aiokef=0.2.5 which uses Locks

### DIFF
--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "dependencies": [],
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.2.2", "getmac==0.8.1"]
+  "requirements": ["aiokef==0.2.5", "getmac==0.8.1"]
 }

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -40,7 +40,6 @@ DEFAULT_INVERSE_SPEAKER_MODE = False
 DOMAIN = "kef"
 
 SCAN_INTERVAL = timedelta(seconds=30)
-PARALLEL_UPDATES = 0
 
 SOURCES = {"LSX": ["Wifi", "Bluetooth", "Aux", "Opt"]}
 SOURCES["LS50"] = SOURCES["LSX"] + ["Usb"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -172,7 +172,7 @@ aioimaplib==0.7.15
 aiokafka==0.5.1
 
 # homeassistant.components.kef
-aiokef==0.2.2
+aiokef==0.2.5
 
 # homeassistant.components.lifx
 aiolifx==0.6.7


### PR DESCRIPTION
## Description:
Updates aiokef to 0.2.3 and sets the PARALLEL_UPDATES correctly.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
