### PR TITLE
Handle location API being exhausted

### DIFF
--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -174,6 +174,10 @@ async def _get_ipapi(session: aiohttp.ClientSession) -> Optional[Dict[str, Any]]
     except (aiohttp.ClientError, ValueError):
         return None
 
+    # ipapi allows 30k free requests/month. Some users exhaust those.
+    if raw_info.get("latitude") == "Sign up to access":
+        return None
+
     return {
         "ip": raw_info.get("ip"),
         "country_code": raw_info.get("country"),

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -92,6 +92,19 @@ async def test_detect_location_info_ipapi(aioclient_mock, session):
     assert info.use_metric
 
 
+async def test_detect_location_info_ipapi_exhaust(aioclient_mock, session):
+    """Test detect location info using ipapi.co."""
+    aioclient_mock.get(location_util.IPAPI, json={"latitude": "Sign up to access"})
+    aioclient_mock.get(location_util.IP_API, text=load_fixture("ip-api.com.json"))
+
+    info = await location_util.async_detect_location_info(session, _test_real=True)
+
+    assert info is not None
+    # ip_api result because ipapi got skipped
+    assert info.country_code == "US"
+    assert len(aioclient_mock.mock_calls) == 2
+
+
 async def test_detect_location_info_ip_api(aioclient_mock, session):
     """Test detect location info using ip-api.com."""
     aioclient_mock.get(location_util.IP_API, text=load_fixture("ip-api.com.json"))


### PR DESCRIPTION
## Description:
Some users have apps installed that exhaust their free 30k monthly API calls to ipapi.co. In that case it will not error out but instead add "Sign up" values instead of real data. This PR catches that.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
