### PR TITLE
Fix small typo in alarmdotcom component

### DIFF
--- a/homeassistant/components/alarmdotcom/alarm_control_panel.py
+++ b/homeassistant/components/alarmdotcom/alarm_control_panel.py
@@ -115,7 +115,7 @@ class AlarmDotCom(alarm.AlarmControlPanel):
             await self._alarm.async_alarm_disarm()
 
     async def async_alarm_arm_home(self, code=None):
-        """Send arm hom command."""
+        """Send arm home command."""
         if self._validate_code(code):
             await self._alarm.async_alarm_arm_home()
 


### PR DESCRIPTION

## Description:

I am fixing small typo in alarmdotcom component. 

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
