### PR TITLE
Add brightness and colour temp attributes to Flux switch

### DIFF
--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -118,9 +118,7 @@ async def async_set_lights_temp(hass, lights, mired, brightness, transition):
             if transition is not None:
                 service_data[ATTR_TRANSITION] = transition
             await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_ON, service_data)
-    self._attributes = {}
-    self._attributes['Brightness'] = brightness
-    self._attributes['Colour Temperature'] = round(1000000 / mired,0)
+
 
 async def async_set_lights_rgb(hass, lights, rgb, transition):
     """Set color of array of lights."""
@@ -346,6 +344,9 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
+            self._attributes = {}
+            self._attributes['Brightness'] = brightness
+            self._attributes['Colour Temperature'] = round(1000000 / mired,0)
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -206,8 +206,6 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._transition = transition
         self.unsub_tracker = None
         self._attributes = {}
-        self._attributes['Brightness'] = ''
-        self._attributes['Colour Temperature'] = ''
 
     @property
     def name(self):
@@ -223,7 +221,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
     def device_state_attributes(self):
         """Return the attributes of the switch."""
         return self._attributes
-    
+
     async def async_added_to_hass(self):
         """Call when entity about to be added to hass."""
         last_state = await self.async_get_last_state()
@@ -328,6 +326,13 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
+            self._attributes = {}
+            self._attributes["Colour Temperature (K)"] = int(temp)
+            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
+            self._attributes["x, y"] = (
+                str(round(x_val, 4)) + ", " + str(round(y_val, 4))
+            )
+
         elif self._mode == MODE_RGB:
             await async_set_lights_rgb(self.hass, self._lights, rgb, self._transition)
             _LOGGER.debug(
@@ -337,6 +342,14 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
+            r_val, g_val, b_val = rgb
+            self._attributes = {}
+            self._attributes["Colour Temperature (K)"] = int(temp)
+            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
+            self._attributes["rgb"] = (
+                str(int(r_val)) + ", " + str(int(g_val)) + ", " + str(int(b_val))
+            )
+
         else:
             # Convert to mired and clamp to allowed values
             mired = color_temperature_kelvin_to_mired(temp)
@@ -352,9 +365,10 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
-        self._attributes = {}
-        self._attributes['Brightness'] = str(round(brightness/255*100,1)) + "%"
-        self._attributes['Colour Temperature'] = str(int(temp)) + "K"
+            self._attributes = {}
+            self._attributes["Colour Temperature (K)"] = int(temp)
+            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
+            self._attributes["mireds"] = int(mired)
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -206,8 +206,8 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._transition = transition
         self.unsub_tracker = None
         self._attributes = {}
-        self._attributes['Brightness'] = ''
-        self._attributes['Colour Temperature'] = ''
+        self._attributes['Brightness'] = ""
+        self._attributes['Colour Temperature'] = ""
 
     @property
     def name(self):
@@ -353,8 +353,8 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 now,
             )
             self._attributes = {}
-            self._attributes['Brightness'] = (brightness/255) + '%' 
-            self._attributes['Colour Temperature'] = round(1000000 / mired,0) + 'K'
+            self._attributes['Brightness'] = str(round(brightness/255,1) + "%" 
+            self._attributes['Colour Temperature'] = str((round(1000000 / mired,0)) + "K"
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -118,7 +118,9 @@ async def async_set_lights_temp(hass, lights, mired, brightness, transition):
             if transition is not None:
                 service_data[ATTR_TRANSITION] = transition
             await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_ON, service_data)
-
+    self._attributes = {}
+    self._attributes['Brightness'] = brightness
+    self._attributes['Colour Temperature'] = round(1000000 / mired,0)
 
 async def async_set_lights_rgb(hass, lights, rgb, transition):
     """Set color of array of lights."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -205,6 +205,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._interval = interval
         self._transition = transition
         self.unsub_tracker = None
+        self._attributes
 
     @property
     def name(self):
@@ -216,6 +217,11 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         """Return true if switch is on."""
         return self.unsub_tracker is not None
 
+    @property
+    def device_state_attributes(self):
+        """Return the attributes of the switch."""
+        return self._attributes
+    
     async def async_added_to_hass(self):
         """Call when entity about to be added to hass."""
         last_state = await self.async_get_last_state()

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -353,8 +353,8 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 now,
             )
             self._attributes = {}
-            self._attributes['Brightness'] = str(round(brightness/255,1)) + "%"
-            self._attributes['Colour Temperature'] = str(round(1000000 / mired,0)) + "K"
+            self._attributes['Brightness'] = str(round(brightness/255*100,1)) + "%"
+            self._attributes['Colour Temperature'] = str(int(1000000 / mired)) + "K"
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -206,8 +206,8 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._transition = transition
         self.unsub_tracker = None
         self._attributes = {}
-        self._attributes['Brightness'] = ""
-        self._attributes['Colour Temperature'] = ""
+        self._attributes['Brightness'] = ''
+        self._attributes['Colour Temperature'] = ''
 
     @property
     def name(self):

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -206,8 +206,8 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._transition = transition
         self.unsub_tracker = None
         self._attributes = {}
-        self._attributes['Brightness'] = 0
-        self._attributes['Colour Temperature'] = 0
+        self._attributes['Brightness'] = ''
+        self._attributes['Colour Temperature'] = ''
 
     @property
     def name(self):
@@ -353,8 +353,8 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 now,
             )
             self._attributes = {}
-            self._attributes['Brightness'] = brightness
-            self._attributes['Colour Temperature'] = round(1000000 / mired,0)
+            self._attributes['Brightness'] = (brightness/255) + '%' 
+            self._attributes['Colour Temperature'] = round(1000000 / mired,0) + 'K'
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -353,8 +353,8 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 now,
             )
             self._attributes = {}
-            self._attributes['Brightness'] = str(round(brightness/255,1) + "%" 
-            self._attributes['Colour Temperature'] = str((round(1000000 / mired,0)) + "K"
+            self._attributes['Brightness'] = str(round(brightness/255,1)) + "%"
+            self._attributes['Colour Temperature'] = str(round(1000000 / mired,0)) + "K"
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -352,9 +352,9 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
-            self._attributes = {}
-            self._attributes['Brightness'] = str(round(brightness/255*100,1)) + "%"
-            self._attributes['Colour Temperature'] = str(int(1000000 / mired)) + "K"
+        self._attributes = {}
+        self._attributes['Brightness'] = str(round(brightness/255*100,1)) + "%"
+        self._attributes['Colour Temperature'] = str(int(1000000 / mired)) + "K"
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -354,7 +354,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
             )
         self._attributes = {}
         self._attributes['Brightness'] = str(round(brightness/255*100,1)) + "%"
-        self._attributes['Colour Temperature'] = str(int(1000000 / mired)) + "K"
+        self._attributes['Colour Temperature'] = str(int(temp)) + "K"
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -205,7 +205,9 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._interval = interval
         self._transition = transition
         self.unsub_tracker = None
-        self._attributes
+        self._attributes = {}
+        self._attributes['Brightness'] = 0
+        self._attributes['Colour Temperature'] = 0
 
     @property
     def name(self):

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -205,7 +205,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._interval = interval
         self._transition = transition
         self.unsub_tracker = None
-        self._attributes = {}
+        self._state_attributes = {}
 
     @property
     def name(self):
@@ -220,7 +220,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
     @property
     def device_state_attributes(self):
         """Return the attributes of the switch."""
-        return self._attributes
+        return self._state_attributes
 
     async def async_added_to_hass(self):
         """Call when entity about to be added to hass."""
@@ -326,10 +326,10 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
-            self._attributes = {}
-            self._attributes["Colour Temperature (K)"] = int(temp)
-            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
-            self._attributes["x, y"] = (
+            self._state_attributes = {}
+            self._state_attributes["Colour Temperature (K)"] = int(temp)
+            self._state_attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
+            self._state_attributes["x, y"] = (
                 str(round(x_val, 4)) + ", " + str(round(y_val, 4))
             )
 
@@ -343,10 +343,10 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 now,
             )
             r_val, g_val, b_val = rgb
-            self._attributes = {}
-            self._attributes["Colour Temperature (K)"] = int(temp)
-            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
-            self._attributes["rgb"] = (
+            self._state_attributes = {}
+            self._state_attributes["Colour Temperature (K)"] = int(temp)
+            self._state_attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
+            self._state_attributes["rgb"] = (
                 str(int(r_val)) + ", " + str(int(g_val)) + ", " + str(int(b_val))
             )
 
@@ -365,10 +365,10 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
-            self._attributes = {}
-            self._attributes["Colour Temperature (K)"] = int(temp)
-            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
-            self._attributes["mireds"] = int(mired)
+            self._state_attributes = {}
+            self._state_attributes["Colour Temperature (K)"] = int(temp)
+            self._state_attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
+            self._state_attributes["mireds"] = int(mired)
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -205,7 +205,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
         self._interval = interval
         self._transition = transition
         self.unsub_tracker = None
-        self._attributes = {}
+        self._state_attributes = {}
 
     @property
     def name(self):
@@ -220,7 +220,7 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
     @property
     def device_state_attributes(self):
         """Return the attributes of the switch."""
-        return self._attributes
+        return self._state_attributes
 
     async def async_added_to_hass(self):
         """Call when entity about to be added to hass."""
@@ -326,12 +326,10 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
-            self._attributes = {}
-            self._attributes["Colour Temperature (K)"] = int(temp)
-            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
-            self._attributes["x, y"] = (
-                str(round(x_val, 4)) + ", " + str(round(y_val, 4))
-            )
+            self._state_attributes = {}
+            self._state_attributes["Colour Temperature (K)"] = f"{int(temp)}"
+            self._state_attributes["Brightness (%)"] = f"{int(brightness / 255 * 100)}"
+            self._state_attributes["x, y"] = f"{round(x_val,4)}, {round(y_val,4)}"
 
         elif self._mode == MODE_RGB:
             await async_set_lights_rgb(self.hass, self._lights, rgb, self._transition)
@@ -343,12 +341,10 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 now,
             )
             r_val, g_val, b_val = rgb
-            self._attributes = {}
-            self._attributes["Colour Temperature (K)"] = int(temp)
-            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
-            self._attributes["rgb"] = (
-                str(int(r_val)) + ", " + str(int(g_val)) + ", " + str(int(b_val))
-            )
+            self._state_attributes = {}
+            self._state_attributes["Colour Temperature (K)"] = f"{int(temp)}"
+            self._state_attributes["Brightness (%)"] = f"{int(brightness / 255 * 100)}"
+            self._state_attributes["rgb"] = f"{int(r_val)}, {int(g_val)}, {int(b_val)}"
 
         else:
             # Convert to mired and clamp to allowed values
@@ -365,10 +361,10 @@ class FluxSwitch(SwitchDevice, RestoreEntity):
                 time_state,
                 now,
             )
-            self._attributes = {}
-            self._attributes["Colour Temperature (K)"] = int(temp)
-            self._attributes["Brightness (%)"] = round(brightness / 255 * 100, 1)
-            self._attributes["mireds"] = int(mired)
+            self._state_attributes = {}
+            self._state_attributes["Colour Temperature (K)"] = f"{int(temp)}"
+            self._state_attributes["Brightness (%)"] = f"{int(brightness / 255 * 100)}"
+            self._state_attributes["mireds"] = f"{int(mired)}"
 
     def find_start_time(self, now):
         """Return sunrise or start_time if given."""


### PR DESCRIPTION
## Description:  

I have added colour temperature and brightness to the Flux switch state attributes.  

mired values are also shown when mode == mired, 
xy values are shown when mode == xy, 
rgb values are shown when mode == rgb.

This is my first contribution to the project so please forgive my first attempts.



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
