### PR TITLE
Update outdated documentation links in json files

### DIFF
--- a/homeassistant/components/apprise/manifest.json
+++ b/homeassistant/components/apprise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "apprise",
   "name": "Apprise",
-  "documentation": "https://www.home-assistant.io/components/apprise",
+  "documentation": "https://www.home-assistant.io/integrations/apprise",
   "requirements": ["apprise==0.8.3"],
   "dependencies": [],
   "codeowners": ["@caronc"]

--- a/homeassistant/components/geonetnz_volcano/manifest.json
+++ b/homeassistant/components/geonetnz_volcano/manifest.json
@@ -2,7 +2,7 @@
   "domain": "geonetnz_volcano",
   "name": "GeoNet NZ Volcano",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/components/geonetnz_volcano",
+  "documentation": "https://www.home-assistant.io/integrations/geonetnz_volcano",
   "requirements": ["aio_geojson_geonetnz_volcano==0.5"],
   "dependencies": [],
   "codeowners": ["@exxamalte"]

--- a/homeassistant/components/pcal9535a/manifest.json
+++ b/homeassistant/components/pcal9535a/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "pcal9535a",
   "name": "PCAL9535A I/O Expander",
-  "documentation": "https://www.home-assistant.io/components/pcal9535a",
+  "documentation": "https://www.home-assistant.io/integrations/pcal9535a",
   "requirements": ["pcal9535a==0.7"],
   "dependencies": [],
   "codeowners": ["@Shulyaka"]

--- a/homeassistant/components/sinch/manifest.json
+++ b/homeassistant/components/sinch/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sinch",
   "name": "Sinch SMS",
-  "documentation": "https://www.home-assistant.io/components/sinch",
+  "documentation": "https://www.home-assistant.io/integrations/sinch",
   "dependencies": [],
   "codeowners": ["@bendikrb"],
   "requirements": ["clx-sdk-xms==1.0.0"]

--- a/homeassistant/components/starline/manifest.json
+++ b/homeassistant/components/starline/manifest.json
@@ -2,7 +2,7 @@
   "domain": "starline",
   "name": "StarLine",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/components/starline",
+  "documentation": "https://www.home-assistant.io/integrations/starline",
   "requirements": ["starline==0.1.3"],
   "dependencies": [],
   "codeowners": ["@anonym-tsk"]

--- a/homeassistant/components/versasense/manifest.json
+++ b/homeassistant/components/versasense/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "versasense",
   "name": "VersaSense",
-  "documentation": "https://www.home-assistant.io/components/versasense",
+  "documentation": "https://www.home-assistant.io/integrations/versasense",
   "dependencies": [],
   "codeowners": ["@flamm3blemuff1n"],
   "requirements": ["pyversasense==0.0.6"]


### PR DESCRIPTION
##  Description:
- replace `components` with `integrations` in all outdated manifest.json files

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
