### PR TITLE
Add Salt Fiber Box device tracker

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -603,6 +603,7 @@ omit =
     homeassistant/components/russound_rnet/media_player.py
     homeassistant/components/sabnzbd/*
     homeassistant/components/saj/sensor.py
+    homeassistant/components/salt/device_tracker.py
     homeassistant/components/satel_integra/*
     homeassistant/components/scrape/sensor.py
     homeassistant/components/scsgate/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -280,6 +280,7 @@ homeassistant/components/rmvtransport/* @cgtobi
 homeassistant/components/roomba/* @pschmitt
 homeassistant/components/safe_mode/* @home-assistant/core
 homeassistant/components/saj/* @fredericvl
+homeassistant/components/salt/* @bjornorri
 homeassistant/components/samsungtv/* @escoand
 homeassistant/components/scene/* @home-assistant/core
 homeassistant/components/scrape/* @fabaff

--- a/homeassistant/components/salt/__init__.py
+++ b/homeassistant/components/salt/__init__.py
@@ -1,0 +1,1 @@
+"""The salt component."""

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -1,0 +1,83 @@
+"""Support for Salt Fiber Box routers."""
+import logging
+
+from saltbox import SaltBox
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    DeviceScanner,
+)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_IP = "192.168.1.1"
+DEFAULT_USERNAME = "admin"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string,
+        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    }
+)
+
+
+def get_scanner(hass, config):
+    """Return the Salt device scanner."""
+    scanner = SaltDeviceScanner(config[DOMAIN])
+    return scanner if scanner.success_init else None
+
+
+class SaltDeviceScanner(DeviceScanner):
+    """This class queries a Salt Fiber Box router."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        host = config[CONF_HOST]
+        username = config[CONF_USERNAME]
+        password = config[CONF_PASSWORD]
+        self.saltbox = SaltBox(f"http://{host}", username, password)
+        self.online_clients = []
+
+        # Test the router is accessible.
+        data = self.get_salt_data()
+        self.success_init = data is not None
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+        return [client["mac"] for client in self.online_clients]
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        if not self.online_clients:
+            return None
+        for client in self.online_clients:
+            if client["mac"] == device:
+                return client["name"]
+        return None
+
+    def _update_info(self):
+        """Pull the current information from the Salt router."""
+        if not self.success_init:
+            return False
+
+        _LOGGER.info("Loading data from Salt Fiber Box")
+        data = self.get_salt_data()
+        if not data:
+            return False
+
+        self.online_clients = data
+        return True
+
+    def get_salt_data(self):
+        """Retrieve data from Salt router and return parsed result."""
+        try:
+            return self.saltbox.get_online_clients()
+        except:  # noqa: E722  # pylint: disable=bare-except
+            _LOGGER.info("Could not get data from Salt Fiber Box")
+        return self.online_clients

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -60,7 +60,8 @@ class SaltDeviceScanner(DeviceScanner):
     def get_salt_data(self):
         """Retrieve data from Salt router and return parsed result."""
         try:
-            return self.saltbox.get_online_clients()
+            clients = self.saltbox.get_online_clients()
+            return clients if clients is not None else []
         except (RouterLoginException, RouterNotReachableException) as error:
             _LOGGER.warning(error)
             return []

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -68,4 +68,4 @@ class SaltDeviceScanner(DeviceScanner):
         """Pull the current information from the Salt router."""
         _LOGGER.debug("Loading data from Salt Fiber Box")
         data = self.get_salt_data()
-        self.online_clients = data if data else []
+        self.online_clients = data or []

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -29,8 +29,7 @@ def get_scanner(hass, config):
 
     # Test whether the router is accessible.
     data = scanner.get_salt_data()
-    return scanner if data is not None else None
-
+    return scanner if data else None
 
 class SaltDeviceScanner(DeviceScanner):
     """This class queries a Salt Fiber Box router."""
@@ -61,7 +60,7 @@ class SaltDeviceScanner(DeviceScanner):
         """Retrieve data from Salt router and return parsed result."""
         try:
             clients = self.saltbox.get_online_clients()
-            return clients if clients is not None else []
+            return clients if clients else []
         except (RouterLoginException, RouterNotReachableException) as error:
             _LOGGER.warning(error)
             return []

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -1,8 +1,7 @@
 """Support for Salt Fiber Box routers."""
 import logging
 
-from saltbox import SaltBox
-from saltbox import RouterLoginException, RouterNotReachableException
+from saltbox import RouterLoginException, RouterNotReachableException, SaltBox
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -62,8 +61,8 @@ class SaltDeviceScanner(DeviceScanner):
         """Retrieve data from Salt router and return parsed result."""
         try:
             return self.saltbox.get_online_clients()
-        except (RouterLoginException, RouterNotReachableException) as e:
-            _LOGGER.warning(e)
+        except (RouterLoginException, RouterNotReachableException) as error:
+            _LOGGER.warning(error)
             return []
 
     def _update_info(self):

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -79,5 +79,5 @@ class SaltDeviceScanner(DeviceScanner):
         try:
             return self.saltbox.get_online_clients()
         except:  # noqa: E722  # pylint: disable=bare-except
-            _LOGGER.info("Could not get data from Salt Fiber Box")
+            _LOGGER.warning("Could not get data from Salt Fiber Box")
         return self.online_clients

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -29,7 +29,7 @@ def get_scanner(hass, config):
 
     # Test whether the router is accessible.
     data = scanner.get_salt_data()
-    return scanner if data else None
+    return scanner if data is not None else None
 
 
 class SaltDeviceScanner(DeviceScanner):
@@ -59,12 +59,13 @@ class SaltDeviceScanner(DeviceScanner):
         """Retrieve data from Salt router and return parsed result."""
         try:
             clients = self.saltbox.get_online_clients()
-            return clients if clients else []
+            return clients
         except (RouterLoginException, RouterNotReachableException) as error:
             _LOGGER.warning(error)
-            return []
+            return None
 
     def _update_info(self):
         """Pull the current information from the Salt router."""
         _LOGGER.debug("Loading data from Salt Fiber Box")
-        self.online_clients = self.get_salt_data()
+        data = self.get_salt_data()
+        self.online_clients = data if data else []

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -14,13 +14,10 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_IP = "192.168.1.1"
-DEFAULT_USERNAME = "admin"
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string,
-        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
     }
 )

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -68,5 +68,5 @@ class SaltDeviceScanner(DeviceScanner):
 
     def _update_info(self):
         """Pull the current information from the Salt router."""
-        _LOGGER.info("Loading data from Salt Fiber Box")
+        _LOGGER.debug("Loading data from Salt Fiber Box")
         self.online_clients = self.get_salt_data()

--- a/homeassistant/components/salt/device_tracker.py
+++ b/homeassistant/components/salt/device_tracker.py
@@ -31,6 +31,7 @@ def get_scanner(hass, config):
     data = scanner.get_salt_data()
     return scanner if data else None
 
+
 class SaltDeviceScanner(DeviceScanner):
     """This class queries a Salt Fiber Box router."""
 
@@ -49,8 +50,6 @@ class SaltDeviceScanner(DeviceScanner):
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
-        if not self.online_clients:
-            return None
         for client in self.online_clients:
             if client["mac"] == device:
                 return client["name"]

--- a/homeassistant/components/salt/manifest.json
+++ b/homeassistant/components/salt/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "salt",
+  "name": "Salt Fiber Box",
+  "documentation": "https://www.home-assistant.io/integrations/salt",
+  "requirements": ["saltbox==0.1.2"],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": ["@bjornorri"]
+}

--- a/homeassistant/components/salt/manifest.json
+++ b/homeassistant/components/salt/manifest.json
@@ -2,7 +2,7 @@
   "domain": "salt",
   "name": "Salt Fiber Box",
   "documentation": "https://www.home-assistant.io/integrations/salt",
-  "requirements": ["saltbox==0.1.2"],
+  "requirements": ["saltbox==0.1.3"],
   "dependencies": [],
   "codeowners": ["@bjornorri"]
 }

--- a/homeassistant/components/salt/manifest.json
+++ b/homeassistant/components/salt/manifest.json
@@ -1,8 +1,8 @@
 {
-  "domain": "salt",
-  "name": "Salt Fiber Box",
-  "documentation": "https://www.home-assistant.io/integrations/salt",
-  "requirements": ["saltbox==0.1.3"],
-  "dependencies": [],
-  "codeowners": ["@bjornorri"]
+    "domain": "salt",
+    "name": "Salt Fiber Box",
+    "documentation": "https://www.home-assistant.io/integrations/salt",
+    "requirements": ["saltbox==0.1.3"],
+    "dependencies": [],
+    "codeowners": ["@bjornorri"]
 }

--- a/homeassistant/components/salt/manifest.json
+++ b/homeassistant/components/salt/manifest.json
@@ -3,9 +3,6 @@
   "name": "Salt Fiber Box",
   "documentation": "https://www.home-assistant.io/integrations/salt",
   "requirements": ["saltbox==0.1.2"],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
   "dependencies": [],
   "codeowners": ["@bjornorri"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1779,6 +1779,9 @@ russound_rio==0.1.7
 # homeassistant.components.yamaha
 rxv==0.6.0
 
+# homeassistant.components.salt
+saltbox==0.1.2
+
 # homeassistant.components.samsungtv
 samsungctl[websocket]==0.7.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1780,7 +1780,7 @@ russound_rio==0.1.7
 rxv==0.6.0
 
 # homeassistant.components.salt
-saltbox==0.1.2
+saltbox==0.1.3
 
 # homeassistant.components.samsungtv
 samsungctl[websocket]==0.7.1


### PR DESCRIPTION
## Description:
Implements a device_tracker platform for the [Salt Fiber Box](https://fiber.salt.ch/en/fiber/equipment/fiber-box). Salt is a Swiss internet provider.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11811

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: salt
    password: YOUR_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
