### PR TITLE
Allow ZHA device creation for the Zigbee coordinator

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -906,6 +906,11 @@ def async_load_api(hass):
     async def remove(service):
         """Remove a node from the network."""
         ieee = service.data.get(ATTR_IEEE_ADDRESS)
+        zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+        zha_device = zha_gateway.get_device(ieee)
+        if zha_device.is_coordinator:
+            _LOGGER.info("Removing the coordinator (%s) is not allowed", ieee)
+            return
         _LOGGER.info("Removing node %s", ieee)
         await application_controller.remove(ieee)
 

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -165,8 +165,10 @@ class ZHADevice(LogMixin):
     @property
     def device_type(self):
         """Return the logical device type for the device."""
-        device_type = self._zigpy_device.node_desc.logical_type
-        return device_type.name if device_type else UNKNOWN
+        node_descriptor = self._zigpy_device.node_desc
+        return (
+            node_descriptor.logical_type.name if node_descriptor.is_valid else UNKNOWN
+        )
 
     @property
     def power_source(self):

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -135,8 +135,6 @@ class ZHAGateway:
                 await coro
 
         for device in self.application_controller.devices.values():
-            if device.nwk == 0x0000:
-                continue
             init_tasks.append(
                 init_with_semaphore(self.async_device_restored(device), semaphore)
             )
@@ -160,9 +158,6 @@ class ZHAGateway:
 
     def raw_device_initialized(self, device):
         """Handle a device initialization without quirks loaded."""
-        if device.nwk == 0x0000:
-            return
-
         manuf = device.manufacturer
         async_dispatcher_send(
             self._hass,
@@ -336,9 +331,6 @@ class ZHAGateway:
 
     async def async_device_initialized(self, device):
         """Handle device joined and basic information discovered (async)."""
-        if device.nwk == 0x0000:
-            return
-
         zha_device = self._async_get_or_create_device(device)
 
         _LOGGER.debug(


### PR DESCRIPTION
## Description:
This PR removes the restriction that was in place preventing the creation of a ZHA device for the Zigbee coordinator. This fixes a hard error on the OOTB devices page when attempting to load device triggers and actions if someone selects the coordinator and it allows us to interact with the coordinator in group management in the ZHA configuration panel

**DO NOT MERGE WITHOUT UI PR: https://github.com/home-assistant/home-assistant-polymer/pull/4541** 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]