### PR TITLE
Add missing strings to Almond

### DIFF
--- a/homeassistant/components/almond/strings.json
+++ b/homeassistant/components/almond/strings.json
@@ -3,6 +3,10 @@
     "step": {
       "pick_implementation": {
         "title": "Pick Authentication Method"
+      },
+      "hassio_confirm": {
+        "title": "Almond via Hass.io add-on",
+        "description": "Do you want to configure Home Assistant to connect to Almond provided by the Hass.io add-on: {addon}?"
       }
     },
     "abort": {


### PR DESCRIPTION
## Description:

There are translation strings missing for the Almond configuration flow, causing empty dialogs to be shown.

**Related issue (if applicable):** fixes #31001 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
