### PR TITLE
Fix sensor type creation with multiple Ambient weather stations

### DIFF
--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -19,7 +19,13 @@ from . import (
     TYPE_BATTOUT,
     AmbientWeatherEntity,
 )
-from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TYPE_BINARY_SENSOR
+from .const import (
+    ATTR_LAST_DATA,
+    ATTR_MONITORED_CONDITIONS,
+    DATA_CLIENT,
+    DOMAIN,
+    TYPE_BINARY_SENSOR,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +41,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     binary_sensor_list = []
     for mac_address, station in ambient.stations.items():
-        for condition in ambient.monitored_conditions:
+        for condition in station[ATTR_MONITORED_CONDITIONS]:
             name, _, kind, device_class = SENSOR_TYPES[condition]
             if kind == TYPE_BINARY_SENSOR:
                 binary_sensor_list.append(

--- a/homeassistant/components/ambient_station/const.py
+++ b/homeassistant/components/ambient_station/const.py
@@ -2,6 +2,7 @@
 DOMAIN = "ambient_station"
 
 ATTR_LAST_DATA = "last_data"
+ATTR_MONITORED_CONDITIONS = "monitored_conditions"
 
 CONF_APP_KEY = "app_key"
 

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -9,7 +9,13 @@ from . import (
     TYPE_SOLARRADIATION_LX,
     AmbientWeatherEntity,
 )
-from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TYPE_SENSOR
+from .const import (
+    ATTR_LAST_DATA,
+    ATTR_MONITORED_CONDITIONS,
+    DATA_CLIENT,
+    DOMAIN,
+    TYPE_SENSOR,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +31,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     sensor_list = []
     for mac_address, station in ambient.stations.items():
-        for condition in ambient.monitored_conditions:
+        for condition in station[ATTR_MONITORED_CONDITIONS]:
             name, unit, kind, device_class = SENSOR_TYPES[condition]
             if kind == TYPE_SENSOR:
                 sensor_list.append(


### PR DESCRIPTION
## Description:

The `ambient_pws` integration had a bug where, despite supporting multiple weather stations, the same sensor types would be created for every station – even if different stations had different sensor types attached to them. This PR fixes that.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/30513

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
