### PR TITLE
Reinstate and deprecate filename option for hue config

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -44,7 +44,11 @@ CONFIG_SCHEMA = vol.Schema(
         DOMAIN: vol.Schema(
             {
                 vol.Optional(CONF_BRIDGES): vol.All(
-                    cv.ensure_list, [BRIDGE_CONFIG_SCHEMA]
+                    cv.ensure_list,
+                    [
+                        cv.deprecated("filename", invalidation_version="0.106.0"),
+                        vol.All(BRIDGE_CONFIG_SCHEMA),
+                    ],
                 )
             }
         )

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -33,6 +33,7 @@ async def test_setup_defined_hosts_known_auth(hass):
                             hue.CONF_HOST: "0.0.0.0",
                             hue.CONF_ALLOW_HUE_GROUPS: False,
                             hue.CONF_ALLOW_UNREACHABLE: True,
+                            "filename": "bla",
                         }
                     }
                 },
@@ -49,6 +50,7 @@ async def test_setup_defined_hosts_known_auth(hass):
             hue.CONF_HOST: "0.0.0.0",
             hue.CONF_ALLOW_HUE_GROUPS: False,
             hue.CONF_ALLOW_UNREACHABLE: True,
+            "filename": "bla",
         }
     }
 


### PR DESCRIPTION
## Description:
In #30000 I removed the `filename` option because I thought that no one was using it. That was not the case, it was still mentioned in the docs and people thought they had to use it (it hasn't been used by the code since March 2018!). 

So instead now deprecating it, and marked for removal in 106.

Docs: https://github.com/home-assistant/home-assistant.io/pull/11773

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/30820


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
