### PR TITLE
Fix sending message to MS Teams after reset

### DIFF
--- a/homeassistant/components/msteams/notify.py
+++ b/homeassistant/components/msteams/notify.py
@@ -39,16 +39,18 @@ class MSTeamsNotificationService(BaseNotificationService):
     def __init__(self, webhook_url):
         """Initialize the service."""
         self._webhook_url = webhook_url
-        self.teams_message = pymsteams.connectorcard(self._webhook_url)
 
     def send_message(self, message=None, **kwargs):
         """Send a message to the webhook."""
+
+        teams_message = pymsteams.connectorcard(self._webhook_url)
+
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = kwargs.get(ATTR_DATA)
 
-        self.teams_message.title(title)
+        teams_message.title(title)
 
-        self.teams_message.text(message)
+        teams_message.text(message)
 
         if data is not None:
             file_url = data.get(ATTR_FILE_URL)
@@ -60,8 +62,8 @@ class MSTeamsNotificationService(BaseNotificationService):
 
                 message_section = pymsteams.cardsection()
                 message_section.addImage(file_url)
-                self.teams_message.addSection(message_section)
+                teams_message.addSection(message_section)
         try:
-            self.teams_message.send()
+            teams_message.send()
         except RuntimeError as err:
             _LOGGER.error("Could not send notification. Error: %s", err)


### PR DESCRIPTION
## Description:
Fixes issue about messages not being reset after sending it to microsoft teams.

**Related issue (if applicable):** fixes #29822

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
