### PR TITLE
Support  SELECT_SOURCE for Bose soundtouch

### DIFF
--- a/homeassistant/components/soundtouch/const.py
+++ b/homeassistant/components/soundtouch/const.py
@@ -1,6 +1,17 @@
 """Constants for the Bose Soundtouch component."""
+from enum import Enum
+
 DOMAIN = "soundtouch"
 SERVICE_PLAY_EVERYWHERE = "play_everywhere"
 SERVICE_CREATE_ZONE = "create_zone"
 SERVICE_ADD_ZONE_SLAVE = "add_zone_slave"
 SERVICE_REMOVE_ZONE_SLAVE = "remove_zone_slave"
+BLUETOOTH_SOURCE = "BLUETOOTH"
+
+
+class Source(Enum):
+    """sources supported by bose soundtouch."""
+
+    AUX = "AUX"
+    BLUETOOTH = "BLUETOOTH"
+    PRODUCT_SOURCE = "PRODUCT"

--- a/homeassistant/components/soundtouch/const.py
+++ b/homeassistant/components/soundtouch/const.py
@@ -6,12 +6,9 @@ SERVICE_PLAY_EVERYWHERE = "play_everywhere"
 SERVICE_CREATE_ZONE = "create_zone"
 SERVICE_ADD_ZONE_SLAVE = "add_zone_slave"
 SERVICE_REMOVE_ZONE_SLAVE = "remove_zone_slave"
-BLUETOOTH_SOURCE = "BLUETOOTH"
 
 
-class Source(Enum):
-    """sources supported by bose soundtouch."""
+class ExtendSource(Enum):
+    """new sources supported by bose soundtouch."""
 
-    AUX = "AUX"
-    BLUETOOTH = "BLUETOOTH"
     PRODUCT_SOURCE = "PRODUCT"

--- a/homeassistant/components/soundtouch/manifest.json
+++ b/homeassistant/components/soundtouch/manifest.json
@@ -2,7 +2,7 @@
   "domain": "soundtouch",
   "name": "Bose Soundtouch",
   "documentation": "https://www.home-assistant.io/integrations/soundtouch",
-  "requirements": ["libsoundtouch==0.7.2"],
+  "requirements": ["libsoundtouch==0.8.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -209,7 +209,6 @@ class SoundTouchDevice(MediaPlayerDevice):
         self._sources = []
         self._sourcename = {}
         self._namesource = {}
-        _LOGGER.debug(f"CONF_RESOURCES: {self._resources}")
         if self._resources:
             for pair in self._resources:
                 source = pair["source"].upper()
@@ -218,9 +217,6 @@ class SoundTouchDevice(MediaPlayerDevice):
                 self._sourcename[source] = name
                 self._namesource[name] = source
                 self._namesource[source] = source
-        _LOGGER.debug(
-            f"_sources= {self._sources}, _sourcename={self._sourcename}, _namesource={self._namesource}"
-        )
 
     @property
     def config(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -778,7 +778,7 @@ libpyvivotek==0.4.0
 librouteros==3.0.0
 
 # homeassistant.components.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.8.0
 
 # homeassistant.components.life360
 life360==4.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ keyrings.alt==3.4.0
 libpurecool==0.6.0
 
 # homeassistant.components.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.8.0
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
support  SELECT_SOURCE for Bose soundtouch, and show friendly_name

## Type of change
- [x] New feature (which adds functionality to an existing integration)

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
media_player:
  - platform: soundtouch
    host: 192.168.100.99
    name: bose_soundtouch_083944
    resources:
      - name: "BluRayPlayer"
        source: "HDMI_3"
      - name: "XBox360"
        source: "HDMI_1"
      - name: "TMall Box"
        source: "HDMI_4"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
