### PR TITLE
Deprecate hide_if_away from device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -53,11 +53,14 @@ SOURCE_TYPES = (
 
 NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(
     None,
-    vol.Schema(
-        {
-            vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
-            vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
-        }
+    vol.All(
+        cv.deprecated(CONF_AWAY_HIDE, invalidation_version="0.107.0"),
+        vol.Schema(
+            {
+                vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
+                vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
+            }
+        ),
     ),
 )
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -528,21 +528,24 @@ async def async_load_config(
 
     This method is a coroutine.
     """
-    dev_schema = vol.Schema(
-        {
-            vol.Required(CONF_NAME): cv.string,
-            vol.Optional(CONF_ICON, default=None): vol.Any(None, cv.icon),
-            vol.Optional("track", default=False): cv.boolean,
-            vol.Optional(CONF_MAC, default=None): vol.Any(
-                None, vol.All(cv.string, vol.Upper)
-            ),
-            vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
-            vol.Optional("gravatar", default=None): vol.Any(None, cv.string),
-            vol.Optional("picture", default=None): vol.Any(None, cv.string),
-            vol.Optional(CONF_CONSIDER_HOME, default=consider_home): vol.All(
-                cv.time_period, cv.positive_timedelta
-            ),
-        }
+    dev_schema = vol.All(
+        cv.deprecated(CONF_AWAY_HIDE, invalidation_version="0.107.0"),
+        vol.Schema(
+            {
+                vol.Required(CONF_NAME): cv.string,
+                vol.Optional(CONF_ICON, default=None): vol.Any(None, cv.icon),
+                vol.Optional("track", default=False): cv.boolean,
+                vol.Optional(CONF_MAC, default=None): vol.Any(
+                    None, vol.All(cv.string, vol.Upper)
+                ),
+                vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
+                vol.Optional("gravatar", default=None): vol.Any(None, cv.string),
+                vol.Optional("picture", default=None): vol.Any(None, cv.string),
+                vol.Optional(CONF_CONSIDER_HOME, default=consider_home): vol.All(
+                    cv.time_period, cv.positive_timedelta
+                ),
+            }
+        ),
     )
     result = []
     try:


### PR DESCRIPTION
## Breaking Change:

The `hide_if_away` configuration option for device trackers has been deprecated and pending for removal in Home Assistant 0.107.0.

Please ensure this configuration option is not used in your configuration and isn't present in the, also deprecated, `known_devices.yaml` file.

## Description:

See breaking changes 😉 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11766

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: netgear
    host: IP_ADDRESS
    username: YOUR_USERNAME
    interval_seconds: 10
    consider_home: 180
    new_device_defaults:
      track_new_devices: true
      hide_if_away: true
```

## Example entry for `known_devices.yaml`:
```yaml
devicename:
  name: Friendly Name
  mac: EA:AA:55:E7:C6:94
  picture: https://www.home-assistant.io/images/favicon-192x192.png
  track: true
  hide_if_away: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
