### PR TITLE
Bump aiobotocore to 0.11.1

### DIFF
--- a/homeassistant/components/aws/manifest.json
+++ b/homeassistant/components/aws/manifest.json
@@ -2,7 +2,7 @@
   "domain": "aws",
   "name": "Amazon Web Services (AWS)",
   "documentation": "https://www.home-assistant.io/integrations/aws",
-  "requirements": ["aiobotocore==0.10.4"],
+  "requirements": ["aiobotocore==0.11.1"],
   "dependencies": [],
   "codeowners": ["@awarecan", "@robbiet480"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -141,7 +141,7 @@ aioasuswrt==1.1.22
 aioautomatic==0.6.5
 
 # homeassistant.components.aws
-aiobotocore==0.10.4
+aiobotocore==0.11.1
 
 # homeassistant.components.dnsip
 aiodns==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -53,7 +53,7 @@ aioasuswrt==1.1.22
 aioautomatic==0.6.5
 
 # homeassistant.components.aws
-aiobotocore==0.10.4
+aiobotocore==0.11.1
 
 # homeassistant.components.esphome
 aioesphomeapi==2.6.1


### PR DESCRIPTION
## Description:
Bumped aiobotocore version from 0.10.4 to 0.11.1 in aws component

**Related issue (if applicable):** fixes #28499

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
