### PR TITLE
Add disabled entities support to WLED

### DIFF
--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -118,10 +118,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class WLEDEntity(Entity):
     """Defines a base WLED entity."""
 
-    def __init__(self, entry_id: str, wled: WLED, name: str, icon: str) -> None:
+    def __init__(
+        self,
+        entry_id: str,
+        wled: WLED,
+        name: str,
+        icon: str,
+        enabled_default: bool = True,
+    ) -> None:
         """Initialize the WLED entity."""
         self._attributes: Dict[str, Union[str, int, float]] = {}
         self._available = True
+        self._enabled_default = enabled_default
         self._entry_id = entry_id
         self._icon = icon
         self._name = name
@@ -142,6 +150,11 @@ class WLEDEntity(Entity):
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._available
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return self._enabled_default
 
     @property
     def should_poll(self) -> bool:
@@ -171,6 +184,9 @@ class WLEDEntity(Entity):
 
     async def async_update(self) -> None:
         """Update WLED entity."""
+        if not self.enabled:
+            return
+
         if self.wled.device is None:
             self._available = False
             return

--- a/homeassistant/components/wled/sensor.py
+++ b/homeassistant/components/wled/sensor.py
@@ -50,13 +50,14 @@ class WLEDSensor(WLEDDeviceEntity):
         icon: str,
         unit_of_measurement: str,
         key: str,
+        enabled_default: bool = True,
     ) -> None:
         """Initialize WLED sensor."""
         self._state = None
         self._unit_of_measurement = unit_of_measurement
         self._key = key
 
-        super().__init__(entry_id, wled, name, icon)
+        super().__init__(entry_id, wled, name, icon, enabled_default)
 
     @property
     def unique_id(self) -> str:
@@ -109,6 +110,7 @@ class WLEDUptimeSensor(WLEDSensor):
             "mdi:clock-outline",
             None,
             "uptime",
+            enabled_default=False,
         )
 
     @property
@@ -134,6 +136,7 @@ class WLEDFreeHeapSensor(WLEDSensor):
             "mdi:memory",
             DATA_BYTES,
             "free_heap",
+            enabled_default=False,
         )
 
     async def _wled_update(self) -> None:

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -3,11 +3,13 @@ from datetime import datetime
 
 from asynctest import patch
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.wled.const import (
     ATTR_LED_COUNT,
     ATTR_MAX_POWER,
     CURRENT_MA,
     DATA_BYTES,
+    DOMAIN,
 )
 from homeassistant.const import ATTR_ICON, ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
@@ -22,11 +24,31 @@ async def test_sensors(
 ) -> None:
     """Test the creation and values of the WLED sensors."""
 
+    entry = await init_integration(hass, aioclient_mock, skip_setup=True)
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    # Pre-create registry entries for disabled by default sensors
+    registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "aabbccddeeff_uptime",
+        suggested_object_id="wled_rgb_light_uptime",
+        disabled_by=None,
+    )
+
+    registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "aabbccddeeff_free_heap",
+        suggested_object_id="wled_rgb_light_free_memory",
+        disabled_by=None,
+    )
+
+    # Setup
     test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=dt_util.UTC)
     with patch("homeassistant.components.wled.sensor.utcnow", return_value=test_time):
-        await init_integration(hass, aioclient_mock)
-
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.wled_rgb_light_estimated_current")
     assert state
@@ -36,7 +58,7 @@ async def test_sensors(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == CURRENT_MA
     assert state.state == "470"
 
-    entry = entity_registry.async_get("sensor.wled_rgb_light_estimated_current")
+    entry = registry.async_get("sensor.wled_rgb_light_estimated_current")
     assert entry
     assert entry.unique_id == "aabbccddeeff_estimated_current"
 
@@ -46,7 +68,7 @@ async def test_sensors(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.state == "2019-11-11T09:10:00+00:00"
 
-    entry = entity_registry.async_get("sensor.wled_rgb_light_uptime")
+    entry = registry.async_get("sensor.wled_rgb_light_uptime")
     assert entry
     assert entry.unique_id == "aabbccddeeff_uptime"
 
@@ -56,6 +78,30 @@ async def test_sensors(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == DATA_BYTES
     assert state.state == "14600"
 
-    entry = entity_registry.async_get("sensor.wled_rgb_light_free_memory")
+    entry = registry.async_get("sensor.wled_rgb_light_free_memory")
     assert entry
     assert entry.unique_id == "aabbccddeeff_free_heap"
+
+
+async def test_disabled_by_default_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the disabled by default WLED sensors."""
+    await init_integration(hass, aioclient_mock)
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    state = hass.states.get("sensor.wled_rgb_light_uptime")
+    assert state is None
+
+    entry = registry.async_get("sensor.wled_rgb_light_uptime")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by == "integration"
+
+    state = hass.states.get("sensor.wled_rgb_light_free_memory")
+    assert state is None
+
+    entry = registry.async_get("sensor.wled_rgb_light_free_memory")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by == "integration"


### PR DESCRIPTION
## Description:

Adds support for disabled entities to the WLED integration.
Also disables the free memory & uptime sensors by default on integration set up.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
