### PR TITLE
switch evohome to use a whitelist for valid zonetype

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -663,7 +663,7 @@ class EvoChild(EvoDevice):
         except IndexError:
             self._setpoints = {}
             _LOGGER.warning(
-                "Failed to get setpoints - report as an issue if this error persists",
+                "Failed to get setpoints, report as an issue if this error persists",
                 exc_info=True,
             )
 

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -663,7 +663,8 @@ class EvoChild(EvoDevice):
         except IndexError:
             self._setpoints = {}
             _LOGGER.warning(
-                "Failed to get setpoints - please report as an issue", exc_info=True
+                "Failed to get setpoints - report as an issue if this error persists",
+                exc_info=True,
             )
 
         return self._setpoints

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -112,7 +112,7 @@ async def async_setup_platform(
         else:
             _LOGGER.warning(
                 "Ignoring: %s (%s), id=%s, name=%s: unknown/invalid zone type, "
-                "- report as an issue if you feel this zone type should be supported",
+                "report as an issue if you feel this zone type should be supported",
                 zone.zoneType,
                 zone.modelType,
                 zone.zoneId,

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -97,15 +97,7 @@ async def async_setup_platform(
 
     zones = []
     for zone in broker.tcs.zones.values():
-        if zone.zoneType == "Unknown":
-            _LOGGER.warning(
-                "Ignoring: %s (%s), id=%s, name=%s: invalid zone type",
-                zone.zoneType,
-                zone.modelType,
-                zone.zoneId,
-                zone.name,
-            )
-        else:
+        if zone.modelType == "HeatingZone" or zone.zoneType == "Thermostat":
             _LOGGER.debug(
                 "Adding: %s (%s), id=%s, name=%s",
                 zone.zoneType,
@@ -116,6 +108,16 @@ async def async_setup_platform(
 
             new_entity = EvoZone(broker, zone)
             zones.append(new_entity)
+
+        else:
+            _LOGGER.warning(
+                "Ignoring: %s (%s), id=%s, name=%s: unknown/invalid zone type, "
+                "- report as an issue if you feel this zone type should be supported",
+                zone.zoneType,
+                zone.modelType,
+                zone.zoneId,
+                zone.name,
+            )
 
     async_add_entities([controller] + zones, update_before_add=True)
 


### PR DESCRIPTION
## Breaking Change:
None

## Description:
Swicth from blacklist to a whitelist fro determining what zones are valid.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
