### PR TITLE
Fix availability for hue lights and sensors

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -26,17 +26,20 @@ PHUE_CONFIG_FILE = "phue.conf"
 CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
 DEFAULT_ALLOW_HUE_GROUPS = True
 
-BRIDGE_CONFIG_SCHEMA = vol.Schema(
-    {
-        # Validate as IP address and then convert back to a string.
-        vol.Required(CONF_HOST): vol.All(ipaddress.ip_address, cv.string),
-        vol.Optional(
-            CONF_ALLOW_UNREACHABLE, default=DEFAULT_ALLOW_UNREACHABLE
-        ): cv.boolean,
-        vol.Optional(
-            CONF_ALLOW_HUE_GROUPS, default=DEFAULT_ALLOW_HUE_GROUPS
-        ): cv.boolean,
-    }
+BRIDGE_CONFIG_SCHEMA = vol.All(
+    cv.deprecated("filename", invalidation_version="0.106.0"),
+    vol.Schema(
+        {
+            # Validate as IP address and then convert back to a string.
+            vol.Required(CONF_HOST): vol.All(ipaddress.ip_address, cv.string),
+            vol.Optional(
+                CONF_ALLOW_UNREACHABLE, default=DEFAULT_ALLOW_UNREACHABLE
+            ): cv.boolean,
+            vol.Optional(
+                CONF_ALLOW_HUE_GROUPS, default=DEFAULT_ALLOW_HUE_GROUPS
+            ): cv.boolean,
+        }
+    ),
 )
 
 CONFIG_SCHEMA = vol.Schema(
@@ -44,11 +47,7 @@ CONFIG_SCHEMA = vol.Schema(
         DOMAIN: vol.Schema(
             {
                 vol.Optional(CONF_BRIDGES): vol.All(
-                    cv.ensure_list,
-                    [
-                        cv.deprecated("filename", invalidation_version="0.106.0"),
-                        vol.All(BRIDGE_CONFIG_SCHEMA),
-                    ],
+                    cv.ensure_list, [BRIDGE_CONFIG_SCHEMA]
                 )
             }
         )


### PR DESCRIPTION
## Description: 
- fixed the deprecation of filename which was made in #30846, however the filename belongs to the BRIDGE_CONFIG_SCHEMA instead of the CONFIG_SCHEMA, see #30000 for reference

**Related issue (if applicable):** fixes #30876<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
  bridges:
    - host: 192.168.1.102
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
