### PR TITLE
Add SUPPORT_VOLUME_STEP for older Pioneer receivers

### DIFF
--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -13,6 +13,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_STEP,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -36,6 +37,7 @@ DEFAULT_SOURCES = {}
 SUPPORT_PIONEER = (
     SUPPORT_PAUSE
     | SUPPORT_VOLUME_SET
+    | SUPPORT_VOLUME_STEP
     | SUPPORT_VOLUME_MUTE
     | SUPPORT_TURN_ON
     | SUPPORT_TURN_OFF


### PR DESCRIPTION
## Description:

Older Pioneer models like the Pioneer VSX-528 require `SUPPORT_VOLUME_STEP` to control the volume.

Doc PR: https://github.com/home-assistant/home-assistant.io/pull/11952

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html