### PR TITLE
Adds icon endpoint to NO_AUTH

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -31,7 +31,7 @@ NO_TIMEOUT = re.compile(
     r")$"
 )
 
-NO_AUTH = re.compile(r"^(?:" r"|app/.*" r"|addons/[^/]+/logo" r")$")
+NO_AUTH = re.compile(r"^(?:" r"|app/.*" r"|addons/[^/]+/logo" r"|addons/[^/]+/icon" r")$")
 
 
 class HassIOView(HomeAssistantView):

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -31,7 +31,9 @@ NO_TIMEOUT = re.compile(
     r")$"
 )
 
-NO_AUTH = re.compile(r"^(?:" r"|app/.*" r"|addons/[^/]+/logo" r"|addons/[^/]+/icon" r")$")
+NO_AUTH = re.compile(
+    r"^(?:" r"|app/.*" r"|addons/[^/]+/logo" r"|addons/[^/]+/icon" r")$"
+)
 
 
 class HassIOView(HomeAssistantView):

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -60,7 +60,7 @@ async def test_forward_request_no_auth_for_panel(
 
 
 async def test_forward_request_no_auth_for_logo(hassio_client, aioclient_mock):
-    """Test no auth needed for ."""
+    """Test no auth needed for logo."""
     aioclient_mock.get("http://127.0.0.1/addons/bl_b392/logo", text="response")
 
     resp = await hassio_client.get("/api/hassio/addons/bl_b392/logo")
@@ -72,9 +72,10 @@ async def test_forward_request_no_auth_for_logo(hassio_client, aioclient_mock):
 
     # Check we forwarded command
     assert len(aioclient_mock.mock_calls) == 1
-    
+
+
 async def test_forward_request_no_auth_for_icon(hassio_client, aioclient_mock):
-    """Test no auth needed for ."""
+    """Test no auth needed for icon."""
     aioclient_mock.get("http://127.0.0.1/addons/bl_b392/icon", text="response")
 
     resp = await hassio_client.get("/api/hassio/addons/bl_b392/icon")

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -72,6 +72,20 @@ async def test_forward_request_no_auth_for_logo(hassio_client, aioclient_mock):
 
     # Check we forwarded command
     assert len(aioclient_mock.mock_calls) == 1
+    
+async def test_forward_request_no_auth_for_icon(hassio_client, aioclient_mock):
+    """Test no auth needed for ."""
+    aioclient_mock.get("http://127.0.0.1/addons/bl_b392/icon", text="response")
+
+    resp = await hassio_client.get("/api/hassio/addons/bl_b392/icon")
+
+    # Check we got right response
+    assert resp.status == 200
+    body = await resp.text()
+    assert body == "response"
+
+    # Check we forwarded command
+    assert len(aioclient_mock.mock_calls) == 1
 
 
 async def test_forward_log_request(hassio_client, aioclient_mock):


### PR DESCRIPTION
## Description:

Adds add-on icon to the NO_AUTH list so it can be referenced in the same manner in the frontend as add-on image.

<!--
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```
-->
## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.
-->
If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
