### PR TITLE
Add proxmoxve SSLError check and remove log spam

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -5,6 +5,7 @@ import time
 
 from proxmoxer import ProxmoxAPI
 from proxmoxer.backends.https import AuthenticationError
+from requests.exceptions import SSLError
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -17,6 +18,9 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
+
+# Disable constant logs of requests to Proxmox
+logging.getLogger("proxmoxer.core").setLevel(level=logging.WARNING)
 
 DOMAIN = "proxmoxve"
 PROXMOX_CLIENTS = "proxmox_clients"
@@ -93,6 +97,9 @@ def setup(hass, config):
             _LOGGER.warning(
                 "Invalid credentials for proxmox instance %s:%d", host, port
             )
+            continue
+        except SSLError:
+            _LOGGER.error("Unable to verify proxmox server SSL. try using \"verify_ssl: false\"")
             continue
 
         hass.data[PROXMOX_CLIENTS][f"{host}:{port}"] = proxmox_client

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -97,7 +97,7 @@ def setup(hass, config):
             )
             continue
         except SSLError:
-            _LOGGER.error("Unable to verify proxmox server SSL. try using \"verify_ssl: false\"")
+            _LOGGER.error("Unable to verify proxmox server SSL. Try using \"verify_ssl: false\"")
             continue
 
         hass.data[PROXMOX_CLIENTS][f"{host}:{port}"] = proxmox_client

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -19,8 +19,6 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-# Disable constant logs of requests to Proxmox
-logging.getLogger("proxmoxer.core").setLevel(level=logging.WARNING)
 
 DOMAIN = "proxmoxve"
 PROXMOX_CLIENTS = "proxmox_clients"

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -98,7 +98,7 @@ def setup(hass, config):
             continue
         except SSLError:
             _LOGGER.error(
-                "Unable to verify proxmox server SSL. Try using \"verify_ssl: false\""
+                'Unable to verify proxmox server SSL. Try using "verify_ssl: false"'
             )
             continue
 

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -97,7 +97,9 @@ def setup(hass, config):
             )
             continue
         except SSLError:
-            _LOGGER.error("Unable to verify proxmox server SSL. Try using \"verify_ssl: false\"")
+            _LOGGER.error(
+                "Unable to verify proxmox server SSL. Try using \"verify_ssl: false\""
+			)
             continue
 
         hass.data[PROXMOX_CLIENTS][f"{host}:{port}"] = proxmox_client

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -99,7 +99,7 @@ def setup(hass, config):
         except SSLError:
             _LOGGER.error(
                 "Unable to verify proxmox server SSL. Try using \"verify_ssl: false\""
-			)
+            )
             continue
 
         hass.data[PROXMOX_CLIENTS][f"{host}:{port}"] = proxmox_client

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
   "dependencies": [],
   "codeowners": ["@k4ds3"],
-  "requirements": ["proxmoxer==1.0.3"]
+  "requirements": ["proxmoxer==1.0.4"]
 }

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
   "dependencies": [],
   "codeowners": ["@k4ds3"],
-  "requirements": ["proxmoxer==1.0.3", "requests==2.22.0"]
+  "requirements": ["proxmoxer==1.0.3"]
 }

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
   "dependencies": [],
   "codeowners": ["@k4ds3"],
-  "requirements": ["proxmoxer==1.0.3"]
+  "requirements": ["proxmoxer==1.0.3", "requests==2.22.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1046,7 +1046,7 @@ prometheus_client==0.7.1
 protobuf==3.6.1
 
 # homeassistant.components.proxmoxve
-proxmoxer==1.0.3
+proxmoxer==1.0.4
 
 # homeassistant.components.systemmonitor
 psutil==5.6.7


### PR DESCRIPTION
## Description:
Add an exception handler for un-verified SSL certs and change dependency logger to not spam log with polling requests.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
