### PR TITLE
Update emulated_roku to 0.1.9

### DIFF
--- a/homeassistant/components/emulated_roku/manifest.json
+++ b/homeassistant/components/emulated_roku/manifest.json
@@ -3,7 +3,7 @@
   "name": "Emulated Roku",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/emulated_roku",
-  "requirements": ["emulated_roku==0.1.8"],
+  "requirements": ["emulated_roku==0.1.9"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -474,7 +474,7 @@ eliqonline==1.2.2
 elkm1-lib==0.7.15
 
 # homeassistant.components.emulated_roku
-emulated_roku==0.1.8
+emulated_roku==0.1.9
 
 # homeassistant.components.enocean
 enocean==0.50

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -171,7 +171,7 @@ eebrightbox==0.0.4
 elgato==0.2.0
 
 # homeassistant.components.emulated_roku
-emulated_roku==0.1.8
+emulated_roku==0.1.9
 
 # homeassistant.components.season
 ephem==3.7.7.0


### PR DESCRIPTION
## Description:
Updates emulated_roku to 0.1.9, which gets rid of the `reuse_address=True is no longer supported` error.

Related to #30779

## Checklist:
The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
