### PR TITLE
Add services to geniushub

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -247,7 +247,7 @@ class GeniusDevice(GeniusEntity):
             attrs["last_comms"] = self._last_comms.isoformat()
 
         state = dict(self._device.data["state"])
-        if "_state" in self._device.data:  # only for v3 API
+        if "_state" in self._device.data:  # only via v3 API
             state.update(self._device.data["_state"])
 
         attrs["state"] = {
@@ -258,7 +258,7 @@ class GeniusDevice(GeniusEntity):
 
     async def async_update(self) -> None:
         """Update an entity's state data."""
-        if "_state" in self._device.data:  # only for v3 API
+        if "_state" in self._device.data:  # only via v3 API
             self._last_comms = dt_util.utc_from_timestamp(
                 self._device.data["_state"]["lastComms"]
             )

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -168,8 +168,6 @@ class GeniusBroker:
         self.client = client
         self._hub_uid = hub_uid
 
-        self.entity_by_uid = {}
-
     @property
     def hub_uid(self) -> int:
         """Return the Hub UID (MAC address)."""
@@ -237,8 +235,6 @@ class GeniusDevice(GeniusEntity):
 
         self._device = device
         self._unique_id = f"{broker.hub_uid}_device_{device.id}"
-
-        broker.entity_by_uid[self._unique_id] = self
         self._last_comms = self._state_attr = None
 
     @property
@@ -278,8 +274,6 @@ class GeniusZone(GeniusEntity):
         self._zone = zone
         self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
 
-        broker.entity_by_uid[self._unique_id] = self
-
     async def _refresh(self, payload: Optional[dict] = None) -> None:
         """Process any signals."""
         if payload is None:
@@ -305,7 +299,6 @@ class GeniusZone(GeniusEntity):
             )
 
         await self._zone.set_mode(mode)
-        return
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -208,8 +208,7 @@ class GeniusEntity(Entity):
 
     async def _refresh(self, payload: Optional[dict] = None) -> None:
         """Process any signals."""
-        if payload is None:
-            self.async_schedule_update_ha_state(force_refresh=True)
+        self.async_schedule_update_ha_state(force_refresh=True)
 
     @property
     def unique_id(self) -> Optional[str]:
@@ -295,6 +294,7 @@ class GeniusZone(GeniusEntity):
             duration = payload["data"].get(ATTR_DURATION, timedelta(hours=1))
 
             await self._zone.set_override(temperature, int(duration.totalseconds()))
+            return
 
         # pylint: disable=protected-access
         if mode == "footprint" and not self._zone._has_pir:

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -15,5 +15,6 @@ set_zone_mode:
       example: 18.5
     duration:
       description: >-
-          The duration in minutes. Optional, defaults to 60. Used only by override mode.
-      example: 120
+          The duration of the override. Used only by override mode.  Optional, default 1
+          hour, maximum 24 hours.
+      example: '{"minutes": 135}'

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -12,9 +12,8 @@ set_zone_mode:
       example: override
     temperature:
       description: The target temperature. Used only by override mode.
-      example: 21.5
+      example: 18.5
     duration:
       description: >-
-          The duration in minutes. Used only by override mode. Set to 0 for the override
-          to end at the next setpoint.
-      example: 60
+          The duration in minutes. Optional, defaults to 60. Used only by override mode.
+      example: 120

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -1,3 +1,4 @@
+# Support for a Genius Hub system
 # Describes the format for available services
 
 set_zone_mode:

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -8,7 +8,7 @@ set_zone_mode:
       description: The zone's entity_id.
       example: climate.kitchen
     mode:
-      description: 'The mode: off, timer or footprint.'
+      description: 'One of: off, timer or footprint.'
       example: timer
 
 set_zone_override:

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -6,15 +6,23 @@ set_zone_mode:
   fields:
     entity_id:
       description: The zone's entity_id.
-      example: climate.bathroom
+      example: climate.kitchen
     mode:
-      description: 'The mode, one of: off, override, timer or footprint.'
-      example: override
+      description: 'The mode: off, timer or footprint.'
+      example: timer
+
+set_zone_override:
+  description: >-
+      Override the zone's setpoint for a given duration.
+  fields:
+    entity_id:
+      description: The zone's entity_id.
+      example: climate.bathroom
     temperature:
-      description: The target temperature. Used only by override mode.
-      example: 18.5
+      description: The target temperature, to 0.1 C.
+      example: 19.2
     duration:
       description: >-
-          The duration of the override. Used only by override mode.  Optional, default 1
-          hour, maximum 24 hours.
+          The duration of the override. Optional, default 1 hour, maximum 24 hours.
       example: '{"minutes": 135}'
+

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -1,0 +1,20 @@
+# Describes the format for available services
+
+set_zone_mode:
+  description: >-
+      Set the zone to an operating mode.
+  fields:
+    entity_id:
+      description: The zone's entity_id.
+      example: climate.bathroom
+    mode:
+      description: 'The mode, one of: off, override, timer or footprint.'
+      example: override
+    temperature:
+      description: The target temperature. Used only by override mode.
+      example: 21.5
+    duration:
+      description: >-
+          The duration in minutes. Used only by override mode. Set to 0 for the override
+          to end at the next setpoint.
+      example: 60


### PR DESCRIPTION
## Breaking Change:
Known none.

## Description:
Add services to **geniushub**: these expose the full functionality of the system, using geniushub's own schema:
 - `set_zone_mode`: set teh zone mode (e.g. footprint mode)
 - `set_zone_override`: set the zone to target temp for a period of time

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11798

## Example entry for `configuration.yaml` (if applicable): **unchanged**

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
