### PR TITLE
Fix unavailable state for spotify media player

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -383,7 +383,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         """Return the media player features that are supported."""
         if self._user is not None and self._user["product"] == "premium":
             return SUPPORT_SPOTIFY
-        return None
+        return 0
 
     @property
     def media_content_type(self):


### PR DESCRIPTION
## Description:
- state became unavailable after #30545
- changed the return value from `None` to `0` to fix the occurring TypeError:
```
Error doing job: Task exception was never retrieved
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 284, in async_update_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 314, in _async_write_ha_state
    attr = self.capability_attributes
  File "/usr/src/homeassistant/homeassistant/components/media_player/__init__.py", line 791, in capability_attributes
    if supported_features & SUPPORT_SELECT_SOURCE:
TypeError: unsupported operand type(s) for &: 'NoneType' and 'int'
```

**Related issue (if applicable):** fixes #30883<home-assistant issue number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: spotify
    client_id: YOUR_CLIENT_ID
    client_secret: YOUR_CLIENT_SECRET
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
