### PR TITLE
Add update_entry dict to unique ID flow abort helper

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -817,24 +817,18 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         raise data_entry_flow.UnknownHandler
 
     @callback
-    def _abort_if_unique_id_configured(
-        self, update_entry: Dict[Any, Any] = None
-    ) -> None:
+    def _abort_if_unique_id_configured(self, updates: Dict[Any, Any] = None) -> None:
         """Abort if the unique ID is already configured."""
+        assert self.hass
         if self.unique_id is None:
             return
 
         for entry in self._async_current_entries():
             if entry.unique_id == self.unique_id:
-                if (
-                    self.hass is not None
-                    and update_entry is not None
-                    and not update_entry.items() <= entry.data.items()
-                ):
-                    data = (entry.data or {}).copy()
-                    data.update(update_entry)
-                    self.hass.config_entries.async_update_entry(entry, data=data)
-
+                if updates is not None and not updates.items() <= entry.data.items():
+                    self.hass.config_entries.async_update_entry(
+                        entry, data={**entry.data, **updates}
+                    )
                 raise data_entry_flow.AbortFlow("already_configured")
 
     async def async_set_unique_id(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -817,10 +817,21 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         raise data_entry_flow.UnknownHandler
 
     @callback
-    def _abort_if_unique_id_configured(self) -> None:
+    def _abort_if_unique_id_configured(
+        self, update_entry: Dict[Any, Any] = None
+    ) -> None:
         """Abort if the unique ID is already configured."""
         if self.unique_id is None:
             return
+
+        if update_entry is not None:
+            for entry in self._async_current_entries():
+                if (
+                    entry.unique_id == self.unique_id
+                    and not update_entry.items() <= entry.data.items()
+                ):
+                    entry.data.update(update_entry)
+                    raise data_entry_flow.AbortFlow("already_configured")
 
         if self.unique_id in self._async_current_ids():
             raise data_entry_flow.AbortFlow("already_configured")

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1080,6 +1080,40 @@ async def test_unique_id_existing_entry(hass, manager):
     assert len(async_remove_entry.mock_calls) == 1
 
 
+async def test_unique_id_update_existing_entry(hass, manager):
+    """Test that we update an entry if there already is an entry with unique ID."""
+    hass.config.components.add("comp")
+    entry = MockConfigEntry(
+        domain="comp",
+        data={"additional": "data", "host": "0.0.0.0"},
+        unique_id="mock-unique-id",
+    )
+    entry.add_to_hass(hass)
+
+    mock_integration(
+        hass, MockModule("comp"),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+
+        VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            await self.async_set_unique_id("mock-unique-id")
+            await self._abort_if_unique_id_configured(update_entry={"host": "1.1.1.1"})
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        result = await manager.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert entry.data["host"] == "1.1.1.1"
+    assert entry.data["additional"] == "data"
+
+
 async def test_unique_id_in_progress(hass, manager):
     """Test that we abort if there is already a flow in progress with same unique id."""
     mock_integration(hass, MockModule("comp"))

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1101,7 +1101,7 @@ async def test_unique_id_update_existing_entry(hass, manager):
 
         async def async_step_user(self, user_input=None):
             await self.async_set_unique_id("mock-unique-id")
-            await self._abort_if_unique_id_configured(update_entry={"host": "1.1.1.1"})
+            await self._abort_if_unique_id_configured(updates={"host": "1.1.1.1"})
 
     with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
         result = await manager.flow.async_init(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1114,6 +1114,43 @@ async def test_unique_id_update_existing_entry(hass, manager):
     assert entry.data["additional"] == "data"
 
 
+async def test_unique_id_not_update_existing_entry(hass, manager):
+    """Test that we do not update an entry if existing entry has the data."""
+    hass.config.components.add("comp")
+    entry = MockConfigEntry(
+        domain="comp",
+        data={"additional": "data", "host": "0.0.0.0"},
+        unique_id="mock-unique-id",
+    )
+    entry.add_to_hass(hass)
+
+    mock_integration(
+        hass, MockModule("comp"),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+
+        VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            await self.async_set_unique_id("mock-unique-id")
+            await self._abort_if_unique_id_configured(updates={"host": "0.0.0.0"})
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}), patch(
+        "homeassistant.config_entries.ConfigEntries.async_update_entry"
+    ) as async_update_entry:
+        result = await manager.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert entry.data["host"] == "0.0.0.0"
+    assert entry.data["additional"] == "data"
+    assert len(async_update_entry.mock_calls) == 0
+
+
 async def test_unique_id_in_progress(hass, manager):
     """Test that we abort if there is already a flow in progress with same unique id."""
     mock_integration(hass, MockModule("comp"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Flows implementing a unique ID, can abort flows quick and easy using the `_abort_if_unique_id_configured` helper method, in case the unique ID is already configured.

However, especially with discovery, just aborting is maybe not wished for. For example, something in the users' network changed, devices got a new IP address (new router?).

This adds an additional parameter `update_entries` to `_abort_if_unique_id_configured`, allowing to pass in a dict with data to update the existing config entry with, in case it already exists.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```py
self._abort_if_unique_id_configured(update_entry={"host": "1.1.1.1"})
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to PR: #31087
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
