### PR TITLE
Add foundation for integration services

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -118,5 +118,4 @@ async def async_setup_entry(hass, entry):
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, MP_DOMAIN)
     )
-
     return True

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -1,13 +1,10 @@
 """Support to embed Sonos."""
-import asyncio
-
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOSTS
+from homeassistant.const import CONF_HOSTS
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DOMAIN
 
@@ -33,53 +30,12 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-SERVICE_JOIN = "join"
-SERVICE_UNJOIN = "unjoin"
-SERVICE_SNAPSHOT = "snapshot"
-SERVICE_RESTORE = "restore"
-SERVICE_SET_TIMER = "set_sleep_timer"
-SERVICE_CLEAR_TIMER = "clear_sleep_timer"
-SERVICE_UPDATE_ALARM = "update_alarm"
-SERVICE_SET_OPTION = "set_option"
-SERVICE_PLAY_QUEUE = "play_queue"
-
-ATTR_SLEEP_TIME = "sleep_time"
-ATTR_ALARM_ID = "alarm_id"
-ATTR_VOLUME = "volume"
-ATTR_ENABLED = "enabled"
-ATTR_INCLUDE_LINKED_ZONES = "include_linked_zones"
-ATTR_MASTER = "master"
-ATTR_WITH_GROUP = "with_group"
-ATTR_NIGHT_SOUND = "night_sound"
-ATTR_SPEECH_ENHANCE = "speech_enhance"
-ATTR_QUEUE_POSITION = "queue_position"
-
-SONOS_JOIN_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_MASTER): cv.entity_id,
-        vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
-    }
-)
-
-SONOS_UNJOIN_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids})
-
-SONOS_STATES_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
-        vol.Optional(ATTR_WITH_GROUP, default=True): cv.boolean,
-    }
-)
-
-
-DATA_SERVICE_EVENT = "sonos_service_idle"
-
 
 async def async_setup(hass, config):
     """Set up the Sonos component."""
     conf = config.get(DOMAIN)
 
     hass.data[DOMAIN] = conf or {}
-    hass.data[DATA_SERVICE_EVENT] = asyncio.Event()
 
     if conf is not None:
         hass.async_create_task(
@@ -87,28 +43,6 @@ async def async_setup(hass, config):
                 DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
             )
         )
-
-    async def service_handle(service):
-        """Dispatch a service call."""
-        hass.data[DATA_SERVICE_EVENT].clear()
-        async_dispatcher_send(hass, DOMAIN, service.service, service.data)
-        await hass.data[DATA_SERVICE_EVENT].wait()
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_JOIN, service_handle, schema=SONOS_JOIN_SCHEMA
-    )
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_UNJOIN, service_handle, schema=SONOS_UNJOIN_SCHEMA
-    )
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_SNAPSHOT, service_handle, schema=SONOS_STATES_SCHEMA
-    )
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_RESTORE, service_handle, schema=SONOS_STATES_SCHEMA
-    )
 
     return True
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -237,17 +237,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async def async_service_handle(service_call: ServiceCall):
         """Handle dispatched services."""
-        entity_ids = await platform.async_extract_from_service(service_call)
+        entities = await platform.async_extract_from_service(service_call)
 
-        if not entity_ids:
+        if not entities:
             return
-
-        entities = hass.data[DATA_SONOS].entities
 
         if service_call.service == SERVICE_JOIN:
             master = platform.entities.get(service_call.data[ATTR_MASTER])
             if master:
-                await SonosEntity.join_multi(hass, master[0], entities)
+                await SonosEntity.join_multi(hass, master, entities)
             else:
                 _LOGGER.error(
                     "Invalid master specified for join service: %s",

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -135,7 +135,7 @@ SONOS_SET_OPTION_SCHEMA = vol.Schema(
 SONOS_PLAY_QUEUE_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
-        vol.Optional(ATTR_QUEUE_POSITION, default=0): cv.positive_int,
+        vol.Optional(ATTR_QUEUE_POSITION): cv.positive_int,
     }
 )
 
@@ -1241,7 +1241,7 @@ class SonosEntity(MediaPlayerDevice):
             self.soco.dialog_mode = speech_enhance
 
     @soco_error()
-    def play_queue(self, queue_position):
+    def play_queue(self, queue_position=0):
         """Start playing the queue."""
         self.soco.play_from_queue(queue_position)
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -565,10 +565,10 @@ class SonosEntity(MediaPlayerDevice):
 
             player = self.soco
 
-            def subscribe(service, action):
+            def subscribe(sonos_service, action):
                 """Add a subscription to a pysonos service."""
                 queue = _ProcessSonosEventQueue(action)
-                sub = service.subscribe(auto_renew=True, event_queue=queue)
+                sub = sonos_service.subscribe(auto_renew=True, event_queue=queue)
                 self._subscriptions.append(sub)
 
             subscribe(player.avTransport, self.update_media)

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -234,7 +234,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.async_add_executor_job(_discovery)
 
     platform = entity_platform.current_platform.get()
-    management_lock = asyncio.Lock()
 
     async def async_service_handle(service_call: ServiceCall):
         """Handle dispatched services."""
@@ -245,26 +244,25 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         entities = hass.data[DATA_SONOS].entities
 
-        async with management_lock:
-            if service_call.service == SERVICE_JOIN:
-                master = platform.entities.get(service_call.data[ATTR_MASTER])
-                if master:
-                    await SonosEntity.join_multi(hass, master[0], entities)
-                else:
-                    _LOGGER.error(
-                        "Invalid master specified for join service: %s",
-                        service_call.data[ATTR_MASTER],
-                    )
-            elif service_call.service == SERVICE_UNJOIN:
-                await SonosEntity.unjoin_multi(hass, entities)
-            elif service_call.service == SERVICE_SNAPSHOT:
-                await SonosEntity.snapshot_multi(
-                    hass, entities, service_call.data[ATTR_WITH_GROUP]
+        if service_call.service == SERVICE_JOIN:
+            master = platform.entities.get(service_call.data[ATTR_MASTER])
+            if master:
+                await SonosEntity.join_multi(hass, master[0], entities)
+            else:
+                _LOGGER.error(
+                    "Invalid master specified for join service: %s",
+                    service_call.data[ATTR_MASTER],
                 )
-            elif service_call.service == SERVICE_RESTORE:
-                await SonosEntity.restore_multi(
-                    hass, entities, service_call.data[ATTR_WITH_GROUP]
-                )
+        elif service_call.service == SERVICE_UNJOIN:
+            await SonosEntity.unjoin_multi(hass, entities)
+        elif service_call.service == SERVICE_SNAPSHOT:
+            await SonosEntity.snapshot_multi(
+                hass, entities, service_call.data[ATTR_WITH_GROUP]
+            )
+        elif service_call.service == SERVICE_RESTORE:
+            await SonosEntity.restore_multi(
+                hass, entities, service_call.data[ATTR_WITH_GROUP]
+            )
 
     service.async_register_admin_service(
         hass, SONOS_DOMAIN, SERVICE_JOIN, async_service_handle, SONOS_JOIN_SCHEMA

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.core import ServiceCall, callback
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import config_validation as cv, entity_platform, service
 from homeassistant.util.dt import utcnow
 
 from . import (
@@ -266,20 +266,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     hass, entities, service_call.data[ATTR_WITH_GROUP]
                 )
 
-    hass.services.async_register(
-        SONOS_DOMAIN, SERVICE_JOIN, async_service_handle, schema=SONOS_JOIN_SCHEMA
+    service.async_register_admin_service(
+        hass, SONOS_DOMAIN, SERVICE_JOIN, async_service_handle, SONOS_JOIN_SCHEMA
     )
 
-    hass.services.async_register(
-        SONOS_DOMAIN, SERVICE_UNJOIN, async_service_handle, schema=SONOS_UNJOIN_SCHEMA
+    service.async_register_admin_service(
+        hass, SONOS_DOMAIN, SERVICE_UNJOIN, async_service_handle, SONOS_UNJOIN_SCHEMA
     )
 
-    hass.services.async_register(
-        SONOS_DOMAIN, SERVICE_SNAPSHOT, async_service_handle, schema=SONOS_STATES_SCHEMA
+    service.async_register_admin_service(
+        hass, SONOS_DOMAIN, SERVICE_SNAPSHOT, async_service_handle, SONOS_STATES_SCHEMA
     )
 
-    hass.services.async_register(
-        SONOS_DOMAIN, SERVICE_RESTORE, async_service_handle, schema=SONOS_STATES_SCHEMA
+    service.async_register_admin_service(
+        hass, SONOS_DOMAIN, SERVICE_RESTORE, async_service_handle, SONOS_STATES_SCHEMA
     )
 
     platform.async_register_entity_service(

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -57,15 +57,10 @@ from . import (
     CONF_INTERFACE_ADDR,
     DATA_SERVICE_EVENT,
     DOMAIN as SONOS_DOMAIN,
-    SERVICE_CLEAR_TIMER,
     SERVICE_JOIN,
-    SERVICE_PLAY_QUEUE,
     SERVICE_RESTORE,
-    SERVICE_SET_OPTION,
-    SERVICE_SET_TIMER,
     SERVICE_SNAPSHOT,
     SERVICE_UNJOIN,
-    SERVICE_UPDATE_ALARM,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -197,20 +192,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             await SonosEntity.snapshot_multi(hass, entities, data[ATTR_WITH_GROUP])
         elif service == SERVICE_RESTORE:
             await SonosEntity.restore_multi(hass, entities, data[ATTR_WITH_GROUP])
-        else:
-            for entity in entities:
-                if service == SERVICE_SET_TIMER:
-                    call = entity.set_sleep_timer
-                elif service == SERVICE_CLEAR_TIMER:
-                    call = entity.clear_sleep_timer
-                elif service == SERVICE_UPDATE_ALARM:
-                    call = entity.set_alarm
-                elif service == SERVICE_SET_OPTION:
-                    call = entity.set_option
-                elif service == SERVICE_PLAY_QUEUE:
-                    call = entity.play_queue
-
-                hass.async_add_executor_job(call, data)
 
         # We are ready for the next service call
         hass.data[DATA_SERVICE_EVENT].set()

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -187,7 +187,9 @@ class EntityComponent:
 
         This method must be run in the event loop.
         """
-        return async_extract_entities(self.hass, self.entities, service, expand_group)
+        return await async_extract_entities(
+            self.hass, self.entities, service, expand_group
+        )
 
     @callback
     def async_register_entity_service(self, name, schema, func, required_features=None):

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -183,9 +183,8 @@ class EntityComponent:
 
         async def handle_service(call):
             """Handle the service."""
-            service_name = f"{self.domain}.{name}"
             await self.hass.helpers.service.entity_service_call(
-                self._platforms.values(), func, call, service_name, required_features
+                self._platforms.values(), func, call, required_features
             )
 
         self.hass.services.async_register(self.domain, name, handle_service, schema)

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -461,7 +461,7 @@ class EntityPlatform:
 
         This method must be run in the event loop.
         """
-        return async_extract_entities(
+        return await async_extract_entities(
             self.hass, self.entities.values(), service, expand_group
         )
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -264,9 +264,7 @@ def async_set_service_schema(hass, domain, service, schema):
 
 
 @bind_hass
-async def entity_service_call(
-    hass, platforms, func, call, service_name="", required_features=None
-):
+async def entity_service_call(hass, platforms, func, call, required_features=None):
     """Handle an entity service call.
 
     Calls all platforms simultaneously.

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -109,12 +109,32 @@ def extract_entity_ids(hass, service_call, expand_group=True):
 
 
 @bind_hass
+async def async_extract_entities(hass, entities, service_call, expand_group=True):
+    """Extract a list of entity objects from a service call.
+
+    Will convert group entity ids to the entity ids it represents.
+    """
+    data_ent_id = service_call.data.get(ATTR_ENTITY_ID)
+
+    if data_ent_id is None:
+        return []
+
+    if data_ent_id == ENTITY_MATCH_ALL:
+        return [entity for entity in entities if entity.available]
+
+    entity_ids = await async_extract_entity_ids(hass, service_call, expand_group)
+    return [
+        entity
+        for entity in entities
+        if entity.available and entity.entity_id in entity_ids
+    ]
+
+
+@bind_hass
 async def async_extract_entity_ids(hass, service_call, expand_group=True):
     """Extract a list of entity ids from a service call.
 
     Will convert group entity ids to the entity ids it represents.
-
-    Async friendly.
     """
     entity_ids = service_call.data.get(ATTR_ENTITY_ID)
     area_ids = service_call.data.get(ATTR_AREA_ID)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -116,13 +116,11 @@ async def async_extract_entities(hass, entities, service_call, expand_group=True
     """
     data_ent_id = service_call.data.get(ATTR_ENTITY_ID)
 
-    if data_ent_id is None:
-        return []
-
     if data_ent_id == ENTITY_MATCH_ALL:
         return [entity for entity in entities if entity.available]
 
     entity_ids = await async_extract_entity_ids(hass, service_call, expand_group)
+
     return [
         entity
         for entity in entities

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -301,7 +301,7 @@ async def test_setup_entry(hass):
     assert p_hass is hass
     assert p_entry is entry
 
-    assert component.platforms[entry.entry_id].scan_interval == timedelta(seconds=5)
+    assert component._platforms[entry.entry_id].scan_interval == timedelta(seconds=5)
 
 
 async def test_setup_entry_platform_not_exist(hass):

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -12,7 +12,7 @@ from homeassistant.const import ENTITY_MATCH_ALL
 import homeassistant.core as ha
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import discovery
-from homeassistant.helpers.entity_component import EntityComponent, async_get_platform
+from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -429,22 +429,3 @@ async def test_extract_all_use_match_all(hass, caplog):
     assert (
         "Not passing an entity ID to a service to target all entities is deprecated"
     ) not in caplog.text
-
-
-async def test_platforms_for_config_entry(hass):
-    """Test returning the platforms for a config entry."""
-    entry = MockConfigEntry(domain="mod2")
-    entry.add_to_hass(hass)
-
-    mock_integration(hass, MockModule("mod2"))
-    mock_entity_platform(
-        hass,
-        "light.mod2",
-        MockPlatform(async_setup_entry=asynctest.CoroutineMock(return_value=True)),
-    )
-
-    await hass.config_entries.async_forward_entry_setup(entry, "light")
-
-    assert async_get_platform(hass, entry, "switch") is None
-    platform = async_get_platform(hass, entry, "light")
-    assert platform is not None

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -740,18 +740,3 @@ async def test_extract_from_service_filter_out_non_existing_entities(hass):
         ent.entity_id
         for ent in (await service.async_extract_entities(hass, entities, call))
     ]
-
-
-async def test_extract_all_use_match_all(hass):
-    """Test extract all with None and *."""
-    entities = [
-        MockEntity(name="test_1", entity_id="test_domain.test_1"),
-        MockEntity(name="test_2", entity_id="test_domain.test_2"),
-    ]
-
-    call = ha.ServiceCall("test", "service", {"entity_id": "all"})
-
-    assert ["test_domain.test_1", "test_domain.test_2"] == [
-        ent.entity_id
-        for ent in (await service.async_extract_entities(hass, entities, call))
-    ]


### PR DESCRIPTION
## Breaking Change:
The following Sonos services now need to be called by a user with admin access: `sonos.join`, `sonos.unjoin`, `sonos.snapshot`, `sonos.restore`.

Sonos services now no longer will default to all entities if no `entity_id` is passed in. This has been aligned with the other services in Home Assistant. To target all, add `entity_id: all`.

## Description:
Integration developers that want to offer services are each having to implement their own entity extraction logic to get to their own entity objects. I've seen:
 - keeping their own registry of entities
 - forwarding all service calls to the dispatcher

All these implementations are painful because if we add things like selecting entity by `area_id`, these custom solutions won't support this.

So here is a proposal to make it easy for integrations to convert a service call to a list of their entities. I have updated some of the Sonos services as an example of how this could be applied.

If we like this approach, we can expand this (in a future PR) by also adding `async_register_entity_service` to entity platform.

CC @frenck 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
