### PR TITLE
Enhance info_from_service function in zeroconf integration

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -148,15 +148,20 @@ def handle_homekit(hass, info) -> bool:
 
 def info_from_service(service):
     """Return prepared info from mDNS entries."""
-    properties = {}
+    properties = {"_raw": {}}
 
     for key, value in service.properties.items():
+        # See https://ietf.org/rfc/rfc6763.html#section-6.4 and
+        # https://ietf.org/rfc/rfc6763.html#section-6.5 for expected encodings
+        # for property keys and values
+        key = key.decode("ascii")
+        properties["_raw"][key] = value
+
         try:
             if isinstance(value, bytes):
-                value = value.decode("utf-8")
-            properties[key.decode("utf-8")] = value
+                properties[key] = value.decode("utf-8")
         except UnicodeDecodeError:
-            _LOGGER.warning("Unicode decode error on %s: %s", key, value)
+            properties[key] = None
 
     address = service.addresses[0]
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -161,7 +161,7 @@ def info_from_service(service):
             if isinstance(value, bytes):
                 properties[key] = value.decode("utf-8")
         except UnicodeDecodeError:
-            properties[key] = None
+            pass
 
     address = service.addresses[0]
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -31,7 +31,7 @@ def get_service_info_mock(service_type, name):
         weight=0,
         priority=0,
         server="name.local.",
-        properties={b"macaddress": b"ABCDEF012345"},
+        properties={b"macaddress": b"ABCDEF012345", b"non-utf8-value": b"ABCDEF\x8a"},
     )
 
 
@@ -93,3 +93,16 @@ async def test_homekit_match_full(hass, mock_zeroconf):
     assert len(mock_service_browser.mock_calls) == 1
     assert len(mock_config_flow.mock_calls) == 2
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
+
+
+async def test_info_from_service_non_utf8(hass):
+    """Test info_from_service handles non UTF-8 property values correctly."""
+    service_type = "_test._tcp.local."
+    info = zeroconf.info_from_service(
+        get_service_info_mock(service_type, f"test.{service_type}")
+    )
+    raw_info = info["properties"].pop("_raw", False)
+    assert raw_info
+    assert len(info["properties"].keys()) == len(raw_info.keys())
+    assert info["properties"]["non-utf8-value"] is None
+    assert raw_info["non-utf8-value"] is not None

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -103,6 +103,6 @@ async def test_info_from_service_non_utf8(hass):
     )
     raw_info = info["properties"].pop("_raw", False)
     assert raw_info
-    assert len(info["properties"].keys()) == len(raw_info.keys())
+    assert len(info["properties"].keys()) <= len(raw_info.keys())
     assert "non-utf8-value" not in info["properties"]
     assert raw_info["non-utf8-value"] is not None

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -104,5 +104,5 @@ async def test_info_from_service_non_utf8(hass):
     raw_info = info["properties"].pop("_raw", False)
     assert raw_info
     assert len(info["properties"].keys()) == len(raw_info.keys())
-    assert info["properties"]["non-utf8-value"] is None
+    assert "non-utf8-value" not in info["properties"]
     assert raw_info["non-utf8-value"] is not None

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -103,6 +103,6 @@ async def test_info_from_service_non_utf8(hass):
     )
     raw_info = info["properties"].pop("_raw", False)
     assert raw_info
-    assert len(info["properties"].keys()) == len(raw_info.keys())
+    assert len(info["properties"]) == len(raw_info)
     assert info["properties"]["non-utf8-value"] is None
     assert raw_info["non-utf8-value"] is not None


### PR DESCRIPTION
## Description:
Per #30949 it was discovered that it is not safe to assume that all properties retrieved from a Zeroconf service are UTF-8 decodable (https://ietf.org/rfc/rfc6763.html#section-6.5). This change will attempt to UTF-8 decode all properties but will return None for the property value if that is not possible. In addition, a new `_raw` key was added to `properties` to store the raw byte-string property values retrieved from `zeroconf`. The decoding for property keys was also changed to ASCII per the RFC (https://ietf.org/rfc/rfc6763.html#section-6.4)

I added a test to ensure these changes work as intended

**Related issue (if applicable):** #30949

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
