### PR TITLE
Fix HomeKit behavior with lights supporting color and temperature

### DIFF
--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -66,15 +66,20 @@ class Light(HomeAccessory):
         self._features = self.hass.states.get(self.entity_id).attributes.get(
             ATTR_SUPPORTED_FEATURES
         )
+
         if self._features & SUPPORT_BRIGHTNESS:
             self.chars.append(CHAR_BRIGHTNESS)
-        if self._features & SUPPORT_COLOR_TEMP:
-            self.chars.append(CHAR_COLOR_TEMPERATURE)
+
         if self._features & SUPPORT_COLOR:
             self.chars.append(CHAR_HUE)
             self.chars.append(CHAR_SATURATION)
             self._hue = None
             self._saturation = None
+        elif self._features & SUPPORT_COLOR_TEMP:
+            # ColorTemperature and Hue characteristic should not be
+            # exposed both. Both states are tracked separately in HomeKit,
+            # causing "source of truth" problems.
+            self.chars.append(CHAR_COLOR_TEMPERATURE)
 
         serv_light = self.add_preload_service(SERV_LIGHTBULB, self.chars)
         self.char_on = serv_light.configure_char(
@@ -88,6 +93,7 @@ class Light(HomeAccessory):
             self.char_brightness = serv_light.configure_char(
                 CHAR_BRIGHTNESS, value=100, setter_callback=self.set_brightness
             )
+
         if CHAR_COLOR_TEMPERATURE in self.chars:
             min_mireds = self.hass.states.get(self.entity_id).attributes.get(
                 ATTR_MIN_MIREDS, 153
@@ -101,10 +107,12 @@ class Light(HomeAccessory):
                 properties={PROP_MIN_VALUE: min_mireds, PROP_MAX_VALUE: max_mireds},
                 setter_callback=self.set_color_temperature,
             )
+
         if CHAR_HUE in self.chars:
             self.char_hue = serv_light.configure_char(
                 CHAR_HUE, value=0, setter_callback=self.set_hue
             )
+
         if CHAR_SATURATION in self.chars:
             self.char_saturation = serv_light.configure_char(
                 CHAR_SATURATION, value=75, setter_callback=self.set_saturation

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -177,6 +177,25 @@ async def test_light_color_temperature(hass, hk_driver, cls, events):
     assert events[-1].data[ATTR_VALUE] == "color temperature at 250"
 
 
+async def test_light_color_temperature_and_rgb_color(hass, hk_driver, cls, events):
+    """Test light with color temperature and rgb color not exposing temperature."""
+    entity_id = "light.demo"
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP | SUPPORT_COLOR,
+            ATTR_COLOR_TEMP: 190,
+            ATTR_HS_COLOR: (260, 90),
+        },
+    )
+    await hass.async_block_till_done()
+    acc = cls.light(hass, hk_driver, "Light", entity_id, 2, None)
+
+    assert not hasattr(acc, "char_color_temperature")
+
+
 async def test_light_rgb_color(hass, hk_driver, cls, events):
     """Test light with rgb_color."""
     entity_id = "light.demo"


### PR DESCRIPTION
## Description:

If a light supports both the `Hue` and `ColorTemperature` characteristic types, HomeKit will actually keep both states separate and active and the same time.

This causes a problem in several ways since we no longer know what the truth is at this point. This is the best visible from the Home app itself:

![2020-01-14 13 38 08](https://user-images.githubusercontent.com/195327/72351064-effa8100-36df-11ea-9d60-0418d2a4194b.gif)

_(sorry for the low-quality GIF, for more examples, see first linked issue below)_

The only option we have is to decide what to use. This PR implements a change that prevents exposing the `ColorTemperature` characteristic when the light supports `Hue` as well (like Hue).

It resolves the issues linked below, and most likely issues with people using a lot of Philips Hue bulb trying to apply scenes to a bunch of those (which may cause some bulbs not to change as set in the scene).

In the Home apps, even with only `Hue` set, the color temperature selection remains available. However, colors are sent to Home Assistant, instead of a temperature.


After movie:

![2020-01-14 15 17 59](https://user-images.githubusercontent.com/195327/72351713-284e8f00-36e1-11ea-87c1-5ed5472f7a2a.gif)


**Related issue (if applicable):** fixes #19251 fixes #23394 fixes #27170 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
