### PR TITLE
Fix HomeKit window covering to support float numbers in the position

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -119,7 +119,7 @@ class WindowCovering(HomeAccessory):
     def update_state(self, new_state):
         """Update cover position after state changed."""
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
-        if isinstance(current_position, int):
+        if isinstance(current_position, (float, int)):
             self.char_current_position.set_value(current_position)
             if (
                 self._homekit_target is None

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -120,6 +120,7 @@ class WindowCovering(HomeAccessory):
         """Update cover position after state changed."""
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
         if isinstance(current_position, (float, int)):
+            current_position = int(current_position)
             self.char_current_position.set_value(current_position)
             if (
                 self._homekit_target is None

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -153,8 +153,8 @@ async def test_window_set_cover_position(hass, hk_driver, cls, events):
 
     hass.states.async_set(entity_id, STATE_OPENING, {ATTR_CURRENT_POSITION: 70.0})
     await hass.async_block_till_done()
-    assert acc.char_current_position.value == 70.0
-    assert acc.char_target_position.value == 70.0
+    assert acc.char_current_position.value == 70
+    assert acc.char_target_position.value == 70
     assert acc.char_position_state.value == 1
 
     hass.states.async_set(entity_id, STATE_CLOSING, {ATTR_CURRENT_POSITION: 50})

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -151,6 +151,12 @@ async def test_window_set_cover_position(hass, hk_driver, cls, events):
     assert acc.char_target_position.value == 60
     assert acc.char_position_state.value == 1
 
+    hass.states.async_set(entity_id, STATE_OPENING, {ATTR_CURRENT_POSITION: 70.0})
+    await hass.async_block_till_done()
+    assert acc.char_current_position.value == 70.0
+    assert acc.char_target_position.value == 70.0
+    assert acc.char_position_state.value == 1
+
     hass.states.async_set(entity_id, STATE_CLOSING, {ATTR_CURRENT_POSITION: 50})
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 50


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a bug fix of the HomeKit Cover component. The template platform stores the cover position as a [float number](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/template/cover.py#L420). Due to `isinstance` check, the HomeKit instance cannot update the target position, and the accessory stuck in the opening state (see attached screenshot).

<img src="https://user-images.githubusercontent.com/15189627/72927562-c8965a80-3d56-11ea-8d05-dd33491b219f.png" width="200">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
homekit:
  filter:
    include_entities:
      - cover.example

input_number:
  example:
    min: 0
    max: 100

cover:
  - platform: template
    covers:
      example:
        position_template: "{{ states('input_number.example') | int }}"
        set_cover_position:
          service: input_number.set_value
          data_template:
            entity_id: input_number.example
            value: "{{ position }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
