### PR TITLE
Deprecate history_graph integration

### DIFF
--- a/homeassistant/components/history_graph/__init__.py
+++ b/homeassistant/components/history_graph/__init__.py
@@ -35,6 +35,11 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Load graph configurations."""
+    _LOGGER.warning(
+        "The history_graph integration has been deprecated and is pending for removal "
+        "in Home Assistant 0.107.0."
+    )
+
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     graphs = []
 


### PR DESCRIPTION
## Breaking Change:

The `history_graph` integration has been deprecated and pending for removal in Home Assistant 0.107.0. This integration was used for the old states UI.

## Description:

See breaking changes 😉 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11768

## Example entry for `configuration.yaml` (if applicable):
```yaml
history_graph:
  example:
    entities:
      - light.demo
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
