### PR TITLE
Remove monitored conditions from OpenUV

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -178,7 +178,7 @@ async def async_unload_entry(hass, config_entry):
 async def async_migrate_entry(hass, config_entry):
     """Migrate the config entry upon new versions."""
     version = config_entry.version
-    data = config_entry.data
+    data = {**config_entry.data}
 
     _LOGGER.debug("Migrating from version %s", version)
 
@@ -188,7 +188,7 @@ async def async_migrate_entry(hass, config_entry):
         data.pop(CONF_SENSORS, None)
         version = config_entry.version = 2
         hass.config_entries.async_update_entry(config_entry, data=data)
-        _LOGGER.info("Migration to version %s successful", version)
+        _LOGGER.debug("Migration to version %s successful", version)
 
     return True
 

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_ELEVATION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_MONITORED_CONDITIONS,
     CONF_SENSORS,
 )
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -52,60 +51,6 @@ TYPE_SAFE_EXPOSURE_TIME_4 = "safe_exposure_time_type_4"
 TYPE_SAFE_EXPOSURE_TIME_5 = "safe_exposure_time_type_5"
 TYPE_SAFE_EXPOSURE_TIME_6 = "safe_exposure_time_type_6"
 
-BINARY_SENSORS = {TYPE_PROTECTION_WINDOW: ("Protection Window", "mdi:sunglasses")}
-
-BINARY_SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(BINARY_SENSORS)): vol.All(
-            cv.ensure_list, [vol.In(BINARY_SENSORS)]
-        )
-    }
-)
-
-SENSORS = {
-    TYPE_CURRENT_OZONE_LEVEL: ("Current Ozone Level", "mdi:vector-triangle", "du"),
-    TYPE_CURRENT_UV_INDEX: ("Current UV Index", "mdi:weather-sunny", "index"),
-    TYPE_CURRENT_UV_LEVEL: ("Current UV Level", "mdi:weather-sunny", None),
-    TYPE_MAX_UV_INDEX: ("Max UV Index", "mdi:weather-sunny", "index"),
-    TYPE_SAFE_EXPOSURE_TIME_1: (
-        "Skin Type 1 Safe Exposure Time",
-        "mdi:timer",
-        "minutes",
-    ),
-    TYPE_SAFE_EXPOSURE_TIME_2: (
-        "Skin Type 2 Safe Exposure Time",
-        "mdi:timer",
-        "minutes",
-    ),
-    TYPE_SAFE_EXPOSURE_TIME_3: (
-        "Skin Type 3 Safe Exposure Time",
-        "mdi:timer",
-        "minutes",
-    ),
-    TYPE_SAFE_EXPOSURE_TIME_4: (
-        "Skin Type 4 Safe Exposure Time",
-        "mdi:timer",
-        "minutes",
-    ),
-    TYPE_SAFE_EXPOSURE_TIME_5: (
-        "Skin Type 5 Safe Exposure Time",
-        "mdi:timer",
-        "minutes",
-    ),
-    TYPE_SAFE_EXPOSURE_TIME_6: (
-        "Skin Type 6 Safe Exposure Time",
-        "mdi:timer",
-        "minutes",
-    ),
-}
-
-SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)): vol.All(
-            cv.ensure_list, [vol.In(SENSORS)]
-        )
-    }
-)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -115,8 +60,6 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_ELEVATION): float,
                 vol.Optional(CONF_LATITUDE): cv.latitude,
                 vol.Optional(CONF_LONGITUDE): cv.longitude,
-                vol.Optional(CONF_BINARY_SENSORS, default={}): BINARY_SENSOR_SCHEMA,
-                vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
             }
         )
     },
@@ -142,12 +85,7 @@ async def async_setup(hass, config):
     if identifier in configured_instances(hass):
         return True
 
-    data = {
-        CONF_API_KEY: conf[CONF_API_KEY],
-        CONF_BINARY_SENSORS: conf[CONF_BINARY_SENSORS],
-        CONF_SENSORS: conf[CONF_SENSORS],
-    }
-
+    data = {CONF_API_KEY: conf[CONF_API_KEY]}
     if CONF_LATITUDE in conf:
         data[CONF_LATITUDE] = conf[CONF_LATITUDE]
     if CONF_LONGITUDE in conf:
@@ -178,13 +116,7 @@ async def async_setup_entry(hass, config_entry):
                 config_entry.data.get(CONF_LONGITUDE, hass.config.longitude),
                 websession,
                 altitude=config_entry.data.get(CONF_ELEVATION, hass.config.elevation),
-            ),
-            config_entry.data.get(CONF_BINARY_SENSORS, {}).get(
-                CONF_MONITORED_CONDITIONS, list(BINARY_SENSORS)
-            ),
-            config_entry.data.get(CONF_SENSORS, {}).get(
-                CONF_MONITORED_CONDITIONS, list(SENSORS)
-            ),
+            )
         )
         await openuv.async_update()
         hass.data[DOMAIN][DATA_OPENUV_CLIENT][config_entry.entry_id] = openuv
@@ -243,39 +175,49 @@ async def async_unload_entry(hass, config_entry):
     return True
 
 
+async def async_migrate_entry(hass, config_entry):
+    """Migrate the config entry upon new versions."""
+    version = config_entry.version
+    data = config_entry.data
+
+    _LOGGER.debug("Migrating from version %s", version)
+
+    # 1 -> 2: Remove unused condition data:
+    if version == 1:
+        data.pop(CONF_BINARY_SENSORS, None)
+        data.pop(CONF_SENSORS, None)
+        version = config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data=data)
+        _LOGGER.info("Migration to version %s successful", version)
+
+    return True
+
+
 class OpenUV:
     """Define a generic OpenUV object."""
 
-    def __init__(self, client, binary_sensor_conditions, sensor_conditions):
+    def __init__(self, client):
         """Initialize."""
-        self.binary_sensor_conditions = binary_sensor_conditions
         self.client = client
         self.data = {}
-        self.sensor_conditions = sensor_conditions
 
     async def async_update_protection_data(self):
         """Update binary sensor (protection window) data."""
-
-        if TYPE_PROTECTION_WINDOW in self.binary_sensor_conditions:
-            try:
-                resp = await self.client.uv_protection_window()
-                self.data[DATA_PROTECTION_WINDOW] = resp["result"]
-            except OpenUvError as err:
-                _LOGGER.error("Error during protection data update: %s", err)
-                self.data[DATA_PROTECTION_WINDOW] = {}
-                return
+        try:
+            resp = await self.client.uv_protection_window()
+            self.data[DATA_PROTECTION_WINDOW] = resp["result"]
+        except OpenUvError as err:
+            _LOGGER.error("Error during protection data update: %s", err)
+            self.data[DATA_PROTECTION_WINDOW] = {}
 
     async def async_update_uv_index_data(self):
         """Update sensor (uv index, etc) data."""
-
-        if any(c in self.sensor_conditions for c in SENSORS):
-            try:
-                data = await self.client.uv_index()
-                self.data[DATA_UV] = data
-            except OpenUvError as err:
-                _LOGGER.error("Error during uv index data update: %s", err)
-                self.data[DATA_UV] = {}
-                return
+        try:
+            data = await self.client.uv_index()
+            self.data[DATA_UV] = data
+        except OpenUvError as err:
+            _LOGGER.error("Error during uv index data update: %s", err)
+            self.data[DATA_UV] = {}
 
     async def async_update(self):
         """Update sensor/binary sensor data."""

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -7,7 +7,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.dt import as_local, parse_datetime, utcnow
 
 from . import (
-    BINARY_SENSORS,
     DATA_OPENUV_CLIENT,
     DATA_PROTECTION_WINDOW,
     DOMAIN,
@@ -17,10 +16,13 @@ from . import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
 ATTR_PROTECTION_WINDOW_ENDING_TIME = "end_time"
 ATTR_PROTECTION_WINDOW_ENDING_UV = "end_uv"
 ATTR_PROTECTION_WINDOW_STARTING_TIME = "start_time"
 ATTR_PROTECTION_WINDOW_STARTING_UV = "start_uv"
+
+BINARY_SENSORS = {TYPE_PROTECTION_WINDOW: ("Protection Window", "mdi:sunglasses")}
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -28,10 +30,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     openuv = hass.data[DOMAIN][DATA_OPENUV_CLIENT][entry.entry_id]
 
     binary_sensors = []
-    for sensor_type in openuv.binary_sensor_conditions:
-        name, icon = BINARY_SENSORS[sensor_type]
+    for kind, attrs in BINARY_SENSORS.items():
+        name, icon = attrs
         binary_sensors.append(
-            OpenUvBinarySensor(openuv, sensor_type, name, icon, entry.entry_id)
+            OpenUvBinarySensor(openuv, kind, name, icon, entry.entry_id)
         )
 
     async_add_entities(binary_sensors, True)

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -32,7 +32,7 @@ def configured_instances(hass):
 class OpenUvFlowHandler(config_entries.ConfigFlow):
     """Handle an OpenUV config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):

--- a/homeassistant/components/openuv/sensor.py
+++ b/homeassistant/components/openuv/sensor.py
@@ -9,7 +9,6 @@ from . import (
     DATA_OPENUV_CLIENT,
     DATA_UV,
     DOMAIN,
-    SENSORS,
     TOPIC_UPDATE,
     TYPE_CURRENT_OZONE_LEVEL,
     TYPE_CURRENT_UV_INDEX,
@@ -43,17 +42,52 @@ UV_LEVEL_HIGH = "High"
 UV_LEVEL_MODERATE = "Moderate"
 UV_LEVEL_LOW = "Low"
 
+SENSORS = {
+    TYPE_CURRENT_OZONE_LEVEL: ("Current Ozone Level", "mdi:vector-triangle", "du"),
+    TYPE_CURRENT_UV_INDEX: ("Current UV Index", "mdi:weather-sunny", "index"),
+    TYPE_CURRENT_UV_LEVEL: ("Current UV Level", "mdi:weather-sunny", None),
+    TYPE_MAX_UV_INDEX: ("Max UV Index", "mdi:weather-sunny", "index"),
+    TYPE_SAFE_EXPOSURE_TIME_1: (
+        "Skin Type 1 Safe Exposure Time",
+        "mdi:timer",
+        "minutes",
+    ),
+    TYPE_SAFE_EXPOSURE_TIME_2: (
+        "Skin Type 2 Safe Exposure Time",
+        "mdi:timer",
+        "minutes",
+    ),
+    TYPE_SAFE_EXPOSURE_TIME_3: (
+        "Skin Type 3 Safe Exposure Time",
+        "mdi:timer",
+        "minutes",
+    ),
+    TYPE_SAFE_EXPOSURE_TIME_4: (
+        "Skin Type 4 Safe Exposure Time",
+        "mdi:timer",
+        "minutes",
+    ),
+    TYPE_SAFE_EXPOSURE_TIME_5: (
+        "Skin Type 5 Safe Exposure Time",
+        "mdi:timer",
+        "minutes",
+    ),
+    TYPE_SAFE_EXPOSURE_TIME_6: (
+        "Skin Type 6 Safe Exposure Time",
+        "mdi:timer",
+        "minutes",
+    ),
+}
+
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up a Nest sensor based on a config entry."""
     openuv = hass.data[DOMAIN][DATA_OPENUV_CLIENT][entry.entry_id]
 
     sensors = []
-    for sensor_type in openuv.sensor_conditions:
-        name, icon, unit = SENSORS[sensor_type]
-        sensors.append(
-            OpenUvSensor(openuv, sensor_type, name, icon, unit, entry.entry_id)
-        )
+    for kind, attrs in SENSORS.items():
+        name, icon, unit = attrs
+        sensors.append(OpenUvSensor(openuv, kind, name, icon, unit, entry.entry_id))
 
     async_add_entities(sensors, True)
 


### PR DESCRIPTION
## Breaking Change:

It is no longer possible to specify monitored conditions within the OpenUV integration; all entities are added by default.

## Description:

Per [ADR 0003](https://github.com/home-assistant/architecture/blob/master/adr/0003-monitor-condition-and-data-selectors.md), this PR removes the concept of monitored conditions from OpenUV. All entity types are added by default. The integration uses more than one API call, but since we update the entities via service call (and all service calls are available by default), I made the choice to include everything.

This PR also includes a config entry migration to clean up monitored conditions data as necessary.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/11825

## Example entry for `configuration.yaml` (if applicable):
```yaml
openuv:
  api_key: !secret openuv_api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
