### PR TITLE
Allow OpenUV entities to be unavailable

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -289,8 +289,14 @@ class OpenUvEntity(Entity):
     def __init__(self, openuv):
         """Initialize."""
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._available = True
         self._name = None
         self.openuv = openuv
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -100,7 +100,10 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorDevice):
         data = self.openuv.data[DATA_PROTECTION_WINDOW]
 
         if not data:
+            self._available = False
             return
+
+        self._available = True
 
         for key in ("from_time", "to_time", "from_uv", "to_uv"):
             if not data.get(key):

--- a/homeassistant/components/openuv/sensor.py
+++ b/homeassistant/components/openuv/sensor.py
@@ -124,7 +124,14 @@ class OpenUvSensor(OpenUvEntity):
 
     async def async_update(self):
         """Update the state."""
-        data = self.openuv.data[DATA_UV]["result"]
+        data = self.openuv.data[DATA_UV].get("result")
+
+        if not data:
+            self._available = False
+            return
+
+        self._available = True
+
         if self._sensor_type == TYPE_CURRENT_OZONE_LEVEL:
             self._state = data["ozone"]
         elif self._sensor_type == TYPE_CURRENT_UV_INDEX:


### PR DESCRIPTION
## Description:

This PR adds the `available` property to all OpenUV entities so that they properly render as `unavailable` in Lovelace.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/30973

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
openuv:
  api_key: !secret openuv_api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
