### PR TITLE
Revert "Pulseaudio: Changed default port from 4712 to 4713"

### DIFF
--- a/homeassistant/components/pulseaudio_loopback/switch.py
+++ b/homeassistant/components/pulseaudio_loopback/switch.py
@@ -22,7 +22,7 @@ CONF_TCP_TIMEOUT = "tcp_timeout"
 DEFAULT_BUFFER_SIZE = 1024
 DEFAULT_HOST = "localhost"
 DEFAULT_NAME = "paloopback"
-DEFAULT_PORT = 4713
+DEFAULT_PORT = 4712
 DEFAULT_TCP_TIMEOUT = 3
 
 IGNORED_SWITCH_WARN = "Switch is already in the desired state. Ignoring."


### PR DESCRIPTION
### Breaking Change:
The default port was incorrectly changed to 4713, however the official documentation states that the default port is 4712 for module-cli-protocol which is used in this integration. Therefore, the port has been changed back to 4712 and all previously configured switches now need to listen to port 4712.

Reverts home-assistant/home-assistant#28857

- reverts back to the original default port of pulseaudio since it is the correct port for the used module-cli-protocol
- brought to attention by @vKnmnn here: https://github.com/home-assistant/home-assistant.io/pull/11224#issuecomment-575892461

Pull request to update/revert the documentation: https://github.com/home-assistant/home-assistant.io/pull/11799