### PR TITLE
deCONZ - Fix issue with group unique id when normalising bridge id

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -1,10 +1,11 @@
 """Support for deCONZ devices."""
 import voluptuous as vol
 
+from homeassistant.config_entries import _UNDEF
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 from .config_flow import get_master_gateway
-from .const import CONF_MASTER_GATEWAY, DOMAIN
+from .const import CONF_BRIDGE_ID, CONF_GROUP_ID_BASE, CONF_MASTER_GATEWAY, DOMAIN
 from .gateway import DeconzGateway
 from .services import async_setup_services, async_unload_services
 
@@ -37,8 +38,14 @@ async def async_setup_entry(hass, config_entry):
 
     # 0.104 introduced config entry unique id, this makes upgrading possible
     if config_entry.unique_id is None:
+
+        new_data = _UNDEF
+        if CONF_BRIDGE_ID in config_entry.data:
+            new_data = dict(config_entry.data)
+            new_data[CONF_GROUP_ID_BASE] = config_entry.data[CONF_BRIDGE_ID]
+
         hass.config_entries.async_update_entry(
-            config_entry, unique_id=gateway.api.config.bridgeid
+            config_entry, unique_id=gateway.api.config.bridgeid, data=new_data
         )
 
     hass.data[DOMAIN][config_entry.unique_id] = gateway

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import aiohttp_client
 from .const import (
     CONF_ALLOW_CLIP_SENSOR,
     CONF_ALLOW_DECONZ_GROUPS,
-    CONF_BRIDGEID,
+    CONF_BRIDGE_ID,
     DEFAULT_ALLOW_CLIP_SENSOR,
     DEFAULT_ALLOW_DECONZ_GROUPS,
     DEFAULT_PORT,
@@ -74,7 +74,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             for bridge in self.bridges:
                 if bridge[CONF_HOST] == user_input[CONF_HOST]:
-                    self.bridge_id = bridge[CONF_BRIDGEID]
+                    self.bridge_id = bridge[CONF_BRIDGE_ID]
                     self.deconz_config = {
                         CONF_HOST: bridge[CONF_HOST],
                         CONF_PORT: bridge[CONF_PORT],

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -5,7 +5,8 @@ _LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "deconz"
 
-CONF_BRIDGEID = "bridgeid"
+CONF_BRIDGE_ID = "bridgeid"
+CONF_GROUP_ID_BASE = "group_id_base"
 
 DEFAULT_PORT = 80
 DEFAULT_ALLOW_CLIP_SENSOR = False

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.util.color as color_util
 
 from .const import (
+    CONF_GROUP_ID_BASE,
     COVER_TYPES,
     DOMAIN as DECONZ_DOMAIN,
     NEW_GROUP,
@@ -205,7 +206,11 @@ class DeconzGroup(DeconzLight):
         """Set up group and create an unique id."""
         super().__init__(device, gateway)
 
-        self._unique_id = f"{self.gateway.api.config.bridgeid}-{self._device.deconz_id}"
+        group_id_base = self.gateway.config_entry.unique_id
+        if CONF_GROUP_ID_BASE in self.gateway.config_entry.data:
+            group_id_base = self.gateway.config_entry.data[CONF_GROUP_ID_BASE]
+
+        self._unique_id = f"{group_id_base}-{self._device.deconz_id}"
 
     @property
     def unique_id(self):

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -6,7 +6,7 @@ from homeassistant.helpers import config_validation as cv
 from .config_flow import get_master_gateway
 from .const import (
     _LOGGER,
-    CONF_BRIDGEID,
+    CONF_BRIDGE_ID,
     DOMAIN,
     NEW_GROUP,
     NEW_LIGHT,
@@ -27,14 +27,14 @@ SERVICE_CONFIGURE_DEVICE_SCHEMA = vol.All(
             vol.Optional(SERVICE_ENTITY): cv.entity_id,
             vol.Optional(SERVICE_FIELD): cv.matches_regex("/.*"),
             vol.Required(SERVICE_DATA): dict,
-            vol.Optional(CONF_BRIDGEID): str,
+            vol.Optional(CONF_BRIDGE_ID): str,
         }
     ),
     cv.has_at_least_one_key(SERVICE_ENTITY, SERVICE_FIELD),
 )
 
 SERVICE_DEVICE_REFRESH = "device_refresh"
-SERVICE_DEVICE_REFRESH_SCHEMA = vol.All(vol.Schema({vol.Optional(CONF_BRIDGEID): str}))
+SERVICE_DEVICE_REFRESH_SCHEMA = vol.All(vol.Schema({vol.Optional(CONF_BRIDGE_ID): str}))
 
 
 async def async_setup_services(hass):
@@ -97,7 +97,7 @@ async def async_configure_service(hass, data):
     See Dresden Elektroniks REST API documentation for details:
     http://dresden-elektronik.github.io/deconz-rest-doc/rest/
     """
-    bridgeid = data.get(CONF_BRIDGEID)
+    bridgeid = data.get(CONF_BRIDGE_ID)
     field = data.get(SERVICE_FIELD, "")
     entity_id = data.get(SERVICE_ENTITY)
     data = data[SERVICE_DATA]
@@ -119,8 +119,8 @@ async def async_configure_service(hass, data):
 async def async_refresh_devices_service(hass, data):
     """Refresh available devices from deCONZ."""
     gateway = get_master_gateway(hass)
-    if CONF_BRIDGEID in data:
-        gateway = hass.data[DOMAIN][data[CONF_BRIDGEID]]
+    if CONF_BRIDGE_ID in data:
+        gateway = hass.data[DOMAIN][data[CONF_BRIDGE_ID]]
 
     groups = set(gateway.api.groups.keys())
     lights = set(gateway.api.lights.keys())

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -5,7 +5,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components import deconz
-from homeassistant.components.deconz.const import CONF_BRIDGEID
+from homeassistant.components.deconz.const import CONF_BRIDGE_ID
 
 from .test_gateway import BRIDGEID, setup_deconz_integration
 
@@ -91,7 +91,7 @@ async def test_configure_service_with_field(hass):
 
     data = {
         deconz.services.SERVICE_FIELD: "/light/2",
-        CONF_BRIDGEID: BRIDGEID,
+        CONF_BRIDGE_ID: BRIDGEID,
         deconz.services.SERVICE_DATA: {"on": True, "attr1": 10, "attr2": 20},
     }
 
@@ -180,7 +180,7 @@ async def test_service_refresh_devices(hass):
     """Test that service can refresh devices."""
     gateway = await setup_deconz_integration(hass)
 
-    data = {CONF_BRIDGEID: BRIDGEID}
+    data = {CONF_BRIDGE_ID: BRIDGEID}
 
     with patch(
         "pydeconz.DeconzSession.request",


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Store old bridgeid to use with group unique id if user upgrades from before 0.104

**Related issue (if applicable):** fixes #30875

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
