### PR TITLE
Bugfix hassio initialize of auth data

### DIFF
--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -123,6 +123,10 @@ class HassIOPasswordReset(HassIOBaseAuth):
         """Check User credentials."""
         provider = self._get_provider()
 
+        # Load data if not allready done
+        if provider.data is None:
+            await provider.async_initialize()
+
         try:
             await self.hass.async_add_executor_job(
                 provider.data.change_password, username, password


### PR DESCRIPTION
## Description:

Fix bug:
```
File "/usr/src/homeassistant/homeassistant/components/hassio/auth.py", line 128, in _change_password
    provider.data.change_password, username, password
AttributeError: 'NoneType' object has no attribute 'change_password'
```
