### PR TITLE
Add battery voltage state attribute for ZHA devices

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -22,6 +22,7 @@ from ..const import (
     SIGNAL_ATTR_UPDATED,
     SIGNAL_MOVE_LEVEL,
     SIGNAL_SET_LEVEL,
+    SIGNAL_STATE_ATTR,
 )
 from ..helpers import get_attr_id_by_name
 
@@ -355,6 +356,14 @@ class PowerConfigurationChannel(ZigbeeChannel):
             async_dispatcher_send(
                 self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
             )
+            return
+        attr_name = self.cluster.attributes.get(attrid, [attrid])[0]
+        async_dispatcher_send(
+            self._zha_device.hass,
+            f"{self.unique_id}_{SIGNAL_STATE_ATTR}",
+            attr_name,
+            value,
+        )
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -208,9 +208,9 @@ class Battery(Sensor):
             state_attrs["battery_quantity"] = battery_quantity
         return state_attrs
 
-    def async_update_state_attribute(self, attr_name, value):
+    def async_update_state_attribute(self, key, value):
         """Update a single device state attribute."""
-        if attr_name == "battery_voltage":
+        if key == "battery_voltage":
             self._device_state_attributes["voltage"] = f"{round(value/10, 1)}V"
             self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -127,7 +127,7 @@ class Sensor(ZhaEntity):
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""
         await super().async_added_to_hass()
-        self._device_state_attributes = await self.async_state_attr_provider()
+        self._device_state_attributes.update(await self.async_state_attr_provider())
 
         await self.async_accept_signal(
             self._channel, SIGNAL_ATTR_UPDATED, self.async_set_state
@@ -207,6 +207,12 @@ class Battery(Sensor):
         if battery_quantity is not None:
             state_attrs["battery_quantity"] = battery_quantity
         return state_attrs
+
+    def async_update_state_attribute(self, attr_name, value):
+        """Update a single device state attribute."""
+        if attr_name == "battery_voltage":
+            self._device_state_attributes["voltage"] = f"{round(value/10, 1)}V"
+            self.async_schedule_update_ha_state()
 
 
 @STRICT_MATCH(channel_names=CHANNEL_ELECTRICAL_MEASUREMENT)


### PR DESCRIPTION
## Description:
Display battery voltage as state attribute on ZHA devices if available.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
