### PR TITLE
Fix auto_bypass in alarmdecoder

### DIFF
--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -121,6 +121,7 @@ def setup(hass, config):
     device = conf.get(CONF_DEVICE)
     display = conf.get(CONF_PANEL_DISPLAY)
     zones = conf.get(CONF_ZONES)
+    auto_bypass = conf.get(CONF_AUTO_BYPASS)
 
     device_type = device.get(CONF_DEVICE_TYPE)
     host = DEFAULT_DEVICE_HOST
@@ -204,7 +205,9 @@ def setup(hass, config):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_alarmdecoder)
 
-    load_platform(hass, "alarm_control_panel", DOMAIN, conf, config)
+    load_platform(
+        hass, "alarm_control_panel", DOMAIN, {CONF_AUTO_BYPASS: auto_bypass}, config
+    )
 
     if zones:
         load_platform(hass, "binary_sensor", DOMAIN, {CONF_ZONES: zones}, config)

--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -121,7 +121,7 @@ def setup(hass, config):
     device = conf.get(CONF_DEVICE)
     display = conf.get(CONF_PANEL_DISPLAY)
     zones = conf.get(CONF_ZONES)
-    auto_bypass = conf.get(CONF_AUTO_BYPASS)
+    auto_bypass = conf[CONF_AUTO_BYPASS]
 
     device_type = device.get(CONF_DEVICE_TYPE)
     host = DEFAULT_DEVICE_HOST

--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -118,12 +118,12 @@ def setup(hass, config):
     conf = config.get(DOMAIN)
 
     restart = False
-    device = conf.get(CONF_DEVICE)
-    display = conf.get(CONF_PANEL_DISPLAY)
-    zones = conf.get(CONF_ZONES)
+    device = conf[CONF_DEVICE]
+    display = conf[CONF_PANEL_DISPLAY]
     auto_bypass = conf[CONF_AUTO_BYPASS]
+    zones = conf.get(CONF_ZONES)
 
-    device_type = device.get(CONF_DEVICE_TYPE)
+    device_type = device[CONF_DEVICE_TYPE]
     host = DEFAULT_DEVICE_HOST
     port = DEFAULT_DEVICE_PORT
     path = DEFAULT_DEVICE_PATH

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
-from . import DATA_AD, DOMAIN, SIGNAL_PANEL_MESSAGE
+from . import CONF_AUTO_BYPASS, DATA_AD, DOMAIN, SIGNAL_PANEL_MESSAGE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,11 @@ ALARM_KEYPRESS_SCHEMA = vol.Schema({vol.Required(ATTR_KEYPRESS): cv.string})
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up for AlarmDecoder alarm panels."""
-    device = AlarmDecoderAlarmPanel(discovery_info["autobypass"])
+    if discovery_info is None:
+        return
+
+    auto_bypass = discovery_info[CONF_AUTO_BYPASS]
+    device = AlarmDecoderAlarmPanel(auto_bypass)
     add_entities([device])
 
     def alarm_toggle_chime_handler(service):

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -39,13 +39,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
 
     auto_bypass = discovery_info[CONF_AUTO_BYPASS]
-    device = AlarmDecoderAlarmPanel(auto_bypass)
-    add_entities([device])
+    entity = AlarmDecoderAlarmPanel(auto_bypass)
+    add_entities([entity])
 
     def alarm_toggle_chime_handler(service):
         """Register toggle chime handler."""
         code = service.data.get(ATTR_CODE)
-        device.alarm_toggle_chime(code)
+        entity.alarm_toggle_chime(code)
 
     hass.services.register(
         DOMAIN,
@@ -57,7 +57,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     def alarm_keypress_handler(service):
         """Register keypress handler."""
         keypress = service.data[ATTR_KEYPRESS]
-        device.alarm_keypress(keypress)
+        entity.alarm_keypress(keypress)
 
     hass.services.register(
         DOMAIN,


### PR DESCRIPTION
**Description:**
- auto_bypass was introduced in #30002, however some things are missing for a proper implementation which is added in this PR

**Related issue (if applicable):** #30892<home-assistant issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
