### PR TITLE
Fix pyyaml requirement from 5.2.0 to 5.2

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -18,7 +18,7 @@ netdisco==2.6.0
 pip>=8.0.3
 python-slugify==4.0.0
 pytz>=2019.03
-pyyaml==5.2.0
+pyyaml==5.2
 requests==2.22.0
 ruamel.yaml==0.15.100
 sqlalchemy==1.3.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -12,7 +12,7 @@ cryptography==2.8
 pip>=8.0.3
 python-slugify==4.0.0
 pytz>=2019.03
-pyyaml==5.2.0
+pyyaml==5.2
 requests==2.22.0
 ruamel.yaml==0.15.100
 voluptuous==0.11.7

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ REQUIRES = [
     "pip>=8.0.3",
     "python-slugify==4.0.0",
     "pytz>=2019.03",
-    "pyyaml==5.2.0",
+    "pyyaml==5.2",
     "requests==2.22.0",
     "ruamel.yaml==0.15.100",
     "voluptuous==0.11.7",


### PR DESCRIPTION
## Description:

The actual version on PyPI is 5.2 and not 5.2.0.

This causes an attempted reinstall of pyyaml every time I try to update my dependencies so it's just a small annoyance.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
