### PR TITLE
Make gen_requirements_all.py case insensitive for ignored packages

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -131,7 +131,7 @@ def gather_recursive_requirements(domain, seen=None):
 
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    return any(ign in req for ign in COMMENT_REQUIREMENTS)
+    return any(ign.lower() in req.lower() for ign in COMMENT_REQUIREMENTS)
 
 
 def gather_modules():


### PR DESCRIPTION
## Description:
When I was working on implementing a new platform I have added `RPi.GPIO` to the requirements. It turns out this was actually a blacklisted component in `gen_all_requirements.py` but because I have accidentally wrote `RPI.GPIO` instead (same component, different case) it got added to `requirements_all.txt` anyway. 

This caused `pylint` to fail on a completely different, but already approved component in the dev branch (`rpi_gpio`). Since it took a while to track down this problem I figured I might as well fix `gen_requirements_all.py` to ignore case when matching against blacklisted packages.

**Related issue (if applicable):** #30837

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
