### PR TITLE
Fix connection failure log message in async_setup_entry for Vizio component

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -71,6 +72,21 @@ async def async_setup_entry(
         session=async_get_clientsession(hass, False),
         timeout=DEFAULT_TIMEOUT,
     )
+
+    if not await device.can_connect():
+        fail_auth_msg = ""
+        if token:
+            fail_auth_msg = f"and auth token '{token}' are correct."
+        else:
+            fail_auth_msg = "is correct."
+        _LOGGER.error(
+            "Failed to connect to Vizio device, please check if host '%s' "
+            "is valid and available. Also check if device class '%s' %s",
+            host,
+            device_class,
+            fail_auth_msg,
+        )
+        raise PlatformNotReady
 
     entity = VizioDevice(config_entry, device, name, volume_step, device_class)
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -79,7 +79,7 @@ async def async_setup_entry(
             fail_auth_msg = f"and auth token '{token}' are correct."
         else:
             fail_auth_msg = "is correct."
-        _LOGGER.error(
+        _LOGGER.warning(
             "Failed to connect to Vizio device, please check if host '%s' "
             "is valid and available. Also check if device class '%s' %s",
             host,

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -73,20 +72,7 @@ async def async_setup_entry(
         timeout=DEFAULT_TIMEOUT,
     )
 
-    if not await device.can_connect():
-        fail_auth_msg = ""
-        if token:
-            fail_auth_msg = "and auth token '{token}' are correct."
-        else:
-            fail_auth_msg = "is correct."
-        _LOGGER.error(
-            "Failed to connect to Vizio device, please check if host '{host}'"
-            "is valid and available. Also check if device class '{device_class}' %s",
-            fail_auth_msg,
-        )
-        raise PlatformNotReady
-
-    entity = VizioDevice(config_entry, device, name, volume_step, device_class,)
+    entity = VizioDevice(config_entry, device, name, volume_step, device_class)
 
     async_add_entities([entity], update_before_add=True)
 


### PR DESCRIPTION
## Proposed change
~Before the `vizio` component supported config flow, it was necessary to verify that the device could be connected to during setup so the user could be warned that their configuration may be incorrect. In the new config flow logic, an entry won't be created unless the device can be connected to, so there is no need to do a connection check a second time.~
As part of this reverting this change per review, I realized that I was passing variables incorrectly to the log message. This is now fixed and the PR has been updated to reflect a bugfix.

Also demoted the log message to a warning.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
