### PR TITLE
Update Ring Interval

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -98,7 +98,7 @@ async def async_setup_entry(hass, entry):
             hass, entry.entry_id, ring, "update_devices", timedelta(minutes=1)
         ),
         "dings_data": GlobalDataUpdater(
-            hass, entry.entry_id, ring, "update_dings", timedelta(seconds=10)
+            hass, entry.entry_id, ring, "update_dings", timedelta(seconds=5)
         ),
         "history_data": DeviceDataUpdater(
             hass,

--- a/homeassistant/components/ring/binary_sensor.py
+++ b/homeassistant/components/ring/binary_sensor.py
@@ -1,5 +1,5 @@
 """This component provides HA sensor support for Ring Door Bell/Chimes."""
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
@@ -9,8 +9,6 @@ from . import DOMAIN
 from .entity import RingEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
-
-SCAN_INTERVAL = timedelta(seconds=10)
 
 # Sensor types: Name, category, device_class
 SENSOR_TYPES = {


### PR DESCRIPTION
## Breaking Change:

Nothing

## Description:

The ring integration had a lot of improvements lately and some were specifically around how many calls were being made.  @balloob fixed all of those inefficiencies.

In #14693 it was discovered that we made so many calls that we were apparently being rate limited and this limit was immediately discovered if a user had multiple devices as we were hitting the same endpoint numerous times.  Now that the core issue is fixed we can safely lower the ding interval so the binary sensors around motion and ding update faster.  I have tested this change for the past 24 hours and have not seen a single error around the binary sensors.

Ring has also made changes around when they report the sensor being `on` or `off` as it used to be 2 minutes but now its as long as the device is streaming.  So if the device was only streaming for a few seconds then this update would be completely missed.

I have tested this change against my 4 devices which would definitely hit the rate limit we previously encountered so I am confident this change is good to go.

I have also removed the unused old scan interval since the logic around updates has changed.

**Related issue (if applicable):** fixes #N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):

Configured via integration panel with 2fa code

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
