### PR TITLE
Fix options update during import config flow step for vizio component (Bugfix for #30653)

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -111,7 +111,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if await self.async_set_unique_id(
                     unique_id=unique_id, raise_on_progress=True
                 ):
-                    return self.async_abort(reason="already_setup")
+                    return self.async_abort(
+                        reason="already_setup_with_diff_host_and_name"
+                    )
 
                 return self.async_create_entry(
                     title=user_input[CONF_NAME], data=user_input

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -128,16 +128,19 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if entry.data[CONF_HOST] == import_config[CONF_HOST] and entry.data[
                 CONF_NAME
             ] == import_config.get(CONF_NAME):
-                new_options = {}
+                updated_options = {}
 
                 if entry.data[CONF_VOLUME_STEP] != import_config[CONF_VOLUME_STEP]:
-                    new_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
+                    updated_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
 
-                if new_options:
+                if updated_options:
+                    new_data = entry.data.copy()
+                    new_data.update(updated_options)
+                    new_options = entry.options.copy()
+                    new_options.update(updated_options)
+
                     self.hass.config_entries.async_update_entry(
-                        entry=entry,
-                        data=entry.data.copy().update(new_options),
-                        options=entry.options.copy().update(new_options),
+                        entry=entry, data=new_data, options=new_options,
                     )
                     return self.async_abort(reason="updated_options")
 

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -13,16 +13,14 @@
             }
         },
         "error": {
-            "host_exists": "Host already configured.",
-            "name_exists": "Name already configured.",
+            "host_exists": "Vizio device with specified host already configured.",
+            "name_exists": "Vizio device with specified name already configured.",
             "cant_connect": "Could not connect to the device. [Review the docs](https://www.home-assistant.io/integrations/vizio/) and re-verify that:\n- The device is powered on\n- The device is connected to the network\n- The values you filled in are accurate\nbefore attempting to resubmit.",
             "tv_needs_token": "When Device Type is `tv` then a valid Access Token is needed."
         },
         "abort": {
-            "already_in_progress": "Config flow for vizio component already in progress.",
             "already_setup": "This entry has already been setup.",
-            "host_exists": "Vizio component with host already configured.",
-            "name_exists": "Vizio component with name already configured.",
+            "already_setup_with_diff_host_and_name": "This entry appears to have already been setup with a different host and name based on its serial number. Please remove any old entries from your configuration.yaml and from the Integrations menu before reattempting to add this device.",
             "updated_options": "This entry has already been setup but the options defined in the config do not match the previously imported options values so the config entry has been updated accordingly."
         }
     },

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -89,10 +89,7 @@ def vizio_bypass_update_fixture():
     with patch(
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
         return_value=True,
-    ), patch(
-        "homeassistant.components.vizio.media_player.VizioDevice.async_update",
-        return_value=None,
-    ):
+    ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
         yield
 
 
@@ -369,6 +366,8 @@ async def test_import_flow_update_options(
         context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
     )
+    await hass.async_block_till_done()
+    assert result["result"].options == {CONF_VOLUME_STEP: VOLUME_STEP}
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     entry_id = result["result"].entry_id
 

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -340,6 +340,26 @@ async def test_import_flow_all_fields(
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
 
 
+async def test_import_entity_already_configured(
+    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+) -> None:
+    """Test entity is already configured during import setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
+    )
+    entry.add_to_hass(hass)
+    fail_entry = vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG.copy())
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "import"}, data=fail_entry
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_setup"
+
+
 async def test_import_flow_update_options(
     hass: HomeAssistantType, vizio_connect, vizio_bypass_update
 ) -> None:

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
-from tests.common import MockConfigEntry, mock_coro_func
+from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ def vizio_bypass_update_fixture():
         return_value=True,
     ), patch(
         "homeassistant.components.vizio.media_player.VizioDevice.async_update",
-        return_value=mock_coro_func(return_value=None),
+        return_value=None,
     ):
         yield
 

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -257,13 +257,7 @@ async def test_user_esn_already_exists(
     fail_entry[CONF_NAME] = NAME2
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], fail_entry
+        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
## Description:
#30653 added config flow support, and per the review, I added support to update options values during import if they had changed since the last import. As part of trying to add zeroconf discovery in #30949, I realized I didn't actually test for this change , so I added a test and realized it was broken. This PR fixes the update options logic and adds the corresponding tests.

NOTE: This should get merged to master along with #30653 

**Related issue (if applicable):** fixes issue in #30653 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
