### PR TITLE
Fix fan_modes in tuya climate

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -122,7 +122,7 @@ class TuyaClimateDevice(TuyaDevice, ClimateDevice):
     @property
     def fan_modes(self):
         """Return the list of available fan modes."""
-        return self.tuya.fan_modes()
+        return self.tuya.fan_list()
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""


### PR DESCRIPTION
## Description: 
- TuyaClimate does not have a method called fan_modes() instead it is named [fan_list()](https://github.com/PaulAnnekov/tuyaha/blob/4dd6b6be9b007a513a18ef0fac84bcc58bc4697a/tuyaha/devices/climate.py#L42)
- fixes the following error:
```
2020-01-02 11:05:21 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 286, in async_update_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 327, in _async_write_ha_state
    attr.update(self.state_attributes or {})
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 229, in state_attributes
    data[ATTR_FAN_MODES] = self.fan_modes
  File "/usr/src/homeassistant/homeassistant/components/tuya/climate.py", line 123, in fan_modes
    return self.tuya.fan_modes()
AttributeError: 'TuyaClimate' object has no attribute 'fan_modes'
```


**Related issue (if applicable):** fixes #30382<home-assistant issue number goes here>


## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
