### PR TITLE
Refactor rounding for ZHA electrical measurement sensor.

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -152,8 +152,6 @@ class Sensor(ZhaEntity):
         """Return the state of the entity."""
         if self._state is None:
             return None
-        if isinstance(self._state, float):
-            return str(round(self._state, 2))
         return self._state
 
     def async_set_state(self, state):
@@ -231,7 +229,10 @@ class ElectricalMeasurement(Sensor):
 
     def formatter(self, value) -> int:
         """Return 'normalized' value."""
-        return round(value * self._channel.multiplier / self._channel.divisor)
+        value = value * self._channel.multiplier / self._channel.divisor
+        if value < 100 and self._channel.divisor > 1:
+            return round(value, self._decimals)
+        return round(value)
 
 
 @STRICT_MATCH(channel_names=CHANNEL_MULTISTATE_INPUT)


### PR DESCRIPTION
## Description:
Refactor rounding of ZHA Electrical measurement sensor. Leave one decimal digits for `result < 100` and `divisor > 1`. In other words, if we're consuming more than 100W then it really doesn't matter if we're consuming `100.1W` or `101.4W`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
