### PR TITLE
Fix prometheus component to fully sanitize Unicode characters

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -168,7 +168,7 @@ class PrometheusMetrics:
         return "".join(
             [
                 c
-                if c in string.ascii_letters or c.isdigit() or c == "_" or c == ":"
+                if c in string.ascii_letters or c in string.digits or c == "_" or c == ":"
                 else f"u{hex(ord(c))}"
                 for c in metric
             ]

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -168,7 +168,10 @@ class PrometheusMetrics:
         return "".join(
             [
                 c
-                if c in string.ascii_letters or c in string.digits or c == "_" or c == ":"
+                if c in string.ascii_letters
+                or c in string.digits
+                or c == "_"
+                or c == ":"
                 else f"u{hex(ord(c))}"
                 for c in metric
             ]

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -46,7 +46,9 @@ async def prometheus_client(loop, hass, hass_client):
     sensor4.entity_id = "sensor.wind_direction"
     await sensor4.async_update_ha_state()
 
-    sensor5 = DemoSensor(None, "SPS30 PM <1µm Weight concentration", 3.7069, None, "µg/m³", None)
+    sensor5 = DemoSensor(
+        None, "SPS30 PM <1µm Weight concentration", 3.7069, None, "µg/m³", None
+    )
     sensor5.hass = hass
     sensor5.entity_id = "sensor.sps30_pm_1um_weight_concentration"
     await sensor5.async_update_ha_state()

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -46,6 +46,11 @@ async def prometheus_client(loop, hass, hass_client):
     sensor4.entity_id = "sensor.wind_direction"
     await sensor4.async_update_ha_state()
 
+    sensor5 = DemoSensor(None, "SPS30 PM <1µm Weight concentration", 3.7069, None, "µg/m³", None)
+    sensor5.hass = hass
+    sensor5.entity_id = "sensor.sps30_pm_1um_weight_concentration"
+    await sensor5.async_update_ha_state()
+
     return await hass_client()
 
 
@@ -112,4 +117,10 @@ async def test_view(prometheus_client):  # pylint: disable=redefined-outer-name
         'sensor_unit_u0xb0{domain="sensor",'
         'entity="sensor.wind_direction",'
         'friendly_name="Wind Direction"} 25.0' in body
+    )
+
+    assert (
+        'sensor_unit_u0xb5g_per_mu0xb3{domain="sensor",'
+        'entity="sensor.sps30_pm_1um_weight_concentration",'
+        'friendly_name="SPS30 PM <1µm Weight concentration"} 3.7069' in body
     )


### PR DESCRIPTION
## Description:

Sanitization used `str.isdigit()` to match numerics but that also matches Unicode "digit" characters that require special handling, like superscripts. Failures would look like this:

`ValueError: Invalid metric name: sensor_unit_u0x23_per_m³
`

Changed sanitize to use `string.digits`, which matches only ascii digits, and added test.

See 
https://stackoverflow.com/questions/44891070/whats-the-difference-between-str-isdigit-isnumeric-and-isdecimal-in-python for discussion.

https://docs.python.org/3/library/stdtypes.html#str.isdigit

https://docs.python.org/3.7/library/string.html#string.digits

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
