### PR TITLE
Add kef supports_on option

### DIFF
--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "dependencies": [],
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.2.5", "getmac==0.8.1"]
+  "requirements": ["aiokef==0.2.6", "getmac==0.8.1"]
 }

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -36,7 +36,7 @@ DEFAULT_PORT = 50001
 DEFAULT_MAX_VOLUME = 0.5
 DEFAULT_VOLUME_STEP = 0.05
 DEFAULT_INVERSE_SPEAKER_MODE = False
-DEFAULT_SUPPORTS_ON_OFF = True
+DEFAULT_SUPPORTS_ON = True
 
 DOMAIN = "kef"
 
@@ -48,7 +48,7 @@ SOURCES["LS50"] = SOURCES["LSX"] + ["Usb"]
 CONF_MAX_VOLUME = "maximum_volume"
 CONF_VOLUME_STEP = "volume_step"
 CONF_INVERSE_SPEAKER_MODE = "inverse_speaker_mode"
-CONF_SUPPORTS_ON_OFF = "supports_on_off"
+CONF_SUPPORTS_ON = "supports_on"
 CONF_STANDBY_TIME = "standby_time"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -62,7 +62,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(
             CONF_INVERSE_SPEAKER_MODE, default=DEFAULT_INVERSE_SPEAKER_MODE
         ): cv.boolean,
-        vol.Optional(CONF_SUPPORTS_ON_OFF, default=DEFAULT_SUPPORTS_ON_OFF): cv.boolean,
+        vol.Optional(CONF_SUPPORTS_ON, default=DEFAULT_SUPPORTS_ON): cv.boolean,
         vol.Optional(CONF_STANDBY_TIME): vol.In([20, 60]),
     }
 )
@@ -80,7 +80,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     maximum_volume = config[CONF_MAX_VOLUME]
     volume_step = config[CONF_VOLUME_STEP]
     inverse_speaker_mode = config[CONF_INVERSE_SPEAKER_MODE]
-    supports_on_off = config[CONF_SUPPORTS_ON_OFF]
+    supports_on = config[CONF_SUPPORTS_ON]
     standby_time = config.get(CONF_STANDBY_TIME)
 
     sources = SOURCES[speaker_type]
@@ -112,7 +112,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         volume_step,
         standby_time,
         inverse_speaker_mode,
-        supports_on_off,
+        supports_on,
         sources,
         ioloop=hass.loop,
         unique_id=unique_id,
@@ -137,7 +137,7 @@ class KefMediaPlayer(MediaPlayerDevice):
         volume_step,
         standby_time,
         inverse_speaker_mode,
-        supports_on_off,
+        supports_on,
         sources,
         ioloop,
         unique_id,
@@ -155,7 +155,7 @@ class KefMediaPlayer(MediaPlayerDevice):
             ioloop=ioloop,
         )
         self._unique_id = unique_id
-        self._supports_on_off = supports_on_off
+        self._supports_on = supports_on
 
         self._state = None
         self._muted = None
@@ -213,9 +213,10 @@ class KefMediaPlayer(MediaPlayerDevice):
             | SUPPORT_VOLUME_STEP
             | SUPPORT_VOLUME_MUTE
             | SUPPORT_SELECT_SOURCE
+            | SUPPORT_TURN_OFF
         )
-        if self._supports_on_off:
-            support_kef |= SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+        if self._supports_on:
+            support_kef |= SUPPORT_TURN_ON
 
         return support_kef
 
@@ -246,13 +247,11 @@ class KefMediaPlayer(MediaPlayerDevice):
 
     async def async_turn_off(self):
         """Turn the media player off."""
-        if not self._supports_on_off:
-            raise NotImplementedError()
         await self._speaker.turn_off()
 
     async def async_turn_on(self):
         """Turn the media player on."""
-        if not self._supports_on_off:
+        if not self._supports_on:
             raise NotImplementedError()
         await self._speaker.turn_on()
 

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -214,10 +214,10 @@ class KefMediaPlayer(MediaPlayerDevice):
             | SUPPORT_VOLUME_MUTE
             | SUPPORT_SELECT_SOURCE
         )
-        if not self._supports_on_off:
-            return support_kef
-        else:
-            return support_kef | SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+        if self._supports_on_off:
+            support_kef |= SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+
+        return support_kef
 
     @property
     def source(self):

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -5,7 +5,7 @@ from functools import partial
 import ipaddress
 import logging
 
-from aiokef.aiokef import AsyncKefSpeaker
+from aiokef import AsyncKefSpeaker
 from getmac import get_mac_address
 import voluptuous as vol
 
@@ -36,6 +36,7 @@ DEFAULT_PORT = 50001
 DEFAULT_MAX_VOLUME = 0.5
 DEFAULT_VOLUME_STEP = 0.05
 DEFAULT_INVERSE_SPEAKER_MODE = False
+DEFAULT_SUPPORTS_ON_OFF = True
 
 DOMAIN = "kef"
 
@@ -44,18 +45,10 @@ SCAN_INTERVAL = timedelta(seconds=30)
 SOURCES = {"LSX": ["Wifi", "Bluetooth", "Aux", "Opt"]}
 SOURCES["LS50"] = SOURCES["LSX"] + ["Usb"]
 
-SUPPORT_KEF = (
-    SUPPORT_VOLUME_SET
-    | SUPPORT_VOLUME_STEP
-    | SUPPORT_VOLUME_MUTE
-    | SUPPORT_SELECT_SOURCE
-    | SUPPORT_TURN_OFF
-    | SUPPORT_TURN_ON
-)
-
 CONF_MAX_VOLUME = "maximum_volume"
 CONF_VOLUME_STEP = "volume_step"
 CONF_INVERSE_SPEAKER_MODE = "inverse_speaker_mode"
+CONF_SUPPORTS_ON_OFF = "supports_on_off"
 CONF_STANDBY_TIME = "standby_time"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -69,6 +62,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(
             CONF_INVERSE_SPEAKER_MODE, default=DEFAULT_INVERSE_SPEAKER_MODE
         ): cv.boolean,
+        vol.Optional(CONF_SUPPORTS_ON_OFF, default=DEFAULT_SUPPORTS_ON_OFF): cv.boolean,
         vol.Optional(CONF_STANDBY_TIME): vol.In([20, 60]),
     }
 )
@@ -86,6 +80,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     maximum_volume = config[CONF_MAX_VOLUME]
     volume_step = config[CONF_VOLUME_STEP]
     inverse_speaker_mode = config[CONF_INVERSE_SPEAKER_MODE]
+    supports_on_off = config[CONF_SUPPORTS_ON_OFF]
     standby_time = config.get(CONF_STANDBY_TIME)
 
     sources = SOURCES[speaker_type]
@@ -117,6 +112,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         volume_step,
         standby_time,
         inverse_speaker_mode,
+        supports_on_off,
         sources,
         ioloop=hass.loop,
         unique_id=unique_id,
@@ -141,6 +137,7 @@ class KefMediaPlayer(MediaPlayerDevice):
         volume_step,
         standby_time,
         inverse_speaker_mode,
+        supports_on_off,
         sources,
         ioloop,
         unique_id,
@@ -158,6 +155,7 @@ class KefMediaPlayer(MediaPlayerDevice):
             ioloop=ioloop,
         )
         self._unique_id = unique_id
+        self._supports_on_off = supports_on_off
 
         self._state = None
         self._muted = None
@@ -210,7 +208,16 @@ class KefMediaPlayer(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        return SUPPORT_KEF
+        support_kef = (
+            SUPPORT_VOLUME_SET
+            | SUPPORT_VOLUME_STEP
+            | SUPPORT_VOLUME_MUTE
+            | SUPPORT_SELECT_SOURCE
+        )
+        if not self._supports_on_off:
+            return support_kef
+        else:
+            return support_kef | SUPPORT_TURN_OFF | SUPPORT_TURN_ON
 
     @property
     def source(self):
@@ -239,10 +246,14 @@ class KefMediaPlayer(MediaPlayerDevice):
 
     async def async_turn_off(self):
         """Turn the media player off."""
+        if not self._supports_on_off:
+            raise NotImplementedError()
         await self._speaker.turn_off()
 
     async def async_turn_on(self):
         """Turn the media player on."""
+        if not self._supports_on_off:
+            raise NotImplementedError()
         await self._speaker.turn_on()
 
     async def async_volume_up(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -172,7 +172,7 @@ aioimaplib==0.7.15
 aiokafka==0.5.1
 
 # homeassistant.components.kef
-aiokef==0.2.5
+aiokef==0.2.6
 
 # homeassistant.components.lifx
 aiolifx==0.6.7


### PR DESCRIPTION
## Description:
Adds an option to set `supports_on`. 

The KEF LS50 Wireless models with a serial number below LS50W13074K24L/R2G do not support this.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11812

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
