### PR TITLE
Bump librouteros to 3.0.0

### DIFF
--- a/homeassistant/components/mikrotik/__init__.py
+++ b/homeassistant/components/mikrotik/__init__.py
@@ -2,8 +2,9 @@
 import logging
 import ssl
 
-import librouteros
-from librouteros.login import login_plain, login_token
+from librouteros import connect
+from librouteros.exceptions import LibRouterosError
+from librouteros.login import plain as login_plain, token as login_token
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
@@ -82,11 +83,9 @@ def setup(hass, config):
                 port = MTK_DEFAULT_API_PORT
 
         if login == MTK_LOGIN_PLAIN:
-            login_method = (login_plain,)
-        elif login == MTK_LOGIN_TOKEN:
-            login_method = (login_token,)
+            login_method = login_plain
         else:
-            login_method = (login_plain, login_token)
+            login_method = login_token
 
         try:
             api = MikrotikClient(
@@ -94,11 +93,7 @@ def setup(hass, config):
             )
             api.connect_to_device()
             hass.data[DOMAIN][HOSTS][host] = {"config": device, "api": api}
-        except (
-            librouteros.exceptions.TrapError,
-            librouteros.exceptions.MultiTrapError,
-            librouteros.exceptions.ConnectionError,
-        ) as api_error:
+        except LibRouterosError as api_error:
             _LOGGER.error("Mikrotik %s error %s", host, api_error)
             continue
 
@@ -148,15 +143,9 @@ class MikrotikClient:
             kwargs["ssl_wrapper"] = self._ssl_wrapper
 
         try:
-            self._client = librouteros.connect(
-                self._host, self._user, self._password, **kwargs
-            )
+            self._client = connect(self._host, self._user, self._password, **kwargs)
             self._connected = True
-        except (
-            librouteros.exceptions.TrapError,
-            librouteros.exceptions.MultiTrapError,
-            librouteros.exceptions.ConnectionError,
-        ) as api_error:
+        except LibRouterosError as api_error:
             _LOGGER.error("Mikrotik %s: %s", self._host, api_error)
             self._client = None
             return False
@@ -184,14 +173,7 @@ class MikrotikClient:
                 response = self._client(cmd=cmd, **params)
             else:
                 response = self._client(cmd=cmd)
-        except (librouteros.exceptions.ConnectionError,) as api_error:
-            _LOGGER.error("Mikrotik %s connection error %s", self._host, api_error)
-            self.connect_to_device()
-            return None
-        except (
-            librouteros.exceptions.TrapError,
-            librouteros.exceptions.MultiTrapError,
-        ) as api_error:
+        except LibRouterosError as api_error:
             _LOGGER.error(
                 "Mikrotik %s failed to retrieve data. cmd=[%s] Error: %s",
                 self._host,

--- a/homeassistant/components/mikrotik/manifest.json
+++ b/homeassistant/components/mikrotik/manifest.json
@@ -2,7 +2,7 @@
   "domain": "mikrotik",
   "name": "MikroTik",
   "documentation": "https://www.home-assistant.io/integrations/mikrotik",
-  "requirements": ["librouteros==2.3.0"],
+  "requirements": ["librouteros==3.0.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -775,7 +775,7 @@ libpyfoscam==1.0
 libpyvivotek==0.4.0
 
 # homeassistant.components.mikrotik
-librouteros==2.3.0
+librouteros==3.0.0
 
 # homeassistant.components.soundtouch
 libsoundtouch==0.7.2


### PR DESCRIPTION
## Breaking Change:
Before you did not have to specify the login_method parameter since both login_methods would be attempted.
Now the behaviour has changed and the login_method `token` is used by default.
You will need to adjust the login_method accordingly.

## Description:
- bump librouteros to the latest version, changelog: https://github.com/luqasz/librouteros/blob/master/CHANGELOG.rst
- improve logging of librouteros exceptions

**Related issue (if applicable):** fixes #30745<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11755

## Example entry for `configuration.yaml` (if applicable):
```yaml
mikrotik:
  - host: 192.168.1.1
    username: secret
    password: secret
    login_method: plain
    port: 8728
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
