### PR TITLE
Update NSAPI to 3.0.2

### DIFF
--- a/homeassistant/components/nederlandse_spoorwegen/manifest.json
+++ b/homeassistant/components/nederlandse_spoorwegen/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nederlandse_spoorwegen",
   "name": "Nederlandse Spoorwegen (NS)",
   "documentation": "https://www.home-assistant.io/integrations/nederlandse_spoorwegen",
-  "requirements": ["nsapi==3.0.0"],
+  "requirements": ["nsapi==3.0.1"],
   "dependencies": [],
   "codeowners": ["@YarmoM"]
 }

--- a/homeassistant/components/nederlandse_spoorwegen/manifest.json
+++ b/homeassistant/components/nederlandse_spoorwegen/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nederlandse_spoorwegen",
   "name": "Nederlandse Spoorwegen (NS)",
   "documentation": "https://www.home-assistant.io/integrations/nederlandse_spoorwegen",
-  "requirements": ["nsapi==3.0.1"],
+  "requirements": ["nsapi==3.0.2"],
   "dependencies": [],
   "codeowners": ["@YarmoM"]
 }

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -148,13 +148,13 @@ class NSDepartureSensor(Entity):
             "departure_time_planned": None,
             "departure_time_actual": None,
             "departure_delay": False,
-            "departure_platform_planned": None,
-            "departure_platform_actual": None,
+            "departure_platform_planned": self._trips[0].departure_platform_planned,
+            "departure_platform_actual": self._trips[0].departure_platform_actual,
             "arrival_time_planned": None,
             "arrival_time_actual": None,
             "arrival_delay": False,
-            "arrival_platform_planned": None,
-            "arrival_platform_actual": None,
+            "arrival_platform_planned": self._trips[0].arrival_platform_planned,
+            "arrival_platform_actual": self._trips[0].arrival_platform_actual,
             "next": None,
             "status": self._trips[0].status.lower(),
             "transfers": self._trips[0].nr_transfers,
@@ -168,18 +168,12 @@ class NSDepartureSensor(Entity):
             attributes["departure_time_planned"] = self._trips[
                 0
             ].departure_time_planned.strftime("%H:%M")
-            attributes["departure_platform_planned"] = self._trips[
-                0
-            ].departure_platform_planned
 
         # Actual departure attributes
         if self._trips[0].departure_time_actual is not None:
             attributes["departure_time_actual"] = self._trips[
                 0
             ].departure_time_actual.strftime("%H:%M")
-            attributes["departure_platform_actual"] = self._trips[
-                0
-            ].departure_platform_actual
 
         # Delay departure attributes
         if (
@@ -195,18 +189,12 @@ class NSDepartureSensor(Entity):
             attributes["arrival_time_planned"] = self._trips[
                 0
             ].arrival_time_planned.strftime("%H:%M")
-            attributes["arrival_platform_planned"] = self._trips[
-                0
-            ].arrival_platform_planned
 
         # Actual arrival attributes
         if self._trips[0].arrival_time_actual is not None:
             attributes["arrival_time_actual"] = self._trips[
                 0
             ].arrival_time_actual.strftime("%H:%M")
-            attributes["arrival_platform_actual"] = self._trips[
-                0
-            ].arrival_platform_actual
 
         # Delay arrival attributes
         if (

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -127,19 +127,15 @@ class NSDepartureSensor(Entity):
         # Static attributes
         attributes = {
             "going": self._trips[0].going,
-            "departure_time_planned": self._trips[0].departure_time_planned.strftime(
-                "%H:%M"
-            ),
+            "departure_time_planned": None,
             "departure_time_actual": None,
             "departure_delay": False,
-            "departure_platform_planned": self._trips[0].departure_platform_planned,
+            "departure_platform_planned": None,
             "departure_platform_actual": None,
-            "arrival_time_planned": self._trips[0].arrival_time_planned.strftime(
-                "%H:%M"
-            ),
+            "arrival_time_planned": None,
             "arrival_time_actual": None,
             "arrival_delay": False,
-            "arrival_platform_platform": self._trips[0].arrival_platform_planned,
+            "arrival_platform_planned": None,
             "arrival_platform_actual": None,
             "next": None,
             "status": self._trips[0].status.lower(),
@@ -149,25 +145,60 @@ class NSDepartureSensor(Entity):
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 
-        # Departure attributes
+        # Planned departure attributes
+        if self._trips[0].departure_time_planned is not None:
+            attributes["departure_time_planned"] = self._trips[
+                0
+            ].departure_time_planned.strftime("%H:%M")
+            attributes["departure_platform_planned"] = self._trips[
+                0
+            ].departure_platform_planned
+
+        # Actual departure attributes
         if self._trips[0].departure_time_actual is not None:
             attributes["departure_time_actual"] = self._trips[
                 0
             ].departure_time_actual.strftime("%H:%M")
-            attributes["departure_delay"] = True
+            # attributes["departure_delay"] = True
             attributes["departure_platform_actual"] = self._trips[
                 0
             ].departure_platform_actual
 
-        # Arrival attributes
+        # Delay departure attributes
+        if (
+            attributes["departure_time_planned"]
+            and attributes["departure_time_actual"]
+            and attributes["departure_time_planned"]
+            != attributes["departure_time_actual"]
+        ):
+            attributes["departure_delay"] = True
+
+        # Planned arrival attributes
+        if self._trips[0].arrival_time_planned is not None:
+            attributes["arrival_time_planned"] = self._trips[
+                0
+            ].arrival_time_planned.strftime("%H:%M")
+            attributes["arrival_platform_planned"] = self._trips[
+                0
+            ].arrival_platform_planned
+
+        # Actual arrival attributes
         if self._trips[0].arrival_time_actual is not None:
             attributes["arrival_time_actual"] = self._trips[
                 0
             ].arrival_time_actual.strftime("%H:%M")
-            attributes["arrival_delay"] = True
+            # attributes["arrival_delay"] = True
             attributes["arrival_platform_actual"] = self._trips[
                 0
             ].arrival_platform_actual
+
+        # Delay arrival attributes
+        if (
+            attributes["arrival_time_planned"]
+            and attributes["arrival_time_actual"]
+            and attributes["arrival_time_planned"] != attributes["arrival_time_actual"]
+        ):
+            attributes["arrival_delay"] = True
 
         # Next attributes
         if self._trips[1].departure_time_actual is not None:

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -159,7 +159,6 @@ class NSDepartureSensor(Entity):
             attributes["departure_time_actual"] = self._trips[
                 0
             ].departure_time_actual.strftime("%H:%M")
-            # attributes["departure_delay"] = True
             attributes["departure_platform_actual"] = self._trips[
                 0
             ].departure_platform_actual
@@ -187,7 +186,6 @@ class NSDepartureSensor(Entity):
             attributes["arrival_time_actual"] = self._trips[
                 0
             ].arrival_time_actual.strftime("%H:%M")
-            # attributes["arrival_delay"] = True
             attributes["arrival_platform_actual"] = self._trips[
                 0
             ].arrival_platform_actual

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -7,7 +7,13 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_NAME
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    CONF_API_KEY,
+    CONF_EMAIL,
+    CONF_NAME,
+    CONF_PASSWORD,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -37,12 +43,24 @@ ROUTE_SCHEMA = vol.Schema(
 ROUTES_SCHEMA = vol.All(cv.ensure_list, [ROUTE_SCHEMA])
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {vol.Required(CONF_API_KEY): cv.string, vol.Optional(CONF_ROUTES): ROUTES_SCHEMA}
+    {
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_EMAIL): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_ROUTES): ROUTES_SCHEMA,
+    }
 )
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the departure sensor."""
+
+    if config.get(CONF_EMAIL) or config.get(CONF_PASSWORD):
+        hass.components.persistent_notification.create(
+            'The Nederlandse Spoorwegen component requires a new API key now, please see the <a href="https://www.home-assistant.io/integrations/nederlandse_spoorwegen/">documentation</a> for upgrade instructions.',
+            title="NS upgrade error",
+            notification_id="nederlandse_spoorwegen_upgrade_error",
+        )
 
     nsapi = ns_api.NSAPI(config[CONF_API_KEY])
     try:

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -7,13 +7,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    CONF_API_KEY,
-    CONF_EMAIL,
-    CONF_NAME,
-    CONF_PASSWORD,
-)
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -43,24 +37,12 @@ ROUTE_SCHEMA = vol.Schema(
 ROUTES_SCHEMA = vol.All(cv.ensure_list, [ROUTE_SCHEMA])
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_API_KEY): cv.string,
-        vol.Optional(CONF_EMAIL): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_ROUTES): ROUTES_SCHEMA,
-    }
+    {vol.Required(CONF_API_KEY): cv.string, vol.Optional(CONF_ROUTES): ROUTES_SCHEMA}
 )
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the departure sensor."""
-
-    if config.get(CONF_EMAIL) or config.get(CONF_PASSWORD):
-        hass.components.persistent_notification.create(
-            'The Nederlandse Spoorwegen component requires a new API key now, please see the <a href="https://www.home-assistant.io/integrations/nederlandse_spoorwegen/">documentation</a> for upgrade instructions.',
-            title="NS upgrade error",
-            notification_id="nederlandse_spoorwegen_upgrade_error",
-        )
 
     nsapi = ns_api.NSAPI(config[CONF_API_KEY])
     try:

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         requests.exceptions.ConnectionError,
         requests.exceptions.HTTPError,
     ) as error:
-        _LOGGER.error("Couldn't fetch stations, API password correct?: %s", error)
+        _LOGGER.error("Couldn't fetch stations, API key correct?: %s", error)
         return
 
     sensors = []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -902,7 +902,7 @@ niko-home-control==0.2.1
 niluclient==0.1.2
 
 # homeassistant.components.nederlandse_spoorwegen
-nsapi==3.0.1
+nsapi==3.0.2
 
 # homeassistant.components.nsw_fuel_station
 nsw-fuel-api-client==1.0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -902,7 +902,7 @@ niko-home-control==0.2.1
 niluclient==0.1.2
 
 # homeassistant.components.nederlandse_spoorwegen
-nsapi==3.0.0
+nsapi==3.0.1
 
 # homeassistant.components.nsw_fuel_station
 nsw-fuel-api-client==1.0.10


### PR DESCRIPTION
## Breaking Change:

The "RetrieveTripInformationPublic" API ("Public-Travel-Information" product) will be deprecated on 31-01-2020. All users MUST create a new API token for the "Reisinformatie" API ("Ns-App" product) and use that one instead.

## Description:

The NSAPI dependency was updated to 3.0.2. Changes include:
- fix the API URLs deprecated on 31-01-2020 (IMPORTANT)
- fix a minor inconsistency in train times and platforms

**Related issue (if applicable):** not applicable

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**  home-assistant/home-assistant.io#11843

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
- platform: nederlandse_spoorwegen
  api_key: !secret NS_API_KEY
  routes:
    - name: Amsterdam-Den Haag
      from: Asd
      to: Gvc
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
