### PR TITLE
Fix deCONZ update entry from Hassio discovery

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -216,15 +216,15 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         This flow is triggered by the discovery component.
         """
         self.bridge_id = normalize_bridge_id(user_input[CONF_SERIAL])
-        gateway = self.hass.data.get(DOMAIN, {}).get(self.bridge_id)
 
-        if gateway:
-            return self._update_entry(
-                gateway.config_entry,
-                user_input[CONF_HOST],
-                user_input[CONF_PORT],
-                user_input[CONF_API_KEY],
-            )
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if self.bridge_id == entry.unique_id:
+                return self._update_entry(
+                    entry,
+                    user_input[CONF_HOST],
+                    user_input[CONF_PORT],
+                    user_input[CONF_API_KEY],
+                )
 
         await self.async_set_unique_id(self.bridge_id)
         self._hassio_discovery = user_input


### PR DESCRIPTION
## Description:

The deCONZ integration check for existing entries based on `hass.data` when an Hass.io deCONZ is discovered. However, that doesn't have to be set up yet causing a new instance to be discovered, which is incorrect.

Instead, it should have updated the existing entry.

This PR addresses the issue to not rely on `hass.data` but use the set up `config_entries` in Home Assistant itself.

**Related issue (if applicable):** fixes home-assistant/hassio-addons#1007

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
