### PR TITLE
Revert "Update emulated_roku to 0.1.9 (#30791)"

### DIFF
--- a/homeassistant/components/emulated_roku/manifest.json
+++ b/homeassistant/components/emulated_roku/manifest.json
@@ -3,7 +3,7 @@
   "name": "Emulated Roku",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/emulated_roku",
-  "requirements": ["emulated_roku==0.1.9"],
+  "requirements": ["emulated_roku==0.1.8"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -474,7 +474,7 @@ eliqonline==1.2.2
 elkm1-lib==0.7.15
 
 # homeassistant.components.emulated_roku
-emulated_roku==0.1.9
+emulated_roku==0.1.8
 
 # homeassistant.components.enocean
 enocean==0.50

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -171,7 +171,7 @@ eebrightbox==0.0.4
 elgato==0.2.0
 
 # homeassistant.components.emulated_roku
-emulated_roku==0.1.9
+emulated_roku==0.1.8
 
 # homeassistant.components.season
 ephem==3.7.7.0


### PR DESCRIPTION
This breaks emulated_roku on certain devices, awaiting fix from upstream to go further. This way atleast the old state will be restored (working but errors in log)

## Description:
Revert upgrade to newer emulated_roku, which breaks on eg rpi3 (using hassio). I don't see any breakage on x86_64, which makes testing annoying.

Upstream bug has been reopened with possible fix, awaiting answer there, but reverting this seems like a better bet for 0.140.

**Related issue (if applicable):** #30779, #30907 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

