### PR TITLE
Handle ghost zones gracefully 

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
-    HTTP_BAD_REQUEST,
     HTTP_SERVICE_UNAVAILABLE,
     HTTP_TOO_MANY_REQUESTS,
     TEMP_CELSIUS,
@@ -623,9 +622,7 @@ class EvoChild(EvoDevice):
         Only Zones & DHW controllers (but not the TCS) can have schedules.
         """
         if not self._schedule["DailySchedules"]:
-            # {'DailySchedules': []}, no scheduled setpoints
-            # {'DailySchedules': False}, unable to retreive setpoints
-            return {}
+            return {}  # no schedule {'DailySchedules': []}, so no scheduled setpoints
 
         day_time = dt_util.now()
         day_of_week = int(day_time.strftime("%w"))  # 0 is Sunday
@@ -673,30 +670,13 @@ class EvoChild(EvoDevice):
 
     async def _update_schedule(self) -> None:
         """Get the latest schedule, if any."""
-        if "DailySchedules" in self._schedule:
-            # can we avoid unnecessary I/O?
-            if self._schedule["DailySchedules"] is False:
-                return  # no valid schedule
-            if self._evo_device.setpointStatus["setpointMode"] != EVO_FOLLOW:
-                return  # there's no need to update
+        if "DailySchedules" in self._schedule and not self._schedule["DailySchedules"]:
+            if not self._evo_device.setpointStatus["setpointMode"] == EVO_FOLLOW:
+                return  # avoid unnecessary I/O - there's nothing to update
 
-        try:
-            self._schedule = await self._evo_broker.call_client_api(
-                self._evo_device.schedule(), refresh=False
-            )
-
-        except aiohttp.ClientResponseError as err:
-            if err.status == HTTP_BAD_REQUEST:
-                _LOGGER.warning(
-                    "Error when requesting schedule data for zone %s (%s). "
-                    "Is it a'ghost' zone? Check its configuration and restart HA.",
-                    self._unique_id,
-                    self._name,
-                )
-                # from now on, stop trying to get schedule for this zone
-                self._schedule = {"DailySchedules": False}
-
-            raise  # we don't expect/handle any other Exceptions
+        self._schedule = await self._evo_broker.call_client_api(
+            self._evo_device.schedule(), refresh=False
+        )
 
         _LOGGER.debug("Schedule['%s'] = %s", self.name, self._schedule)
 
@@ -704,7 +684,6 @@ class EvoChild(EvoDevice):
         """Get the latest state data."""
         next_sp_from = self._setpoints.get("next_sp_from", "2000-01-01T00:00:00+00:00")
         if dt_util.now() >= dt_util.parse_datetime(next_sp_from):
-            # no schedule, or it's out-of-date
-            await self._update_schedule()
+            await self._update_schedule()  # no schedule, or it's out-of-date
 
         self._device_state_attrs = {"setpoints": self.setpoints}

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -96,7 +96,7 @@ async def async_setup_platform(
     controller = EvoController(broker, broker.tcs)
 
     zones = []
-    for zone in broker.tcs.zones.values():
+    for zone in [z for z in broker.tcs.zones.values() if z.name]:
         _LOGGER.debug(
             "Found a %s (%s), id=%s, name=%s",
             zone.zoneType,
@@ -104,9 +104,9 @@ async def async_setup_platform(
             zone.zoneId,
             zone.name,
         )
-        new_entity = EvoZone(broker, zone)
-
-        zones.append(new_entity)
+        if zone.zoneType != "Unknown":  # in ["RadiatorZone", "Thermostat"]:
+            new_entity = EvoZone(broker, zone)
+            zones.append(new_entity)
 
     async_add_entities([controller] + zones, update_before_add=True)
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -96,15 +96,24 @@ async def async_setup_platform(
     controller = EvoController(broker, broker.tcs)
 
     zones = []
-    for zone in [z for z in broker.tcs.zones.values() if z.name]:
-        _LOGGER.debug(
-            "Found a %s (%s), id=%s, name=%s",
-            zone.zoneType,
-            zone.modelType,
-            zone.zoneId,
-            zone.name,
-        )
-        if zone.zoneType != "Unknown":  # in ["RadiatorZone", "Thermostat"]:
+    for zone in broker.tcs.zones.values():
+        if zone.zoneType == "Unknown":
+            _LOGGER.warning(
+                "Ignoring: %s (%s), id=%s, name=%s (invalid zone type)",
+                zone.zoneType,
+                zone.modelType,
+                zone.zoneId,
+                zone.name,
+            )
+        else:
+            _LOGGER.debug(
+                "Adding: %s (%s), id=%s, name=%s",
+                zone.zoneType,
+                zone.modelType,
+                zone.zoneId,
+                zone.name,
+            )
+
             new_entity = EvoZone(broker, zone)
             zones.append(new_entity)
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -99,7 +99,7 @@ async def async_setup_platform(
     for zone in broker.tcs.zones.values():
         if zone.zoneType == "Unknown":
             _LOGGER.warning(
-                "Ignoring: %s (%s), id=%s, name=%s (invalid zone type)",
+                "Ignoring: %s (%s), id=%s, name=%s: invalid zone type",
                 zone.zoneType,
                 zone.modelType,
                 zone.zoneId,

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -34,7 +34,7 @@ async def async_setup_platform(
     broker = hass.data[DOMAIN]["broker"]
 
     _LOGGER.debug(
-        "Found the DHW Controller (%s), id: %s",
+        "Adding: DhwController (%s), id=%s",
         broker.tcs.hotwater.zone_type,
         broker.tcs.hotwater.zoneId,
     )


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Adds code to gracefully handle 'ghost zones' - misconfigured zones that would otherwise cause this integration to fail.

**Related issue (if applicable):** fixes #30945

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
