### PR TITLE
Add keep-alive which is required for some hlk-sw16 variants

### DIFF
--- a/homeassistant/components/hlk_sw16/__init__.py
+++ b/homeassistant/components/hlk_sw16/__init__.py
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DATA_DEVICE_REGISTER = "hlk_sw16_device_register"
 DEFAULT_RECONNECT_INTERVAL = 10
+DEFAULT_KEEP_ALIVE_INTERVAL = 3
 CONNECTION_TIMEOUT = 10
 DEFAULT_PORT = 8080
 
@@ -93,6 +94,7 @@ async def async_setup(hass, config):
                 loop=hass.loop,
                 timeout=CONNECTION_TIMEOUT,
                 reconnect_interval=DEFAULT_RECONNECT_INTERVAL,
+                keep_alive_interval=DEFAULT_KEEP_ALIVE_INTERVAL,
             )
 
             hass.data[DATA_DEVICE_REGISTER][device] = client

--- a/homeassistant/components/hlk_sw16/manifest.json
+++ b/homeassistant/components/hlk_sw16/manifest.json
@@ -2,7 +2,7 @@
   "domain": "hlk_sw16",
   "name": "Hi-Link HLK-SW16",
   "documentation": "https://www.home-assistant.io/integrations/hlk_sw16",
-  "requirements": ["hlk-sw16==0.0.7"],
+  "requirements": ["hlk-sw16==0.0.8"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -667,7 +667,7 @@ hikvision==0.4
 hkavr==0.0.5
 
 # homeassistant.components.hlk_sw16
-hlk-sw16==0.0.7
+hlk-sw16==0.0.8
 
 # homeassistant.components.pi_hole
 hole==0.5.0


### PR DESCRIPTION
## Proposed change
Handle new HLK-SW16 variants that don't automatically send date which was being used as a keep alive.


## Type of change
<!--
    What types of changes does your PR introduce to our documention/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #27834(unconfirmed it fixes this exact issue but it likely does) and [keep alive timeout](https://community.home-assistant.io/t/extend-hlk-sw16-wifi-relay-module-support-to-smaller-cheaper-hlk-sw02-hlk-sw04/123450/12)(tested and confirmed this is fixed)
