### PR TITLE
Add support for loading zabbix items as sensors

### DIFF
--- a/homeassistant/components/zabbix/sensor.py
+++ b/homeassistant/components/zabbix/sensor.py
@@ -82,9 +82,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if item_conf:
         for item in item_conf:
             name = item.get(CONF_NAME)
-            id = item.get(CONF_ID)
-            _LOGGER.debug("Creating Zabbix Item %s for ID %s", name, id)
-            sensors.append(ZabbixItemSensor(zapi, id, name))
+            itemid = item.get(CONF_ID)
+            _LOGGER.debug("Creating Zabbix Item %s for ID %s", name, itemid)
+            sensors.append(ZabbixItemSensor(zapi, itemid, name))
 
     # Single sensor that provides the total count of triggers.
     _LOGGER.debug("Creating Zabbix Sensor")
@@ -184,14 +184,14 @@ class ZabbixMultipleHostTriggerCountSensor(ZabbixTriggerCountSensor):
 class ZabbixItemSensor(Entity):
     """Get the latest value for a single item."""
 
-    def __init__(self, zApi, id, name=None):
+    def __init__(self, zApi, itemid, name=None):
         """Initialize Zabbix sensor."""
-        self._id = id
+        self._id = itemid
         self._name = name
         self._zapi = zApi
         self._state = None
         self._unit = None
-        self._attributes = {CONF_ID: id}
+        self._attributes = {CONF_ID: itemid}
 
         item_data = self._zapi.item.get(
             itemids=self._id, output=["name", "units", "lastvalue"]


### PR DESCRIPTION
## Description:

Add support for loading Zabbix items as sensors.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#11820

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: zabbix
    items:
      - id: 12345
        name: "Disk space on server"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
