### PR TITLE
Improve Wemo config entry support, add device info

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -88,8 +88,6 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up a wemo config entry."""
-    loaded_components = set()
-
     config = hass.data[DOMAIN].pop("config")
 
     # Keep track of WeMo device subscriptions for push updates
@@ -105,11 +103,9 @@ async def async_setup_entry(hass, entry):
 
     devices = {}
 
-    _LOGGER.debug("Beginning WeMo device discovery...")
-    _LOGGER.debug("Adding statically configured WeMo devices...")
-
     static_conf = config.get(CONF_STATIC, [])
     if static_conf:
+        _LOGGER.debug("Adding statically configured WeMo devices...")
         for device in await asyncio.gather(
             *[
                 hass.async_add_executor_job(validate_static_config, host, port)
@@ -127,6 +123,8 @@ async def async_setup_entry(hass, entry):
             devices.setdefault(
                 device.serialnumber, device,
             )
+
+    loaded_components = set()
 
     for device in devices.values():
         _LOGGER.debug(
@@ -157,8 +155,6 @@ async def async_setup_entry(hass, entry):
             async_dispatcher_send(
                 hass, f"{DOMAIN}.{component}", device,
             )
-
-    _LOGGER.debug("WeMo device discovery has finished")
 
     return True
 

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -109,7 +109,7 @@ async def async_setup_entry(hass, entry):
         for device in await asyncio.gather(
             *[
                 hass.async_add_executor_job(validate_static_config, host, port)
-                for host, port in config.get(CONF_STATIC, [])
+                for host, port in static_conf
             ]
         ):
             if device is None:

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -7,7 +7,6 @@ from pywemo import discovery
 import requests
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DOMAIN as WEMO_DOMAIN
@@ -32,7 +31,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             requests.exceptions.Timeout,
         ) as err:
             _LOGGER.error("Unable to access %s (%s)", location, err)
-            raise PlatformNotReady
+            return
 
         if device:
             async_add_entities([WemoBinarySensor(hass, device)])

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -24,7 +24,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         mac = discovery_info["mac_address"]
 
         try:
-            device = discovery.device_from_description(location, mac)
+            device = await hass.async_add_executor_job(
+                discovery.device_from_description, location, mac
+            )
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -38,6 +38,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.binary_sensor", _discovered_wemo)
 
+    await asyncio.gather(
+        *[
+            _discovered_wemo(device_info)
+            for device_info in hass.data[WEMO_DOMAIN]["pending"].pop("binary_sensor")
+        ]
+    )
+
 
 class WemoBinarySensor(BinarySensorDevice):
     """Representation a WeMo binary sensor."""
@@ -72,7 +79,7 @@ class WemoBinarySensor(BinarySensorDevice):
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
-        registry = self.hass.data[WEMO_DOMAIN]
+        registry = self.hass.data[WEMO_DOMAIN]["registry"]
         await self.hass.async_add_executor_job(registry.register, self.wemo)
         registry.on(self.wemo, None, self._subscription_callback)
 

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -17,7 +17,6 @@ from homeassistant.components.fan import (
     FanEntity,
 )
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -114,7 +113,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             requests.exceptions.Timeout,
         ) as err:
             _LOGGER.error("Unable to access %s (%s)", location, err)
-            raise PlatformNotReady
+            return
 
         entities.append(entity)
         async_add_entities([entity])

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -25,6 +25,7 @@ from .const import (
 )
 
 SCAN_INTERVAL = timedelta(seconds=10)
+PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -19,6 +19,7 @@ from homeassistant.components.fan import (
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (
     DOMAIN as WEMO_DOMAIN,
@@ -114,6 +115,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         hass.data[DATA_KEY][device.entity_id] = device
         async_add_entities([device])
+
+    async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.fan", _discovered_wemo)
 
     def service_handle(service):
         """Handle the WeMo humidifier services."""

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -61,6 +61,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.light", _discovered_wemo)
 
+    await asyncio.gather(
+        *[
+            _discovered_wemo(device_info)
+            for device_info in hass.data[WEMO_DOMAIN]["pending"].pop("light")
+        ]
+    )
+
 
 def setup_bridge(hass, bridge, async_add_entities):
     """Set up a WeMo link."""
@@ -251,7 +258,7 @@ class WemoDimmer(Light):
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
-        registry = self.hass.data[WEMO_DOMAIN]
+        registry = self.hass.data[WEMO_DOMAIN]["registry"]
         await self.hass.async_add_executor_job(registry.register, self.wemo)
         registry.on(self.wemo, None, self._subscription_callback)
 

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -20,6 +20,7 @@ from homeassistant.components.light import (
     Light,
 )
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.color as color_util
 
@@ -56,6 +57,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             async_add_entities([WemoDimmer(device)])
         else:
             setup_bridge(hass, device, async_add_entities)
+
+    async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.light", _discovered_wemo)
 
 
 def setup_bridge(hass, bridge, async_add_entities):

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -18,7 +18,6 @@ from homeassistant.components.light import (
     Light,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.color as color_util
 
 from .const import DOMAIN as WEMO_DOMAIN
@@ -72,7 +71,7 @@ def setup_bridge(hass, bridge, async_add_entities):
                 new_lights.append(lights[light_id])
 
         if new_lights:
-            run_callback_threadsafe(hass.loop, async_add_entities, new_lights).result()
+            hass.add_job(async_add_entities, new_lights)
 
     update_lights()
 

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -19,7 +19,6 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     Light,
 )
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.color as color_util
@@ -53,7 +52,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             requests.exceptions.Timeout,
         ) as err:
             _LOGGER.error("Unable to access %s (%s)", location, err)
-            raise PlatformNotReady
+            return
 
         if device.model_name == "Dimmer":
             async_add_entities([WemoDimmer(device)])

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -45,7 +45,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         mac = discovery_info["mac_address"]
 
         try:
-            device = discovery.device_from_description(location, mac)
+            device = await hass.async_add_executor_job(
+                discovery.device_from_description, location, mac
+            )
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -41,7 +41,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         mac = discovery_info["mac_address"]
 
         try:
-            device = discovery.device_from_description(location, mac)
+            device = await hass.async_add_executor_job(
+                discovery.device_from_description, location, mac
+            )
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -55,6 +55,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.switch", _discovered_wemo)
 
+    await asyncio.gather(
+        *[
+            _discovered_wemo(device_info)
+            for device_info in hass.data[WEMO_DOMAIN]["pending"].pop("switch")
+        ]
+    )
+
 
 class WemoSwitch(SwitchDevice):
     """Representation of a WeMo switch."""
@@ -209,7 +216,7 @@ class WemoSwitch(SwitchDevice):
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
-        registry = self.hass.data[WEMO_DOMAIN]
+        registry = self.hass.data[WEMO_DOMAIN]["registry"]
         await self.hass.async_add_job(registry.register, self.wemo)
         registry.on(self.wemo, None, self._subscription_callback)
 

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -13,6 +13,7 @@ from homeassistant.util import convert
 from .const import DOMAIN as WEMO_DOMAIN
 
 SCAN_INTERVAL = timedelta(seconds=10)
+PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -9,7 +9,6 @@ import requests
 
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_STANDBY, STATE_UNKNOWN
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import convert
 
@@ -49,7 +48,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             requests.exceptions.Timeout,
         ) as err:
             _LOGGER.error("Unable to access %s (%s)", location, err)
-            raise PlatformNotReady
+            return
 
         if device:
             async_add_entities([WemoSwitch(device)])


### PR DESCRIPTION
## Description:
Drop complete usage of `discovery` in Wemo, use forward config entry setup instead. Add device info for all platforms.

Tested with my Wemo Insight Switch.

![image](https://user-images.githubusercontent.com/1444314/72675491-dd62ad80-3a39-11ea-96cc-9af212975495.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
