### PR TITLE
Code Cleanup for Vizio component

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -43,7 +43,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         for entry in config[DOMAIN]:
             hass.async_create_task(
                 hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
+                    handler=DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
                 )
             )
 
@@ -54,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     """Load the saved entities."""
     for platform in PLATFORMS:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
+            hass.config_entries.async_forward_entry_setup(entry=entry, domain=platform)
         )
 
     return True
@@ -65,7 +65,9 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> boo
     unload_ok = all(
         await asyncio.gather(
             *[
-                hass.config_entries.async_forward_entry_unload(entry, platform)
+                hass.config_entries.async_forward_entry_unload(
+                    entry=entry, domain=platform
+                )
                 for platform in PLATFORMS
             ]
         )

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -43,31 +43,31 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         for entry in config[DOMAIN]:
             hass.async_create_task(
                 hass.config_entries.flow.async_init(
-                    handler=DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
                 )
             )
 
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry) -> bool:
     """Load the saved entities."""
     for platform in PLATFORMS:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry=entry, domain=platform)
+            hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry
+) -> bool:
     """Unload a config entry."""
     unload_ok = all(
         await asyncio.gather(
             *[
-                hass.config_entries.async_forward_entry_unload(
-                    entry=entry, domain=platform
-                )
+                hass.config_entries.async_forward_entry_unload(config_entry, platform)
                 for platform in PLATFORMS
             ]
         )

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -58,15 +58,15 @@ async def async_setup_entry(
     if not config_entry.options:
         volume_step = config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
         hass.config_entries.async_update_entry(
-            entry=config_entry, options={CONF_VOLUME_STEP: volume_step}
+            config_entry, options={CONF_VOLUME_STEP: volume_step}
         )
     else:
         volume_step = config_entry.options[CONF_VOLUME_STEP]
 
     device = VizioAsync(
-        device_id=DEVICE_ID,
-        ip=host,
-        name=name,
+        DEVICE_ID,
+        host,
+        name,
         auth_token=token,
         device_type=VIZIO_DEVICE_CLASSES[device_class],
         session=async_get_clientsession(hass, False),
@@ -86,15 +86,9 @@ async def async_setup_entry(
         )
         raise PlatformNotReady
 
-    entity = VizioDevice(
-        config_entry=config_entry,
-        device=device,
-        name=name,
-        volume_step=volume_step,
-        device_class=device_class,
-    )
+    entity = VizioDevice(config_entry, device, name, volume_step, device_class,)
 
-    async_add_entities(new_entities=[entity], update_before_add=True)
+    async_add_entities([entity], update_before_add=True)
 
 
 class VizioDevice(MediaPlayerDevice):
@@ -175,16 +169,14 @@ class VizioDevice(MediaPlayerDevice):
         # Register callback for when config entry is updated.
         self._async_unsub_listeners.append(
             self._config_entry.add_update_listener(
-                listener=self._async_send_update_options_signal
+                self._async_send_update_options_signal
             )
         )
 
         # Register callback for update event
         self._async_unsub_listeners.append(
             async_dispatcher_connect(
-                hass=self.hass,
-                signal=self._config_entry.entry_id,
-                target=self._async_update_options,
+                self.hass, self._config_entry.entry_id, self._async_update_options,
             )
         )
 
@@ -279,7 +271,7 @@ class VizioDevice(MediaPlayerDevice):
 
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
-        await self._device.input_switch(name=source)
+        await self._device.input_switch(source)
 
     async def async_volume_up(self) -> None:
         """Increasing volume of the device."""

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -58,17 +58,17 @@ async def async_setup_entry(
     if not config_entry.options:
         volume_step = config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
         hass.config_entries.async_update_entry(
-            config_entry, options={CONF_VOLUME_STEP: volume_step}
+            entry=config_entry, options={CONF_VOLUME_STEP: volume_step}
         )
     else:
         volume_step = config_entry.options[CONF_VOLUME_STEP]
 
     device = VizioAsync(
-        DEVICE_ID,
-        host,
-        name,
-        token,
-        VIZIO_DEVICE_CLASSES[device_class],
+        device_id=DEVICE_ID,
+        ip=host,
+        name=name,
+        auth_token=token,
+        device_type=VIZIO_DEVICE_CLASSES[device_class],
         session=async_get_clientsession(hass, False),
         timeout=DEFAULT_TIMEOUT,
     )
@@ -86,9 +86,15 @@ async def async_setup_entry(
         )
         raise PlatformNotReady
 
-    entity = VizioDevice(config_entry, device, name, volume_step, device_class)
+    entity = VizioDevice(
+        config_entry=config_entry,
+        device=device,
+        name=name,
+        volume_step=volume_step,
+        device_class=device_class,
+    )
 
-    async_add_entities([entity], True)
+    async_add_entities(new_entities=[entity], update_before_add=True)
 
 
 class VizioDevice(MediaPlayerDevice):
@@ -122,7 +128,7 @@ class VizioDevice(MediaPlayerDevice):
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     async def async_update(self) -> None:
         """Retrieve latest state of the device."""
-        is_on = await self._device.get_power_state(False)
+        is_on = await self._device.get_power_state(log_api_exception=False)
 
         if is_on is None:
             self._available = False
@@ -139,15 +145,15 @@ class VizioDevice(MediaPlayerDevice):
 
         self._state = STATE_ON
 
-        volume = await self._device.get_current_volume(False)
+        volume = await self._device.get_current_volume(log_api_exception=False)
         if volume is not None:
             self._volume_level = float(volume) / self._max_volume
 
-        input_ = await self._device.get_current_input(False)
+        input_ = await self._device.get_current_input(log_api_exception=False)
         if input_ is not None:
             self._current_input = input_.meta_name
 
-        inputs = await self._device.get_inputs(False)
+        inputs = await self._device.get_inputs(log_api_exception=False)
         if inputs is not None:
             self._available_inputs = [input_.name for input_ in inputs]
 
@@ -169,14 +175,16 @@ class VizioDevice(MediaPlayerDevice):
         # Register callback for when config entry is updated.
         self._async_unsub_listeners.append(
             self._config_entry.add_update_listener(
-                self._async_send_update_options_signal
+                listener=self._async_send_update_options_signal
             )
         )
 
         # Register callback for update event
         self._async_unsub_listeners.append(
             async_dispatcher_connect(
-                self.hass, self._config_entry.entry_id, self._async_update_options
+                hass=self.hass,
+                signal=self._config_entry.entry_id,
+                target=self._async_update_options,
             )
         )
 
@@ -271,11 +279,11 @@ class VizioDevice(MediaPlayerDevice):
 
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
-        await self._device.input_switch(source)
+        await self._device.input_switch(name=source)
 
     async def async_volume_up(self) -> None:
         """Increasing volume of the device."""
-        await self._device.vol_up(self._volume_step)
+        await self._device.vol_up(num=self._volume_step)
 
         if self._volume_level is not None:
             self._volume_level = min(
@@ -284,7 +292,7 @@ class VizioDevice(MediaPlayerDevice):
 
     async def async_volume_down(self) -> None:
         """Decreasing volume of the device."""
-        await self._device.vol_down(self._volume_step)
+        await self._device.vol_down(num=self._volume_step)
 
         if self._volume_level is not None:
             self._volume_level = max(
@@ -296,9 +304,10 @@ class VizioDevice(MediaPlayerDevice):
         if self._volume_level is not None:
             if volume > self._volume_level:
                 num = int(self._max_volume * (volume - self._volume_level))
-                await self._device.vol_up(num)
+                await self._device.vol_up(num=num)
                 self._volume_level = volume
+
             elif volume < self._volume_level:
                 num = int(self._max_volume * (self._volume_level - volume))
-                await self._device.vol_down(num)
+                await self._device.vol_down(num=num)
                 self._volume_level = volume

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -176,7 +176,7 @@ class VizioDevice(MediaPlayerDevice):
         # Register callback for update event
         self._async_unsub_listeners.append(
             async_dispatcher_connect(
-                self.hass, self._config_entry.entry_id, self._async_update_options,
+                self.hass, self._config_entry.entry_id, self._async_update_options
             )
         )
 

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -136,13 +136,13 @@ async def test_user_flow_minimum_fields(
     """Test user config flow with minimum fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id=result["flow_id"],
+        result["flow_id"],
         user_input={
             CONF_NAME: NAME,
             CONF_HOST: HOST,
@@ -165,14 +165,14 @@ async def test_user_flow_all_fields(
     """Test user config flow with all fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id=result["flow_id"],
+        result["flow_id"],
         user_input={
             CONF_NAME: NAME,
             CONF_HOST: HOST,
@@ -192,7 +192,7 @@ async def test_user_flow_all_fields(
 async def test_options_flow(hass: HomeAssistantType) -> None:
     """Test options config flow."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_SPEAKER_CONFIG)
-    entry.add_to_hass(hass=hass)
+    entry.add_to_hass(hass)
 
     assert not entry.options
 
@@ -202,7 +202,7 @@ async def test_options_flow(hass: HomeAssistantType) -> None:
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
-        flow_id=result["flow_id"], user_input={CONF_VOLUME_STEP: VOLUME_STEP}
+        result["flow_id"], user_input={CONF_VOLUME_STEP: VOLUME_STEP}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -219,12 +219,12 @@ async def test_user_host_already_configured(
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
     )
-    entry.add_to_hass(hass=hass)
+    entry.add_to_hass(hass)
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
     fail_entry[CONF_NAME] = "newtestname"
 
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
+        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -240,13 +240,13 @@ async def test_user_name_already_configured(
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
     )
-    entry.add_to_hass(hass=hass)
+    entry.add_to_hass(hass)
 
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
     fail_entry[CONF_HOST] = "0.0.0.0"
 
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
+        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -262,7 +262,7 @@ async def test_user_esn_already_exists(
     # Set up new entry
     MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
-    ).add_to_hass(hass=hass)
+    ).add_to_hass(hass)
 
     # Set up new entry with same unique_id but different host and name
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
@@ -270,7 +270,7 @@ async def test_user_esn_already_exists(
     fail_entry[CONF_NAME] = NAME2
 
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
+        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -282,7 +282,7 @@ async def test_user_error_on_could_not_connect(
 ) -> None:
     """Test with could_not_connect during user_setup."""
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -296,7 +296,7 @@ async def test_user_error_on_tv_needs_token(
 ) -> None:
     """Test when config fails custom validation for non null access token when device_class = tv during user setup."""
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_USER}, data=MOCK_INVALID_TV_CONFIG
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_INVALID_TV_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -310,7 +310,7 @@ async def test_import_flow_minimum_fields(
 ) -> None:
     """Test import config flow with minimum fields."""
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(
             {CONF_HOST: HOST, CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER}
@@ -332,7 +332,7 @@ async def test_import_flow_all_fields(
 ) -> None:
     """Test import config flow with all fields."""
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
     )
@@ -357,11 +357,11 @@ async def test_import_entity_already_configured(
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
         options={CONF_VOLUME_STEP: VOLUME_STEP},
     )
-    entry.add_to_hass(hass=hass)
+    entry.add_to_hass(hass)
     fail_entry = vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG.copy())
 
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_IMPORT}, data=fail_entry
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -375,7 +375,7 @@ async def test_import_flow_update_options(
 ) -> None:
     """Test import config flow with updated options."""
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
     )
@@ -388,7 +388,7 @@ async def test_import_flow_update_options(
     updated_config = MOCK_IMPORT_VALID_TV_CONFIG.copy()
     updated_config[CONF_VOLUME_STEP] = VOLUME_STEP + 1
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(updated_config),
     )
@@ -410,7 +410,7 @@ async def test_zeroconf_flow(
     """Test zeroconf config flow."""
     discovery_info = MOCK_ZEROCONF_ENTRY.copy()
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
     # Form should always show even if all required properties are discovered
@@ -422,7 +422,7 @@ async def test_zeroconf_flow(
     user_input = result["data_schema"](discovery_info)
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id=result["flow_id"], user_input=user_input
+        result["flow_id"], user_input=user_input
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -441,12 +441,12 @@ async def test_zeroconf_flow_already_configured(
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
     )
-    entry.add_to_hass(hass=hass)
+    entry.add_to_hass(hass)
 
     # Try rediscovering same device
     discovery_info = MOCK_ZEROCONF_ENTRY.copy()
     result = await hass.config_entries.flow.async_init(
-        handler=DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
     # Flow should abort because device is already setup

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -129,18 +129,20 @@ def vizio_cant_connect_fixture():
 
 
 async def test_user_flow_minimum_fields(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test user config flow with minimum fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
+        handler=DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
+        flow_id=result["flow_id"],
         user_input={
             CONF_NAME: NAME,
             CONF_HOST: HOST,
@@ -156,19 +158,21 @@ async def test_user_flow_minimum_fields(
 
 
 async def test_user_flow_all_fields(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test user config flow with all fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
+        handler=DOMAIN, context={"source": SOURCE_USER}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
+        flow_id=result["flow_id"],
         user_input={
             CONF_NAME: NAME,
             CONF_HOST: HOST,
@@ -188,19 +192,17 @@ async def test_user_flow_all_fields(
 async def test_options_flow(hass: HomeAssistantType) -> None:
     """Test options config flow."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_SPEAKER_CONFIG)
-    entry.add_to_hass(hass)
+    entry.add_to_hass(hass=hass)
 
     assert not entry.options
 
-    result = await hass.config_entries.options.async_init(
-        entry.entry_id, context={"source": "test"}, data=None
-    )
+    result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={CONF_VOLUME_STEP: VOLUME_STEP}
+        flow_id=result["flow_id"], user_input={CONF_VOLUME_STEP: VOLUME_STEP}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -209,25 +211,20 @@ async def test_options_flow(hass: HomeAssistantType) -> None:
 
 
 async def test_user_host_already_configured(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test host is already configured during user setup."""
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
     )
-    entry.add_to_hass(hass)
+    entry.add_to_hass(hass=hass)
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
     fail_entry[CONF_NAME] = "newtestname"
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=fail_entry
+        handler=DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -235,25 +232,21 @@ async def test_user_host_already_configured(
 
 
 async def test_user_name_already_configured(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test name is already configured during user setup."""
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
     )
-    entry.add_to_hass(hass)
+    entry.add_to_hass(hass=hass)
 
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
     fail_entry[CONF_HOST] = "0.0.0.0"
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], fail_entry
+        handler=DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -261,13 +254,15 @@ async def test_user_name_already_configured(
 
 
 async def test_user_esn_already_exists(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test ESN is already configured with different host and name during user setup."""
     # Set up new entry
     MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
-    ).add_to_hass(hass)
+    ).add_to_hass(hass=hass)
 
     # Set up new entry with same unique_id but different host and name
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
@@ -275,7 +270,7 @@ async def test_user_esn_already_exists(
     fail_entry[CONF_NAME] = NAME2
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
+        handler=DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -283,36 +278,25 @@ async def test_user_esn_already_exists(
 
 
 async def test_user_error_on_could_not_connect(
-    hass: HomeAssistantType, vizio_cant_connect
+    hass: HomeAssistantType, vizio_cant_connect: pytest.fixture
 ) -> None:
     """Test with could_not_connect during user_setup."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
+        handler=DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], MOCK_USER_VALID_TV_CONFIG
-    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "cant_connect"}
 
 
 async def test_user_error_on_tv_needs_token(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test when config fails custom validation for non null access token when device_class = tv during user setup."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], MOCK_INVALID_TV_CONFIG
+        handler=DOMAIN, context={"source": SOURCE_USER}, data=MOCK_INVALID_TV_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -320,12 +304,14 @@ async def test_user_error_on_tv_needs_token(
 
 
 async def test_import_flow_minimum_fields(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test import config flow with minimum fields."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": "import"},
+        handler=DOMAIN,
+        context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(
             {CONF_HOST: HOST, CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER}
         ),
@@ -340,12 +326,14 @@ async def test_import_flow_minimum_fields(
 
 
 async def test_import_flow_all_fields(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test import config flow with all fields."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": "import"},
+        handler=DOMAIN,
+        context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
     )
 
@@ -359,7 +347,9 @@ async def test_import_flow_all_fields(
 
 
 async def test_import_entity_already_configured(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test entity is already configured during import setup."""
     entry = MockConfigEntry(
@@ -367,11 +357,11 @@ async def test_import_entity_already_configured(
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
         options={CONF_VOLUME_STEP: VOLUME_STEP},
     )
-    entry.add_to_hass(hass)
+    entry.add_to_hass(hass=hass)
     fail_entry = vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG.copy())
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "import"}, data=fail_entry
+        handler=DOMAIN, context={"source": SOURCE_IMPORT}, data=fail_entry
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -379,15 +369,18 @@ async def test_import_entity_already_configured(
 
 
 async def test_import_flow_update_options(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_update
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_update: pytest.fixture,
 ) -> None:
     """Test import config flow with updated options."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
+        handler=DOMAIN,
         context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
     )
     await hass.async_block_till_done()
+
     assert result["result"].options == {CONF_VOLUME_STEP: VOLUME_STEP}
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     entry_id = result["result"].entry_id
@@ -395,7 +388,7 @@ async def test_import_flow_update_options(
     updated_config = MOCK_IMPORT_VALID_TV_CONFIG.copy()
     updated_config[CONF_VOLUME_STEP] = VOLUME_STEP + 1
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
+        handler=DOMAIN,
         context={"source": SOURCE_IMPORT},
         data=vol.Schema(VIZIO_SCHEMA)(updated_config),
     )
@@ -409,12 +402,15 @@ async def test_import_flow_update_options(
 
 
 async def test_zeroconf_flow(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup, vizio_guess_device_type
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
+    vizio_guess_device_type: pytest.fixture,
 ) -> None:
     """Test zeroconf config flow."""
     discovery_info = MOCK_ZEROCONF_ENTRY.copy()
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+        handler=DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
     # Form should always show even if all required properties are discovered
@@ -426,7 +422,7 @@ async def test_zeroconf_flow(
     user_input = result["data_schema"](discovery_info)
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=user_input
+        flow_id=result["flow_id"], user_input=user_input
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -437,18 +433,20 @@ async def test_zeroconf_flow(
 
 
 async def test_zeroconf_flow_already_configured(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test entity is already configured during zeroconf setup."""
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
     )
-    entry.add_to_hass(hass)
+    entry.add_to_hass(hass=hass)
 
     # Try rediscovering same device
     discovery_info = MOCK_ZEROCONF_ENTRY.copy()
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+        handler=DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
     # Flow should abort because device is already setup


### PR DESCRIPTION
## Proposed change
To clean up the code in the vizio integration and to make future development easier, I:
- Added missing type hints
- Added parameter names to function calls for named parameters
- Used existing constants instead of strings where it made sense
- Removed code that had no functional value
- Simplified testing logic (merged two steps into one)
- Renamed variables to more clearly state purpose and make private as needed


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
