### PR TITLE
Add state to RFXtrx covers

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -129,7 +129,7 @@ def setup(hass, config):
 
     if dummy_connection:
         rfx_object = rfxtrxmod.Connect(
-            device, None, debug=debug, transport_protocol=rfxtrxmod.DummyTransport2
+            device, None, debug=debug, transport_protocol=rfxtrxmod.DummyTransport2,
         )
     elif port is not None:
         # If port is set then we create a TCP connection
@@ -213,7 +213,7 @@ def get_pt2262_device(device_id):
             and device.masked_id == get_pt2262_deviceid(device_id, device.data_bits)
         ):
             _LOGGER.debug(
-                "rfxtrx: found matching device %s for %s", device_id, device.masked_id
+                "rfxtrx: found matching device %s for %s", device_id, device.masked_id,
             )
             return device
     return None
@@ -305,13 +305,32 @@ def apply_received_command(event):
         return
 
     _LOGGER.debug(
-        "Device_id: %s device_update. Command: %s", device_id, event.values["Command"]
+        "Device_id: %s device_update. Command: %s", device_id, event.values["Command"],
     )
 
-    if event.values["Command"] == "On" or event.values["Command"] == "Off":
+    if event.values["Command"] in [
+        "On",
+        "Off",
+        "Up",
+        "Down",
+        "Stop",
+        "Open (inline relay)",
+        "Close (inline relay)",
+        "Stop (inline relay)",
+    ]:
 
         # Update the rfxtrx device state
-        is_on = event.values["Command"] == "On"
+        command = event.values["Command"]
+        if command in [
+            "On",
+            "Up",
+            "Stop",
+            "Open (inline relay)",
+            "Stop (inline relay)",
+        ]:
+            is_on = True
+        elif command in ["Off", "Down", "Close (inline relay)"]:
+            is_on = False
         RFX_DEVICES[device_id].update_state(is_on)
 
     elif (
@@ -423,14 +442,17 @@ class RfxtrxDevice(Entity):
         elif command == "roll_up":
             for _ in range(self.signal_repetitions):
                 self._event.device.send_open(rfx_object.transport)
+            self._state = True
 
         elif command == "roll_down":
             for _ in range(self.signal_repetitions):
                 self._event.device.send_close(rfx_object.transport)
+            self._state = False
 
         elif command == "stop_roll":
             for _ in range(self.signal_repetitions):
                 self._event.device.send_stop(rfx_object.transport)
+            self._state = True
 
         if self.added_to_hass:
             self.schedule_update_ha_state()

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -82,7 +82,7 @@ class RfxtrxCover(RfxtrxDevice, CoverDevice, RestoreEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return None
+        return not self._state
 
     def open_cover(self, **kwargs):
         """Move the cover up."""


### PR DESCRIPTION
## Description:
This pull request adds a state to rfxtrx cover entities (open/closed). rfxtrx covers didn't had a state, like lights and switches. The state is also updated when using a remote, if the RFXtrx433 transceiver is able to receive commands for the specific protocol. This can be checked in the RFXtrx433 manual, For example, the RFY protocol won't be able to update the state when using the remote, as it only supports transmitting signals, not receiving.  

Also fixed some small black formatting issues.  

**Related issue (if applicable):** fixes #24658 (This issue was already closed with a workaround, but I assume the workaround won't be needed anymore)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) 

If the code communicates with devices, web services, or third-party tools:
  - [n/a] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [n/a] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [n/a] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [n/a] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
