### PR TITLE
Deprecate weblink integration

### DIFF
--- a/homeassistant/components/weblink/__init__.py
+++ b/homeassistant/components/weblink/__init__.py
@@ -36,6 +36,12 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the weblink component."""
+    _LOGGER.warning(
+        "The weblink integration has been deprecated and is pending for removal "
+        "in Home Assistant 0.107.0. Please use this instead: "
+        "https://www.home-assistant.io/lovelace/entities/#weblink"
+    )
+
     links = config.get(DOMAIN)
 
     for link in links.get(CONF_ENTITIES):


### PR DESCRIPTION
## Breaking Change:

The `weblink` integration is now deprecated and pending removal in Home Assistant 0.107.0. This integration only works with the old states UI.

## Description:

See breaking changes 😉 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11767

## Example entry for `configuration.yaml` (if applicable):
```yaml
weblink:
  entities:
    - name: Router
      url: http://192.168.1.1/
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
