### PR TITLE
Fix can't add multiple iCloud accounts (remove account name)

### DIFF
--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -23,7 +23,6 @@ from homeassistant.util.dt import utcnow
 from homeassistant.util.location import distance
 
 from .const import (
-    CONF_ACCOUNT_NAME,
     CONF_GPS_ACCURACY_THRESHOLD,
     CONF_MAX_INTERVAL,
     DEFAULT_GPS_ACCURACY_THRESHOLD,
@@ -100,7 +99,6 @@ ACCOUNT_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_ACCOUNT_NAME): cv.string,
         vol.Optional(CONF_MAX_INTERVAL, default=DEFAULT_MAX_INTERVAL): cv.positive_int,
         vol.Optional(
             CONF_GPS_ACCURACY_THRESHOLD, default=DEFAULT_GPS_ACCURACY_THRESHOLD
@@ -140,20 +138,13 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
-    account_name = entry.data.get(CONF_ACCOUNT_NAME)
     max_interval = entry.data[CONF_MAX_INTERVAL]
     gps_accuracy_threshold = entry.data[CONF_GPS_ACCURACY_THRESHOLD]
 
     icloud_dir = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
 
     account = IcloudAccount(
-        hass,
-        username,
-        password,
-        icloud_dir,
-        account_name,
-        max_interval,
-        gps_accuracy_threshold,
+        hass, username, password, icloud_dir, max_interval, gps_accuracy_threshold,
     )
     await hass.async_add_executor_job(account.setup)
     hass.data[DOMAIN][username] = account
@@ -254,7 +245,6 @@ class IcloudAccount:
         username: str,
         password: str,
         icloud_dir: Store,
-        account_name: str,
         max_interval: int,
         gps_accuracy_threshold: int,
     ):
@@ -262,7 +252,6 @@ class IcloudAccount:
         self.hass = hass
         self._username = username
         self._password = password
-        self._name = account_name or slugify(username.partition("@")[0])
         self._fetch_interval = max_interval
         self._max_interval = max_interval
         self._gps_accuracy_threshold = gps_accuracy_threshold
@@ -435,11 +424,6 @@ class IcloudAccount:
         return result
 
     @property
-    def name(self) -> str:
-        """Return the account name."""
-        return self._name
-
-    @property
     def username(self) -> str:
         """Return the account username."""
         return self._username
@@ -471,7 +455,6 @@ class IcloudDevice:
     def __init__(self, account: IcloudAccount, device: AppleDevice, status):
         """Initialize the iCloud device."""
         self._account = account
-        account_name = account.name
 
         self._device = device
         self._status = status
@@ -494,7 +477,6 @@ class IcloudDevice:
 
         self._attrs = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            CONF_ACCOUNT_NAME: account_name,
             ATTR_ACCOUNT_FETCH_INTERVAL: self._account.fetch_interval,
             ATTR_DEVICE_NAME: self._device_model,
             ATTR_DEVICE_STATUS: None,

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -8,10 +8,8 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.util import slugify
 
 from .const import (
-    CONF_ACCOUNT_NAME,
     CONF_GPS_ACCURACY_THRESHOLD,
     CONF_MAX_INTERVAL,
     DEFAULT_GPS_ACCURACY_THRESHOLD,
@@ -45,14 +43,10 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._trusted_device = None
         self._verification_code = None
 
-    def _configuration_exists(self, username: str, account_name: str) -> bool:
-        """Return True if username or account_name exists in configuration."""
+    def _configuration_exists(self, username: str) -> bool:
+        """Return True if username exists in configuration."""
         for entry in self._async_current_entries():
-            if (
-                entry.data[CONF_USERNAME] == username
-                or entry.data.get(CONF_ACCOUNT_NAME) == account_name
-                or slugify(entry.data[CONF_USERNAME].partition("@")[0]) == account_name
-            ):
+            if entry.data[CONF_USERNAME] == username:
                 return True
         return False
 
@@ -91,13 +85,12 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
-        self._account_name = user_input.get(CONF_ACCOUNT_NAME)
         self._max_interval = user_input.get(CONF_MAX_INTERVAL, DEFAULT_MAX_INTERVAL)
         self._gps_accuracy_threshold = user_input.get(
             CONF_GPS_ACCURACY_THRESHOLD, DEFAULT_GPS_ACCURACY_THRESHOLD
         )
 
-        if self._configuration_exists(self._username, self._account_name):
+        if self._configuration_exists(self._username):
             errors[CONF_USERNAME] = "username_exists"
             return await self._show_setup_form(user_input, errors)
 
@@ -119,7 +112,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data={
                 CONF_USERNAME: self._username,
                 CONF_PASSWORD: self._password,
-                CONF_ACCOUNT_NAME: self._account_name,
                 CONF_MAX_INTERVAL: self._max_interval,
                 CONF_GPS_ACCURACY_THRESHOLD: self._gps_accuracy_threshold,
             },
@@ -127,9 +119,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, user_input):
         """Import a config entry."""
-        if self._configuration_exists(
-            user_input[CONF_USERNAME], user_input.get(CONF_ACCOUNT_NAME)
-        ):
+        if self._configuration_exists(user_input[CONF_USERNAME]):
             return self.async_abort(reason="username_exists")
 
         return await self.async_step_user(user_input)
@@ -214,7 +204,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 CONF_USERNAME: self._username,
                 CONF_PASSWORD: self._password,
-                CONF_ACCOUNT_NAME: self._account_name,
                 CONF_MAX_INTERVAL: self._max_interval,
                 CONF_GPS_ACCURACY_THRESHOLD: self._gps_accuracy_threshold,
             }

--- a/homeassistant/components/icloud/const.py
+++ b/homeassistant/components/icloud/const.py
@@ -3,7 +3,6 @@
 DOMAIN = "icloud"
 SERVICE_UPDATE = f"{DOMAIN}_update"
 
-CONF_ACCOUNT_NAME = "account_name"
 CONF_MAX_INTERVAL = "max_interval"
 CONF_GPS_ACCURACY_THRESHOLD = "gps_accuracy_threshold"
 


### PR DESCRIPTION
## Breaking Change:

`account_name` is removed from the config.yaml, nothing change for the config flow.

## Description:

When I refactored and added the config flow to iCloud, I kept the `account_name` config for yaml, as for legacy, but the only use of it is in iCloud device attributes ...

Also I added a check for already configured iCloud integration, and in that case when you add multiple iCloud via the UI, you will always get "Account already configured" (cf #30877) because it checks `None == None` [here](https://github.com/home-assistant/home-assistant/blob/d63ea198f2a9d65e2be4160f33688534744605df/homeassistant/components/icloud/config_flow.py#L53).

The cause is [in the config_flow](https://github.com/home-assistant/home-assistant/blob/d63ea198f2a9d65e2be4160f33688534744605df/homeassistant/components/icloud/config_flow.py#L94), it should have [this from the init](https://github.com/home-assistant/home-assistant/blob/d63ea198f2a9d65e2be4160f33688534744605df/homeassistant/components/icloud/__init__.py#L265).


I've coded an other fix without breaking change and keeping the `account_name` but as I think it is useless, I prefer clean the code (will link later).

**Related issue:** fixes #30877

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11800

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html