### PR TITLE
Add support for vacuums to Alexa

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -20,6 +20,7 @@ from homeassistant.components import (
     sensor,
     switch,
     timer,
+    vacuum,
 )
 from homeassistant.components.climate import const as climate
 from homeassistant.const import (
@@ -724,3 +725,34 @@ class TimerCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         yield AlexaTimeHoldController(self.entity, allow_remote_resume=True)
         yield Alexa(self.entity)
+
+
+@ENTITY_ADAPTERS.register(vacuum.DOMAIN)
+class VacuumCapabilities(AlexaEntity):
+    """Class to represent vacuum capabilities."""
+
+    def default_display_categories(self):
+        """Return the display categories for this entity."""
+        return [DisplayCategory.OTHER]
+
+    def interfaces(self):
+        """Yield the supported interfaces."""
+        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        if (supported & vacuum.SUPPORT_TURN_ON) and (
+            supported & vacuum.SUPPORT_TURN_OFF
+        ):
+            yield AlexaPowerController(self.entity)
+
+        if supported & vacuum.SUPPORT_FAN_SPEED:
+            yield AlexaRangeController(
+                self.entity, instance=f"{vacuum.DOMAIN}.{vacuum.ATTR_FAN_SPEED}"
+            )
+
+        if supported & vacuum.SUPPORT_PAUSE:
+            support_resume = bool(supported & vacuum.SUPPORT_START)
+            yield AlexaTimeHoldController(
+                self.entity, allow_remote_resume=support_resume
+            )
+
+        yield AlexaEndpointHealth(self.hass, self.entity)
+        yield Alexa(self.hass)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -17,6 +17,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
 )
+import homeassistant.components.vacuum as vacuum
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import Context, callback
 from homeassistant.helpers import entityfilter
@@ -3133,4 +3134,224 @@ async def test_timer_resume(hass):
 
     await assert_request_calls_service(
         "Alexa.TimeHoldController", "Resume", "timer#laundry", "timer.start", hass
+    )
+
+
+async def test_vacuum_discovery(hass):
+    """Test vacuum discovery."""
+    device = (
+        "vacuum.test_1",
+        "docked",
+        {
+            "friendly_name": "Test vacuum 1",
+            "supported_features": vacuum.SUPPORT_TURN_ON
+            | vacuum.SUPPORT_TURN_OFF
+            | vacuum.SUPPORT_START
+            | vacuum.SUPPORT_STOP
+            | vacuum.SUPPORT_PAUSE,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "vacuum#test_1"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test vacuum 1"
+
+    assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.TimeHoldController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+
+async def test_vacuum_fan_speed(hass):
+    """Test vacuum fan speed with rangeController."""
+    device = (
+        "vacuum.test_2",
+        "cleaning",
+        {
+            "friendly_name": "Test vacuum 2",
+            "supported_features": vacuum.SUPPORT_TURN_ON
+            | vacuum.SUPPORT_TURN_OFF
+            | vacuum.SUPPORT_START
+            | vacuum.SUPPORT_STOP
+            | vacuum.SUPPORT_PAUSE
+            | vacuum.SUPPORT_FAN_SPEED,
+            "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
+            "fan_speed": "medium",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "vacuum#test_2"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test vacuum 2"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.RangeController",
+        "Alexa.TimeHoldController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    range_capability = get_capability(capabilities, "Alexa.RangeController")
+    assert range_capability is not None
+    assert range_capability["instance"] == "vacuum.fan_speed"
+
+    capability_resources = range_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "asset",
+        "value": {"assetId": "Alexa.Setting.FanSpeed"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = range_capability["configuration"]
+    assert configuration is not None
+
+    supported_range = configuration["supportedRange"]
+    assert supported_range["minimumValue"] == 0
+    assert supported_range["maximumValue"] == 5
+    assert supported_range["precision"] == 1
+
+    presets = configuration["presets"]
+    assert {
+        "rangeValue": 0,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "off", "locale": "en-US"}}
+            ]
+        },
+    } in presets
+
+    assert {
+        "rangeValue": 1,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "low", "locale": "en-US"}},
+                {"@type": "asset", "value": {"assetId": "Alexa.Value.Minimum"}},
+            ]
+        },
+    } in presets
+
+    assert {
+        "rangeValue": 2,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "medium", "locale": "en-US"}}
+            ]
+        },
+    } in presets
+
+    assert {
+        "rangeValue": 5,
+        "presetResources": {
+            "friendlyNames": [
+                {"@type": "text", "value": {"text": "super sucker", "locale": "en-US"}},
+                {"@type": "asset", "value": {"assetId": "Alexa.Value.Maximum"}},
+            ]
+        },
+    } in presets
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "vacuum#test_2",
+        "vacuum.set_fan_speed",
+        hass,
+        payload={"rangeValue": "1"},
+        instance="vacuum.fan_speed",
+    )
+    assert call.data["fan_speed"] == "low"
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "vacuum#test_2",
+        "vacuum.set_fan_speed",
+        hass,
+        payload={"rangeValue": "5"},
+        instance="vacuum.fan_speed",
+    )
+    assert call.data["fan_speed"] == "super_sucker"
+
+    await assert_range_changes(
+        hass,
+        [("low", "-1"), ("high", "1"), ("medium", "0"), ("super_sucker", "99")],
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "vacuum#test_2",
+        False,
+        "vacuum.set_fan_speed",
+        "fan_speed",
+        instance="vacuum.fan_speed",
+    )
+
+
+async def test_vacuum_pause(hass):
+    """Test vacuum pause with TimeHoldController."""
+    device = (
+        "vacuum.test_3",
+        "cleaning",
+        {
+            "friendly_name": "Test vacuum 3",
+            "supported_features": vacuum.SUPPORT_TURN_ON
+            | vacuum.SUPPORT_TURN_OFF
+            | vacuum.SUPPORT_START
+            | vacuum.SUPPORT_STOP
+            | vacuum.SUPPORT_PAUSE
+            | vacuum.SUPPORT_FAN_SPEED,
+            "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
+            "fan_speed": "medium",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.RangeController",
+        "Alexa.TimeHoldController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    time_hold_capability = get_capability(capabilities, "Alexa.TimeHoldController")
+    assert time_hold_capability is not None
+    configuration = time_hold_capability["configuration"]
+    assert configuration["allowRemoteResume"] is True
+
+    await assert_request_calls_service(
+        "Alexa.TimeHoldController", "Hold", "vacuum#test_3", "vacuum.start_pause", hass
+    )
+
+
+async def test_vacuum_resume(hass):
+    """Test vacuum resume with TimeHoldController."""
+    device = (
+        "vacuum.test_4",
+        "docked",
+        {
+            "friendly_name": "Test vacuum 4",
+            "supported_features": vacuum.SUPPORT_TURN_ON
+            | vacuum.SUPPORT_TURN_OFF
+            | vacuum.SUPPORT_START
+            | vacuum.SUPPORT_STOP
+            | vacuum.SUPPORT_PAUSE
+            | vacuum.SUPPORT_FAN_SPEED,
+            "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
+            "fan_speed": "medium",
+        },
+    )
+    await discovery_test(device, hass)
+
+    await assert_request_calls_service(
+        "Alexa.TimeHoldController",
+        "Resume",
+        "vacuum#test_4",
+        "vacuum.start_pause",
+        hass,
     )


### PR DESCRIPTION
## Description:

This PR really sucks. 😁 

Adds basic vacuum support to Alexa. Yields a `PowerController`, `TimeHoldController`, and `RangeController` for the fan speed depending on the vacuum supported features.

Utterances
> Alexa, turn on vacuum
> Alexa, turn off vacuum
> Alexa, set vacuum fan speed to high
> Alexa, set vacuum fan speed to 3
> Alexa, pause the vacuum
> Alexa, restart the vacuum

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
