### PR TITLE
Extract data management from sun entity

### DIFF
--- a/homeassistant/components/sun/.translations/en.json
+++ b/homeassistant/components/sun/.translations/en.json
@@ -1,0 +1,8 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Only a single configuration of the sun integration is allowed."
+        },
+        "title": "Sun"
+    }
+}

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -255,6 +255,8 @@ class LegacySunEntity(Entity):
     def __init__(self, hass, sun):
         """Initialize."""
         self._async_unsub_dispatcher_connect = None
+        self._attrs = {}
+        self._state = None
         self._sun = sun
         self.hass = hass
 
@@ -266,29 +268,38 @@ class LegacySunEntity(Entity):
     @property
     def state(self):
         """Return the state of the sun."""
-        if self._sun.solar_elevation > HORIZON_ELEVATION:
-            return STATE_ABOVE_HORIZON
-        return STATE_BELOW_HORIZON
+        return self._state
 
     @property
     def state_attributes(self):
         """Return the state attributes of the sun."""
-        return {
-            STATE_ATTR_NEXT_DAWN: self._sun.next_dawn.isoformat(),
-            STATE_ATTR_NEXT_DUSK: self._sun.next_dusk.isoformat(),
-            STATE_ATTR_NEXT_MIDNIGHT: self._sun.next_midnight.isoformat(),
-            STATE_ATTR_NEXT_NOON: self._sun.next_noon.isoformat(),
-            STATE_ATTR_NEXT_RISING: self._sun.next_rising.isoformat(),
-            STATE_ATTR_NEXT_SETTING: self._sun.next_setting.isoformat(),
-            STATE_ATTR_ELEVATION: self._sun.solar_elevation,
-            STATE_ATTR_AZIMUTH: self._sun.solar_azimuth,
-            STATE_ATTR_RISING: self._sun.rising,
-        }
+        return self._attrs
 
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._async_unsub_dispatcher_connect = async_dispatcher_connect(
             self.hass, TOPIC_DATA_UPDATE, self.force_update_state
+        )
+
+    async def async_update(self):
+        """Update the entity."""
+        if self._sun.solar_elevation > HORIZON_ELEVATION:
+            self._state = STATE_ABOVE_HORIZON
+        else:
+            self._state = STATE_BELOW_HORIZON
+
+        self._attrs.update(
+            {
+                STATE_ATTR_NEXT_DAWN: self._sun.next_dawn.isoformat(),
+                STATE_ATTR_NEXT_DUSK: self._sun.next_dusk.isoformat(),
+                STATE_ATTR_NEXT_MIDNIGHT: self._sun.next_midnight.isoformat(),
+                STATE_ATTR_NEXT_NOON: self._sun.next_noon.isoformat(),
+                STATE_ATTR_NEXT_RISING: self._sun.next_rising.isoformat(),
+                STATE_ATTR_NEXT_SETTING: self._sun.next_setting.isoformat(),
+                STATE_ATTR_ELEVATION: self._sun.solar_elevation,
+                STATE_ATTR_AZIMUTH: self._sun.solar_azimuth,
+                STATE_ATTR_RISING: self._sun.rising,
+            }
         )
 
     async def async_will_remove_fromhass(self):

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -205,10 +205,10 @@ class Sun:
         )
         self._update_sun_position(utc_point_in_time)
 
-        async_dispatcher_send(self.hass, TOPIC_DATA_UPDATE)
-
         # Set timer for the next solar event
         async_track_point_in_utc_time(self.hass, self._update_events, self._next_change)
+
+        async_dispatcher_send(self.hass, TOPIC_DATA_UPDATE)
 
         _LOGGER.debug("next time: %s", self._next_change.isoformat())
 
@@ -236,6 +236,8 @@ class Sun:
         async_track_point_in_utc_time(
             self.hass, self._update_sun_position, utc_point_in_time + delta
         )
+
+        async_dispatcher_send(self.hass, TOPIC_DATA_UPDATE)
 
     @callback
     def async_update_location(self):

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -106,7 +106,7 @@ async def async_setup_entry(hass, config_entry):
 
     # Create the "sun.sun" entity for backwards compatibility:
     legacy_entity = LegacySunEntity(hass, sun)
-    legacy_entity.update()
+    legacy_entity.force_update_state()
 
     return True
 
@@ -288,7 +288,7 @@ class LegacySunEntity(Entity):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, TOPIC_DATA_UPDATE, self.update
+            self.hass, TOPIC_DATA_UPDATE, self.force_update_state
         )
 
     async def async_will_remove_fromhass(self):
@@ -297,6 +297,6 @@ class LegacySunEntity(Entity):
             self._async_unsub_dispatcher_connect()
 
     @callback
-    def update(self):
+    def force_update_state(self):
         """Update the entity."""
         self.schedule_update_ha_state(True)

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -304,7 +304,7 @@ class LegacySunEntity(Entity):
             }
         )
 
-    async def async_will_remove_fromhass(self):
+    async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listener when removed."""
         if self._async_unsub_dispatcher_connect:
             self._async_unsub_dispatcher_connect()

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -291,7 +291,7 @@ class LegacySunEntity(Entity):
         """Update the entity."""
         self.schedule_update_ha_state(True)
 
-    async def async_added_tohass(self):
+    async def async_added_to_hass(self):
         """Register callbacks."""
 
         self._async_unsub_dispatcher_connect = async_dispatcher_connect(

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -26,5 +26,4 @@ class SunFlowHandler(config_entries.ConfigFlow):
         """Handle the start of the config flow."""
         if configured_instances(self.hass):  # type: ignore
             return self.async_abort(reason="single_instance_allowed")
-
         return self.async_create_entry(title="Default", data={})

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -1,0 +1,26 @@
+"""Config flow to configure the sun integration."""
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import DOMAIN
+
+
+@callback
+def configured_instances(hass):
+    """Return a set of configured Notion instances."""
+    return set(entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN))
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class SunFlowHandler(config_entries.ConfigFlow):
+    """Handle a sun config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_ASSUMED
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        if configured_instances(self.hass):
+            return self.async_abort(reason="single_instance_allowed")
+
+        return self.async_create_entry(title="Default", data={})

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -1,12 +1,14 @@
 """Config flow to configure the sun integration."""
+from typing import Any, Dict, Optional, Set
+
 from homeassistant import config_entries
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
 
 
 @callback
-def configured_instances(hass):
+def configured_instances(hass: HomeAssistant) -> Set[str]:
     """Return a set of configured Notion instances."""
     return set(entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN))
 
@@ -18,9 +20,11 @@ class SunFlowHandler(config_entries.ConfigFlow):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_ASSUMED
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: Optional[dict] = None
+    ) -> Dict[str, Any]:
         """Handle the start of the config flow."""
-        if configured_instances(self.hass):
+        if configured_instances(self.hass):  # type: ignore
             return self.async_abort(reason="single_instance_allowed")
 
         return self.async_create_entry(title="Default", data={})

--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -1,2 +1,4 @@
 """Constants for the sun integration."""
 DOMAIN = "sun"
+
+TOPIC_DATA_UPDATE = "data_update"

--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -1,0 +1,2 @@
+"""Constants for the sun integration."""
+DOMAIN = "sun"

--- a/homeassistant/components/sun/manifest.json
+++ b/homeassistant/components/sun/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "sun",
   "name": "Sun",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sun",
   "requirements": [],
   "dependencies": [],

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -1,0 +1,8 @@
+{
+    "config": {
+        "title": "Sun",
+        "abort": {
+            "single_instance_allowed": "Only a single configuration of the sun integration is allowed."
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -79,6 +79,7 @@ FLOWS = [
     "somfy",
     "sonos",
     "starline",
+    "sun",
     "tellduslive",
     "tesla",
     "toon",

--- a/tests/components/sun/test_config_flow.py
+++ b/tests/components/sun/test_config_flow.py
@@ -1,0 +1,27 @@
+"""Define tests for the sun config flow."""
+from homeassistant import data_entry_flow
+from homeassistant.components.sun import DOMAIN, config_flow
+
+from tests.common import MockConfigEntry
+
+
+async def test_more_than_one_instance_error(hass):
+    """Test that errors are shown if someone attempts to add more than one sun entry."""
+    MockConfigEntry(domain=DOMAIN, data={}).add_to_hass(hass)
+    flow = config_flow.SunFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_step_user(hass):
+    """Test that the user step works."""
+    flow = config_flow.SunFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "Default"
+    assert result["data"] == {}


### PR DESCRIPTION
##  Description:

As part of modernizing the `sun` integration a bit, this PR separates data management from the `sun.sun` entity. This will allow future PRs to send that same data to other platforms (`sensor`, `binary_sensor`, etc.).

**This should not be merged until https://github.com/home-assistant/home-assistant/pull/30770 is merged.**

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/30761

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sun:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
