### PR TITLE
WIP: Add polling support for various SimpliSafe sensors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -628,6 +628,7 @@ omit =
     homeassistant/components/simplepush/notify.py
     homeassistant/components/simplisafe/__init__.py
     homeassistant/components/simplisafe/alarm_control_panel.py
+    homeassistant/components/simplisafe/binary_sensor.py
     homeassistant/components/simplisafe/lock.py
     homeassistant/components/simulated/sensor.py
     homeassistant/components/sisyphus/*

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.service import (
 )
 
 from .config_flow import configured_instances
-from .const import DATA_CLIENT, DEFAULT_SCAN_INTERVAL, DOMAIN, TOPIC_UPDATE
+from .const import ATTR_SERIAL, DATA_CLIENT, DEFAULT_SCAN_INTERVAL, DOMAIN, TOPIC_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -181,7 +181,7 @@ async def async_setup_entry(hass, config_entry):
     await simplisafe.async_update()
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = simplisafe
 
-    for component in ("alarm_control_panel", "lock"):
+    for component in ("alarm_control_panel", "binary_sensor", "lock"):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
@@ -288,7 +288,7 @@ async def async_unload_entry(hass, entry):
     """Unload a SimpliSafe config entry."""
     tasks = [
         hass.config_entries.async_forward_entry_unload(entry, component)
-        for component in ("alarm_control_panel", "lock")
+        for component in ("alarm_control_panel", "binary_sensor", "lock")
     ]
 
     await asyncio.gather(*tasks)
@@ -345,7 +345,6 @@ class SimpliSafeEntity(Entity):
     def __init__(self, system, name, *, serial=None):
         """Initialize."""
         self._async_unsub_dispatcher_connect = None
-        self._attrs = {ATTR_SYSTEM_ID: system.system_id}
         self._name = name
         self._online = True
         self._system = system
@@ -354,6 +353,8 @@ class SimpliSafeEntity(Entity):
             self._serial = serial
         else:
             self._serial = system.serial
+
+        self._attrs = {ATTR_SERIAL: self._serial, ATTR_SYSTEM_ID: system.system_id}
 
     @property
     def available(self):

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -1,0 +1,90 @@
+"""Support for SimpliSafe binary sensors."""
+import logging
+
+from simplipy.entity import EntityTypes
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import ATTR_TEMPERATURE
+
+from . import SimpliSafeEntity
+from .const import DATA_CLIENT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_SENSOR_TYPE = "sensor_type"
+ATTR_ERROR_STATE = "error_state"
+ATTR_LOW_BATTERY = "low_battery"
+ATTR_TRIGGER_INSTANTLY = "trigger_instantly"
+
+BINARY_SENSOR_TYPES = {
+    EntityTypes.carbon_monoxide: "smoke",
+    EntityTypes.entry: "door",
+    EntityTypes.glass_break: "safety",
+    EntityTypes.leak: "moisture",
+    EntityTypes.motion: "motion",
+    EntityTypes.smoke: "smoke",
+    EntityTypes.temperature: "cold",
+}
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up SimpliSafe locks based on a config entry."""
+    simplisafe = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+
+    async_add_entities(
+        [
+            SimpliSafeBinarySensor(system, sensor, BINARY_SENSOR_TYPES[sensor.type])
+            for system in simplisafe.systems.values()
+            for sensor in system.sensors.values()
+            if sensor.type in BINARY_SENSOR_TYPES
+        ],
+        True,
+    )
+
+
+class SimpliSafeBinarySensor(SimpliSafeEntity, BinarySensorDevice):
+    """A sensor implementation for raincloud device."""
+
+    def __init__(self, system, sensor, device_class):
+        """Initialize."""
+        super().__init__(system, sensor.name, serial=sensor.serial)
+        self._device_class = device_class
+        self._is_on = False
+        self._sensor = sensor
+
+        self._attrs.update({ATTR_SENSOR_TYPE: sensor.type.name})
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
+
+    @property
+    def is_on(self):
+        """Return the status of the sensor."""
+        return self._is_on
+
+    @property
+    def should_poll(self):
+        """Disable polling."""
+        return False
+
+    async def async_update(self):
+        """Update lock status."""
+        if getattr(self._sensor, "offline", False) and self._sensor.offline:
+            self._online = False
+            return
+
+        self._online = True
+
+        self._is_on = self._sensor.triggered
+
+        self._attrs.update(
+            {
+                ATTR_ERROR_STATE: self._sensor.error,
+                ATTR_LOW_BATTERY: self._sensor.low_battery,
+                ATTR_TRIGGER_INSTANTLY: self._sensor.trigger_instantly,
+            }
+        )
+        if self._sensor.type == EntityTypes.temperature:
+            self._attrs[ATTR_TEMPERATURE] = self._sensor.temperature

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -31,15 +31,22 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SimpliSafe locks based on a config entry."""
     simplisafe = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
 
-    async_add_entities(
-        [
-            SimpliSafeBinarySensor(system, sensor, BINARY_SENSOR_TYPES[sensor.type])
-            for system in simplisafe.systems.values()
-            for sensor in system.sensors.values()
-            if sensor.type in BINARY_SENSOR_TYPES
-        ],
-        True,
-    )
+    binary_sensors = []
+    for system in simplisafe.systems.values():
+        if system.version == 2:
+            # We don't currently (or plan to) support retrieving sensors from v2
+            # systems:
+            continue
+
+        for sensor in system.sensors.values():
+            if sensor.type in BINARY_SENSOR_TYPES:
+                binary_sensors.append(
+                    SimpliSafeBinarySensor(
+                        system, sensor, BINARY_SENSOR_TYPES[sensor.type]
+                    )
+                )
+
+    async_add_entities(binary_sensors, True)
 
 
 class SimpliSafeBinarySensor(SimpliSafeEntity, BinarySensorDevice):

--- a/homeassistant/components/simplisafe/const.py
+++ b/homeassistant/components/simplisafe/const.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 
 DOMAIN = "simplisafe"
 
+ATTR_SERIAL = "serial"
+
 DATA_CLIENT = "client"
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==6.0.0"],
+  "requirements": ["simplisafe-python==6.0.1"],
   "dependencies": [],
   "codeowners": ["@bachya"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1816,7 +1816,7 @@ shodan==1.21.2
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==6.0.0
+simplisafe-python==6.0.1
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -585,7 +585,7 @@ samsungctl[websocket]==0.7.1
 sentry-sdk==0.13.5
 
 # homeassistant.components.simplisafe
-simplisafe-python==6.0.0
+simplisafe-python==6.0.1
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
##  Description:

It's never felt terribly safe to poll the SimpliSafe integration that frequently; therefore, I made the decision to not include sensors in the integration (because they wouldn't be real-time). That said, a user in the forum recently told me that [they would still find value, even with a longer polling interval](https://community.home-assistant.io/t/simplisafe-questions/124070/8?u=bachya). So, this PR introduces support for a variety of SimpliSafe sensors:

* CO
* Entry
* Glass Breakage
* Leak
* Motion
* Smoke
* Temperature

The sensors will update at the same interval as the existing alarm control panel (since all the API calls are batched).

Lastly, because v2 systems audibly announce "Your settings have been synchronized" when fetching new data, I am electing to _only_ include this functionality for v3 systems. Should user demand increase, I will consider adding it for v2 systems.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11791

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    username: !secret simplisafe_username
    password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
