### PR TITLE
Remove monitored conditions from RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -10,12 +10,10 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
-    CONF_BINARY_SENSORS,
     CONF_IP_ADDRESS,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SCAN_INTERVAL,
-    CONF_SENSORS,
     CONF_SSL,
 )
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -266,24 +264,6 @@ async def async_unload_entry(hass, config_entry):
     ]
 
     await asyncio.gather(*tasks)
-
-    return True
-
-
-async def async_migrate_entry(hass, config_entry):
-    """Migrate the config entry upon new versions."""
-    version = config_entry.version
-    data = {**config_entry.data}
-
-    _LOGGER.debug("Migrating from version %s", version)
-
-    # 1 -> 2: Remove unused condition data:
-    if version == 1:
-        data.pop(CONF_BINARY_SENSORS, None)
-        data.pop(CONF_SENSORS, None)
-        version = config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=data)
-        _LOGGER.debug("Migration to version %s successful", version)
 
     return True
 

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -10,15 +10,11 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
-    CONF_BINARY_SENSORS,
     CONF_IP_ADDRESS,
-    CONF_MONITORED_CONDITIONS,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SCAN_INTERVAL,
-    CONF_SENSORS,
     CONF_SSL,
-    CONF_SWITCHES,
 )
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
@@ -57,82 +53,6 @@ DEFAULT_ATTRIBUTION = "Data provided by Green Electronics LLC"
 DEFAULT_ICON = "mdi:water"
 DEFAULT_ZONE_RUN = 60 * 10
 
-TYPE_FLOW_SENSOR = "flow_sensor"
-TYPE_FLOW_SENSOR_CLICK_M3 = "flow_sensor_clicks_cubic_meter"
-TYPE_FLOW_SENSOR_CONSUMED_LITERS = "flow_sensor_consumed_liters"
-TYPE_FLOW_SENSOR_START_INDEX = "flow_sensor_start_index"
-TYPE_FLOW_SENSOR_WATERING_CLICKS = "flow_sensor_watering_clicks"
-TYPE_FREEZE = "freeze"
-TYPE_FREEZE_PROTECTION = "freeze_protection"
-TYPE_FREEZE_TEMP = "freeze_protect_temp"
-TYPE_HOT_DAYS = "extra_water_on_hot_days"
-TYPE_HOURLY = "hourly"
-TYPE_MONTH = "month"
-TYPE_RAINDELAY = "raindelay"
-TYPE_RAINSENSOR = "rainsensor"
-TYPE_WEEKDAY = "weekday"
-
-BINARY_SENSORS = {
-    TYPE_FLOW_SENSOR: ("Flow Sensor", "mdi:water-pump"),
-    TYPE_FREEZE: ("Freeze Restrictions", "mdi:cancel"),
-    TYPE_FREEZE_PROTECTION: ("Freeze Protection", "mdi:weather-snowy"),
-    TYPE_HOT_DAYS: ("Extra Water on Hot Days", "mdi:thermometer-lines"),
-    TYPE_HOURLY: ("Hourly Restrictions", "mdi:cancel"),
-    TYPE_MONTH: ("Month Restrictions", "mdi:cancel"),
-    TYPE_RAINDELAY: ("Rain Delay Restrictions", "mdi:cancel"),
-    TYPE_RAINSENSOR: ("Rain Sensor Restrictions", "mdi:cancel"),
-    TYPE_WEEKDAY: ("Weekday Restrictions", "mdi:cancel"),
-}
-
-SENSORS = {
-    TYPE_FLOW_SENSOR_CLICK_M3: (
-        "Flow Sensor Clicks",
-        "mdi:water-pump",
-        "clicks/m^3",
-        None,
-    ),
-    TYPE_FLOW_SENSOR_CONSUMED_LITERS: (
-        "Flow Sensor Consumed Liters",
-        "mdi:water-pump",
-        "liter",
-        None,
-    ),
-    TYPE_FLOW_SENSOR_START_INDEX: (
-        "Flow Sensor Start Index",
-        "mdi:water-pump",
-        "index",
-        None,
-    ),
-    TYPE_FLOW_SENSOR_WATERING_CLICKS: (
-        "Flow Sensor Clicks",
-        "mdi:water-pump",
-        "clicks",
-        None,
-    ),
-    TYPE_FREEZE_TEMP: (
-        "Freeze Protect Temperature",
-        "mdi:thermometer",
-        "°C",
-        "temperature",
-    ),
-}
-
-BINARY_SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(BINARY_SENSORS)): vol.All(
-            cv.ensure_list, [vol.In(BINARY_SENSORS)]
-        )
-    }
-)
-
-SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)): vol.All(
-            cv.ensure_list, [vol.In(SENSORS)]
-        )
-    }
-)
-
 SERVICE_ALTER_PROGRAM = vol.Schema({vol.Required(CONF_PROGRAM_ID): cv.positive_int})
 
 SERVICE_ALTER_ZONE = vol.Schema({vol.Required(CONF_ZONE_ID): cv.positive_int})
@@ -156,9 +76,6 @@ SERVICE_STOP_PROGRAM_SCHEMA = vol.Schema(
 
 SERVICE_STOP_ZONE_SCHEMA = vol.Schema({vol.Required(CONF_ZONE_ID): cv.positive_int})
 
-SWITCH_SCHEMA = vol.Schema({vol.Optional(CONF_ZONE_RUN_TIME): cv.positive_int})
-
-
 CONTROLLER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_IP_ADDRESS): cv.string,
@@ -166,12 +83,9 @@ CONTROLLER_SCHEMA = vol.Schema(
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
-        vol.Optional(CONF_BINARY_SENSORS, default={}): BINARY_SENSOR_SCHEMA,
-        vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
-        vol.Optional(CONF_SWITCHES, default={}): SWITCH_SCHEMA,
+        vol.Optional(CONF_ZONE_RUN_TIME): cv.positive_int,
     }
 )
-
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -227,14 +141,7 @@ async def async_setup_entry(hass, config_entry):
             ssl=config_entry.data[CONF_SSL],
         )
         rainmachine = RainMachine(
-            client,
-            config_entry.data.get(CONF_BINARY_SENSORS, {}).get(
-                CONF_MONITORED_CONDITIONS, list(BINARY_SENSORS)
-            ),
-            config_entry.data.get(CONF_SENSORS, {}).get(
-                CONF_MONITORED_CONDITIONS, list(SENSORS)
-            ),
-            config_entry.data.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN),
+            client, config_entry.data.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN),
         )
         await rainmachine.async_update()
     except RainMachineError as err:
@@ -364,54 +271,20 @@ async def async_unload_entry(hass, config_entry):
 class RainMachine:
     """Define a generic RainMachine object."""
 
-    def __init__(
-        self, client, binary_sensor_conditions, sensor_conditions, default_zone_runtime
-    ):
+    def __init__(self, client, default_zone_runtime):
         """Initialize."""
-        self.binary_sensor_conditions = binary_sensor_conditions
         self.client = client
         self.data = {}
         self.default_zone_runtime = default_zone_runtime
         self.device_mac = self.client.mac
-        self.sensor_conditions = sensor_conditions
 
     async def async_update(self):
         """Update sensor/binary sensor data."""
-
-        tasks = {}
-
-        if TYPE_FLOW_SENSOR in self.binary_sensor_conditions or any(
-            c in self.sensor_conditions
-            for c in (
-                TYPE_FLOW_SENSOR_CLICK_M3,
-                TYPE_FLOW_SENSOR_CONSUMED_LITERS,
-                TYPE_FLOW_SENSOR_START_INDEX,
-                TYPE_FLOW_SENSOR_WATERING_CLICKS,
-            )
-        ):
-            tasks[PROVISION_SETTINGS] = self.client.provisioning.settings()
-
-        if any(
-            c in self.binary_sensor_conditions
-            for c in (
-                TYPE_FREEZE,
-                TYPE_HOURLY,
-                TYPE_MONTH,
-                TYPE_RAINDELAY,
-                TYPE_RAINSENSOR,
-                TYPE_WEEKDAY,
-            )
-        ):
-            tasks[RESTRICTIONS_CURRENT] = self.client.restrictions.current()
-
-        if (
-            any(
-                c in self.binary_sensor_conditions
-                for c in (TYPE_FREEZE_PROTECTION, TYPE_HOT_DAYS)
-            )
-            or TYPE_FREEZE_TEMP in self.sensor_conditions
-        ):
-            tasks[RESTRICTIONS_UNIVERSAL] = self.client.restrictions.universal()
+        tasks = {
+            PROVISION_SETTINGS: self.client.provisioning.settings(),
+            RESTRICTIONS_CURRENT: self.client.restrictions.current(),
+            RESTRICTIONS_UNIVERSAL: self.client.restrictions.universal(),
+        }
 
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)
         for operation, result in zip(tasks, results):

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -10,10 +10,12 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
+    CONF_BINARY_SENSORS,
     CONF_IP_ADDRESS,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SCAN_INTERVAL,
+    CONF_SENSORS,
     CONF_SSL,
 )
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -264,6 +266,24 @@ async def async_unload_entry(hass, config_entry):
     ]
 
     await asyncio.gather(*tasks)
+
+    return True
+
+
+async def async_migrate_entry(hass, config_entry):
+    """Migrate the config entry upon new versions."""
+    version = config_entry.version
+    data = {**config_entry.data}
+
+    _LOGGER.debug("Migrating from version %s", version)
+
+    # 1 -> 2: Remove unused condition data:
+    if version == 1:
+        data.pop(CONF_BINARY_SENSORS, None)
+        data.pop(CONF_SENSORS, None)
+        version = config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data=data)
+        _LOGGER.debug("Migration to version %s successful", version)
 
     return True
 

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -45,8 +45,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     binary_sensors = []
-    for sensor_type, attrs in BINARY_SENSORS.items():
-        name, icon = attrs
+    for sensor_type, (name, icon) in BINARY_SENSORS.items():
         binary_sensors.append(
             RainMachineBinarySensor(rainmachine, sensor_type, name, icon)
         )

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -6,26 +6,38 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
-    BINARY_SENSORS,
     DATA_CLIENT,
     DOMAIN as RAINMACHINE_DOMAIN,
     PROVISION_SETTINGS,
     RESTRICTIONS_CURRENT,
     RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC,
-    TYPE_FLOW_SENSOR,
-    TYPE_FREEZE,
-    TYPE_FREEZE_PROTECTION,
-    TYPE_HOT_DAYS,
-    TYPE_HOURLY,
-    TYPE_MONTH,
-    TYPE_RAINDELAY,
-    TYPE_RAINSENSOR,
-    TYPE_WEEKDAY,
     RainMachineEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+TYPE_FLOW_SENSOR = "flow_sensor"
+TYPE_FREEZE = "freeze"
+TYPE_FREEZE_PROTECTION = "freeze_protection"
+TYPE_HOT_DAYS = "extra_water_on_hot_days"
+TYPE_HOURLY = "hourly"
+TYPE_MONTH = "month"
+TYPE_RAINDELAY = "raindelay"
+TYPE_RAINSENSOR = "rainsensor"
+TYPE_WEEKDAY = "weekday"
+
+BINARY_SENSORS = {
+    TYPE_FLOW_SENSOR: ("Flow Sensor", "mdi:water-pump"),
+    TYPE_FREEZE: ("Freeze Restrictions", "mdi:cancel"),
+    TYPE_FREEZE_PROTECTION: ("Freeze Protection", "mdi:weather-snowy"),
+    TYPE_HOT_DAYS: ("Extra Water on Hot Days", "mdi:thermometer-lines"),
+    TYPE_HOURLY: ("Hourly Restrictions", "mdi:cancel"),
+    TYPE_MONTH: ("Month Restrictions", "mdi:cancel"),
+    TYPE_RAINDELAY: ("Rain Delay Restrictions", "mdi:cancel"),
+    TYPE_RAINSENSOR: ("Rain Sensor Restrictions", "mdi:cancel"),
+    TYPE_WEEKDAY: ("Weekday Restrictions", "mdi:cancel"),
+}
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -33,8 +45,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     binary_sensors = []
-    for sensor_type in rainmachine.binary_sensor_conditions:
-        name, icon = BINARY_SENSORS[sensor_type]
+    for sensor_type, attrs in BINARY_SENSORS.items():
+        name, icon = attrs
         binary_sensors.append(
             RainMachineBinarySensor(rainmachine, sensor_type, name, icon)
         )

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -28,15 +28,15 @@ TYPE_RAINSENSOR = "rainsensor"
 TYPE_WEEKDAY = "weekday"
 
 BINARY_SENSORS = {
-    TYPE_FLOW_SENSOR: ("Flow Sensor", "mdi:water-pump"),
-    TYPE_FREEZE: ("Freeze Restrictions", "mdi:cancel"),
-    TYPE_FREEZE_PROTECTION: ("Freeze Protection", "mdi:weather-snowy"),
-    TYPE_HOT_DAYS: ("Extra Water on Hot Days", "mdi:thermometer-lines"),
-    TYPE_HOURLY: ("Hourly Restrictions", "mdi:cancel"),
-    TYPE_MONTH: ("Month Restrictions", "mdi:cancel"),
-    TYPE_RAINDELAY: ("Rain Delay Restrictions", "mdi:cancel"),
-    TYPE_RAINSENSOR: ("Rain Sensor Restrictions", "mdi:cancel"),
-    TYPE_WEEKDAY: ("Weekday Restrictions", "mdi:cancel"),
+    TYPE_FLOW_SENSOR: ("Flow Sensor", "mdi:water-pump", True),
+    TYPE_FREEZE: ("Freeze Restrictions", "mdi:cancel", True),
+    TYPE_FREEZE_PROTECTION: ("Freeze Protection", "mdi:weather-snowy", True),
+    TYPE_HOT_DAYS: ("Extra Water on Hot Days", "mdi:thermometer-lines", True),
+    TYPE_HOURLY: ("Hourly Restrictions", "mdi:cancel", False),
+    TYPE_MONTH: ("Month Restrictions", "mdi:cancel", False),
+    TYPE_RAINDELAY: ("Rain Delay Restrictions", "mdi:cancel", False),
+    TYPE_RAINSENSOR: ("Rain Sensor Restrictions", "mdi:cancel", False),
+    TYPE_WEEKDAY: ("Weekday Restrictions", "mdi:cancel", False),
 }
 
 
@@ -45,9 +45,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     binary_sensors = []
-    for sensor_type, (name, icon) in BINARY_SENSORS.items():
+    for sensor_type, (name, icon, enabled_by_default) in BINARY_SENSORS.items():
         binary_sensors.append(
-            RainMachineBinarySensor(rainmachine, sensor_type, name, icon)
+            RainMachineBinarySensor(
+                rainmachine, sensor_type, name, icon, enabled_by_default
+            )
         )
 
     async_add_entities(binary_sensors, True)
@@ -56,14 +58,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
     """A sensor implementation for raincloud device."""
 
-    def __init__(self, rainmachine, sensor_type, name, icon):
+    def __init__(self, rainmachine, sensor_type, name, icon, enabled_by_default):
         """Initialize the sensor."""
         super().__init__(rainmachine)
 
+        self._enabled_by_default = enabled_by_default
         self._icon = icon
         self._name = name
         self._sensor_type = sensor_type
         self._state = None
+
+    @property
+    def entity_registry_enabled_default(self):
+        """Determine whether an entity is enabled by default."""
+        return self._enabled_by_default
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -33,7 +33,7 @@ def configured_instances(hass):
 class RainMachineFlowHandler(config_entries.ConfigFlow):
     """Handle a RainMachine config flow."""
 
-    VERSION = 2
+    VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self):

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -33,7 +33,7 @@ def configured_instances(hass):
 class RainMachineFlowHandler(config_entries.ConfigFlow):
     """Handle a RainMachine config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self):

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -10,16 +10,49 @@ from . import (
     PROVISION_SETTINGS,
     RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC,
-    SENSORS,
-    TYPE_FLOW_SENSOR_CLICK_M3,
-    TYPE_FLOW_SENSOR_CONSUMED_LITERS,
-    TYPE_FLOW_SENSOR_START_INDEX,
-    TYPE_FLOW_SENSOR_WATERING_CLICKS,
-    TYPE_FREEZE_TEMP,
     RainMachineEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+TYPE_FLOW_SENSOR_CLICK_M3 = "flow_sensor_clicks_cubic_meter"
+TYPE_FLOW_SENSOR_CONSUMED_LITERS = "flow_sensor_consumed_liters"
+TYPE_FLOW_SENSOR_START_INDEX = "flow_sensor_start_index"
+TYPE_FLOW_SENSOR_WATERING_CLICKS = "flow_sensor_watering_clicks"
+TYPE_FREEZE_TEMP = "freeze_protect_temp"
+
+SENSORS = {
+    TYPE_FLOW_SENSOR_CLICK_M3: (
+        "Flow Sensor Clicks",
+        "mdi:water-pump",
+        "clicks/m^3",
+        None,
+    ),
+    TYPE_FLOW_SENSOR_CONSUMED_LITERS: (
+        "Flow Sensor Consumed Liters",
+        "mdi:water-pump",
+        "liter",
+        None,
+    ),
+    TYPE_FLOW_SENSOR_START_INDEX: (
+        "Flow Sensor Start Index",
+        "mdi:water-pump",
+        "index",
+        None,
+    ),
+    TYPE_FLOW_SENSOR_WATERING_CLICKS: (
+        "Flow Sensor Clicks",
+        "mdi:water-pump",
+        "clicks",
+        None,
+    ),
+    TYPE_FREEZE_TEMP: (
+        "Freeze Protect Temperature",
+        "mdi:thermometer",
+        "°C",
+        "temperature",
+    ),
+}
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -27,8 +60,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     sensors = []
-    for sensor_type in rainmachine.sensor_conditions:
-        name, icon, unit, device_class = SENSORS[sensor_type]
+    for sensor_type, attrs in SENSORS.items():
+        name, icon, unit, device_class = attrs
         sensors.append(
             RainMachineSensor(rainmachine, sensor_type, name, icon, unit, device_class)
         )

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -27,30 +27,35 @@ SENSORS = {
         "mdi:water-pump",
         "clicks/m^3",
         None,
+        False,
     ),
     TYPE_FLOW_SENSOR_CONSUMED_LITERS: (
         "Flow Sensor Consumed Liters",
         "mdi:water-pump",
         "liter",
         None,
+        False,
     ),
     TYPE_FLOW_SENSOR_START_INDEX: (
         "Flow Sensor Start Index",
         "mdi:water-pump",
         "index",
         None,
+        False,
     ),
     TYPE_FLOW_SENSOR_WATERING_CLICKS: (
         "Flow Sensor Clicks",
         "mdi:water-pump",
         "clicks",
         None,
+        False,
     ),
     TYPE_FREEZE_TEMP: (
         "Freeze Protect Temperature",
         "mdi:thermometer",
         "°C",
         "temperature",
+        True,
     ),
 }
 
@@ -60,10 +65,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
     rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     sensors = []
-    for sensor_type, attrs in SENSORS.items():
-        name, icon, unit, device_class = attrs
+    for (
+        sensor_type,
+        (name, icon, unit, device_class, enabled_by_default),
+    ) in SENSORS.items():
         sensors.append(
-            RainMachineSensor(rainmachine, sensor_type, name, icon, unit, device_class)
+            RainMachineSensor(
+                rainmachine,
+                sensor_type,
+                name,
+                icon,
+                unit,
+                device_class,
+                enabled_by_default,
+            )
         )
 
     async_add_entities(sensors, True)
@@ -72,16 +87,31 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class RainMachineSensor(RainMachineEntity):
     """A sensor implementation for raincloud device."""
 
-    def __init__(self, rainmachine, sensor_type, name, icon, unit, device_class):
+    def __init__(
+        self,
+        rainmachine,
+        sensor_type,
+        name,
+        icon,
+        unit,
+        device_class,
+        enabled_by_default,
+    ):
         """Initialize."""
         super().__init__(rainmachine)
 
         self._device_class = device_class
+        self._enabled_by_default = enabled_by_default
         self._icon = icon
         self._name = name
         self._sensor_type = sensor_type
         self._state = None
         self._unit = unit
+
+    @property
+    def entity_registry_enabled_default(self):
+        """Determine whether an entity is enabled by default."""
+        return self._enabled_by_default
 
     @property
     def icon(self) -> str:


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
It is no longer possible to specify monitored conditions within the RainMachine integration; all entities are added by default.

Additionally, the `zone_run_time` parameter is now configured directly within the controller within `configuration.yaml`.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Per [ADR 0003](https://github.com/home-assistant/architecture/blob/master/adr/0003-monitor-condition-and-data-selectors.md), this PR removes the concept of monitored conditions from RainMachine. All entity types are added by default. The integration uses more than one local API call, but since the created entities all connect together, I didn't see a problem automatically including everything.

This PR also includes a config entry migration to clean up monitored conditions data as necessary.

## Type of change
<!--
    What types of changes does your PR introduce to our documention/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
    Supplying a configuration snippet, makes it easier for a maintainer to test
    your PR. Furthermore, for new integrations, it gives an impression of how
    the configuration would look like.
    Note: Remove this section if this PR does not have an example entry.
-->

```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_ip_address
      password: !secret rainmachine_password
```

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/11840

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated in [home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following Integration Quality Scale:
<!-- https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html -->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
