### PR TITLE
Allow filtering of sources for Android TV

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -132,7 +132,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ADB_SERVER_IP): cv.string,
         vol.Optional(CONF_ADB_SERVER_PORT, default=DEFAULT_ADB_SERVER_PORT): cv.port,
         vol.Optional(CONF_GET_SOURCES, default=DEFAULT_GET_SOURCES): cv.boolean,
-        vol.Optional(CONF_APPS, default=dict()): vol.Schema({cv.string: cv.string}),
+        vol.Optional(CONF_APPS, default=dict()): vol.Schema(
+            {cv.string: vol.Any(cv.string, None)}
+        ),
         vol.Optional(CONF_TURN_ON_COMMAND): cv.string,
         vol.Optional(CONF_TURN_OFF_COMMAND): cv.string,
         vol.Optional(CONF_STATE_DETECTION_RULES, default={}): vol.Schema(

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -373,7 +373,7 @@ class ADBDevice(MediaPlayerDevice):
         self._app_id_to_name = APPS.copy()
         self._app_id_to_name.update(apps)
         self._app_name_to_id = {
-            value: key for key, value in self._app_id_to_name.items()
+            value: key for key, value in self._app_id_to_name.items() if value
         }
         self._get_sources = get_sources
         self._keys = KEYS
@@ -600,9 +600,10 @@ class AndroidTVDevice(ADBDevice):
             self._available = False
 
         if running_apps:
-            self._sources = [
+            sources = [
                 self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
             ]
+            self._sources = [source for source in sources if source]
         else:
             self._sources = None
 
@@ -670,9 +671,10 @@ class FireTVDevice(ADBDevice):
             self._available = False
 
         if running_apps:
-            self._sources = [
+            sources = [
                 self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
             ]
+            self._sources = [source for source in sources if source]
         else:
             self._sources = None
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -80,6 +80,7 @@ CONF_ADBKEY = "adbkey"
 CONF_ADB_SERVER_IP = "adb_server_ip"
 CONF_ADB_SERVER_PORT = "adb_server_port"
 CONF_APPS = "apps"
+CONF_EXCLUDE_UNNAMED_APPS = "exclude_unnamed_apps"
 CONF_GET_SOURCES = "get_sources"
 CONF_STATE_DETECTION_RULES = "state_detection_rules"
 CONF_TURN_ON_COMMAND = "turn_on_command"
@@ -140,6 +141,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_STATE_DETECTION_RULES, default={}): vol.Schema(
             {cv.string: ha_state_detection_rules_validator(vol.Invalid)}
         ),
+        vol.Optional(CONF_EXCLUDE_UNNAMED_APPS, default=False): cv.boolean,
     }
 )
 
@@ -232,6 +234,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         config[CONF_GET_SOURCES],
         config.get(CONF_TURN_ON_COMMAND),
         config.get(CONF_TURN_OFF_COMMAND),
+        config[CONF_EXCLUDE_UNNAMED_APPS],
     ]
 
     if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
@@ -367,7 +370,14 @@ class ADBDevice(MediaPlayerDevice):
     """Representation of an Android TV or Fire TV device."""
 
     def __init__(
-        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+        self,
+        aftv,
+        name,
+        apps,
+        get_sources,
+        turn_on_command,
+        turn_off_command,
+        exclude_unnamed_apps,
     ):
         """Initialize the Android TV / Fire TV device."""
         self.aftv = aftv
@@ -385,6 +395,8 @@ class ADBDevice(MediaPlayerDevice):
 
         self.turn_on_command = turn_on_command
         self.turn_off_command = turn_off_command
+
+        self._exclude_unnamed_apps = exclude_unnamed_apps
 
         # ADB exceptions to catch
         if not self.aftv.adb_server_ip:
@@ -560,11 +572,24 @@ class AndroidTVDevice(ADBDevice):
     """Representation of an Android TV device."""
 
     def __init__(
-        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+        self,
+        aftv,
+        name,
+        apps,
+        get_sources,
+        turn_on_command,
+        turn_off_command,
+        exclude_unnamed_apps,
     ):
         """Initialize the Android TV device."""
         super().__init__(
-            aftv, name, apps, get_sources, turn_on_command, turn_off_command
+            aftv,
+            name,
+            apps,
+            get_sources,
+            turn_on_command,
+            turn_off_command,
+            exclude_unnamed_apps,
         )
 
         self._is_volume_muted = None
@@ -603,7 +628,10 @@ class AndroidTVDevice(ADBDevice):
 
         if running_apps:
             sources = [
-                self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
+                self._app_id_to_name.get(
+                    app_id, app_id if not self._exclude_unnamed_apps else None
+                )
+                for app_id in running_apps
             ]
             self._sources = [source for source in sources if source]
         else:
@@ -674,7 +702,10 @@ class FireTVDevice(ADBDevice):
 
         if running_apps:
             sources = [
-                self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
+                self._app_id_to_name.get(
+                    app_id, app_id if not self._exclude_unnamed_apps else None
+                )
+                for app_id in running_apps
             ]
             self._sources = [source for source in sources if source]
         else:

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -299,7 +299,11 @@ async def test_setup_with_adbkey(hass):
 async def _test_sources(hass, config0):
     """Test that sources (i.e., apps) are handled correctly for Android TV and Fire TV devices."""
     config = config0.copy()
-    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1", "com.app.test3": ""}
+    config[DOMAIN][CONF_APPS] = {
+        "com.app.test1": "TEST 1",
+        "com.app.test3": None,
+        "com.app.test4": "",
+    }
     patch_key, entity_id = _setup(config)
 
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
@@ -315,7 +319,7 @@ async def _test_sources(hass, config0):
         patch_update = patchers.patch_androidtv_update(
             "playing",
             "com.app.test1",
-            ["com.app.test1", "com.app.test2", "com.app.test3"],
+            ["com.app.test1", "com.app.test2", "com.app.test3", "com.app.test4"],
             "hdmi",
             False,
             1,
@@ -324,7 +328,7 @@ async def _test_sources(hass, config0):
         patch_update = patchers.patch_firetv_update(
             "playing",
             "com.app.test1",
-            ["com.app.test1", "com.app.test2", "com.app.test3"],
+            ["com.app.test1", "com.app.test2", "com.app.test3", "com.app.test4"],
         )
 
     with patch_update:
@@ -339,7 +343,7 @@ async def _test_sources(hass, config0):
         patch_update = patchers.patch_androidtv_update(
             "playing",
             "com.app.test2",
-            ["com.app.test2", "com.app.test1", "com.app.test3"],
+            ["com.app.test2", "com.app.test1", "com.app.test3", "com.app.test4"],
             "hdmi",
             True,
             0,
@@ -348,7 +352,7 @@ async def _test_sources(hass, config0):
         patch_update = patchers.patch_firetv_update(
             "playing",
             "com.app.test2",
-            ["com.app.test2", "com.app.test1", "com.app.test3"],
+            ["com.app.test2", "com.app.test1", "com.app.test3", "com.app.test4"],
         )
 
     with patch_update:
@@ -375,7 +379,7 @@ async def test_firetv_sources(hass):
 async def _test_select_source(hass, config0, source, expected_arg, method_patch):
     """Test that the methods for launching and stopping apps are called correctly when selecting a source."""
     config = config0.copy()
-    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
+    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1", "com.app.test3": None}
     patch_key, entity_id = _setup(config)
 
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
@@ -432,6 +436,17 @@ async def test_androidtv_select_source_launch_app_id_no_name(hass):
     )
 
 
+async def test_androidtv_select_source_launch_app_hidden(hass):
+    """Test that an app can be launched using its app ID when it is hidden from the sources list."""
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "com.app.test3",
+        "com.app.test3",
+        patchers.PATCH_LAUNCH_APP,
+    )
+
+
 async def test_androidtv_select_source_stop_app_id(hass):
     """Test that an app can be stopped using its app ID."""
     assert await _test_select_source(
@@ -461,6 +476,17 @@ async def test_androidtv_select_source_stop_app_id_no_name(hass):
         CONFIG_ANDROIDTV_ADB_SERVER,
         "!com.app.test2",
         "com.app.test2",
+        patchers.PATCH_STOP_APP,
+    )
+
+
+async def test_androidtv_select_source_stop_app_hidden(hass):
+    """Test that an app can be stopped using its app ID when it is hidden from the sources list."""
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "!com.app.test3",
+        "com.app.test3",
         patchers.PATCH_STOP_APP,
     )
 
@@ -498,6 +524,17 @@ async def test_firetv_select_source_launch_app_id_no_name(hass):
     )
 
 
+async def test_firetv_select_source_launch_app_hidden(hass):
+    """Test that an app can be launched using its app ID when it is hidden from the sources list."""
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "com.app.test3",
+        "com.app.test3",
+        patchers.PATCH_LAUNCH_APP,
+    )
+
+
 async def test_firetv_select_source_stop_app_id(hass):
     """Test that an app can be stopped using its app ID."""
     assert await _test_select_source(
@@ -527,6 +564,17 @@ async def test_firetv_select_source_stop_app_id_no_name(hass):
         CONFIG_FIRETV_ADB_SERVER,
         "!com.app.test2",
         "com.app.test2",
+        patchers.PATCH_STOP_APP,
+    )
+
+
+async def test_firetv_select_source_stop_hidden(hass):
+    """Test that an app can be stopped using its app ID when it is hidden from the sources list."""
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "!com.app.test3",
+        "com.app.test3",
         patchers.PATCH_STOP_APP,
     )
 


### PR DESCRIPTION
## Description:

If you don't want an app to show up in your sources list, you can leave its friendly name empty or give it an empty string as its friendly name in the `apps` configuration entry. You can also set `exclude_unnamed_apps: true` so that all apps that do not have a friendly name provided by you or provided by default in the [backend library](https://github.com/JeffLIrion/python-androidtv/blob/5c39196ade3f88ab453b205fd15b32472d3e0482/androidtv/constants.py#L267-L283) will not be shown in the sources list. 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11816

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: androidtv
    host: 192.168.0.111
    apps:
      com.amazon.tv.launcher: "Fire TV"
      some.background.app:   # this will never show up in the sources list
      another.background_app:  # this will also never show up in the sources list

  - platform: androidtv
    host: 192.168.0.222
    exclude_unnamed_apps: true
    apps:
      com.amazon.tv.launcher: "Fire TV"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
