### PR TITLE
Fix parsing of offset in google calendar

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -86,15 +86,19 @@ def calculate_offset(event, offset):
     summary = event.get("summary", "")
     # check if we have an offset tag in the message
     # time is HH:MM or MM
-    reg = "{}([+-]?[0-9]{{0,2}}(:[0-9]{{0,2}})?)".format(offset)
+    reg = "{}(([+-]?[0-9]{{0,2}}:[0-9]{{0,2}})|([+-]?[0-9]{{1,3}}))".format(offset)
     search = re.search(reg, summary)
     if search and search.group(1):
         time = search.group(1)
         if ":" not in time:
             if time[0] == "+" or time[0] == "-":
-                time = "{}0:{}".format(time[0], time[1:])
+                sign = time[0]
+                time = time[1:]
             else:
-                time = "0:{}".format(time)
+                sign = "+"
+            hours = (int)(int(time) / 60)
+            minutes = int(time) % 60
+            time = "{}{}:{}".format(sign, hours, minutes)
 
         offset_time = time_period_str(time)
         summary = (summary[: search.start()] + summary[search.end() :]).strip()


### PR DESCRIPTION
## Description:

Parsing of offset is either HH:MM or MM. Most people expect MM to mean
any number of minutes, but this has been interpreted as 00:MM, which
means that only MM between 0-59 is possible.

This patch changes the parsing so MM can be any number between 0-999.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
No relevant issues.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
Not changed documentation. The current documentation is still correct, but could have been clarified.

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
