### PR TITLE
Add a AlexaGlobalCatalog value to all labels

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1203,7 +1203,10 @@ class AlexaModeController(AlexaCapability):
                 f"{cover.ATTR_POSITION}.{cover.STATE_CLOSED}",
                 [AlexaGlobalCatalog.VALUE_CLOSE],
             )
-            self._resource.add_mode(f"{cover.ATTR_POSITION}.custom", ["Custom"])
+            self._resource.add_mode(
+                f"{cover.ATTR_POSITION}.custom",
+                ["Custom", AlexaGlobalCatalog.SETTING_PRESET],
+            )
             return self._resource.serialize_capability_resources()
 
         return None
@@ -1397,7 +1400,7 @@ class AlexaRangeController(AlexaCapability):
             unit = self.entity.attributes.get(input_number.ATTR_UNIT_OF_MEASUREMENT)
 
             self._resource = AlexaPresetResource(
-                ["Value"],
+                ["Value", AlexaGlobalCatalog.SETTING_PRESET],
                 min_value=min_value,
                 max_value=max_value,
                 precision=precision,

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1211,18 +1211,26 @@ async def async_api_adjust_range(hass, config, directive, context):
         range_delta = int(range_delta)
         service = SERVICE_SET_COVER_POSITION
         current = entity.attributes.get(cover.ATTR_POSITION)
-        data[cover.ATTR_POSITION] = response_value = min(
-            100, max(0, range_delta + current)
-        )
+        position = response_value = min(100, max(0, range_delta + current))
+        if position == 100:
+            service = cover.SERVICE_OPEN_COVER
+        elif position == 0:
+            service = cover.SERVICE_CLOSE_COVER
+        else:
+            data[cover.ATTR_POSITION] = position
 
     # Cover Tilt
     elif instance == f"{cover.DOMAIN}.tilt":
         range_delta = int(range_delta)
         service = SERVICE_SET_COVER_TILT_POSITION
         current = entity.attributes.get(cover.ATTR_TILT_POSITION)
-        data[cover.ATTR_TILT_POSITION] = response_value = min(
-            100, max(0, range_delta + current)
-        )
+        tilt_position = response_value = min(100, max(0, range_delta + current))
+        if tilt_position == 100:
+            service = cover.SERVICE_OPEN_COVER_TILT
+        elif tilt_position == 0:
+            service = cover.SERVICE_CLOSE_COVER_TILT
+        else:
+            data[cover.ATTR_TILT_POSITION] = tilt_position
 
     # Input Number Value
     elif instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1553,9 +1553,37 @@ async def test_cover_position_range(hass):
     assert properties["namespace"] == "Alexa.RangeController"
     assert properties["value"] == 100
 
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "cover#test_range",
+        "cover.open_cover",
+        hass,
+        payload={"rangeValueDelta": "99"},
+        instance="cover.position",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == 100
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "cover#test_range",
+        "cover.close_cover",
+        hass,
+        payload={"rangeValueDelta": "-99"},
+        instance="cover.position",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == 0
+
     await assert_range_changes(
         hass,
-        [(25, "-5"), (35, "5"), (0, "-99"), (100, "99")],
+        [(25, "-5"), (35, "5")],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_range",
@@ -2769,9 +2797,37 @@ async def test_cover_tilt_position_range(hass):
     assert properties["namespace"] == "Alexa.RangeController"
     assert properties["value"] == 100
 
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "cover#test_tilt_range",
+        "cover.open_cover_tilt",
+        hass,
+        payload={"rangeValueDelta": "99"},
+        instance="cover.tilt",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == 100
+
+    call, msg = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "cover#test_tilt_range",
+        "cover.close_cover_tilt",
+        hass,
+        payload={"rangeValueDelta": "-99"},
+        instance="cover.tilt",
+    )
+    properties = msg["context"]["properties"][0]
+    assert properties["name"] == "rangeValue"
+    assert properties["namespace"] == "Alexa.RangeController"
+    assert properties["value"] == 0
+
     await assert_range_changes(
         hass,
-        [(25, "-5"), (35, "5"), (0, "-99"), (100, "99")],
+        [(25, "-5"), (35, "5")],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_tilt_range",


### PR DESCRIPTION
##  Description:
Update Alexa AdjustRange Handler to use `OPEN_COVER`, `CLOSE_COVER`, `OPEN_COVER_TILT`, `CLOSE_COVER_TILT` services when value is 100 or 0; instead of `SET_COVER_POSITION`, `SET_COVER_POSITION_TILT`. 

Add a AlexaGlobalCatalog value to all labels for international support. 

**Related issue (if applicable):** fixes #30985


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
