### PR TITLE
Add availability status to Modbus entities

### DIFF
--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -1,6 +1,9 @@
 """Support for Modbus switches."""
 import logging
+from typing import Optional
 
+from pymodbus.exceptions import ConnectionException, ModbusException
+from pymodbus.pdu import ExceptionResponse
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA
@@ -116,6 +119,7 @@ class ModbusCoilSwitch(ToggleEntity, RestoreEntity):
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
         self._is_on = None
+        self._available = True
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -134,26 +138,62 @@ class ModbusCoilSwitch(ToggleEntity, RestoreEntity):
         """Return the name of the switch."""
         return self._name
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
+
     def turn_on(self, **kwargs):
         """Set switch on."""
-        self._hub.write_coil(self._slave, self._coil, True)
+        self._write_coil(self._coil, True)
 
     def turn_off(self, **kwargs):
         """Set switch off."""
-        self._hub.write_coil(self._slave, self._coil, False)
+        self._write_coil(self._coil, False)
 
     def update(self):
         """Update the state of the switch."""
-        result = self._hub.read_coils(self._slave, self._coil, 1)
+        self._is_on = self._read_coil(self._coil)
+
+    def _read_coil(self, coil) -> Optional[bool]:
+        """Read coil using the Modbus hub slave."""
         try:
-            self._is_on = bool(result.bits[0])
-        except AttributeError:
-            _LOGGER.error(
-                "No response from hub %s, slave %s, coil %s",
-                self._hub.name,
-                self._slave,
-                self._coil,
-            )
+            result = self._hub.read_coils(self._slave, coil, 1)
+        except ConnectionException:
+            self._set_unavailable()
+            return
+
+        if isinstance(result, (ModbusException, ExceptionResponse)):
+            self._set_unavailable()
+            return
+
+        value = bool(result.bits[0])
+        self._available = True
+
+        return value
+
+    def _write_coil(self, coil, value):
+        """Write coil using the Modbus hub slave."""
+        try:
+            self._hub.write_coil(self._slave, coil, value)
+        except ConnectionException:
+            self._set_unavailable()
+            return
+
+        self._available = True
+
+    def _set_unavailable(self):
+        """Set unavailable state and log it as an error."""
+        if not self._available:
+            return
+
+        _LOGGER.error(
+            "No response from hub %s, slave %s, coil %s",
+            self._hub.name,
+            self._slave,
+            self._coil,
+        )
+        self._available = False
 
 
 class ModbusRegisterSwitch(ModbusCoilSwitch):
@@ -184,6 +224,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
         self._verify_state = verify_state
         self._verify_register = verify_register if verify_register else self._register
         self._register_type = register_type
+        self._available = True
 
         if state_on is not None:
             self._state_on = state_on
@@ -199,46 +240,86 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
 
     def turn_on(self, **kwargs):
         """Set switch on."""
-        self._hub.write_register(self._slave, self._register, self._command_on)
-        if not self._verify_state:
-            self._is_on = True
+
+        # Only holding register is writable
+        if self._register_type == REGISTER_TYPE_HOLDING:
+            self._write_register(self._command_on)
+            if not self._verify_state:
+                self._is_on = True
 
     def turn_off(self, **kwargs):
         """Set switch off."""
-        self._hub.write_register(self._slave, self._register, self._command_off)
-        if not self._verify_state:
-            self._is_on = False
+
+        # Only holding register is writable
+        if self._register_type == REGISTER_TYPE_HOLDING:
+            self._write_register(self._command_off)
+            if not self._verify_state:
+                self._is_on = False
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
 
     def update(self):
         """Update the state of the switch."""
         if not self._verify_state:
             return
 
-        value = 0
-        if self._register_type == REGISTER_TYPE_INPUT:
-            result = self._hub.read_input_registers(self._slave, self._register, 1)
-        else:
-            result = self._hub.read_holding_registers(self._slave, self._register, 1)
-
-        try:
-            value = int(result.registers[0])
-        except AttributeError:
-            _LOGGER.error(
-                "No response from hub %s, slave %s, register %s",
-                self._hub.name,
-                self._slave,
-                self._verify_register,
-            )
-
+        value = self._read_register()
         if value == self._state_on:
             self._is_on = True
         elif value == self._state_off:
             self._is_on = False
-        else:
+        elif value is not None:
             _LOGGER.error(
                 "Unexpected response from hub %s, slave %s register %s, got 0x%2x",
                 self._hub.name,
                 self._slave,
-                self._verify_register,
+                self._register,
                 value,
             )
+
+    def _read_register(self) -> Optional[int]:
+        try:
+            if self._register_type == REGISTER_TYPE_INPUT:
+                result = self._hub.read_input_registers(self._slave, self._register, 1)
+            else:
+                result = self._hub.read_holding_registers(
+                    self._slave, self._register, 1
+                )
+        except ConnectionException:
+            self._set_unavailable()
+            return
+
+        if isinstance(result, (ModbusException, ExceptionResponse)):
+            self._set_unavailable()
+            return
+
+        value = int(result.registers[0])
+        self._available = True
+
+        return value
+
+    def _write_register(self, value):
+        """Write holding register using the Modbus hub slave."""
+        try:
+            self._hub.write_register(self._slave, self._register, value)
+        except ConnectionException:
+            self._set_unavailable()
+            return
+
+        self._available = True
+
+    def _set_unavailable(self):
+        """Set unavailable state and log it as an error."""
+        if not self._available:
+            return
+
+        _LOGGER.error(
+            "No response from hub %s, slave %s, register %s",
+            self._hub.name,
+            self._slave,
+            self._register,
+        )
+        self._available = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds support for reporting availability of the Modbus platform. In the current state, if Modbus communication fails, sensors won't notify the state machine, and the UI is not updated. It is a problem because the user is not aware of an issue unless he checks for Home Assistant logs.

Support was added for all existing Modbus components and manually tested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
