### PR TITLE
Add device tracking support for the Arris TG2492LG router

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -45,6 +45,7 @@ omit =
     homeassistant/components/arest/sensor.py
     homeassistant/components/arest/switch.py
     homeassistant/components/arlo/*
+    homeassistant/components/arris_tg2492lg/*
     homeassistant/components/aruba/device_tracker.py
     homeassistant/components/arwn/sensor.py
     homeassistant/components/asterisk_cdr/mailbox.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,6 +33,7 @@ homeassistant/components/aprs/* @PhilRW
 homeassistant/components/arcam_fmj/* @elupus
 homeassistant/components/arduino/* @fabaff
 homeassistant/components/arest/* @fabaff
+homeassistant/components/arris_tg2492lg/* @vanbalken
 homeassistant/components/asuswrt/* @kennedyshead
 homeassistant/components/aten_pe/* @mtdcr
 homeassistant/components/atome/* @baqs

--- a/homeassistant/components/arris_tg2492lg/__init__.py
+++ b/homeassistant/components/arris_tg2492lg/__init__.py
@@ -1,0 +1,1 @@
+"""The Arris TG2492LG component."""

--- a/homeassistant/components/arris_tg2492lg/device_tracker.py
+++ b/homeassistant/components/arris_tg2492lg/device_tracker.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def get_scanner(hass, config):
     """Return the Arris device scanner."""
     conf = config[DOMAIN]
-    url = "http://" + conf[CONF_HOST]
+    url = f"http://{conf[CONF_HOST]}"
     connect_box = ConnectBox(url, conf[CONF_PASSWORD])
     return ArrisDeviceScanner(connect_box)
 

--- a/homeassistant/components/arris_tg2492lg/device_tracker.py
+++ b/homeassistant/components/arris_tg2492lg/device_tracker.py
@@ -15,12 +15,12 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_IP = "http://192.168.178.1"
+DEFAULT_HOST = "192.168.178.1"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string,
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     }
 )
 
@@ -28,16 +28,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def get_scanner(hass, config):
     """Return the Arris device scanner."""
     conf = config[DOMAIN]
-    connect_box = ConnectBox(conf[CONF_HOST], conf[CONF_PASSWORD])
+    url = "http://" + conf[CONF_HOST]
+    connect_box = ConnectBox(url, conf[CONF_PASSWORD])
     return ArrisDeviceScanner(connect_box)
 
 
 class ArrisDeviceScanner(DeviceScanner):
     """This class queries a Arris TG2492LG router for connected devices."""
 
-    def __init__(self, connect_box):
+    def __init__(self, connect_box: ConnectBox):
         """Initialize the scanner."""
-        self.connect_box: ConnectBox = connect_box
+        self.connect_box = connect_box
         self.last_results: List[Device] = []
 
     def scan_devices(self):

--- a/homeassistant/components/arris_tg2492lg/device_tracker.py
+++ b/homeassistant/components/arris_tg2492lg/device_tracker.py
@@ -1,0 +1,62 @@
+"""Support for Arris TG2492LG router."""
+import logging
+
+from arris_tg2492lg import ConnectBox
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    DeviceScanner,
+)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_IP = "http://192.168.178.1"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string,
+    }
+)
+
+
+def get_scanner(hass, config):
+    """Return the Arris device scanner."""
+    conf = config[DOMAIN]
+    connect_box = ConnectBox(conf[CONF_HOST], conf[CONF_PASSWORD])
+    return ArrisDeviceScanner(connect_box)
+
+
+class ArrisDeviceScanner(DeviceScanner):
+    """This class queries a Arrus TG2492LG router for connected devices."""
+
+    def __init__(self, connect_box):
+        """Initialize the scanner."""
+        self.connect_box: ConnectBox = connect_box
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        devices = self.connect_box.get_connected_devices()
+
+        def filter_online(device):
+            return device.online is True
+
+        def map_mac_address(device):
+            return device.mac
+
+        # filter online devices
+        online_devices = list(filter(filter_online, devices))
+
+        # show only mac address
+        mac_addresses = list(map(map_mac_address, online_devices))
+
+        # remove duplicates as some devices are returned with ipv4 and ipv6
+        return list(set(mac_addresses))
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        return None

--- a/homeassistant/components/arris_tg2492lg/device_tracker.py
+++ b/homeassistant/components/arris_tg2492lg/device_tracker.py
@@ -49,19 +49,17 @@ class ArrisDeviceScanner(DeviceScanner):
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        filter_named = [
-            result.hostname for result in self.last_results if result.mac == device
-        ]
-
-        if filter_named:
-            return filter_named[0]
-        return None
+        name = next(
+            (
+                result.hostname for result in self.last_results
+                if result.mac == device
+            ),
+            None
+        )
+        return name
 
     def _update_info(self):
-        """Ensure the information from the Arris TG2492LG router is up to date.
-
-        Return boolean if scanning successful.
-        """
+        """Ensure the information from the Arris TG2492LG router is up to date."""
         result = self.connect_box.get_connected_devices()
 
         last_results = []

--- a/homeassistant/components/arris_tg2492lg/device_tracker.py
+++ b/homeassistant/components/arris_tg2492lg/device_tracker.py
@@ -50,11 +50,8 @@ class ArrisDeviceScanner(DeviceScanner):
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         name = next(
-            (
-                result.hostname for result in self.last_results
-                if result.mac == device
-            ),
-            None
+            (result.hostname for result in self.last_results if result.mac == device),
+            None,
         )
         return name
 

--- a/homeassistant/components/arris_tg2492lg/manifest.json
+++ b/homeassistant/components/arris_tg2492lg/manifest.json
@@ -3,7 +3,7 @@
   "name": "Arris TG2492LG",
   "documentation": "https://www.home-assistant.io/integrations/arris_tg2492lg",
   "requirements": [
-    "arris-tg2492lg==0.1.0"
+    "arris-tg2492lg==1.0.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/arris_tg2492lg/manifest.json
+++ b/homeassistant/components/arris_tg2492lg/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "arris_tg2492lg",
+  "name": "Arris TG2492LG",
+  "documentation": "https://www.home-assistant.io/integrations/arris_tg2492lg",
+  "requirements": [
+    "arris-tg2492lg==0.1.0"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@vanbalken"
+  ]
+}

--- a/homeassistant/components/arris_tg2492lg/manifest.json
+++ b/homeassistant/components/arris_tg2492lg/manifest.json
@@ -5,7 +5,6 @@
   "requirements": [
     "arris-tg2492lg==1.0.0"
   ],
-  "dependencies": [],
   "codeowners": [
     "@vanbalken"
   ]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -254,7 +254,7 @@ aqualogic==1.0
 arcam-fmj==0.4.3
 
 # homeassistant.components.arris_tg2492lg
-arris-tg2492lg==0.1.0
+arris-tg2492lg==1.0.0
 
 # homeassistant.components.ampio
 asmog==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -253,6 +253,9 @@ aqualogic==1.0
 # homeassistant.components.arcam_fmj
 arcam-fmj==0.4.3
 
+# homeassistant.components.arris_tg2492lg
+arris-tg2492lg==0.1.0
+
 # homeassistant.components.ampio
 asmog==0.0.6
 


### PR DESCRIPTION
## Description:

This pull requests adds support for tracking devices using the Arris TG2492LG router. This is one of the routers provided by [Ziggo](https://www.ziggo.nl/), a cable operator in the Netherlands, to their customers as the Ziggo Connectbox.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#11807

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml entry
device_tracker:
  - platform: arris_tg2492lg
    host: YOUR_ROUTER_IP
    password: YOUR_ADMIN_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
