### PR TITLE
Don't use unit_of_measurement for battery voltage state attribute

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -210,7 +210,7 @@ class Battery(Sensor):
     def async_update_state_attribute(self, key, value):
         """Update a single device state attribute."""
         if key == "battery_voltage":
-            self._device_state_attributes["voltage"] = f"{round(value/10, 1)}V"
+            self._device_state_attributes[key] = round(value / 10, 1)
             self.async_schedule_update_ha_state()
 
 


### PR DESCRIPTION
## Description:
Don't use unit_of_measurement for battery voltage state attribute introduced in https://github.com/home-assistant/home-assistant/pull/30901

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
