### PR TITLE
Hass.io allow to reset password with CLI

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -201,7 +201,7 @@ async def async_setup(hass, config):
             require_admin=True,
         )
 
-    await hassio.update_hass_api(config.get("http", {}), refresh_token.token)
+    await hassio.update_hass_api(config.get("http", {}), refresh_token)
 
     async def push_config(_):
         """Push core config to Hass.io."""

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -290,7 +290,7 @@ async def async_setup(hass, config):
     async_setup_discovery_view(hass, hassio)
 
     # Init auth Hass.io feature
-    async_setup_auth_view(hass)
+    async_setup_auth_view(hass, user)
 
     # Init ingress Hass.io feature
     async_setup_ingress_view(hass, host)

--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -29,18 +29,26 @@ SCHEMA_API_AUTH = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+SCHEMA_API_PASSWORD_RESET = vol.Schema(
+    {vol.Required(ATTR_USERNAME): cv.string, vol.Required(ATTR_PASSWORD): cv.string,},
+    extra=vol.ALLOW_EXTRA,
+)
+
 
 @callback
 def async_setup_auth_view(hass: HomeAssistantType):
     """Auth setup."""
     hassio_auth = HassIOAuth(hass)
+    hassio_passwort_reset = HassIOPasswordReset(hass)
+
     hass.http.register_view(hassio_auth)
+    hass.http.register_view(hassio_passwort_reset)
 
 
 class HassIOAuth(HomeAssistantView):
-    """Hass.io view to handle base part."""
+    """Hass.io view to handle auth requests."""
 
-    name = "api:hassio_auth"
+    name = "api:hassio:auth"
     url = "/api/hassio_auth"
 
     def __init__(self, hass):
@@ -73,5 +81,48 @@ class HassIOAuth(HomeAssistantView):
 
         try:
             await provider.async_validate_login(username, password)
+        except HomeAssistantError:
+            raise HTTPForbidden() from None
+
+
+class HassIOPasswordReset(HomeAssistantView):
+    """Hass.io view to handle password reset requests."""
+
+    name = "api:hassio:auth:password:reset"
+    url = "/api/hassio_auth/password_reset"
+
+    def __init__(self, hass):
+        """Initialize WebView."""
+        self.hass = hass
+
+    @RequestDataValidator(SCHEMA_API_PASSWORD_RESET)
+    async def post(self, request, data):
+        """Handle new discovery requests."""
+        hassio_ip = os.environ["HASSIO"].split(":")[0]
+        if request[KEY_REAL_IP] != ip_address(hassio_ip):
+            _LOGGER.error("Invalid auth request from %s", request[KEY_REAL_IP])
+            raise HTTPForbidden()
+
+        await self._change_password(data[ATTR_USERNAME], data[ATTR_PASSWORD])
+        return web.Response(status=200)
+
+    def _get_provider(self):
+        """Return Homeassistant auth provider."""
+        prv = self.hass.auth.get_auth_provider("homeassistant", None)
+        if prv is not None:
+            return prv
+
+        _LOGGER.error("Can't find Home Assistant auth.")
+        raise HTTPNotFound()
+
+    async def _change_password(self, username, password):
+        """Check User credentials."""
+        provider = self._get_provider()
+
+        try:
+            await self.hass.async_add_executor_job(
+                provider.data.change_password, username, password
+            )
+            await provider.data.async_save()
         except HomeAssistantError:
             raise HTTPForbidden() from None

--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -8,12 +8,13 @@ from aiohttp.web_exceptions import HTTPForbidden, HTTPNotFound
 import voluptuous as vol
 
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.http.const import KEY_REAL_IP
+from homeassistant.components.http.const import KEY_REAL_IP, KEY_HASS_USER
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.auth.models import User
 
 from .const import ATTR_ADDON, ATTR_PASSWORD, ATTR_USERNAME
 
@@ -36,35 +37,35 @@ SCHEMA_API_PASSWORD_RESET = vol.Schema(
 
 
 @callback
-def async_setup_auth_view(hass: HomeAssistantType):
+def async_setup_auth_view(hass: HomeAssistantType, user: User):
     """Auth setup."""
-    hassio_auth = HassIOAuth(hass)
-    hassio_passwort_reset = HassIOPasswordReset(hass)
+    hassio_auth = HassIOAuth(hass, user)
+    hassio_passwort_reset = HassIOPasswordReset(hass, user)
 
     hass.http.register_view(hassio_auth)
     hass.http.register_view(hassio_passwort_reset)
 
 
-class HassIOAuth(HomeAssistantView):
+class HassIOBaseAuth(HomeAssistantView):
     """Hass.io view to handle auth requests."""
 
-    name = "api:hassio:auth"
-    url = "/api/hassio_auth"
-
-    def __init__(self, hass):
+    def __init__(self, hass: HomeAssistantType, user: User):
         """Initialize WebView."""
         self.hass = hass
+        self.user = user
 
-    @RequestDataValidator(SCHEMA_API_AUTH)
-    async def post(self, request, data):
-        """Handle new discovery requests."""
+    def _check_access(self, request: web.Request):
+        """Check if this call is from Supervisor."""
+        # Check caller IP
         hassio_ip = os.environ["HASSIO"].split(":")[0]
         if request[KEY_REAL_IP] != ip_address(hassio_ip):
             _LOGGER.error("Invalid auth request from %s", request[KEY_REAL_IP])
             raise HTTPForbidden()
 
-        await self._check_login(data[ATTR_USERNAME], data[ATTR_PASSWORD])
-        return web.Response(status=200)
+        # Check caller token
+        if request[KEY_HASS_USER].id != self.user.id:
+            _LOGGER.error("Invalid auth request from %s", request[KEY_HASS_USER].name)
+            raise HTTPForbidden()
 
     def _get_provider(self):
         """Return Homeassistant auth provider."""
@@ -74,6 +75,21 @@ class HassIOAuth(HomeAssistantView):
 
         _LOGGER.error("Can't find Home Assistant auth.")
         raise HTTPNotFound()
+
+
+class HassIOAuth(HassIOBaseAuth):
+    """Hass.io view to handle auth requests."""
+
+    name = "api:hassio:auth"
+    url = "/api/hassio_auth"
+
+    @RequestDataValidator(SCHEMA_API_AUTH)
+    async def post(self, request, data):
+        """Handle new discovery requests."""
+        self._check_access(request)
+
+        await self._check_login(data[ATTR_USERNAME], data[ATTR_PASSWORD])
+        return web.Response(status=200)
 
     async def _check_login(self, username, password):
         """Check User credentials."""
@@ -85,35 +101,19 @@ class HassIOAuth(HomeAssistantView):
             raise HTTPForbidden() from None
 
 
-class HassIOPasswordReset(HomeAssistantView):
+class HassIOPasswordReset(HassIOBaseAuth):
     """Hass.io view to handle password reset requests."""
 
     name = "api:hassio:auth:password:reset"
     url = "/api/hassio_auth/password_reset"
 
-    def __init__(self, hass):
-        """Initialize WebView."""
-        self.hass = hass
-
     @RequestDataValidator(SCHEMA_API_PASSWORD_RESET)
     async def post(self, request, data):
         """Handle new discovery requests."""
-        hassio_ip = os.environ["HASSIO"].split(":")[0]
-        if request[KEY_REAL_IP] != ip_address(hassio_ip):
-            _LOGGER.error("Invalid auth request from %s", request[KEY_REAL_IP])
-            raise HTTPForbidden()
+        self._check_access(request)
 
         await self._change_password(data[ATTR_USERNAME], data[ATTR_PASSWORD])
         return web.Response(status=200)
-
-    def _get_provider(self):
-        """Return Homeassistant auth provider."""
-        prv = self.hass.auth.get_auth_provider("homeassistant", None)
-        if prv is not None:
-            return prv
-
-        _LOGGER.error("Can't find Home Assistant auth.")
-        raise HTTPNotFound()
 
     async def _change_password(self, username, password):
         """Check User credentials."""

--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -5,9 +5,9 @@ import os
 
 from aiohttp import web
 from aiohttp.web_exceptions import (
-    HTTPUnauthorized,
     HTTPInternalServerError,
     HTTPNotFound,
+    HTTPUnauthorized,
 )
 import voluptuous as vol
 

--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -31,7 +31,7 @@ SCHEMA_API_AUTH = vol.Schema(
 )
 
 SCHEMA_API_PASSWORD_RESET = vol.Schema(
-    {vol.Required(ATTR_USERNAME): cv.string, vol.Required(ATTR_PASSWORD): cv.string,},
+    {vol.Required(ATTR_USERNAME): cv.string, vol.Required(ATTR_PASSWORD): cv.string},
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -4,7 +4,11 @@ import logging
 import os
 
 from aiohttp import web
-from aiohttp.web_exceptions import HTTPForbidden, HTTPInternalServerError, HTTPNotFound
+from aiohttp.web_exceptions import (
+    HTTPUnauthorized,
+    HTTPInternalServerError,
+    HTTPNotFound,
+)
 import voluptuous as vol
 
 from homeassistant.auth.models import User
@@ -60,12 +64,12 @@ class HassIOBaseAuth(HomeAssistantView):
         hassio_ip = os.environ["HASSIO"].split(":")[0]
         if request[KEY_REAL_IP] != ip_address(hassio_ip):
             _LOGGER.error("Invalid auth request from %s", request[KEY_REAL_IP])
-            raise HTTPForbidden()
+            raise HTTPUnauthorized()
 
         # Check caller token
         if request[KEY_HASS_USER].id != self.user.id:
             _LOGGER.error("Invalid auth request from %s", request[KEY_HASS_USER].name)
-            raise HTTPForbidden()
+            raise HTTPUnauthorized()
 
     def _get_provider(self):
         """Return Homeassistant auth provider."""
@@ -98,7 +102,7 @@ class HassIOAuth(HassIOBaseAuth):
         try:
             await provider.async_validate_login(username, password)
         except HomeAssistantError:
-            raise HTTPForbidden() from None
+            raise HTTPUnauthorized() from None
 
 
 class HassIOPasswordReset(HassIOBaseAuth):

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -130,7 +130,7 @@ class HassIO:
             "ssl": CONF_SSL_CERTIFICATE in http_config,
             "port": port,
             "watchdog": True,
-            "refresh_token": refresh_token,
+            "refresh_token": refresh_token.token,
         }
 
         if CONF_SERVER_HOST in http_config:

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -42,7 +42,7 @@ def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
         hass.state = CoreState.starting
         hass.loop.run_until_complete(async_setup_component(hass, "hassio", {}))
 
-    return hass_api.call_args.args[1]
+    return hass_api.call_args[0][1]
 
 
 @pytest.fixture

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -32,7 +32,7 @@ def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
     with patch(
         "homeassistant.components.hassio.HassIO.update_hass_api",
         return_value=mock_coro({"result": "ok"}),
-    ), patch(
+    ) as hass_api, patch(
         "homeassistant.components.hassio.HassIO.update_hass_timezone",
         return_value=mock_coro({"result": "ok"}),
     ), patch(
@@ -41,6 +41,8 @@ def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
     ):
         hass.state = CoreState.starting
         hass.loop.run_until_complete(async_setup_component(hass, "hassio", {}))
+
+    return hass_api.call_args.args[1]
 
 
 @pytest.fixture
@@ -53,6 +55,15 @@ def hassio_client(hassio_stubs, hass, hass_client):
 def hassio_noauth_client(hassio_stubs, hass, aiohttp_client):
     """Return a Hass.io HTTP client without auth."""
     return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
+
+
+@pytest.fixture
+async def hassio_client_supervisor(hass, aiohttp_client, hassio_stubs):
+    """Return an authenticated HTTP client."""
+    access_token = hass.auth.async_create_access_token(hassio_stubs)
+    return await aiohttp_client(
+        hass.http.app, headers={"Authorization": f"Bearer {access_token}"},
+    )
 
 
 @pytest.fixture

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -6,14 +6,14 @@ from homeassistant.exceptions import HomeAssistantError
 from tests.common import mock_coro
 
 
-async def test_login_success(hass, hassio_client):
+async def test_auth_success(hass, hassio_client_supervisor):
     """Test no auth needed for ."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
         "HassAuthProvider.async_validate_login",
         Mock(return_value=mock_coro()),
     ) as mock_login:
-        resp = await hassio_client.post(
+        resp = await hassio_client_supervisor.post(
             "/api/hassio_auth",
             json={"username": "test", "password": "123456", "addon": "samba"},
         )
@@ -23,14 +23,48 @@ async def test_login_success(hass, hassio_client):
         mock_login.assert_called_with("test", "123456")
 
 
-async def test_login_error(hass, hassio_client):
+async def test_auth_fails_no_supervisor(hass, hassio_client):
+    """Test if only supervisor can access."""
+    with patch(
+        "homeassistant.auth.providers.homeassistant."
+        "HassAuthProvider.async_validate_login",
+        Mock(return_value=mock_coro()),
+    ) as mock_login:
+        resp = await hassio_client.post(
+            "/api/hassio_auth",
+            json={"username": "test", "password": "123456", "addon": "samba"},
+        )
+
+        # Check we got right response
+        assert resp.status == 403
+        assert not mock_login.called
+
+
+async def test_auth_fails_no_auth(hass, hassio_noauth_client):
+    """Test if only supervisor can access."""
+    with patch(
+        "homeassistant.auth.providers.homeassistant."
+        "HassAuthProvider.async_validate_login",
+        Mock(return_value=mock_coro()),
+    ) as mock_login:
+        resp = await hassio_noauth_client.post(
+            "/api/hassio_auth",
+            json={"username": "test", "password": "123456", "addon": "samba"},
+        )
+
+        # Check we got right response
+        assert resp.status == 401
+        assert not mock_login.called
+
+
+async def test_login_error(hass, hassio_client_supervisor):
     """Test no auth needed for error."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
         "HassAuthProvider.async_validate_login",
         Mock(side_effect=HomeAssistantError()),
     ) as mock_login:
-        resp = await hassio_client.post(
+        resp = await hassio_client_supervisor.post(
             "/api/hassio_auth",
             json={"username": "test", "password": "123456", "addon": "samba"},
         )
@@ -40,28 +74,28 @@ async def test_login_error(hass, hassio_client):
         mock_login.assert_called_with("test", "123456")
 
 
-async def test_login_no_data(hass, hassio_client):
+async def test_login_no_data(hass, hassio_client_supervisor):
     """Test auth with no data -> error."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
         "HassAuthProvider.async_validate_login",
         Mock(side_effect=HomeAssistantError()),
     ) as mock_login:
-        resp = await hassio_client.post("/api/hassio_auth")
+        resp = await hassio_client_supervisor.post("/api/hassio_auth")
 
         # Check we got right response
         assert resp.status == 400
         assert not mock_login.called
 
 
-async def test_login_no_username(hass, hassio_client):
+async def test_login_no_username(hass, hassio_client_supervisor):
     """Test auth with no username in data -> error."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
         "HassAuthProvider.async_validate_login",
         Mock(side_effect=HomeAssistantError()),
     ) as mock_login:
-        resp = await hassio_client.post(
+        resp = await hassio_client_supervisor.post(
             "/api/hassio_auth", json={"password": "123456", "addon": "samba"}
         )
 
@@ -70,14 +104,14 @@ async def test_login_no_username(hass, hassio_client):
         assert not mock_login.called
 
 
-async def test_login_success_extra(hass, hassio_client):
+async def test_login_success_extra(hass, hassio_client_supervisor):
     """Test auth with extra data."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
         "HassAuthProvider.async_validate_login",
         Mock(return_value=mock_coro()),
     ) as mock_login:
-        resp = await hassio_client.post(
+        resp = await hassio_client_supervisor.post(
             "/api/hassio_auth",
             json={
                 "username": "test",

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -36,7 +36,7 @@ async def test_auth_fails_no_supervisor(hass, hassio_client):
         )
 
         # Check we got right response
-        assert resp.status == 403
+        assert resp.status == 401
         assert not mock_login.called
 
 
@@ -70,7 +70,7 @@ async def test_login_error(hass, hassio_client_supervisor):
         )
 
         # Check we got right response
-        assert resp.status == 403
+        assert resp.status == 401
         mock_login.assert_called_with("test", "123456")
 
 
@@ -153,7 +153,7 @@ async def test_password_fails_no_supervisor(hass, hassio_client):
         )
 
         # Check we got right response
-        assert resp.status == 403
+        assert resp.status == 401
         assert not mock_save.called
 
 

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -129,7 +129,8 @@ async def test_login_success_extra(hass, hassio_client_supervisor):
 async def test_password_success(hass, hassio_client_supervisor):
     """Test no auth needed for ."""
     with patch(
-        "homeassistant.components.hassio.auth.HassIOPasswordReset._change_password"
+        "homeassistant.components.hassio.auth.HassIOPasswordReset._change_password",
+        Mock(return_value=mock_coro()),
     ) as mock_change:
         resp = await hassio_client_supervisor.post(
             "/api/hassio_auth/password_reset",


### PR DESCRIPTION
## Description:

Add an endpoint to hassio auth API which we use to have one user backend overall, also to change password. So we can this expose to API with special permission to reset a password.

- [x] Tests