### PR TITLE
Update pyatmo to 3.2.2 and add available property

### DIFF
--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/integrations/netatmo",
   "requirements": [
-    "pyatmo==3.2.0"
+    "pyatmo==3.2.1"
   ],
   "dependencies": [
     "webhook"

--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/integrations/netatmo",
   "requirements": [
-    "pyatmo==3.2.1"
+    "pyatmo==3.2.2"
   ],
   "dependencies": [
     "webhook"

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -427,6 +427,11 @@ class NetatmoPublicSensor(Entity):
         """Return the unit of measurement of this entity."""
         return self._unit_of_measurement
 
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return bool(self._state)
+
     def update(self):
         """Get the latest data from Netatmo API and updates the states."""
         self.netatmo_data.update()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1137,7 +1137,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==3.2.0
+pyatmo==3.2.1
 
 # homeassistant.components.atome
 pyatome==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1137,7 +1137,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==3.2.1
+pyatmo==3.2.2
 
 # homeassistant.components.atome
 pyatome==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,9 +173,6 @@ elgato==0.2.0
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.9
 
-# homeassistant.components.entur_public_transport
-enturclient==0.2.1
-
 # homeassistant.components.season
 ephem==3.7.7.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,6 +173,9 @@ elgato==0.2.0
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.9
 
+# homeassistant.components.entur_public_transport
+enturclient==0.2.1
+
 # homeassistant.components.season
 ephem==3.7.7.0
 
@@ -399,7 +402,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==3.2.0
+pyatmo==3.2.1
 
 # homeassistant.components.blackbird
 pyblackbird==0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -402,7 +402,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==3.2.1
+pyatmo==3.2.2
 
 # homeassistant.components.blackbird
 pyblackbird==0.5


### PR DESCRIPTION
## Description:
This release fixes issues when single weather stations/modules are not reachable. 

**Related issue (if applicable):** fixes #30291 and fixes #30842

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
