### PR TITLE
Add template bitwise_xor, bitwise_left, bitwise_right, strtoint and hex

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -815,6 +815,14 @@ def strptime(string, fmt):
         return string
 
 
+def strtoint(value):
+    """Try to convert string to long integer."""
+    try:
+        return int(value, base=16)
+    except (ValueError):
+        return None
+
+
 def fail_when_undefined(value):
     """Filter to force a failure when the value is undefined."""
     if isinstance(value, jinja2.Undefined):
@@ -871,6 +879,21 @@ def bitwise_and(first_value, second_value):
 def bitwise_or(first_value, second_value):
     """Perform a bitwise or operation."""
     return first_value | second_value
+
+
+def bitwise_xor(first_value, second_value):
+    """Perform a bitwise XOR operation."""
+    return first_value ^ second_value
+
+
+def bitwise_left(first_value, second_value):
+    """Perform a bitwise left shift operation."""
+    return first_value << second_value
+
+
+def bitwise_right(first_value, second_value):
+    """Perform a bitwise right shift operation."""
+    return first_value >> second_value
 
 
 def base64_encode(value):
@@ -949,6 +972,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["regex_findall_index"] = regex_findall_index
         self.filters["bitwise_and"] = bitwise_and
         self.filters["bitwise_or"] = bitwise_or
+        self.filters["bitwise_xor"] = bitwise_xor
+        self.filters["bitwise_left"] = bitwise_left
+        self.filters["bitwise_right"] = bitwise_right
         self.filters["ord"] = ord
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
@@ -968,6 +994,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["as_timestamp"] = forgiving_as_timestamp
         self.globals["relative_time"] = dt_util.get_age
         self.globals["strptime"] = strptime
+        self.globals["strtoint"] = strtoint
+        self.globals["hex"] = hex
         if hass is None:
             return
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1011,6 +1011,97 @@ def test_bitwise_or(hass):
     assert tpl.async_render() == str(8 | 2)
 
 
+def test_bitwise_xor(hass):
+    """Test bitwise_xor method."""
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_xor(8) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(8 ^ 8)
+    tpl = template.Template(
+        """
+{{ 10 | bitwise_xor(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(10 ^ 2)
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_xor(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(8 ^ 2)
+
+
+def test_bitwise_left(hass):
+    """Test bitwise_left method."""
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_left(8) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(8 << 8)
+    tpl = template.Template(
+        """
+{{ 10 | bitwise_left(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(10 << 2)
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_left(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(8 << 2)
+
+
+def test_bitwise_right(hass):
+    """Test bitwise_right method."""
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_right(8) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(8 >> 8)
+    tpl = template.Template(
+        """
+{{ 10 | bitwise_right(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(10 >> 2)
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_right(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == str(8 >> 2)
+
+
+def test_hex(hass):
+    """Test the hex filter."""
+    assert template.Template("{{ hex(4) }}", hass).async_render() == "0x4"
+    assert template.Template("{{ hex(15) }}", hass).async_render() == "0xf"
+    assert template.Template("{{ hex(241) }}", hass).async_render() == "0xf1"
+    assert template.Template("{{ hex(2564) }}", hass).async_render() == "0xa04"
+
+
+def test_strtoint(hass):
+    """Test the strtoint filter."""
+    assert template.Template('{{ strtoint("4") }}', hass).async_render() == "4"
+    assert template.Template('{{ strtoint("0x01") }}', hass).async_render() == "1"
+    assert template.Template('{{ strtoint("0xF1") }}', hass).async_render() == "241"
+    assert template.Template('{{ strtoint("0xF") }}', hass).async_render() == "15"
+
+
 def test_distance_function_with_1_state(hass):
     """Test distance function with 1 state."""
     _set_up_units(hass)


### PR DESCRIPTION
## Description:
Bitwise functions are important part of any integration. This PR adds the missing ones. Most industrial devices communicate by sending raw bytes and most states are determined by bitflags.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
