### PR TITLE
Fix capability_attributes when supported_features is None

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -785,7 +785,7 @@ class MediaPlayerDevice(Entity):
     @property
     def capability_attributes(self):
         """Return capabilitiy attributes."""
-        supported_features = self.supported_features
+        supported_features = self.supported_features or 0
         data = {}
 
         if supported_features & SUPPORT_SELECT_SOURCE:

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -146,7 +146,7 @@ class WaterHeaterDevice(Entity):
     @property
     def capability_attributes(self):
         """Return capabilitiy attributes."""
-        supported_features = self.supported_features
+        supported_features = self.supported_features or 0
 
         data = {
             ATTR_MIN_TEMP: show_temp(


### PR DESCRIPTION
## Description:

If the `supported_features` property is `None`, then `supported_features & SUPPORT_*` will cause an exception.  This fixes that issue.  

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/30883

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
