### PR TITLE
Add tahoma io:AwningValanceIOComponent

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -34,8 +34,11 @@ CONFIG_SCHEMA = vol.Schema(
 TAHOMA_COMPONENTS = ["scene", "sensor", "cover", "switch", "binary_sensor"]
 
 TAHOMA_TYPES = {
+    "io:AwningValanceIOComponent": "cover",
     "io:ExteriorVenetianBlindIOComponent": "cover",
+    "io:DiscreteGarageOpenerIOComponent": "cover",
     "io:HorizontalAwningIOComponent": "cover",
+    "io:GarageOpenerIOComponent": "cover",
     "io:LightIOSystemSensor": "sensor",
     "io:OnOffIOComponent": "switch",
     "io:OnOffLightIOComponent": "switch",
@@ -49,8 +52,6 @@ TAHOMA_TYPES = {
     "io:VerticalExteriorAwningIOComponent": "cover",
     "io:VerticalInteriorBlindVeluxIOComponent": "cover",
     "io:WindowOpenerVeluxIOComponent": "cover",
-    "io:GarageOpenerIOComponent": "cover",
-    "io:DiscreteGarageOpenerIOComponent": "cover",
     "rtds:RTDSContactSensor": "sensor",
     "rtds:RTDSMotionSensor": "sensor",
     "rtds:RTDSSmokeSensor": "smoke",

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -28,8 +28,11 @@ ATTR_LOCK_ORIG = "lock_originator"
 HORIZONTAL_AWNING = "io:HorizontalAwningIOComponent"
 
 TAHOMA_DEVICE_CLASSES = {
-    "io:ExteriorVenetianBlindIOComponent": DEVICE_CLASS_BLIND,
     HORIZONTAL_AWNING: DEVICE_CLASS_AWNING,
+    "io:AwningValanceIOComponent": DEVICE_CLASS_AWNING,
+    "io:DiscreteGarageOpenerIOComponent": DEVICE_CLASS_GARAGE,
+    "io:ExteriorVenetianBlindIOComponent": DEVICE_CLASS_BLIND,
+    "io:GarageOpenerIOComponent": DEVICE_CLASS_GARAGE,
     "io:RollerShutterGenericIOComponent": DEVICE_CLASS_SHUTTER,
     "io:RollerShutterUnoIOComponent": DEVICE_CLASS_SHUTTER,
     "io:RollerShutterVeluxIOComponent": DEVICE_CLASS_SHUTTER,
@@ -37,8 +40,6 @@ TAHOMA_DEVICE_CLASSES = {
     "io:VerticalExteriorAwningIOComponent": DEVICE_CLASS_AWNING,
     "io:VerticalInteriorBlindVeluxIOComponent": DEVICE_CLASS_BLIND,
     "io:WindowOpenerVeluxIOComponent": DEVICE_CLASS_WINDOW,
-    "io:GarageOpenerIOComponent": DEVICE_CLASS_GARAGE,
-    "io:DiscreteGarageOpenerIOComponent": DEVICE_CLASS_GARAGE,
     "rts:BlindRTSComponent": DEVICE_CLASS_BLIND,
     "rts:CurtainRTSComponent": DEVICE_CLASS_CURTAIN,
     "rts:DualCurtainRTSComponent": DEVICE_CLASS_CURTAIN,
@@ -228,22 +229,22 @@ class TahomaCover(TahomaDevice, CoverDevice):
             == "io:RollerShutterWithLowSpeedManagementIOComponent"
         ):
             self.apply_action("setPosition", "secured")
-        elif self.tahoma_device.type in (
-            "rts:BlindRTSComponent",
+        elif self.tahoma_device.type in {
             "io:ExteriorVenetianBlindIOComponent",
-            "rts:VenetianBlindRTSComponent",
+            "rts:BlindRTSComponent",
             "rts:DualCurtainRTSComponent",
             "rts:ExteriorVenetianBlindRTSComponent",
-            "rts:BlindRTSComponent",
-        ):
+            "rts:VenetianBlindRTSComponent",
+        }:
             self.apply_action("my")
-        elif self.tahoma_device.type in (
+        elif self.tahoma_device.type in {
             HORIZONTAL_AWNING,
+            "io:AwningValanceIOComponent",
             "io:RollerShutterGenericIOComponent",
             "io:VerticalExteriorAwningIOComponent",
             "io:VerticalInteriorBlindVeluxIOComponent",
             "io:WindowOpenerVeluxIOComponent",
-        ):
+        }:
             self.apply_action("stop")
         else:
             self.apply_action("stopIdentify")


### PR DESCRIPTION
## Description:

Adds _io:AwningValanceIOComponent_ (same like _io:VerticalExteriorAwningIOComponent_), sorts the devices and removes duplicate _rts:BlindRTSComponent_ from cover.py. Following the issue #24673 the devices should be the same and behave like the same. 

**Related issue (if applicable):** fixes #24673

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** -

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
