### PR TITLE
Use config_entry.unique_id in iCloud

### DIFF
--- a/homeassistant/components/icloud/.translations/en.json
+++ b/homeassistant/components/icloud/.translations/en.json
@@ -1,12 +1,11 @@
 {
     "config": {
         "abort": {
-            "username_exists": "Account already configured"
+            "already_configured": "Account already configured"
         },
         "error": {
             "login": "Login error: please check your email & password",
             "send_verification_code": "Failed to send verification code",
-            "username_exists": "Account already configured",
             "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again"
         },
         "step": {

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -141,6 +141,10 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     max_interval = entry.data[CONF_MAX_INTERVAL]
     gps_accuracy_threshold = entry.data[CONF_GPS_ACCURACY_THRESHOLD]
 
+    # For backwards compat
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(entry, unique_id=username)
+
     icloud_dir = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
 
     account = IcloudAccount(

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -43,8 +43,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._trusted_device = None
         self._verification_code = None
 
-        self.context = {}
-
     async def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
 

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -45,13 +45,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.context = {}
 
-    def _configuration_exists(self, username: str) -> bool:
-        """Return True if username exists in configuration."""
-        for entry in self._async_current_entries():
-            if entry.data[CONF_USERNAME] == username:
-                return True
-        return False
-
     async def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
 
@@ -121,9 +114,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, user_input):
         """Import a config entry."""
-        if self._configuration_exists(user_input[CONF_USERNAME]):
-            return self.async_abort(reason="already_configured")
-
         return await self.async_step_user(user_input)
 
     async def async_step_trusted_device(self, user_input=None, errors=None):

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -84,8 +84,9 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         # Check if already configured
-        await self.async_set_unique_id(self._username)
-        self._abort_if_unique_id_configured()
+        if self.unique_id is None:
+            await self.async_set_unique_id(self._username)
+            self._abort_if_unique_id_configured()
 
         try:
             self.api = await self.hass.async_add_executor_job(

--- a/homeassistant/components/icloud/strings.json
+++ b/homeassistant/components/icloud/strings.json
@@ -26,13 +26,12 @@
             }
         },
         "error": {
-            "username_exists": "Account already configured",
             "login": "Login error: please check your email & password",
             "send_verification_code": "Failed to send verification code",
             "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again"
         },
         "abort": {
-            "username_exists": "Account already configured"
+            "already_configured": "Account already configured"
         }
     }
 }

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -324,9 +324,10 @@ async def test_verification_code_success(hass: HomeAssistantType, service: Magic
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_TRUSTED_DEVICE: 0}
     )
+    service.return_value.requires_2fa = False
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_VERIFICATION_CODE: 0}
+        result["flow_id"], {CONF_VERIFICATION_CODE: "0"}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == USERNAME
@@ -351,7 +352,7 @@ async def test_validate_verification_code_failed(
     )
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_VERIFICATION_CODE: 0}
+        result["flow_id"], {CONF_VERIFICATION_CODE: "0"}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == CONF_TRUSTED_DEVICE

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -329,6 +329,7 @@ async def test_verification_code_success(hass: HomeAssistantType, service: Magic
         result["flow_id"], {CONF_VERIFICATION_CODE: 0}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == USERNAME
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Use config_entry.unique_id in iCloud

Related to this comment : https://github.com/home-assistant/home-assistant/pull/30898#discussion_r367983703

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html