### PR TITLE
Remove option to configure SimpliSafe scan interval

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -100,7 +100,13 @@ ACCOUNT_CONFIG_SCHEMA = vol.Schema(
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_CODE): cv.string,
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+            cv.time_period,
+            lambda value: value.seconds,
+            # For a reverse-engineered polling-based API, don't scan any faster than the
+            # default:
+            vol.Range(min=DEFAULT_SCAN_INTERVAL.seconds),
+        ),
     }
 )
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -1,6 +1,5 @@
 """Support for SimpliSafe alarm systems."""
 import asyncio
-from datetime import timedelta
 import logging
 
 from simplipy import API
@@ -9,13 +8,7 @@ from simplipy.system.v3 import VOLUME_HIGH, VOLUME_LOW, VOLUME_MEDIUM, VOLUME_OF
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import (
-    CONF_CODE,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_TOKEN,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
@@ -100,13 +93,6 @@ ACCOUNT_CONFIG_SCHEMA = vol.Schema(
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_CODE): cv.string,
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
-            cv.time_period,
-            lambda value: value.seconds,
-            # For a reverse-engineered polling-based API, don't scan any faster than the
-            # default:
-            vol.Range(min=DEFAULT_SCAN_INTERVAL.seconds),
-        ),
     }
 )
 
@@ -166,7 +152,6 @@ async def async_setup(hass, config):
                     CONF_USERNAME: account[CONF_USERNAME],
                     CONF_PASSWORD: account[CONF_PASSWORD],
                     CONF_CODE: account.get(CONF_CODE),
-                    CONF_SCAN_INTERVAL: account[CONF_SCAN_INTERVAL],
                 },
             )
         )
@@ -208,7 +193,7 @@ async def async_setup_entry(hass, config_entry):
         async_dispatcher_send(hass, TOPIC_UPDATE)
 
     hass.data[DOMAIN][DATA_LISTENER][config_entry.entry_id] = async_track_time_interval(
-        hass, refresh, timedelta(seconds=config_entry.data[CONF_SCAN_INTERVAL])
+        hass, refresh, DEFAULT_SCAN_INTERVAL
     )
 
     # Register the base station for each system:

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -6,17 +6,11 @@ from simplipy.errors import SimplipyError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_CODE,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_TOKEN,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DOMAIN
 
 
 @callback
@@ -72,15 +66,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow):
         except SimplipyError:
             return await self._show_form({"base": "invalid_credentials"})
 
-        scan_interval = user_input.get(
-            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.seconds
-        )
-
         return self.async_create_entry(
             title=user_input[CONF_USERNAME],
-            data={
-                CONF_USERNAME: username,
-                CONF_TOKEN: simplisafe.refresh_token,
-                CONF_SCAN_INTERVAL: scan_interval,
-            },
+            data={CONF_USERNAME: username, CONF_TOKEN: simplisafe.refresh_token},
         )

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -72,13 +72,15 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow):
         except SimplipyError:
             return await self._show_form({"base": "invalid_credentials"})
 
-        scan_interval = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        scan_interval = user_input.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.seconds
+        )
 
         return self.async_create_entry(
             title=user_input[CONF_USERNAME],
             data={
                 CONF_USERNAME: username,
                 CONF_TOKEN: simplisafe.refresh_token,
-                CONF_SCAN_INTERVAL: scan_interval.seconds,
+                CONF_SCAN_INTERVAL: scan_interval,
             },
         )

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -1,16 +1,10 @@
 """Define tests for the SimpliSafe config flow."""
-from datetime import timedelta
 import json
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.simplisafe import DOMAIN, config_flow
-from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_TOKEN,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 
 from tests.common import MockConfigEntry, mock_coro
 
@@ -85,7 +79,6 @@ async def test_step_import(hass):
                     assert result["data"] == {
                         CONF_USERNAME: "user@email.com",
                         CONF_TOKEN: "12345abc",
-                        CONF_SCAN_INTERVAL: 30,
                     }
 
 
@@ -94,7 +87,6 @@ async def test_step_user(hass):
     conf = {
         CONF_USERNAME: "user@email.com",
         CONF_PASSWORD: "password",
-        CONF_SCAN_INTERVAL: timedelta(seconds=90),
     }
 
     flow = config_flow.SimpliSafeFlowHandler()
@@ -116,5 +108,4 @@ async def test_step_user(hass):
                     assert result["data"] == {
                         CONF_USERNAME: "user@email.com",
                         CONF_TOKEN: "12345abc",
-                        CONF_SCAN_INTERVAL: 90,
                     }


### PR DESCRIPTION
## Breaking Change:

It is no longer possible to configure a `scan_interval` for the SimpliSafe integration within `configuration.yaml`.

## Description:

The SimpliSafe integration currently allows users to define a scan interval. Based on my interactions with SimpliSafe, that makes me uneasy; if users set too low of an interval, I'm concerned SimpliSafe will harm the integration for everyone. So, this PR removes that option and sets a code-defined scan interval.

I did not make a config schema chance here because leaving `scan_interval` won't harm anything.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    username: !secret simplisafe_username
    password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
