### PR TITLE
Add support for Bosch BMP280 Sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -75,6 +75,7 @@ omit =
     homeassistant/components/bluetooth_tracker/*
     homeassistant/components/bme280/sensor.py
     homeassistant/components/bme680/sensor.py
+    homeassistant/components/bmp280/sensor.py
     homeassistant/components/bmw_connected_drive/*
     homeassistant/components/bom/camera.py
     homeassistant/components/bom/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,6 +52,7 @@ homeassistant/components/beewi_smartclim/* @alemuro
 homeassistant/components/bitcoin/* @fabaff
 homeassistant/components/bizkaibus/* @UgaitzEtxebarria
 homeassistant/components/blink/* @fronzbot
+homeassistant/components/bmp280/* @belidzs
 homeassistant/components/bmw_connected_drive/* @gerard33
 homeassistant/components/bom/* @maddenp
 homeassistant/components/braviatv/* @robbiet480

--- a/homeassistant/components/bmp280/__init__.py
+++ b/homeassistant/components/bmp280/__init__.py
@@ -1,0 +1,1 @@
+"""The Bosch BMP280 sensor integration."""

--- a/homeassistant/components/bmp280/manifest.json
+++ b/homeassistant/components/bmp280/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "bmp280",
   "name": "Bosch BMP280 Environmental Sensor",
-  "documentation": "https://www.home-assistant.io/components/bmp280",
+  "documentation": "https://www.home-assistant.io/integrations/bmp280",
   "dependencies": [],
   "codeowners": ["@belidzs"],
   "requirements": ["adafruit-circuitpython-bmp280==3.1.1", "RPi.GPIO==0.7.0"],

--- a/homeassistant/components/bmp280/manifest.json
+++ b/homeassistant/components/bmp280/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/components/bmp280",
   "dependencies": [],
   "codeowners": ["@belidzs"],
-  "requirements": ["adafruit-circuitpython-bmp280==3.1.1", "RPI.GPIO==0.7.0"],
+  "requirements": ["adafruit-circuitpython-bmp280==3.1.1", "RPi.GPIO==0.7.0"],
   "quality_scale": "silver"
 }

--- a/homeassistant/components/bmp280/manifest.json
+++ b/homeassistant/components/bmp280/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "bmp280",
+  "name": "Bosch BMP280 Environmental Sensor",
+  "documentation": "https://www.home-assistant.io/components/bmp280",
+  "dependencies": [],
+  "codeowners": ["@belidzs"],
+  "requirements": ["adafruit-circuitpython-bmp280==3.1.1", "RPI.GPIO==0.7.0"],
+  "quality_scale": "silver"
+}

--- a/homeassistant/components/bmp280/sensor.py
+++ b/homeassistant/components/bmp280/sensor.py
@@ -1,0 +1,163 @@
+"""Platform for Bosch BMP280 Environmental Sensor integration."""
+import logging
+
+from adafruit_bmp280 import Adafruit_BMP280_I2C
+import busio
+import voluptuous as vol
+
+from homeassistant.components.sensor import (
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    PLATFORM_SCHEMA,
+)
+from homeassistant.const import CONF_NAME, PRESSURE_HPA, TEMP_CELSIUS
+from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "BMP280"
+DEFAULT_I2C_ADDRESS = 0x77
+
+MIN_I2C_ADDRESS = 0x76
+MAX_I2C_ADDRESS = 0x77
+
+CONF_I2C_ADDRESS = "i2c_address"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_I2C_ADDRESS, default=DEFAULT_I2C_ADDRESS): vol.All(
+            vol.Coerce(int), vol.Range(min=MIN_I2C_ADDRESS, max=MAX_I2C_ADDRESS)
+        ),
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+    try:
+        # this throws an exception if board is not supported
+        import board
+
+        # initializing I2C bus using the auto-detected pins
+        i2c = busio.I2C(board.SCL, board.SDA)
+        # initializing the sensor
+        bmp280 = Adafruit_BMP280_I2C(i2c, address=config.get(CONF_I2C_ADDRESS))
+        # use custom name if there's any
+        name = config.get(CONF_NAME)
+        # BMP280 has both temperature and pressure sensing capability
+        add_entities(
+            [Bmp280TemperatureSensor(bmp280, name), Bmp280PressureSensor(bmp280, name)]
+        )
+    except NotImplementedError as error:
+        # this is thrown right after the import statement if the board is unsupported
+        if error.args[0] == "Board not supported":
+            _LOGGER.error(
+                "Failed to determine board type. Is this instance running on a Raspberry Pi or a similar I2C capable device?"
+            )
+            raise PlatformNotReady()
+        else:
+            raise error
+    except ValueError as error:
+        # this happens when the board is I2C capable, but the device is not found at the configured address
+        if str(error.args[0]).startswith("No I2C device at address"):
+            _LOGGER.error(error.args[0])
+            raise PlatformNotReady()
+        else:
+            raise error
+
+
+class Bmp280Sensor(Entity):
+    """Base class for BMP280 entities."""
+
+    errored = False
+
+    def __init__(
+        self,
+        bmp280: Adafruit_BMP280_I2C,
+        name: str,
+        unit_of_measurement: str,
+        device_class: str,
+    ):
+        """Initialize the sensor."""
+        self._bmp280 = bmp280
+        self._name = name
+        self._unit_of_measurement = unit_of_measurement
+        self._device_class = device_class
+        self._state = None
+        self._errored = False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit_of_measurement
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
+
+    @property
+    def available(self) -> bool:
+        """Return if the device is currently available."""
+        return not Bmp280Sensor.errored
+
+
+class Bmp280TemperatureSensor(Bmp280Sensor):
+    """Representation of a Bosch BMP280 Temperature Sensor."""
+
+    def __init__(self, bmp280: Adafruit_BMP280_I2C, name: str):
+        """Initialize the entity."""
+        super().__init__(
+            bmp280, f"{name} Temperature", TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE
+        )
+
+    def update(self):
+        """Fetch new state data for the sensor."""
+        try:
+            self._state = round(self._bmp280.temperature, 1)
+            if Bmp280Sensor.errored:
+                _LOGGER.warning("Communication restored with temperature sensor")
+                Bmp280Sensor.errored = False
+        except OSError:
+            # this is thrown when a working sensor is unplugged between two updates
+            _LOGGER.warning(
+                "Unable to read temperature data due to a communication problem"
+            )
+            Bmp280Sensor.errored = True
+
+
+class Bmp280PressureSensor(Bmp280Sensor):
+    """Representation of a Bosch BMP280 Barometric Pressure Sensor."""
+
+    def __init__(self, bmp280: Adafruit_BMP280_I2C, name: str):
+        """Initialize the entity."""
+        super().__init__(
+            bmp280, f"{name} Pressure", PRESSURE_HPA, DEVICE_CLASS_PRESSURE
+        )
+
+    def update(self):
+        """Fetch new state data for the sensor."""
+        try:
+            self._state = round(self._bmp280.pressure)
+            if Bmp280Sensor.errored:
+                _LOGGER.warning("Communication restored with pressure sensor")
+                Bmp280Sensor.errored = False
+        except OSError:
+            # this is thrown when a working sensor is unplugged between two updates
+            _LOGGER.warning(
+                "Unable to read pressure data due to a communication problem"
+            )
+            Bmp280Sensor.errored = True

--- a/homeassistant/components/bmp280/sensor.py
+++ b/homeassistant/components/bmp280/sensor.py
@@ -58,15 +58,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 "Failed to determine board type. Is this instance running on a Raspberry Pi or a similar I2C capable device?"
             )
             raise PlatformNotReady()
-        else:
-            raise error
+        raise error
     except ValueError as error:
         # this happens when the board is I2C capable, but the device is not found at the configured address
         if str(error.args[0]).startswith("No I2C device at address"):
             _LOGGER.error(error.args[0])
             raise PlatformNotReady()
-        else:
-            raise error
+        raise error
 
 
 class Bmp280Sensor(Entity):

--- a/homeassistant/components/bmp280/sensor.py
+++ b/homeassistant/components/bmp280/sensor.py
@@ -2,7 +2,7 @@
 import logging
 
 from adafruit_bmp280 import Adafruit_BMP280_I2C
-import busio
+from busio import I2C
 import voluptuous as vol
 
 from homeassistant.components.sensor import (

--- a/homeassistant/components/bmp280/sensor.py
+++ b/homeassistant/components/bmp280/sensor.py
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         import board
 
         # initializing I2C bus using the auto-detected pins
-        i2c = busio.I2C(board.SCL, board.SDA)
+        i2c = I2C(board.SCL, board.SDA)
         # initializing the sensor
         bmp280 = Adafruit_BMP280_I2C(i2c, address=config.get(CONF_I2C_ADDRESS))
         # use custom name if there's any

--- a/homeassistant/components/bmp280/sensor.py
+++ b/homeassistant/components/bmp280/sensor.py
@@ -67,8 +67,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class Bmp280Sensor(Entity):
     """Base class for BMP280 entities."""
 
-    errored = False
-
     def __init__(
         self,
         bmp280: Adafruit_BMP280_I2C,
@@ -107,7 +105,7 @@ class Bmp280Sensor(Entity):
     @property
     def available(self) -> bool:
         """Return if the device is currently available."""
-        return not Bmp280Sensor.errored
+        return not self._errored
 
 
 class Bmp280TemperatureSensor(Bmp280Sensor):
@@ -124,15 +122,15 @@ class Bmp280TemperatureSensor(Bmp280Sensor):
         """Fetch new state data for the sensor."""
         try:
             self._state = round(self._bmp280.temperature, 1)
-            if Bmp280Sensor.errored:
+            if self._errored:
                 _LOGGER.warning("Communication restored with temperature sensor")
-                Bmp280Sensor.errored = False
+                self._errored = False
         except OSError:
             # this is thrown when a working sensor is unplugged between two updates
             _LOGGER.warning(
                 "Unable to read temperature data due to a communication problem"
             )
-            Bmp280Sensor.errored = True
+            self._errored = True
 
 
 class Bmp280PressureSensor(Bmp280Sensor):
@@ -149,12 +147,12 @@ class Bmp280PressureSensor(Bmp280Sensor):
         """Fetch new state data for the sensor."""
         try:
             self._state = round(self._bmp280.pressure)
-            if Bmp280Sensor.errored:
+            if self._errored:
                 _LOGGER.warning("Communication restored with pressure sensor")
-                Bmp280Sensor.errored = False
+                self._errored = False
         except OSError:
             # this is thrown when a working sensor is unplugged between two updates
             _LOGGER.warning(
                 "Unable to read pressure data due to a communication problem"
             )
-            Bmp280Sensor.errored = True
+            self._errored = True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -83,6 +83,9 @@ PyViCare==0.1.7
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.12.4
 
+# homeassistant.components.bmp280
+RPI.GPIO==0.7.0
+
 # homeassistant.components.mcp23017
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.7.0
@@ -110,6 +113,9 @@ abodepy==0.18.1
 
 # homeassistant.components.mcp23017
 adafruit-blinka==3.9.0
+
+# homeassistant.components.bmp280
+adafruit-circuitpython-bmp280==3.1.1
 
 # homeassistant.components.mcp23017
 adafruit-circuitpython-mcp230xx==2.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -84,8 +84,6 @@ PyViCare==0.1.7
 PyXiaomiGateway==0.12.4
 
 # homeassistant.components.bmp280
-RPI.GPIO==0.7.0
-
 # homeassistant.components.mcp23017
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.7.0


### PR DESCRIPTION
## Description:
Implement support for the Bosch BMP280 Environmental Sensor

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11769

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: bmp280
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
