### PR TITLE
UniFi integration move to push messaging

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -1,7 +1,7 @@
 """Support for devices connected to UniFi POE."""
 import voluptuous as vol
 
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
@@ -95,6 +95,8 @@ async def async_setup_entry(hass, config_entry):
         name="UniFi Controller",
         # sw_version=config.raw['swversion'],
     )
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, controller.shutdown)
 
     return True
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -339,7 +339,7 @@ class UniFiController:
 
 
 async def get_controller(
-    hass, host, username, password, port, site, verify_ssl, async_callback
+    hass, host, username, password, port, site, verify_ssl, async_callback=None
 ):
     """Create a controller object and verify authentication."""
     sslcontext = None

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -297,7 +297,7 @@ class UniFiController:
     @callback
     def reconnect(self) -> None:
         """Prepare to reconnect UniFi session."""
-        LOGGER.debug("Reconnecting to UniFi in %i.", RETRY_TIMER)
+        LOGGER.debug("Reconnecting to UniFi in %i", RETRY_TIMER)
         self.hass.loop.create_task(self.async_reconnect())
 
     async def async_reconnect(self) -> None:

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,8 +3,12 @@
   "name": "Ubiquiti UniFi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": ["aiounifi==11"],
+  "requirements": [
+    "aiounifi==12"
+  ],
   "dependencies": [],
-  "codeowners": ["@kane610"],
+  "codeowners": [
+    "@kane610"
+  ],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -4,10 +4,10 @@ import logging
 from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_registry import DISABLED_CONFIG_ENTRY
+
+from .unifi_client import UniFiClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     @callback
     def update_controller():
         """Update the values of the controller."""
-        update_items(controller, async_add_entities, sensors)
+        add_entities(controller, async_add_entities, sensors)
 
     controller.listeners.append(
         async_dispatcher_connect(hass, controller.signal_update, update_controller)
@@ -61,8 +61,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 @callback
-def update_items(controller, async_add_entities, sensors):
-    """Update sensors from the controller."""
+def add_entities(controller, async_add_entities, sensors):
+    """Add new sensor entities from the controller."""
     new_sensors = []
 
     for client_id in controller.api.clients:
@@ -73,9 +73,6 @@ def update_items(controller, async_add_entities, sensors):
             item_id = f"{direction}-{client_id}"
 
             if item_id in sensors:
-                sensor = sensors[item_id]
-                if sensor.enabled:
-                    sensor.async_schedule_update_ha_state()
                 continue
 
             sensors[item_id] = sensor_class(
@@ -87,14 +84,8 @@ def update_items(controller, async_add_entities, sensors):
         async_add_entities(new_sensors)
 
 
-class UniFiBandwidthSensor(Entity):
-    """UniFi Bandwidth sensor base class."""
-
-    def __init__(self, client, controller):
-        """Set up client."""
-        self.client = client
-        self.controller = controller
-        self.is_wired = self.client.mac not in controller.wireless_clients
+class UniFiRxBandwidthSensor(UniFiClient):
+    """Receiving bandwidth sensor."""
 
     @property
     def entity_registry_enabled_default(self):
@@ -102,37 +93,6 @@ class UniFiBandwidthSensor(Entity):
         if self.controller.option_allow_bandwidth_sensors:
             return True
         return False
-
-    async def async_added_to_hass(self):
-        """Client entity created."""
-        LOGGER.debug("New UniFi bandwidth sensor %s (%s)", self.name, self.client.mac)
-
-    async def async_update(self):
-        """Synchronize state with controller.
-
-        Make sure to update self.is_wired if client is wireless, there is an issue when clients go offline that they get marked as wired.
-        """
-        LOGGER.debug(
-            "Updating UniFi bandwidth sensor %s (%s)", self.entity_id, self.client.mac
-        )
-        await self.controller.request_update()
-
-        if self.is_wired and self.client.mac in self.controller.wireless_clients:
-            self.is_wired = False
-
-    @property
-    def available(self) -> bool:
-        """Return if controller is available."""
-        return self.controller.available
-
-    @property
-    def device_info(self):
-        """Return a device description for device registry."""
-        return {"connections": {(CONNECTION_NETWORK_MAC, self.client.mac)}}
-
-
-class UniFiRxBandwidthSensor(UniFiBandwidthSensor):
-    """Receiving bandwidth sensor."""
 
     @property
     def state(self):
@@ -153,7 +113,7 @@ class UniFiRxBandwidthSensor(UniFiBandwidthSensor):
         return f"rx-{self.client.mac}"
 
 
-class UniFiTxBandwidthSensor(UniFiBandwidthSensor):
+class UniFiTxBandwidthSensor(UniFiRxBandwidthSensor):
     """Transmitting bandwidth sensor."""
 
     @property

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -1,14 +1,14 @@
 """Support for devices connected to UniFi POE."""
 import logging
-from pprint import pformat
 
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
+
+from .unifi_client import UniFiClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switches for UniFi component.
 
-    Switches are controlling network switch ports with Poe.
+    Switches are controlling network access and switch ports with POE.
     """
     controller = get_controller_from_config_entry(hass, config_entry)
 
@@ -55,7 +55,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     @callback
     def update_controller():
         """Update the values of the controller."""
-        update_items(controller, async_add_entities, switches, switches_off)
+        add_entities(controller, async_add_entities, switches, switches_off)
 
     controller.listeners.append(
         async_dispatcher_connect(hass, controller.signal_update, update_controller)
@@ -66,8 +66,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 @callback
-def update_items(controller, async_add_entities, switches, switches_off):
-    """Update POE port state from the controller."""
+def add_entities(controller, async_add_entities, switches, switches_off):
+    """Add new switch entities from the controller."""
     new_switches = []
     devices = controller.api.devices
 
@@ -77,13 +77,6 @@ def update_items(controller, async_add_entities, switches, switches_off):
         block_client_id = f"block-{client_id}"
 
         if block_client_id in switches:
-            if switches[block_client_id].enabled:
-                LOGGER.debug(
-                    "Updating UniFi block switch %s (%s)",
-                    switches[block_client_id].entity_id,
-                    switches[block_client_id].client.mac,
-                )
-                switches[block_client_id].async_schedule_update_ha_state()
             continue
 
         if client_id not in controller.api.clients_all:
@@ -99,13 +92,6 @@ def update_items(controller, async_add_entities, switches, switches_off):
         poe_client_id = f"poe-{client_id}"
 
         if poe_client_id in switches:
-            if switches[poe_client_id].enabled:
-                LOGGER.debug(
-                    "Updating UniFi POE switch %s (%s)",
-                    switches[poe_client_id].entity_id,
-                    switches[poe_client_id].client.mac,
-                )
-                switches[poe_client_id].async_schedule_update_ha_state()
             continue
 
         client = controller.api.clients[client_id]
@@ -148,42 +134,21 @@ def update_items(controller, async_add_entities, switches, switches_off):
         async_add_entities(new_switches)
 
 
-class UniFiClient:
-    """Base class for UniFi switches."""
-
-    def __init__(self, client, controller):
-        """Set up switch."""
-        self.client = client
-        self.controller = controller
-
-    async def async_update(self):
-        """Synchronize state with controller."""
-        await self.controller.request_update()
-
-    @property
-    def name(self):
-        """Return the name of the client."""
-        return self.client.name or self.client.hostname
-
-    @property
-    def device_info(self):
-        """Return a device description for device registry."""
-        return {"connections": {(CONNECTION_NETWORK_MAC, self.client.mac)}}
-
-
 class UniFiPOEClientSwitch(UniFiClient, SwitchDevice, RestoreEntity):
     """Representation of a client that uses POE."""
 
     def __init__(self, client, controller):
         """Set up POE switch."""
         super().__init__(client, controller)
+
         self.poe_mode = None
         if self.client.sw_port and self.port.poe_mode != "off":
             self.poe_mode = self.port.poe_mode
 
     async def async_added_to_hass(self):
         """Call when entity about to be added to Home Assistant."""
-        LOGGER.debug("New UniFi POE switch %s (%s)", self.name, self.client.mac)
+        await super().async_added_to_hass()
+
         state = await self.async_get_last_state()
 
         if state is None:
@@ -197,16 +162,6 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchDevice, RestoreEntity):
 
         if not self.client.sw_port:
             self.client.raw["sw_port"] = state.attributes["port"]
-
-    async def async_update(self):
-        """Log client information after update."""
-        await super().async_update()
-
-        LOGGER.debug(
-            "Updating UniFi POE controlled client %s\n%s",
-            self.entity_id,
-            pformat(self.client.raw),
-        )
 
     @property
     def unique_id(self):
@@ -267,10 +222,6 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchDevice, RestoreEntity):
 class UniFiBlockClientSwitch(UniFiClient, SwitchDevice):
     """Representation of a blockable client."""
 
-    async def async_added_to_hass(self):
-        """Call when entity about to be added to Home Assistant."""
-        LOGGER.debug("New UniFi Block switch %s (%s)", self.name, self.client.mac)
-
     @property
     def unique_id(self):
         """Return a unique identifier for this switch."""
@@ -280,11 +231,6 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchDevice):
     def is_on(self):
         """Return true if client is allowed to connect."""
         return not self.client.blocked
-
-    @property
-    def available(self):
-        """Return if controller is available."""
-        return self.controller.available
 
     async def async_turn_on(self, **kwargs):
         """Turn on connectivity for client."""

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -1,0 +1,66 @@
+"""Base class for UniFi clients."""
+
+import logging
+
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UniFiClient(Entity):
+    """Base class for UniFi clients."""
+
+    def __init__(self, client, controller) -> None:
+        """Set up client."""
+        self.client = client
+        self.controller = controller
+        self.listeners = []
+        self.is_wired = self.client.mac not in controller.wireless_clients
+
+    async def async_added_to_hass(self) -> None:
+        """Client entity created."""
+        LOGGER.debug("New UniFi client %s (%s)", self.name, self.client.mac)
+        self.client.register_callback(self.async_update_callback)
+        self.listeners.append(
+            async_dispatcher_connect(
+                self.hass, self.controller.signal_reachable, self.async_update_callback
+            )
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect client object when removed."""
+        self.client.remove_callback(self.async_update_callback)
+        for unsub_dispatcher in self.listeners:
+            unsub_dispatcher()
+
+    @callback
+    def async_update_callback(self) -> None:
+        """Update the clients state."""
+        if self.is_wired and self.client.mac in self.controller.wireless_clients:
+            self.is_wired = False
+        print(f"Updating client {self.entity_id} {self.client.mac}")
+        LOGGER.debug("Updating client %s %s", self.entity_id, self.client.mac)
+        self.async_schedule_update_ha_state()
+
+    @property
+    def name(self) -> str:
+        """Return the name of the client."""
+        return self.client.name or self.client.hostname
+
+    @property
+    def available(self) -> bool:
+        """Return if controller is available."""
+        return self.controller.available
+
+    @property
+    def device_info(self) -> dict:
+        """Return a client description for device registry."""
+        return {"connections": {(CONNECTION_NETWORK_MAC, self.client.mac)}}
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -41,7 +41,6 @@ class UniFiClient(Entity):
         """Update the clients state."""
         if self.is_wired and self.client.mac in self.controller.wireless_clients:
             self.is_wired = False
-        print(f"Updating client {self.entity_id} {self.client.mac}")
         LOGGER.debug("Updating client %s %s", self.entity_id, self.client.mac)
         self.async_schedule_update_ha_state()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -196,7 +196,7 @@ aiopylgtv==0.2.7
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==11
+aiounifi==12
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -75,7 +75,7 @@ aiopylgtv==0.2.7
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==11
+aiounifi==12
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -236,6 +236,30 @@ async def test_reset_after_successful_setup(hass):
     assert len(controller.listeners) == 0
 
 
+async def test_wireless_client_event_calls_update_wireless_devices(hass):
+    """Call update_wireless_devices method when receiving wireless client event."""
+    controller = await setup_unifi_integration(hass)
+
+    with patch(
+        "homeassistant.components.unifi.controller.UniFiController.update_wireless_clients",
+        return_value=None,
+    ) as wireless_clients_mock:
+        controller.api.websocket._data = {
+            "meta": {"rc": "ok", "message": "events"},
+            "data": [
+                {
+                    "datetime": "2020-01-20T19:37:04Z",
+                    "key": aiounifi.events.WIRELESS_CLIENT_CONNECTED,
+                    "msg": "User[11:22:33:44:55:66] has connected to WLAN",
+                    "time": 1579549024893,
+                }
+            ],
+        }
+        controller.api.session_handler("data")
+
+        assert wireless_clients_mock.assert_called_once
+
+
 async def test_get_controller(hass):
     """Successful call."""
     with patch("aiounifi.Controller.login", return_value=Mock()):

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -136,11 +136,12 @@ async def test_tracked_devices(hass):
 
     client_1_copy = copy(CLIENT_1)
     client_1_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
+    event = {"meta": {"message": "sta:sync"}, "data": [client_1_copy]}
+    controller.api.message_handler(event)
     device_1_copy = copy(DEVICE_1)
     device_1_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    controller.mock_client_responses.append([client_1_copy])
-    controller.mock_device_responses.append([device_1_copy])
-    await controller.async_update()
+    event = {"meta": {"message": "device:sync"}, "data": [device_1_copy]}
+    controller.api.message_handler(event)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -151,9 +152,8 @@ async def test_tracked_devices(hass):
 
     device_1_copy = copy(DEVICE_1)
     device_1_copy["disabled"] = True
-    controller.mock_client_responses.append({})
-    controller.mock_device_responses.append([device_1_copy])
-    await controller.async_update()
+    event = {"meta": {"message": "device:sync"}, "data": [device_1_copy]}
+    controller.api.message_handler(event)
     await hass.async_block_till_done()
 
     device_1 = hass.states.get("device_tracker.device_1")
@@ -194,9 +194,8 @@ async def test_wireless_client_go_wired_issue(hass):
 
     client_1_client["is_wired"] = True
     client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    controller.mock_client_responses.append([client_1_client])
-    controller.mock_device_responses.append({})
-    await controller.async_update()
+    event = {"meta": {"message": "sta:sync"}, "data": [client_1_client]}
+    controller.api.message_handler(event)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -207,9 +206,8 @@ async def test_wireless_client_go_wired_issue(hass):
         "utcnow",
         return_value=(dt_util.utcnow() + timedelta(minutes=5)),
     ):
-        controller.mock_client_responses.append([client_1_client])
-        controller.mock_device_responses.append({})
-        await controller.async_update()
+        event = {"meta": {"message": "sta:sync"}, "data": [client_1_client]}
+        controller.api.message_handler(event)
         await hass.async_block_till_done()
 
         client_1 = hass.states.get("device_tracker.client_1")
@@ -217,9 +215,8 @@ async def test_wireless_client_go_wired_issue(hass):
 
     client_1_client["is_wired"] = False
     client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    controller.mock_client_responses.append([client_1_client])
-    controller.mock_device_responses.append({})
-    await controller.async_update()
+    event = {"meta": {"message": "sta:sync"}, "data": [client_1_client]}
+    controller.api.message_handler(event)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -90,8 +90,8 @@ async def test_sensors(hass):
     clients[1]["rx_bytes"] = 2345000000
     clients[1]["tx_bytes"] = 6789000000
 
-    controller.mock_client_responses.append(clients)
-    await controller.async_update()
+    event = {"meta": {"message": "sta:sync"}, "data": clients}
+    controller.api.message_handler(event)
     await hass.async_block_till_done()
 
     wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR moves UniFi integration from polling data during normal operations to use web socket signalling. This hopefully solves the issue where the integration seem to happen in a never ending loop requesting more data from UniFi leading to HASS being unusable.

- [x] Fix signalling of new clients/devices
- [x] Fix reconnection logic
- [x] Fix tests

<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30168

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
