### PR TITLE
Allow input_* and timer component setup without config

### DIFF
--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -105,7 +105,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     )
 
     await yaml_collection.async_load(
-        [{CONF_ID: id_, **(conf or {})} for id_, conf in config[DOMAIN].items()]
+        [{CONF_ID: id_, **(conf or {})} for id_, conf in config.get(DOMAIN, {}).items()]
     )
     await storage_collection.async_load()
 
@@ -132,7 +132,10 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         if conf is None:
             return
         await yaml_collection.async_load(
-            [{CONF_ID: id_, **(conf or {})} for id_, conf in conf[DOMAIN].items()]
+            [
+                {CONF_ID: id_, **(conf or {})}
+                for id_, conf in conf.get(DOMAIN, {}).items()
+            ]
         )
 
     homeassistant.helpers.service.async_register_admin_service(

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -105,7 +105,6 @@ CONFIG_SCHEMA = vol.Schema(
             )
         )
     },
-    required=True,
     extra=vol.ALLOW_EXTRA,
 )
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
@@ -135,7 +134,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     )
 
     await yaml_collection.async_load(
-        [{CONF_ID: id_, **(conf or {})} for id_, conf in config[DOMAIN].items()]
+        [{CONF_ID: id_, **(conf or {})} for id_, conf in config.get(DOMAIN, {}).items()]
     )
     await storage_collection.async_load()
 
@@ -162,7 +161,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         if conf is None:
             conf = {DOMAIN: {}}
         await yaml_collection.async_load(
-            [{CONF_ID: id_, **conf} for id_, conf in conf[DOMAIN].items()]
+            [{CONF_ID: id_, **conf} for id_, conf in conf.get(DOMAIN, {}).items()]
         )
 
     homeassistant.helpers.service.async_register_admin_service(

--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -81,7 +81,6 @@ CONFIG_SCHEMA = vol.Schema(
             )
         )
     },
-    required=True,
     extra=vol.ALLOW_EXTRA,
 )
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
@@ -109,7 +108,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     )
 
     await yaml_collection.async_load(
-        [{CONF_ID: id_, **cfg} for id_, cfg in config[DOMAIN].items()]
+        [{CONF_ID: id_, **cfg} for id_, cfg in config.get(DOMAIN, {}).items()]
     )
     await storage_collection.async_load()
 
@@ -136,7 +135,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         if conf is None:
             conf = {DOMAIN: {}}
         await yaml_collection.async_load(
-            [{CONF_ID: id_, **cfg} for id_, cfg in conf[DOMAIN].items()]
+            [{CONF_ID: id_, **cfg} for id_, cfg in conf.get(DOMAIN, {}).items()]
         )
 
     homeassistant.helpers.service.async_register_admin_service(

--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -109,7 +109,6 @@ CONFIG_SCHEMA = vol.Schema(
             )
         )
     },
-    required=True,
     extra=vol.ALLOW_EXTRA,
 )
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
@@ -137,7 +136,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     )
 
     await yaml_collection.async_load(
-        [{CONF_ID: id_, **(conf or {})} for id_, conf in config[DOMAIN].items()]
+        [{CONF_ID: id_, **(conf or {})} for id_, conf in config.get(DOMAIN, {}).items()]
     )
     await storage_collection.async_load()
 
@@ -164,7 +163,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         if conf is None:
             conf = {DOMAIN: {}}
         await yaml_collection.async_load(
-            [{CONF_ID: id_, **(cfg or {})} for id_, cfg in conf[DOMAIN].items()]
+            [{CONF_ID: id_, **(cfg or {})} for id_, cfg in conf.get(DOMAIN, {}).items()]
         )
 
     homeassistant.helpers.service.async_register_admin_service(

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -111,7 +111,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     collection.attach_entity_component_collection(component, storage_collection, Timer)
 
     await yaml_collection.async_load(
-        [{CONF_ID: id_, **cfg} for id_, cfg in config[DOMAIN].items()]
+        [{CONF_ID: id_, **cfg} for id_, cfg in config.get(DOMAIN, {}).items()]
     )
     await storage_collection.async_load()
 
@@ -138,7 +138,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         if conf is None:
             conf = {DOMAIN: {}}
         await yaml_collection.async_load(
-            [{CONF_ID: id_, **cfg} for id_, cfg in conf[DOMAIN].items()]
+            [{CONF_ID: id_, **cfg} for id_, cfg in conf.get(DOMAIN, {}).items()]
         )
 
     homeassistant.helpers.service.async_register_admin_service(

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -333,3 +333,22 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     state = hass.states.get(input_entity_id)
     assert state is None
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+
+
+async def test_setup_no_config(hass, hass_admin_user):
+    """Test component setup with no config."""
+    count_start = len(hass.states.async_entity_ids())
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file", autospec=True, return_value={}
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+        await hass.async_block_till_done()
+
+    assert count_start == len(hass.states.async_entity_ids())

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -543,3 +543,22 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     state = hass.states.get(input_entity_id)
     assert float(state.state) == 10
+
+
+async def test_setup_no_config(hass, hass_admin_user):
+    """Test component setup with no config."""
+    count_start = len(hass.states.async_entity_ids())
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file", autospec=True, return_value={}
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+        await hass.async_block_till_done()
+
+    assert count_start == len(hass.states.async_entity_ids())

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -595,3 +595,22 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     state = hass.states.get(input_entity_id)
     assert state.state == "even newer option"
+
+
+async def test_setup_no_config(hass, hass_admin_user):
+    """Test component setup with no config."""
+    count_start = len(hass.states.async_entity_ids())
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file", autospec=True, return_value={}
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+        await hass.async_block_till_done()
+
+    assert count_start == len(hass.states.async_entity_ids())

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -483,3 +483,22 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_EDITABLE]
     assert state.attributes[ATTR_MAX] == 44
     assert state.attributes[ATTR_MIN] == 0
+
+
+async def test_setup_no_config(hass, hass_admin_user):
+    """Test component setup with no config."""
+    count_start = len(hass.states.async_entity_ids())
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file", autospec=True, return_value={}
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+        await hass.async_block_till_done()
+
+    assert count_start == len(hass.states.async_entity_ids())

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -534,3 +534,22 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert state.state == STATUS_IDLE
     assert state.attributes[ATTR_DURATION] == str(cv.time_period(42))
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) == timer_entity_id
+
+
+async def test_setup_no_config(hass, hass_admin_user):
+    """Test component setup with no config."""
+    count_start = len(hass.states.async_entity_ids())
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file", autospec=True, return_value={}
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+        await hass.async_block_till_done()
+
+    assert count_start == len(hass.states.async_entity_ids())


### PR DESCRIPTION
## Description:
Allow `input_*` and `timer` components setup without config section in `configuration.yaml`

**Related issue (if applicable):** #30494 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
