### PR TITLE
Bump pyvizio version to 0.1.1

### DIFF
--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "Vizio SmartCast TV",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.0.20"],
+  "requirements": ["pyvizio==0.1.1"],
   "dependencies": [],
   "codeowners": ["@raman325"],
   "config_flow": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1693,7 +1693,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.20
+pyvizio==0.1.1
 
 # homeassistant.components.velux
 pyvlx==0.2.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -558,7 +558,7 @@ pyvera==0.3.7
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.0.20
+pyvizio==0.1.1
 
 # homeassistant.components.html5
 pywebpush==1.9.2


### PR DESCRIPTION
## Description:
Bump `pyvizio` to 0.1.1. This will *not* resolve issue #30817 and a different version bump will have to be merged into master for the 0.104 version.

~**Related issue (if applicable):** fixes #30817~