### PR TITLE
Fix state handling for older webos versions

### DIFF
--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "webostv",
   "name": "LG webOS Smart TV",
   "documentation": "https://www.home-assistant.io/integrations/webostv",
-  "requirements": ["aiopylgtv==0.3.0"],
+  "requirements": ["aiopylgtv==0.3.2"],
   "dependencies": ["configurator"],
   "codeowners": ["@bendavid"]
 }

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -227,11 +227,10 @@ class LgWebOSMediaPlayerEntity(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the device."""
-        client_state = self._client.power_state.get("state")
-        if client_state in [None, "Power Off", "Suspend", "Active Standby"]:
-            return STATE_OFF
+        if self._client.is_on:
+            return STATE_ON
 
-        return STATE_ON
+        return STATE_OFF
 
     @property
     def is_volume_muted(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -190,7 +190,7 @@ aionotion==1.1.0
 aiopvapi==1.6.14
 
 # homeassistant.components.webostv
-aiopylgtv==0.3.0
+aiopylgtv==0.3.2
 
 # homeassistant.components.switcher_kis
 aioswitcher==2019.4.26

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -69,7 +69,7 @@ aiohue==1.10.1
 aionotion==1.1.0
 
 # homeassistant.components.webostv
-aiopylgtv==0.3.0
+aiopylgtv==0.3.2
 
 # homeassistant.components.switcher_kis
 aioswitcher==2019.4.26


### PR DESCRIPTION
The changes introduced by https://github.com/home-assistant/home-assistant/pull/31042 cause problems for some older webos versions (see https://github.com/bendavid/aiopylgtv/issues/9).  Fixed by improved error handling in client library, plus fallback for state detection in home assistant.
