### PR TITLE
Allow string values on zwave.set_node_value

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -126,8 +126,8 @@ SET_CONFIG_PARAMETER_SCHEMA = vol.Schema(
 SET_NODE_VALUE_SCHEMA = vol.Schema(
     {
         vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),
-        vol.Required(const.ATTR_VALUE_ID): vol.Coerce(int),
-        vol.Required(const.ATTR_CONFIG_VALUE): vol.Coerce(int),
+        vol.Required(const.ATTR_VALUE_ID): vol.Any(vol.Coerce(int), cv.string),
+        vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(vol.Coerce(int), cv.string),
     }
 )
 

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -75,9 +75,9 @@ set_node_value:
     node_id:
       description: Node id of the device to set the value on (integer).
     value_id:
-      description: Value id of the value to set (integer).
+      description: Value id of the value to set (integer or string).
     value:
-      description: Value to set (integer).
+      description: Value to set (integer or string).
 
 refresh_node_value:
   description: Refresh the value for a given value_id on a Z-Wave device.

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1797,6 +1797,31 @@ class TestZWaveServices(unittest.TestCase):
 
         assert self.zwave_network.nodes[14].values[12].data == 2
 
+    def test_set_node_value_with_long_id_and_text_value(self):
+        """Test zwave set_node_value service."""
+        value = MockValue(
+            index=87512398541236578,
+            command_class=const.COMMAND_CLASS_SWITCH_COLOR,
+            data="#ff0000",
+        )
+        node = MockNode(node_id=14, command_classes=[const.COMMAND_CLASS_SWITCH_COLOR])
+        node.values = {87512398541236578: value}
+        node.get_values.return_value = node.values
+        self.zwave_network.nodes = {14: node}
+
+        self.hass.services.call(
+            "zwave",
+            "set_node_value",
+            {
+                const.ATTR_NODE_ID: 14,
+                const.ATTR_VALUE_ID: "87512398541236578",
+                const.ATTR_CONFIG_VALUE: "#00ff00",
+            },
+        )
+        self.hass.block_till_done()
+
+        assert self.zwave_network.nodes[14].values[87512398541236578].data == "#00ff00"
+
     def test_refresh_node_value(self):
         """Test zwave refresh_node_value service."""
         node = MockNode(


### PR DESCRIPTION
## Proposed change

Change allows value_id and config value on `zwave.set_node_value` to be string in addition to int

This allows for:

* Accessing longer value_ids. In some cases, value ids in z-wave nodes are very large (17 digits in my case). Passing them as int does not seem to work well (python probably truncates the number), but passing them as string works fine
* Changing color values, which are represented as hex string

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Code quality improvements to existing code or addition of tests



## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.