### PR TITLE
Fix iCloud when no family members

### DIFF
--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -297,10 +297,11 @@ class IcloudAccount:
         self._owner_fullname = f"{user_info['firstName']} {user_info['lastName']}"
 
         self._family_members_fullname = {}
-        for prs_id, member in user_info["membersInfo"].items():
-            self._family_members_fullname[
-                prs_id
-            ] = f"{member['firstName']} {member['lastName']}"
+        if user_info.get("membersInfo") is not None:
+            for prs_id, member in user_info["membersInfo"].items():
+                self._family_members_fullname[
+                    prs_id
+                ] = f"{member['firstName']} {member['lastName']}"
 
         self._devices = {}
         self.update_devices()


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Should be added to 0.104.1 since the bug was introduced in 0.104.0 and block the use of the integration for all people who doesn't have iCloud Family Sharing.

**Related issue :** fixes #30829

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]