### PR TITLE
Update pyubee to 0.8

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -354,6 +354,7 @@ homeassistant/components/tts/* @robbiet480
 homeassistant/components/twentemilieu/* @frenck
 homeassistant/components/twilio_call/* @robbiet480
 homeassistant/components/twilio_sms/* @robbiet480
+homeassistant/components/ubee/* @mzdrale
 homeassistant/components/unifi/* @kane610
 homeassistant/components/unifiled/* @florisvdk
 homeassistant/components/upc_connect/* @pvizeli

--- a/homeassistant/components/ubee/manifest.json
+++ b/homeassistant/components/ubee/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ubee",
   "name": "Ubee Router",
   "documentation": "https://www.home-assistant.io/integrations/ubee",
-  "requirements": ["pyubee==0.7"],
+  "requirements": ["pyubee==0.8"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@mzdrale"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1675,7 +1675,7 @@ pytradfri[async]==6.4.0
 pytrafikverket==0.1.5.9
 
 # homeassistant.components.ubee
-pyubee==0.7
+pyubee==0.8
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==0.0.5


### PR DESCRIPTION
## Breaking Change:


## Description:
Updated pyubee to 0.8, which fixes issue when `EVW32C-0N` router doesn't assign hostname to client.

**Related issue (if applicable):** 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** 

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
