### PR TITLE
Add missing strings to Withings

### DIFF
--- a/homeassistant/components/withings/strings.json
+++ b/homeassistant/components/withings/strings.json
@@ -8,7 +8,15 @@
         "data": {
           "profile": "Profile"
         }
-      }
+      },
+      "pick_implementation": { "title": "Pick Authentication Method" }
+    },
+    "abort": {
+      "authorize_url_timeout": "Timeout generating authorize url.",
+      "missing_configuration": "The Withings integration is not configured. Please follow the documentation."
+    },
+    "create_entry": {
+      "default": "Successfully authenticated with Withings."
     }
   }
 }


### PR DESCRIPTION
## Description:

The Withing integration is missing strings, causing some dialogs not to have any text.

**Related issue (if applicable):** fixes #31003 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
