### PR TITLE
Fix error during setup process of Mikrotik

### DIFF
--- a/homeassistant/components/mikrotik/__init__.py
+++ b/homeassistant/components/mikrotik/__init__.py
@@ -156,7 +156,7 @@ class MikrotikClient:
 
     def get_hostname(self):
         """Return device host name."""
-        data = self.command(MIKROTIK_SERVICES[IDENTITY])
+        data = list(self.command(MIKROTIK_SERVICES[IDENTITY]))
         return data[0][NAME] if data else None
 
     def connected(self):


### PR DESCRIPTION
**Description:**

- this PR solves an error during setup of a Mikrotik hub
- example error:
```log
2020-01-15 21:25:42 ERROR (MainThread) [homeassistant.setup] Error during setup of component mikrotik
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/setup.py", line 176, in _async_setup_component
    component.setup, hass, processed_config  # type: ignore
  File "/usr/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/mikrotik/__init__.py", line 94, in setup
    api.connect_to_device()
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/mikrotik/__init__.py", line 153, in connect_to_device
    self.hostname = self.get_hostname()
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/mikrotik/__init__.py", line 160, in get_hostname
    return data[0][NAME] if data else None
TypeError: 'generator' object is not subscriptable
```

**Related issue (if applicable):** fixes #30745<home-assistant issue number goes here>
**Related PR (if applicable):** completes #30800

## Example entry for `configuration.yaml` (if applicable):
```yaml
mikrotik:
  - host: 192.168.1.1
    username: secret
    password: secret
    login_method: plain
    port: 8728
```

## Checklist:
  - [x] The code change is tested and works locally. (see https://github.com/home-assistant/home-assistant/issues/30745#issuecomment-574893653)
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
