### PR TITLE
Use storage based collections for Timer platform

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "timer"
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
-DEFAULT_DURATION = timedelta(0)
+DEFAULT_DURATION = 0
 ATTR_DURATION = "duration"
 ATTR_REMAINING = "remaining"
 CONF_DURATION = "duration"

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -168,7 +168,10 @@ class TimerStorageCollection(collection.StorageCollection):
 
     async def _process_create_data(self, data: typing.Dict) -> typing.Dict:
         """Validate the config is valid."""
-        return self.CREATE_SCHEMA(data)
+        data = self.CREATE_SCHEMA(data)
+        # make duration JSON serializeable
+        data[CONF_DURATION] = str(data[CONF_DURATION])
+        return data
 
     @callback
     def _get_suggested_id(self, info: typing.Dict) -> str:
@@ -177,8 +180,10 @@ class TimerStorageCollection(collection.StorageCollection):
 
     async def _update_data(self, data: dict, update_data: typing.Dict) -> typing.Dict:
         """Return a new updated data object."""
-        update_data = self.UPDATE_SCHEMA(update_data)
-        return {**data, **update_data}
+        data = {**data, **self.UPDATE_SCHEMA(update_data)}
+        # make duration JSON serializeable
+        data[CONF_DURATION] = str(data[CONF_DURATION])
+        return data
 
 
 class Timer(RestoreEntity):

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -503,7 +503,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
     assert resp["success"]
 
     state = hass.states.get(timer_entity_id)
-    assert state.attributes[ATTR_DURATION] == cv.time_period(33)
+    assert state.attributes[ATTR_DURATION] == str(cv.time_period(33))
 
 
 async def test_ws_create(hass, hass_ws_client, storage_setup):
@@ -533,5 +533,5 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     state = hass.states.get(timer_entity_id)
     assert state.state == STATUS_IDLE
-    assert state.attributes[ATTR_DURATION] == cv.time_period(42)
+    assert state.attributes[ATTR_DURATION] == str(cv.time_period(42))
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) == timer_entity_id

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -27,19 +27,55 @@ from homeassistant.components.timer import (
     STATUS_PAUSED,
 )
 from homeassistant.const import (
+    ATTR_EDITABLE,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
+    ATTR_ID,
+    ATTR_NAME,
     CONF_ENTITY_ID,
     SERVICE_RELOAD,
 )
 from homeassistant.core import Context, CoreState
 from homeassistant.exceptions import Unauthorized
+from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def storage_setup(hass, hass_storage):
+    """Storage setup."""
+
+    async def _storage(items=None, config=None):
+        if items is None:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {
+                    "items": [
+                        {
+                            ATTR_ID: "from_storage",
+                            ATTR_NAME: "timer from storage",
+                            ATTR_DURATION: 0,
+                        }
+                    ]
+                },
+            }
+        else:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {"items": items},
+            }
+        if config is None:
+            config = {DOMAIN: {}}
+        return await async_setup_component(hass, DOMAIN, config)
+
+    return _storage
 
 
 async def test_config(hass):
@@ -92,7 +128,9 @@ async def test_config_options(hass):
     assert "0:00:10" == state_2.attributes.get(ATTR_DURATION)
 
     assert STATUS_IDLE == state_3.state
-    assert str(DEFAULT_DURATION) == state_3.attributes.get(CONF_DURATION)
+    assert str(cv.time_period(DEFAULT_DURATION)) == state_3.attributes.get(
+        CONF_DURATION
+    )
 
 
 async def test_methods_and_events(hass):
@@ -208,6 +246,7 @@ async def test_no_initial_state_and_no_restore_state(hass):
 async def test_config_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
+    ent_reg = await entity_registry.async_get_registry(hass)
 
     _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
 
@@ -235,6 +274,9 @@ async def test_config_reload(hass, hass_admin_user, hass_read_only_user):
     assert state_1 is not None
     assert state_2 is not None
     assert state_3 is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
 
     assert STATUS_IDLE == state_1.state
     assert ATTR_ICON not in state_1.attributes
@@ -284,6 +326,9 @@ async def test_config_reload(hass, hass_admin_user, hass_read_only_user):
     assert state_1 is None
     assert state_2 is not None
     assert state_3 is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
     assert STATUS_IDLE == state_2.state
     assert "Hello World reloaded" == state_2.attributes.get(ATTR_FRIENDLY_NAME)
@@ -360,3 +405,133 @@ async def test_timer_restarted_event(hass):
 
     assert results[-1].event_type == EVENT_TIMER_RESTARTED
     assert len(results) == 4
+
+
+async def test_load_from_storage(hass, storage_setup):
+    """Test set up from storage."""
+    assert await storage_setup()
+    state = hass.states.get(f"{DOMAIN}.timer_from_storage")
+    assert state.state == STATUS_IDLE
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "timer from storage"
+    assert state.attributes.get(ATTR_EDITABLE)
+
+
+async def test_editable_state_attribute(hass, storage_setup):
+    """Test editable attribute."""
+    assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
+
+    state = hass.states.get(f"{DOMAIN}.{DOMAIN}_from_storage")
+    assert state.state == STATUS_IDLE
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "timer from storage"
+    assert state.attributes.get(ATTR_EDITABLE)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert not state.attributes.get(ATTR_EDITABLE)
+    assert state.state == STATUS_IDLE
+
+
+async def test_ws_list(hass, hass_ws_client, storage_setup):
+    """Test listing via WS."""
+    assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 6, "type": f"{DOMAIN}/list"})
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    storage_ent = "from_storage"
+    yaml_ent = "from_yaml"
+    result = {item["id"]: item for item in resp["result"]}
+
+    assert len(result) == 1
+    assert storage_ent in result
+    assert yaml_ent not in result
+    assert result[storage_ent][ATTR_NAME] == "timer from storage"
+
+
+async def test_ws_delete(hass, hass_ws_client, storage_setup):
+    """Test WS delete cleans up entity registry."""
+    assert await storage_setup()
+
+    timer_id = "from_storage"
+    timer_entity_id = f"{DOMAIN}.{DOMAIN}_{timer_id}"
+    ent_reg = await entity_registry.async_get_registry(hass)
+
+    state = hass.states.get(timer_entity_id)
+    assert state is not None
+    from_reg = ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id)
+    assert from_reg == timer_entity_id
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 6, "type": f"{DOMAIN}/delete", f"{DOMAIN}_id": f"{timer_id}"}
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(timer_entity_id)
+    assert state is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) is None
+
+
+async def test_update(hass, hass_ws_client, storage_setup):
+    """Test updating timer entity."""
+
+    assert await storage_setup()
+
+    timer_id = "from_storage"
+    timer_entity_id = f"{DOMAIN}.{DOMAIN}_{timer_id}"
+    ent_reg = await entity_registry.async_get_registry(hass)
+
+    state = hass.states.get(timer_entity_id)
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "timer from storage"
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) == timer_entity_id
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": 6,
+            "type": f"{DOMAIN}/update",
+            f"{DOMAIN}_id": f"{timer_id}",
+            CONF_DURATION: 33,
+        }
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(timer_entity_id)
+    assert state.attributes[ATTR_DURATION] == cv.time_period(33)
+
+
+async def test_ws_create(hass, hass_ws_client, storage_setup):
+    """Test create WS."""
+    assert await storage_setup(items=[])
+
+    timer_id = "new_timer"
+    timer_entity_id = f"{DOMAIN}.{timer_id}"
+    ent_reg = await entity_registry.async_get_registry(hass)
+
+    state = hass.states.get(timer_entity_id)
+    assert state is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) is None
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": 6,
+            "type": f"{DOMAIN}/create",
+            CONF_NAME: "New Timer",
+            CONF_DURATION: 42,
+        }
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(timer_entity_id)
+    assert state.state == STATUS_IDLE
+    assert state.attributes[ATTR_DURATION] == cv.time_period(42)
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) == timer_entity_id


### PR DESCRIPTION
## Description:
Use collections helpers from #30313 to manage timer entities.

**Related issue (if applicable):**  #30494 

@balloob Tagging you cause I need some guideness. `vol.Optional(CONF_DURATION, default=DEFAULT_DURATION): cv.time_period` produces a `datetime.timedelta()` object which is not json serializeable, so it fails with:
```
DEBUG    homeassistant.components.websocket_api.http.connection.140224241729664:http.py:65 Sending {'id': 6, 'type': 'result', 'success': True, 'result': {'name': 'New Timer', 'duration': datetime.timedelta(seconds=42), 'id': 'new_timer'}}
ERROR    homeassistant.components.websocket_api.http.connection.140224241729664:http.py:75 Unable to serialize to JSON: Object of type timedelta is not JSON serializable
{'id': 6, 'type': 'result', 'success': True, 'result': {'name': 'New Timer', 'duration': datetime.timedelta(seconds=42), 'id': 'new_timer'}}
```

How should we handle it? I almost want in `_create_data()`/`_update_data()` to dump it back as json after schema validation. Thoughts???

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
