### PR TITLE
deCONZ - Fix service device refresh calling state update

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -54,11 +54,13 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorDevice):
     """Representation of a deCONZ binary sensor."""
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the sensor's state."""
-        changed = set(self._device.changed_keys)
+        if ignore_update:
+            return
+
         keys = {"on", "reachable", "state"}
-        if force_update or any(key in changed for key in keys):
+        if force_update or self._device.changed_keys.intersection(keys):
             self.async_schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -97,8 +97,11 @@ class DeconzDevice(DeconzBase, Entity):
             unsub_dispatcher()
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the device's state."""
+        if ignore_update:
+            return
+
         self.async_schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -39,17 +39,21 @@ class DeconzEvent(DeconzBase):
         self._device = None
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self, force_update=False, ignore_update=False):
         """Fire the event if reason is that state is updated."""
-        if "state" in self._device.changed_keys:
-            data = {
-                CONF_ID: self.event_id,
-                CONF_UNIQUE_ID: self.serial,
-                CONF_EVENT: self._device.state,
-            }
-            if self._device.gesture:
-                data[CONF_GESTURE] = self._device.gesture
-            self.gateway.hass.bus.async_fire(CONF_DECONZ_EVENT, data)
+        if ignore_update or "state" not in self._device.changed_keys:
+            return
+
+        data = {
+            CONF_ID: self.event_id,
+            CONF_UNIQUE_ID: self.serial,
+            CONF_EVENT: self._device.state,
+        }
+
+        if self._device.gesture:
+            data[CONF_GESTURE] = self._device.gesture
+
+        self.gateway.hass.bus.async_fire(CONF_DECONZ_EVENT, data)
 
     async def async_update_device_registry(self):
         """Update device registry."""

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,13 +3,17 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==67"],
+  "requirements": [
+    "pydeconz==68"
+  ],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"
     }
   ],
   "dependencies": [],
-  "codeowners": ["@kane610"],
+  "codeowners": [
+    "@kane610"
+  ],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -97,11 +97,13 @@ class DeconzSensor(DeconzDevice):
     """Representation of a deCONZ sensor."""
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the sensor's state."""
-        changed = set(self._device.changed_keys)
+        if ignore_update:
+            return
+
         keys = {"on", "reachable", "state"}
-        if force_update or any(key in changed for key in keys):
+        if force_update or self._device.changed_keys.intersection(keys):
             self.async_schedule_update_ha_state()
 
     @property
@@ -155,11 +157,13 @@ class DeconzBattery(DeconzDevice):
     """Battery class for when a device is only represented as an event."""
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the battery's state, if needed."""
-        changed = set(self._device.changed_keys)
+        if ignore_update:
+            return
+
         keys = {"battery", "reachable"}
-        if force_update or any(key in changed for key in keys):
+        if force_update or self._device.changed_keys.intersection(keys):
             self.async_schedule_update_ha_state()
 
     @property
@@ -217,7 +221,7 @@ class DeconzSensorStateTracker:
         self.sensor = None
 
     @callback
-    def async_update_callback(self):
+    def async_update_callback(self, ignore_update=False):
         """Sensor state updated."""
         if "battery" in self.sensor.changed_keys:
             async_dispatcher_send(

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -127,7 +127,7 @@ async def async_refresh_devices_service(hass, data):
     scenes = set(gateway.api.scenes.keys())
     sensors = set(gateway.api.sensors.keys())
 
-    await gateway.api.refresh_state()
+    await gateway.api.refresh_state(ignore_update=True)
 
     gateway.async_add_device_callback(
         NEW_GROUP,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1191,7 +1191,7 @@ pydaikin==1.6.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==67
+pydeconz==68
 
 # homeassistant.components.delijn
 pydelijn==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -417,7 +417,7 @@ pycoolmasternet==0.0.4
 pydaikin==1.6.1
 
 # homeassistant.components.deconz
-pydeconz==67
+pydeconz==68
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
Unintentional behavioural change when updating data management in pydeconz. This allows controlling whether or not an update should be ignored.

**Related issue (if applicable):** fixes #30890

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]