### PR TITLE
Add support for Amcrest alarm_triggered to binary_sensors

### DIFF
--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -7,6 +7,7 @@ from amcrest import AmcrestError
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_PROBLEM,
     BinarySensorDevice,
 )
 from homeassistant.const import CONF_BINARY_SENSORS, CONF_NAME
@@ -24,10 +25,12 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=BINARY_SENSOR_SCAN_INTERVAL_SECS)
 
+BINARY_SENSOR_ALARM_TRIGGERED = "alarm_triggered"
 BINARY_SENSOR_MOTION_DETECTED = "motion_detected"
 BINARY_SENSOR_ONLINE = "online"
 # Binary sensor types are defined like: Name, device class
 BINARY_SENSORS = {
+    BINARY_SENSOR_ALARM_TRIGGERED: ("Alarm Triggered", DEVICE_CLASS_PROBLEM),
     BINARY_SENSOR_MOTION_DETECTED: ("Motion Detected", DEVICE_CLASS_MOTION),
     BINARY_SENSOR_ONLINE: ("Online", DEVICE_CLASS_CONNECTIVITY),
 }
@@ -99,6 +102,11 @@ class AmcrestBinarySensor(BinarySensorDevice):
 
             elif self._sensor_type == BINARY_SENSOR_ONLINE:
                 self._state = self._api.available
+                
+            elif self._sensor_type == BINARY_SENSOR_ALARM_TRIGGERED:
+                event = self._api.event_channels_happened("AlarmLocal")
+                self._state = bool("channels" in event)
+                
         except AmcrestError as error:
             log_update_error(_LOGGER, "update", self.name, "binary sensor", error)
 

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -102,11 +102,11 @@ class AmcrestBinarySensor(BinarySensorDevice):
 
             elif self._sensor_type == BINARY_SENSOR_ONLINE:
                 self._state = self._api.available
-                
+
             elif self._sensor_type == BINARY_SENSOR_ALARM_TRIGGERED:
                 event = self._api.event_channels_happened("AlarmLocal")
                 self._state = bool("channels" in event)
-                
+
         except AmcrestError as error:
             log_update_error(_LOGGER, "update", self.name, "binary sensor", error)
 


### PR DESCRIPTION
On my Amcrest AD110 Video Doorbell Camera, the normal Home Assistant amcrest component's motion_detected binary sensor does not match the actual motion detection that's presented through the Amcrest iOS app. The motion_detected binary sensor appears to map to just the video motion detection that is just one component of the actual detection. The doorbell under the covers seemingly merges the video motion with the PIR motion data to determine if a motion detection alert should be sent to the smartphone app, recorded locally in the microSD and/or sent to their cloud.

The AlarmLocal event accessible via amcrest-python appears analogous to the actual motion detection on the doorbell.  I've successfully used this updated change as a custom_component and verified that alarm_triggered events correspond to actual motion detection events sent to my smartphone.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
amcrest:
  - host: 192.168.1.100
    name: Doorbell
    binary_sensors:
      - alarm_triggered
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
