### PR TITLE
Add additional alarm states to SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -157,10 +157,10 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
 
     async def async_update(self):
         """Update alarm status."""
-        event_data = self._simplisafe.last_event_data[self._system.system_id]
+        last_event = self._simplisafe.last_event_data[self._system.system_id]
 
-        if event_data.get("pinName"):
-            self._changed_by = event_data["pinName"]
+        if last_event.get("pinName"):
+            self._changed_by = last_event["pinName"]
 
         if self._system.state == SystemStates.error:
             self._online = False
@@ -184,8 +184,6 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
             self._state = STATE_ALARM_DISARMED
         else:
             self._state = None
-
-        last_event = self._simplisafe.last_event_data[self._system.system_id]
 
         try:
             last_event_sensor_type = EntityTypes(last_event["sensorType"]).name

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -19,7 +19,9 @@ from homeassistant.const import (
     CONF_CODE,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
+    STATE_ALARM_TRIGGERED,
 )
 from homeassistant.util.dt import utc_from_timestamp
 
@@ -80,7 +82,6 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
         self._simplisafe = simplisafe
         self._state = None
 
-        self._attrs.update({ATTR_ALARM_ACTIVE: self._system.alarm_going_off})
         if self._system.version == 3:
             self._attrs.update(
                 {
@@ -168,16 +169,20 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
 
         self._online = True
 
-        if self._system.state == SystemStates.off:
-            self._state = STATE_ALARM_DISARMED
-        elif self._system.state in (SystemStates.home, SystemStates.home_count):
-            self._state = STATE_ALARM_ARMED_HOME
+        if self._system.alarm_going_off:
+            self._state = STATE_ALARM_TRIGGERED
+        elif self._system.state == SystemStates.away:
+            self._state = STATE_ALARM_ARMED_AWAY
         elif self._system.state in (
-            SystemStates.away,
             SystemStates.away_count,
             SystemStates.exit_delay,
+            SystemStates.home_count,
         ):
-            self._state = STATE_ALARM_ARMED_AWAY
+            self._state = STATE_ALARM_ARMING
+        elif self._system.state == SystemStates.home:
+            self._state = STATE_ALARM_ARMED_HOME
+        elif self._system.state == SystemStates.off:
+            self._state = STATE_ALARM_DISARMED
         else:
             self._state = None
 

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -30,7 +30,6 @@ from .const import DATA_CLIENT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_ALARM_ACTIVE = "alarm_active"
 ATTR_ALARM_DURATION = "alarm_duration"
 ATTR_ALARM_VOLUME = "alarm_volume"
 ATTR_BATTERY_BACKUP_POWER_LEVEL = "battery_backup_power_level"


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
SimpliSafe alarm control panel entities no longer have the `alarm_active` attribute; that information is now communicated via a `triggered` state value.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adjusts the SimpliSafe integration to use the `triggered` and `arming` states (which weren't present before).

## Type of change
<!--
    What types of changes does your PR introduce to our documention/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
    Supplying a configuration snippet, makes it easier for a maintainer to test
    your PR. Furthermore, for new integrations, it gives an impression of how
    the configuration would look like.
    Note: Remove this section if this PR does not have an example entry.
-->

```yaml
simplisafe:
  accounts:
    username: !secret simplisafe_username
    password: !secret simplisafe_password
```

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated in [home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following Integration Quality Scale:
<!-- https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html -->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
- [x] 🤷‍♂ The integration has elements of each (😆)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
