### PR TITLE
Deprecate states UI options in group integration

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -73,15 +73,19 @@ def _conf_preprocess(value):
     return value
 
 
-GROUP_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_ENTITIES): vol.Any(cv.entity_ids, None),
-        CONF_VIEW: cv.boolean,
-        CONF_NAME: cv.string,
-        CONF_ICON: cv.icon,
-        CONF_CONTROL: CONTROL_TYPES,
-        CONF_ALL: cv.boolean,
-    }
+GROUP_SCHEMA = vol.All(
+    cv.deprecated(CONF_CONTROL, invalidation_version="0.107.0"),
+    cv.deprecated(CONF_VIEW, invalidation_version="0.107.0"),
+    vol.Schema(
+        {
+            vol.Optional(CONF_ENTITIES): vol.Any(cv.entity_ids, None),
+            CONF_VIEW: cv.boolean,
+            CONF_NAME: cv.string,
+            CONF_ICON: cv.icon,
+            CONF_CONTROL: CONTROL_TYPES,
+            CONF_ALL: cv.boolean,
+        }
+    ),
 )
 
 CONFIG_SCHEMA = vol.Schema(
@@ -317,18 +321,23 @@ async def async_setup(hass, config):
         DOMAIN,
         SERVICE_SET,
         locked_service_handler,
-        schema=vol.Schema(
-            {
-                vol.Required(ATTR_OBJECT_ID): cv.slug,
-                vol.Optional(ATTR_NAME): cv.string,
-                vol.Optional(ATTR_VIEW): cv.boolean,
-                vol.Optional(ATTR_ICON): cv.string,
-                vol.Optional(ATTR_CONTROL): CONTROL_TYPES,
-                vol.Optional(ATTR_VISIBLE): cv.boolean,
-                vol.Optional(ATTR_ALL): cv.boolean,
-                vol.Exclusive(ATTR_ENTITIES, "entities"): cv.entity_ids,
-                vol.Exclusive(ATTR_ADD_ENTITIES, "entities"): cv.entity_ids,
-            }
+        schema=vol.All(
+            cv.deprecated(ATTR_CONTROL, invalidation_version="0.107.0"),
+            cv.deprecated(ATTR_VIEW, invalidation_version="0.107.0"),
+            cv.deprecated(ATTR_VISIBLE, invalidation_version="0.107.0"),
+            vol.Schema(
+                {
+                    vol.Required(ATTR_OBJECT_ID): cv.slug,
+                    vol.Optional(ATTR_NAME): cv.string,
+                    vol.Optional(ATTR_VIEW): cv.boolean,
+                    vol.Optional(ATTR_ICON): cv.string,
+                    vol.Optional(ATTR_CONTROL): CONTROL_TYPES,
+                    vol.Optional(ATTR_VISIBLE): cv.boolean,
+                    vol.Optional(ATTR_ALL): cv.boolean,
+                    vol.Exclusive(ATTR_ENTITIES, "entities"): cv.entity_ids,
+                    vol.Exclusive(ATTR_ADD_ENTITIES, "entities"): cv.entity_ids,
+                }
+            ),
         ),
     )
 
@@ -342,6 +351,11 @@ async def async_setup(hass, config):
     async def visibility_service_handler(service):
         """Change visibility of a group."""
         visible = service.data.get(ATTR_VISIBLE)
+
+        _LOGGER.warning(
+            "The group.set_visibility service has been deprecated and will"
+            "be removed in Home Assistant 0.107.0."
+        )
 
         tasks = []
         for group in await component.async_extract_from_service(


### PR DESCRIPTION
## Breaking Change:

Group configurations options, services and service options related to the old states UI are now deprecated and pending for removal in Home Assistant 0.107.0.

This includes:
- The `view` and `control` configuration options for a group.
- The `group.set_visibility` service call
- The `control`, `visible`, `view` options on the `group.set` service call.

Please ensure your configuration and automations don't use these anymore.

## Description:

See breaking changes.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11765

## Example entry for `configuration.yaml` (if applicable):
```yaml
group:
  example:
    name: Example
    view: true
    control: hidden
    entities:
      - light.demo
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
