### PR TITLE
Bump python-synology to 0.4.0 : Add support for DSM v5 + fix sensors unknown for 15 min

### DIFF
--- a/homeassistant/components/synologydsm/manifest.json
+++ b/homeassistant/components/synologydsm/manifest.json
@@ -2,7 +2,7 @@
   "domain": "synologydsm",
   "name": "SynologyDSM",
   "documentation": "https://www.home-assistant.io/integrations/synologydsm",
-  "requirements": ["python-synology==0.3.0"],
+  "requirements": ["python-synology==0.4.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/synologydsm/sensor.py
+++ b/homeassistant/components/synologydsm/sensor.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
+    CONF_API_VERSION,
     CONF_DISKS,
     CONF_HOST,
     CONF_MONITORED_CONDITIONS,
@@ -82,6 +83,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SSL, default=True): cv.boolean,
+        vol.Optional(CONF_API_VERSION): cv.positive_int,
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(
@@ -110,8 +112,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         use_ssl = config.get(CONF_SSL)
         unit = hass.config.units.temperature_unit
         monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
+        api_version = config.get(CONF_API_VERSION)
 
-        api = SynoApi(host, port, username, password, unit, use_ssl)
+        api = SynoApi(host, port, username, password, unit, use_ssl, api_version)
 
         sensors = [
             SynoNasUtilSensor(api, name, variable, _UTILISATION_MON_COND[variable])
@@ -150,13 +153,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class SynoApi:
     """Class to interface with Synology DSM API."""
 
-    def __init__(self, host, port, username, password, temp_unit, use_ssl):
+    def __init__(self, host, port, username, password, temp_unit, use_ssl, api_version):
         """Initialize the API wrapper class."""
 
         self.temp_unit = temp_unit
 
         try:
-            self._api = SynologyDSM(host, port, username, password, use_https=use_ssl)
+            self._api = SynologyDSM(
+                host,
+                port,
+                username,
+                password,
+                use_https=use_ssl,
+                debugmode=False,
+                dsm_version=api_version,
+            )
         except:  # noqa: E722 pylint: disable=bare-except
             _LOGGER.error("Error setting up Synology DSM")
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1617,7 +1617,7 @@ python-sochain-api==0.0.2
 python-songpal==0.11.2
 
 # homeassistant.components.synologydsm
-python-synology==0.3.0
+python-synology==0.4.0
 
 # homeassistant.components.tado
 python-tado==0.2.9


### PR DESCRIPTION
## Description:
Updated python-synology component to allow backward compatibility with Synology DSM 5.x

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: synologydsm
    host: 192.168.0.2
    port: 5001
    api_version: 5
    username: username
    password: password
    monitored_conditions:
      - disk_name
      - disk_device
      - disk_smart_status
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) - https://github.com/home-assistant/home-assistant.io/pull/11833

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
