### PR TITLE
Update Hue existing config entry with discovery data

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -170,7 +170,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         bridge = self._async_get_bridge(host, discovery_info[ssdp.ATTR_UPNP_SERIAL])
 
         await self.async_set_unique_id(bridge.id)
-        self._abort_if_unique_id_configured({CONF_HOST: bridge.host})
+        self._abort_if_unique_id_configured(updates={CONF_HOST: bridge.host})
 
         self.bridge = bridge
         return await self.async_step_link()
@@ -182,7 +182,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         await self.async_set_unique_id(bridge.id)
-        self._abort_if_unique_id_configured({CONF_HOST: bridge.host})
+        self._abort_if_unique_id_configured(updates={CONF_HOST: bridge.host})
 
         self.bridge = bridge
         return await self.async_step_link()

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -10,6 +10,8 @@ import voluptuous as vol
 
 from homeassistant import config_entries, core
 from homeassistant.components import ssdp
+from homeassistant.const import CONF_HOST
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers import aiohttp_client
 
 from .bridge import authenticate_bridge
@@ -49,6 +51,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             websession=aiohttp_client.async_get_clientsession(self.hass),
             bridge_id=bridge_id,
         )
+
+    def _update_existing_entry(self, bridge: aiohue.Bridge) -> None:
+        """Update existing config entry."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if bridge.id == entry.unique_id and bridge.host != entry.data[CONF_HOST]:
+                entry.data[CONF_HOST] = bridge.host
+                self.hass.config_entries.async_update_entry(entry)
 
     async def async_step_init(self, user_input=None):
         """Handle a flow start."""
@@ -169,7 +178,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         bridge = self._async_get_bridge(host, discovery_info[ssdp.ATTR_UPNP_SERIAL])
 
         await self.async_set_unique_id(bridge.id)
-        self._abort_if_unique_id_configured()
+        try:
+            self._abort_if_unique_id_configured()
+        except AbortFlow as abort:
+            # Try to update an existing entry
+            self._update_existing_entry(bridge)
+            raise abort
+
         self.bridge = bridge
         return await self.async_step_link()
 
@@ -180,7 +195,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         await self.async_set_unique_id(bridge.id)
-        self._abort_if_unique_id_configured()
+        try:
+            self._abort_if_unique_id_configured()
+        except AbortFlow as abort:
+            # Try to update an existing entry
+            self._update_existing_entry(bridge)
+            raise abort
+
         self.bridge = bridge
         return await self.async_step_link()
 

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -215,7 +215,7 @@ async def test_flow_link_timeout(hass):
 
 
 async def test_flow_link_unknown_error(hass):
-    """Test config flow."""
+    """Test if a unknown error happend during the linking processes."""
     mock_bridge = get_mock_bridge(mock_create_user=CoroutineMock(side_effect=OSError),)
     with patch(
         "homeassistant.components.hue.config_flow.discover_nupnp",
@@ -324,7 +324,7 @@ async def test_bridge_ssdp_emulated_hue(hass):
 
 
 async def test_bridge_ssdp_missing_location(hass):
-    """Test if discovery info is from an emulated hue instance."""
+    """Test if discovery info is missing a location attribute."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": "ssdp"},
@@ -339,7 +339,7 @@ async def test_bridge_ssdp_missing_location(hass):
 
 
 async def test_bridge_ssdp_missing_serial(hass):
-    """Test if discovery info is from an emulated hue instance."""
+    """Test if discovery info is a serial attribute."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": "ssdp"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds some additional magic to the Hue Bridge discovery. Instead of just aborting a config flow when a bridge is already configured (by the unique config flow ID), it now updates the bridge host in the existing configuration entry.

This deals/handles changing hostnames/IP addresses in the network, causing Home Assistant to automatically recover a lost bridge.

PS: it also adds 2 additional tests to improve the coverage on the configuration flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
