### PR TITLE
Update emulated_roku to 0.2.0

### DIFF
--- a/homeassistant/components/emulated_roku/manifest.json
+++ b/homeassistant/components/emulated_roku/manifest.json
@@ -3,7 +3,7 @@
   "name": "Emulated Roku",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/emulated_roku",
-  "requirements": ["emulated_roku==0.1.9"],
+  "requirements": ["emulated_roku==0.2.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -474,7 +474,7 @@ eliqonline==1.2.2
 elkm1-lib==0.7.15
 
 # homeassistant.components.emulated_roku
-emulated_roku==0.1.9
+emulated_roku==0.2.0
 
 # homeassistant.components.enocean
 enocean==0.50

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -171,7 +171,7 @@ eebrightbox==0.0.4
 elgato==0.2.0
 
 # homeassistant.components.emulated_roku
-emulated_roku==0.1.9
+emulated_roku==0.2.0
 
 # homeassistant.components.season
 ephem==3.7.7.0


### PR DESCRIPTION
## Description:

Implement emulated_roku 0.2.0, which fixes the issue with the UDP port.

Upstream issue: https://gitlab.com/mindig.marton/emulated_roku/issues/3

**Related issue (if applicable)**: #30779, #30907

Caveat: the previous version, 0.1.9, also worked for me on my intel device.

```2020-01-19 17:02:08 INFO (SyncWorker_3) [homeassistant.util.package] Attempting install of emulated_roku==0.2.0
2020-01-19 17:02:15 INFO (MainThread) [homeassistant.setup] Setting up emulated_roku
2020-01-19 17:02:15 INFO (MainThread) [homeassistant.setup] Setup of domain emulated_roku took 0.0 seconds.
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
