### PR TITLE
Use default media player device classes for vizio component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -783,7 +783,9 @@ omit =
     homeassistant/components/viaggiatreno/sensor.py
     homeassistant/components/vicare/*
     homeassistant/components/vivotek/camera.py
-    homeassistant/components/vizio/*
+    homeassistant/components/vizio/__init__.py
+    homeassistant/components/vizio/const.py
+    homeassistant/components/vizio/media_player.py
     homeassistant/components/vlc/media_player.py
     homeassistant/components/vlc_telnet/media_player.py
     homeassistant/components/volkszaehler/sensor.py

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -3,46 +3,27 @@ import asyncio
 
 import voluptuous as vol
 
-from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
+from homeassistant.components.media_player import DEVICE_CLASS_TV
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_DEVICE_CLASS,
-    CONF_HOST,
-    CONF_NAME,
-)
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_DEVICE_CLASS
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEFAULT_VOLUME_STEP, DOMAIN
-
-DEFAULT_DEVICE_CLASS = DEVICE_CLASS_TV
-ICON = {DEVICE_CLASS_TV: "mdi:television", DEVICE_CLASS_SPEAKER: "mdi:speaker"}
+from .const import DOMAIN, VIZIO_SCHEMA
 
 
 def validate_auth(config: ConfigType) -> ConfigType:
-    """Validate presence of CONF_ACCESS_TOKEN when CONF_DEVICE_CLASS=tv."""
+    """Validate presence of CONF_ACCESS_TOKEN when CONF_DEVICE_CLASS == DEVICE_CLASS_TV."""
     token = config.get(CONF_ACCESS_TOKEN)
     if config[CONF_DEVICE_CLASS] == DEVICE_CLASS_TV and not token:
         raise vol.Invalid(
-            f"When '{CONF_DEVICE_CLASS}' is '{DEVICE_CLASS_TV}' then '{CONF_ACCESS_TOKEN}' is required.",
+            f"When '{CONF_DEVICE_CLASS}' is '{DEVICE_CLASS_TV}' then "
+            f"'{CONF_ACCESS_TOKEN}' is required.",
             path=[CONF_ACCESS_TOKEN],
         )
 
     return config
 
-
-VIZIO_SCHEMA = {
-    vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
-        cv.string, vol.Lower, vol.In([DEVICE_CLASS_TV, DEVICE_CLASS_SPEAKER])
-    ),
-    vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
-        vol.Coerce(int), vol.Range(min=1, max=10)
-    ),
-}
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -10,18 +10,11 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_HOST,
     CONF_NAME,
-    CONF_TIMEOUT,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .const import (
-    CONF_VOLUME_STEP,
-    DEFAULT_NAME,
-    DEFAULT_TIMEOUT,
-    DEFAULT_VOLUME_STEP,
-    DOMAIN,
-)
+from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEFAULT_VOLUME_STEP, DOMAIN
 
 DEFAULT_DEVICE_CLASS = DEVICE_CLASS_TV
 ICON = {DEVICE_CLASS_TV: "mdi:television", DEVICE_CLASS_SPEAKER: "mdi:speaker"}
@@ -47,9 +40,6 @@ VIZIO_SCHEMA = {
         cv.string, vol.Lower, vol.In([DEVICE_CLASS_TV, DEVICE_CLASS_SPEAKER])
     ),
     vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
-        vol.Coerce(int), vol.Range(min=1, max=10)
-    ),
-    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
         vol.Coerce(int), vol.Range(min=1, max=10)
     ),
 }

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -1,31 +1,36 @@
 """The vizio component."""
 import voluptuous as vol
 
+from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_DEVICE_CLASS,
     CONF_HOST,
     CONF_NAME,
+    CONF_TIMEOUT,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import (
     CONF_VOLUME_STEP,
-    DEFAULT_DEVICE_CLASS,
     DEFAULT_NAME,
+    DEFAULT_TIMEOUT,
     DEFAULT_VOLUME_STEP,
     DOMAIN,
 )
+
+DEFAULT_DEVICE_CLASS = DEVICE_CLASS_TV
+ICON = {DEVICE_CLASS_TV: "mdi:television", DEVICE_CLASS_SPEAKER: "mdi:speaker"}
 
 
 def validate_auth(config: ConfigType) -> ConfigType:
     """Validate presence of CONF_ACCESS_TOKEN when CONF_DEVICE_CLASS=tv."""
     token = config.get(CONF_ACCESS_TOKEN)
-    if config[CONF_DEVICE_CLASS] == "tv" and not token:
+    if config[CONF_DEVICE_CLASS] == DEVICE_CLASS_TV and not token:
         raise vol.Invalid(
-            f"When '{CONF_DEVICE_CLASS}' is 'tv' then '{CONF_ACCESS_TOKEN}' is required.",
+            f"When '{CONF_DEVICE_CLASS}' is '{DEVICE_CLASS_TV}' then '{CONF_ACCESS_TOKEN}' is required.",
             path=[CONF_ACCESS_TOKEN],
         )
 
@@ -37,9 +42,12 @@ VIZIO_SCHEMA = {
     vol.Optional(CONF_ACCESS_TOKEN): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
-        cv.string, vol.Lower, vol.In(["tv", "soundbar"])
+        cv.string, vol.Lower, vol.In([DEVICE_CLASS_TV, DEVICE_CLASS_SPEAKER])
     ),
     vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=10)
+    ),
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
         vol.Coerce(int), vol.Range(min=1, max=10)
     ),
 }

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -143,8 +143,8 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if options_changed:
                     self.hass.config_entries.async_update_entry(
                         entry=entry,
-                        data=entry.data.copy().update(options_changed),
-                        options=entry.options.copy().update(options_changed),
+                        data=entry.data.copy().update(new_options),
+                        options=entry.options.copy().update(new_options),
                     )
                     return self.async_abort(reason="updated_options")
 

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -13,18 +13,11 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_HOST,
     CONF_NAME,
-    CONF_TIMEOUT,
 )
 from homeassistant.core import callback
 
 from . import DEFAULT_DEVICE_CLASS, validate_auth
-from .const import (
-    CONF_VOLUME_STEP,
-    DEFAULT_NAME,
-    DEFAULT_TIMEOUT,
-    DEFAULT_VOLUME_STEP,
-    DOMAIN,
-)
+from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEFAULT_VOLUME_STEP, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,9 +127,6 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if entry.data[CONF_VOLUME_STEP] != import_config[CONF_VOLUME_STEP]:
                     new_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
 
-                if entry.data[CONF_TIMEOUT] != import_config[CONF_TIMEOUT]:
-                    new_options[CONF_TIMEOUT] = import_config[CONF_TIMEOUT]
-
                 if new_options:
                     self.hass.config_entries.async_update_entry(
                         entry=entry,
@@ -173,11 +163,7 @@ class VizioOptionsConfigFlow(config_entries.OptionsFlow):
                 default=self.config_entry.options.get(
                     CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP
                 ),
-            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
-            vol.Optional(
-                CONF_TIMEOUT,
-                default=self.config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
-            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10))
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -29,8 +29,8 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def update_schema_defaults(input_dict: Dict[str, Any]) -> vol.Schema:
-    """Update schema defaults based on user input/config dict. Retains info already provided for future form views."""
+def _config_flow_schema(input_dict: Dict[str, Any]) -> vol.Schema:
+    """Return schema defaults based on user input/config dict. Retain info already provided for future form views by setting them as defaults in schema."""
     return vol.Schema(
         {
             vol.Required(
@@ -74,7 +74,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # Store current values in case setup fails and user needs to edit
-            self.user_schema = update_schema_defaults(user_input)
+            self.user_schema = _config_flow_schema(user_input)
 
             # Check if new config entry matches any existing config entries
             for entry in self.hass.config_entries.async_entries(DOMAIN):
@@ -118,7 +118,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     title=user_input[CONF_NAME], data=user_input
                 )
 
-        schema = self.user_schema or self.import_schema or update_schema_defaults({})
+        schema = self.user_schema or self.import_schema or _config_flow_schema({})
 
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
@@ -148,7 +148,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_setup")
 
         # Store import values in case setup fails so user can see error
-        self.import_schema = update_schema_defaults(import_config)
+        self.import_schema = _config_flow_schema(import_config)
 
         return await self.async_step_user(user_input=import_config)
 

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -146,7 +146,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         data=entry.data.copy().update(options_changed),
                         options=entry.options.copy().update(options_changed),
                     )
-                    return self.async_abort(reason="updated_volume_step")
+                    return self.async_abort(reason="updated_options")
 
                 return self.async_abort(reason="already_setup")
 

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -130,17 +130,14 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_NAME
             ] == import_config.get(CONF_NAME):
                 new_options = {}
-                options_changed = False
 
                 if entry.data[CONF_VOLUME_STEP] != import_config[CONF_VOLUME_STEP]:
-                    options_changed = True
                     new_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
 
                 if entry.data[CONF_TIMEOUT] != import_config[CONF_TIMEOUT]:
-                    options_changed = True
                     new_options[CONF_TIMEOUT] = import_config[CONF_TIMEOUT]
 
-                if options_changed:
+                if new_options:
                     self.hass.config_entries.async_update_entry(
                         entry=entry,
                         data=entry.data.copy().update(new_options),

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -16,8 +16,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 
-from . import DEFAULT_DEVICE_CLASS, validate_auth
-from .const import CONF_VOLUME_STEP, DEFAULT_NAME, DEFAULT_VOLUME_STEP, DOMAIN
+from . import validate_auth
+from .const import (
+    CONF_VOLUME_STEP,
+    DEFAULT_DEVICE_CLASS,
+    DEFAULT_NAME,
+    DEFAULT_VOLUME_STEP,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -1,8 +1,76 @@
 """Constants used by vizio component."""
+from datetime import timedelta
+
+from pyvizio.const import (
+    DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV as VIZIO_DEVICE_CLASS_TV,
+)
+import voluptuous as vol
+
+from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
+from homeassistant.components.media_player.const import (
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_STEP,
+)
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_DEVICE_CLASS,
+    CONF_HOST,
+    CONF_NAME,
+)
+import homeassistant.helpers.config_validation as cv
+
 CONF_VOLUME_STEP = "volume_step"
 
+DEFAULT_DEVICE_CLASS = DEVICE_CLASS_TV
 DEFAULT_NAME = "Vizio SmartCast"
 DEFAULT_VOLUME_STEP = 1
+
 DEVICE_ID = "pyvizio"
 
 DOMAIN = "vizio"
+ICON = {DEVICE_CLASS_TV: "mdi:television", DEVICE_CLASS_SPEAKER: "mdi:speaker"}
+
+COMMON_SUPPORTED_COMMANDS = (
+    SUPPORT_SELECT_SOURCE
+    | SUPPORT_TURN_ON
+    | SUPPORT_TURN_OFF
+    | SUPPORT_VOLUME_MUTE
+    | SUPPORT_VOLUME_SET
+    | SUPPORT_VOLUME_STEP
+)
+
+SUPPORTED_COMMANDS = {
+    DEVICE_CLASS_SPEAKER: COMMON_SUPPORTED_COMMANDS,
+    DEVICE_CLASS_TV: (
+        COMMON_SUPPORTED_COMMANDS | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
+    ),
+}
+
+# Since Vizio component relies on device class, this dict will ensure that changes to
+# the values of DEVICE_CLASS_SPEAKER or DEVICE_CLASS_TV don't require changes to pyvizio.
+VIZIO_DEVICE_CLASSES = {
+    DEVICE_CLASS_SPEAKER: VIZIO_DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV: VIZIO_DEVICE_CLASS_TV,
+}
+
+VIZIO_SCHEMA = {
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
+        cv.string, vol.Lower, vol.In([DEVICE_CLASS_TV, DEVICE_CLASS_SPEAKER])
+    ),
+    vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=10)
+    ),
+}
+
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -2,7 +2,6 @@
 CONF_VOLUME_STEP = "volume_step"
 
 DEFAULT_NAME = "Vizio SmartCast"
-DEFAULT_TIMEOUT = 5
 DEFAULT_VOLUME_STEP = 1
 DEVICE_ID = "pyvizio"
 

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -2,10 +2,8 @@
 CONF_VOLUME_STEP = "volume_step"
 
 DEFAULT_NAME = "Vizio SmartCast"
+DEFAULT_TIMEOUT = 5
 DEFAULT_VOLUME_STEP = 1
-DEFAULT_DEVICE_CLASS = "tv"
 DEVICE_ID = "pyvizio"
 
 DOMAIN = "vizio"
-
-ICON = {"tv": "mdi:television", "soundbar": "mdi:speaker"}

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "Vizio SmartCast TV",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.1.0"],
+  "requirements": ["pyvizio==0.1.1"],
   "dependencies": [],
   "codeowners": ["@raman325"],
   "config_flow": true

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "Vizio SmartCast TV",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.0.20"],
+  "requirements": ["pyvizio==0.1.0"],
   "dependencies": [],
   "codeowners": ["@raman325"],
   "config_flow": true

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -1,30 +1,11 @@
 """Vizio SmartCast Device support."""
-from datetime import timedelta
 import logging
 from typing import Callable, List
 
 from pyvizio import VizioAsync
-from pyvizio.const import (
-    DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
-    DEVICE_CLASS_TV as VIZIO_DEVICE_CLASS_TV,
-)
 
 from homeassistant import util
-from homeassistant.components.media_player import (
-    DEVICE_CLASS_SPEAKER,
-    DEVICE_CLASS_TV,
-    MediaPlayerDevice,
-)
-from homeassistant.components.media_player.const import (
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP,
-)
+from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
@@ -43,38 +24,22 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import ICON
-from .const import CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP, DEVICE_ID, DOMAIN
+from .const import (
+    CONF_VOLUME_STEP,
+    DEFAULT_VOLUME_STEP,
+    DEVICE_ID,
+    DOMAIN,
+    ICON,
+    MIN_TIME_BETWEEN_FORCED_SCANS,
+    MIN_TIME_BETWEEN_SCANS,
+    SUPPORTED_COMMANDS,
+    VIZIO_DEVICE_CLASSES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 PARALLEL_UPDATES = 0
-
-COMMON_SUPPORTED_COMMANDS = (
-    SUPPORT_SELECT_SOURCE
-    | SUPPORT_TURN_ON
-    | SUPPORT_TURN_OFF
-    | SUPPORT_VOLUME_MUTE
-    | SUPPORT_VOLUME_SET
-    | SUPPORT_VOLUME_STEP
-)
-
-SUPPORTED_COMMANDS = {
-    DEVICE_CLASS_SPEAKER: COMMON_SUPPORTED_COMMANDS,
-    DEVICE_CLASS_TV: (
-        COMMON_SUPPORTED_COMMANDS | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
-    ),
-}
-
-# Since Vizio component relies on device class, this dict will ensure that changes to
-# the values of DEVICE_CLASS_SPEAKER or DEVICE_CLASS_TV don't require changes to pyvizio.
-VIZIO_DEVICE_CLASS = {
-    DEVICE_CLASS_SPEAKER: VIZIO_DEVICE_CLASS_SPEAKER,
-    DEVICE_CLASS_TV: VIZIO_DEVICE_CLASS_TV,
-}
 
 
 async def async_setup_entry(
@@ -86,7 +51,7 @@ async def async_setup_entry(
     host = config_entry.data[CONF_HOST]
     token = config_entry.data.get(CONF_ACCESS_TOKEN)
     name = config_entry.data[CONF_NAME]
-    device_class = VIZIO_DEVICE_CLASS[config_entry.data[CONF_DEVICE_CLASS]]
+    device_class = config_entry.data[CONF_DEVICE_CLASS]
 
     # If config entry options not set up, set them up, otherwise assign values managed in options
     if not config_entry.options:
@@ -102,7 +67,7 @@ async def async_setup_entry(
         host,
         name,
         token,
-        device_class,
+        VIZIO_DEVICE_CLASSES[device_class],
         session=async_get_clientsession(hass, False),
     )
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -74,12 +74,12 @@ async def async_setup_entry(
     if not await device.can_connect():
         fail_auth_msg = ""
         if token:
-            fail_auth_msg = "and auth token are correct."
+            fail_auth_msg = "and auth token '{token}' are correct."
         else:
             fail_auth_msg = "is correct."
         _LOGGER.error(
-            "Failed to connect to Vizio component, please check if host "
-            "is valid and available. Also check if device class %s",
+            "Failed to connect to Vizio device, please check if host '{host}'"
+            "is valid and available. Also check if device class '{device_class}' %s",
             fail_auth_msg,
         )
         raise ConfigEntryNotReady

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.exceptions import PlatformNotReady
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -78,11 +78,11 @@ async def async_setup_entry(
         else:
             fail_auth_msg = "is correct."
         _LOGGER.error(
-            "Failed to set up Vizio platform, please check if host "
+            "Failed to connect to Vizio platform, please check if host "
             "is valid and available. Also check if device class %s",
             fail_auth_msg,
         )
-        raise PlatformNotReady
+        raise ConfigEntryNotReady
 
     entity = VizioDevice(config_entry, device, name, volume_step, device_class)
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -78,7 +78,7 @@ async def async_setup_entry(
         else:
             fail_auth_msg = "is correct."
         _LOGGER.error(
-            "Failed to connect to Vizio platform, please check if host "
+            "Failed to connect to Vizio component, please check if host "
             "is valid and available. Also check if device class %s",
             fail_auth_msg,
         )

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -70,19 +69,6 @@ async def async_setup_entry(
         VIZIO_DEVICE_CLASSES[device_class],
         session=async_get_clientsession(hass, False),
     )
-
-    if not await device.can_connect():
-        fail_auth_msg = ""
-        if token:
-            fail_auth_msg = "and auth token are correct."
-        else:
-            fail_auth_msg = "is correct."
-        _LOGGER.error(
-            "Failed to set up Vizio platform, please check if host "
-            "is valid and available. Also check if device class %s",
-            fail_auth_msg,
-        )
-        raise PlatformNotReady
 
     entity = VizioDevice(config_entry, device, name, volume_step, device_class)
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -74,10 +74,12 @@ async def async_setup_entry(
     if not await device.can_connect():
         fail_auth_msg = ""
         if token:
-            fail_auth_msg = ", auth token is correct"
+            fail_auth_msg = "and auth token are correct."
+        else:
+            fail_auth_msg = "is correct."
         _LOGGER.error(
             "Failed to set up Vizio platform, please check if host "
-            "is valid and available, device type is correct%s",
+            "is valid and available. Also check if device class %s",
             fail_auth_msg,
         )
         raise PlatformNotReady

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -23,7 +23,7 @@
             "already_setup": "This entry has already been setup.",
             "host_exists": "Vizio component with host already configured.",
             "name_exists": "Vizio component with name already configured.",
-            "updated_volume_step": "This entry has already been setup but the volume step size in the config does not match the config entry so the config entry has been updated accordingly."
+            "updated_options": "This entry has already been setup but the options defined in the config does not match the previously imported options values so the config entry has been updated accordingly."
         }
     },
     "options": {

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -23,7 +23,7 @@
             "already_setup": "This entry has already been setup.",
             "host_exists": "Vizio component with host already configured.",
             "name_exists": "Vizio component with name already configured.",
-            "updated_options": "This entry has already been setup but the options defined in the config does not match the previously imported options values so the config entry has been updated accordingly."
+            "updated_options": "This entry has already been setup but the options defined in the config do not match the previously imported options values so the config entry has been updated accordingly."
         }
     },
     "options": {

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -32,7 +32,8 @@
             "init": {
                 "title": "Update Vizo SmartCast Options",
                 "data": {
-                    "volume_step": "Volume Step Size"
+                    "volume_step": "Volume Step Size",
+                    "timeout": "API Request Timeout (seconds)"
                 }
             }
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1693,7 +1693,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.20
+pyvizio==0.1.0
 
 # homeassistant.components.velux
 pyvlx==0.2.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1693,7 +1693,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.0
+pyvizio==0.1.1
 
 # homeassistant.components.velux
 pyvlx==0.2.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -558,7 +558,7 @@ pyvera==0.3.7
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.0
+pyvizio==0.1.1
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -558,7 +558,7 @@ pyvera==0.3.7
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.20
+pyvizio==0.1.0
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -35,14 +35,14 @@ VOLUME_STEP = 2
 TIMEOUT = 3
 UNIQUE_ID = "testid"
 
-MOCK_USER_VALID_TV_ENTRY = {
+MOCK_USER_VALID_TV_CONFIG = {
     CONF_NAME: NAME,
     CONF_HOST: HOST,
     CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
     CONF_ACCESS_TOKEN: ACCESS_TOKEN,
 }
 
-MOCK_IMPORT_VALID_TV_ENTRY = {
+MOCK_IMPORT_VALID_TV_CONFIG = {
     CONF_NAME: NAME,
     CONF_HOST: HOST,
     CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
@@ -51,13 +51,13 @@ MOCK_IMPORT_VALID_TV_ENTRY = {
     CONF_TIMEOUT: TIMEOUT,
 }
 
-MOCK_INVALID_TV_ENTRY = {
+MOCK_INVALID_TV_CONFIG = {
     CONF_NAME: NAME,
     CONF_HOST: HOST,
     CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
 }
 
-MOCK_SPEAKER_ENTRY = {
+MOCK_SPEAKER_CONFIG = {
     CONF_NAME: NAME,
     CONF_HOST: HOST,
     CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
@@ -144,7 +144,7 @@ async def test_user_flow_all_fields(hass: HomeAssistantType, vizio_connect) -> N
 
 async def test_options_flow(hass: HomeAssistantType) -> None:
     """Test options config flow."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_SPEAKER_ENTRY)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_SPEAKER_CONFIG)
     entry.add_to_hass(hass)
 
     assert not entry.options
@@ -173,11 +173,11 @@ async def test_user_host_already_configured(
     """Test host is already configured during user setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=MOCK_SPEAKER_ENTRY,
+        data=MOCK_SPEAKER_CONFIG,
         options={CONF_VOLUME_STEP: VOLUME_STEP, CONF_TIMEOUT: TIMEOUT},
     )
     entry.add_to_hass(hass)
-    fail_entry = MOCK_SPEAKER_ENTRY.copy()
+    fail_entry = MOCK_SPEAKER_CONFIG.copy()
     fail_entry[CONF_NAME] = "newtestname"
 
     result = await hass.config_entries.flow.async_init(
@@ -201,12 +201,12 @@ async def test_user_name_already_configured(
     """Test name is already configured during user setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=MOCK_SPEAKER_ENTRY,
+        data=MOCK_SPEAKER_CONFIG,
         options={CONF_VOLUME_STEP: VOLUME_STEP, CONF_TIMEOUT: TIMEOUT},
     )
     entry.add_to_hass(hass)
 
-    fail_entry = MOCK_SPEAKER_ENTRY.copy()
+    fail_entry = MOCK_SPEAKER_CONFIG.copy()
     fail_entry[CONF_HOST] = "0.0.0.0"
 
     result = await hass.config_entries.flow.async_init(
@@ -235,7 +235,7 @@ async def test_user_error_on_could_not_connect(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], MOCK_USER_VALID_TV_ENTRY
+        result["flow_id"], MOCK_USER_VALID_TV_CONFIG
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "cant_connect"}
@@ -253,7 +253,7 @@ async def test_user_error_on_tv_needs_token(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], MOCK_INVALID_TV_ENTRY
+        result["flow_id"], MOCK_INVALID_TV_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -286,7 +286,7 @@ async def test_import_flow_all_fields(hass: HomeAssistantType, vizio_connect) ->
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": "import"},
-        data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_ENTRY),
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -305,11 +305,11 @@ async def test_import_entity_already_configured(
     """Test entity is already configured during import setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_ENTRY),
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
         options={CONF_VOLUME_STEP: VOLUME_STEP, CONF_TIMEOUT: TIMEOUT},
     )
     entry.add_to_hass(hass)
-    fail_entry = vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_ENTRY.copy())
+    fail_entry = vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG.copy())
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "import"}, data=fail_entry

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -7,12 +7,12 @@ import voluptuous as vol
 
 from homeassistant import data_entry_flow
 from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
-from homeassistant.components.vizio import VIZIO_SCHEMA
 from homeassistant.components.vizio.const import (
     CONF_VOLUME_STEP,
     DEFAULT_NAME,
     DEFAULT_VOLUME_STEP,
     DOMAIN,
+    VIZIO_SCHEMA,
 )
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -11,7 +11,6 @@ from homeassistant.components.vizio import VIZIO_SCHEMA
 from homeassistant.components.vizio.const import (
     CONF_VOLUME_STEP,
     DEFAULT_NAME,
-    DEFAULT_TIMEOUT,
     DEFAULT_VOLUME_STEP,
     DOMAIN,
 )
@@ -20,7 +19,6 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_HOST,
     CONF_NAME,
-    CONF_TIMEOUT,
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -32,7 +30,6 @@ NAME = "Vizio"
 HOST = "192.168.1.1:9000"
 ACCESS_TOKEN = "deadbeef"
 VOLUME_STEP = 2
-TIMEOUT = 3
 UNIQUE_ID = "testid"
 
 MOCK_USER_VALID_TV_CONFIG = {
@@ -48,7 +45,6 @@ MOCK_IMPORT_VALID_TV_CONFIG = {
     CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
     CONF_ACCESS_TOKEN: ACCESS_TOKEN,
     CONF_VOLUME_STEP: VOLUME_STEP,
-    CONF_TIMEOUT: TIMEOUT,
 }
 
 MOCK_INVALID_TV_CONFIG = {
@@ -157,14 +153,12 @@ async def test_options_flow(hass: HomeAssistantType) -> None:
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={CONF_VOLUME_STEP: VOLUME_STEP, CONF_TIMEOUT: TIMEOUT},
+        result["flow_id"], user_input={CONF_VOLUME_STEP: VOLUME_STEP},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
-    assert result["data"][CONF_TIMEOUT] == TIMEOUT
 
 
 async def test_user_host_already_configured(
@@ -174,7 +168,7 @@ async def test_user_host_already_configured(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_SPEAKER_CONFIG,
-        options={CONF_VOLUME_STEP: VOLUME_STEP, CONF_TIMEOUT: TIMEOUT},
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
     )
     entry.add_to_hass(hass)
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
@@ -202,7 +196,7 @@ async def test_user_name_already_configured(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_SPEAKER_CONFIG,
-        options={CONF_VOLUME_STEP: VOLUME_STEP, CONF_TIMEOUT: TIMEOUT},
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
     )
     entry.add_to_hass(hass)
 
@@ -278,7 +272,6 @@ async def test_import_flow_minimum_fields(
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_DEVICE_CLASS] == DEVICE_CLASS_SPEAKER
     assert result["data"][CONF_VOLUME_STEP] == DEFAULT_VOLUME_STEP
-    assert result["data"][CONF_TIMEOUT] == DEFAULT_TIMEOUT
 
 
 async def test_import_flow_all_fields(hass: HomeAssistantType, vizio_connect) -> None:
@@ -296,7 +289,6 @@ async def test_import_flow_all_fields(hass: HomeAssistantType, vizio_connect) ->
     assert result["data"][CONF_DEVICE_CLASS] == DEVICE_CLASS_TV
     assert result["data"][CONF_ACCESS_TOKEN] == ACCESS_TOKEN
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
-    assert result["data"][CONF_TIMEOUT] == TIMEOUT
 
 
 async def test_import_entity_already_configured(
@@ -306,7 +298,7 @@ async def test_import_entity_already_configured(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
-        options={CONF_VOLUME_STEP: VOLUME_STEP, CONF_TIMEOUT: TIMEOUT},
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
     )
     entry.add_to_hass(hass)
     fail_entry = vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG.copy())


### PR DESCRIPTION
## Breaking Change:
The options for the `device_class` config parameter used to be `tv` or `soundbar`. The options are now `tv` or `speaker` to align with the device classes defined in the `media_player` component and to add Amazon Alexa and Google Assistant support. This change only affects users who were using the integration to control a Vizio Sound Bar since the `tv` device class remains unchanged.

## Description:
Enhancements:
- Switched `device_class` config parameter options from `tv` and `soundbar` to `tv` and `speaker`
- Added an options flow test

Maintenance:
-  Renamed private function in `config_flow`
- Updated config entry load and unload to use platform list

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11756

## Example entry for `configuration.yaml` (if applicable):
```yaml
vizio:
  - host: IP_ADDRESS
    access_token: AUTH_TOKEN
    device_type: speaker
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
