### PR TITLE
Add disabled entities support to AdGuard

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -142,11 +142,14 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigType) -> bool
 class AdGuardHomeEntity(Entity):
     """Defines a base AdGuard Home entity."""
 
-    def __init__(self, adguard, name: str, icon: str) -> None:
+    def __init__(
+        self, adguard, name: str, icon: str, enabled_default: bool = True
+    ) -> None:
         """Initialize the AdGuard Home entity."""
-        self._name = name
-        self._icon = icon
         self._available = True
+        self._enabled_default = enabled_default
+        self._icon = icon
+        self._name = name
         self.adguard = adguard
 
     @property
@@ -160,12 +163,20 @@ class AdGuardHomeEntity(Entity):
         return self._icon
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return self._enabled_default
+
+    @property
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._available
 
     async def async_update(self) -> None:
         """Update AdGuard Home entity."""
+        if not self.enabled:
+            return
+
         try:
             await self._adguard_update()
             self._available = True

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -51,14 +51,20 @@ class AdGuardHomeSensor(AdGuardHomeDeviceEntity):
     """Defines a AdGuard Home sensor."""
 
     def __init__(
-        self, adguard, name: str, icon: str, measurement: str, unit_of_measurement: str
+        self,
+        adguard,
+        name: str,
+        icon: str,
+        measurement: str,
+        unit_of_measurement: str,
+        enabled_default: bool = True,
     ) -> None:
         """Initialize AdGuard Home sensor."""
         self._state = None
         self._unit_of_measurement = unit_of_measurement
         self.measurement = measurement
 
-        super().__init__(adguard, name, icon)
+        super().__init__(adguard, name, icon, enabled_default)
 
     @property
     def unique_id(self) -> str:
@@ -109,6 +115,7 @@ class AdGuardHomeBlockedFilteringSensor(AdGuardHomeSensor):
             "mdi:magnify-close",
             "blocked_filtering",
             "queries",
+            enabled_default=False,
         )
 
     async def _adguard_update(self) -> None:
@@ -214,7 +221,12 @@ class AdGuardHomeRulesCountSensor(AdGuardHomeSensor):
     def __init__(self, adguard):
         """Initialize AdGuard Home sensor."""
         super().__init__(
-            adguard, "AdGuard Rules Count", "mdi:counter", "rules_count", "rules"
+            adguard,
+            "AdGuard Rules Count",
+            "mdi:counter",
+            "rules_count",
+            "rules",
+            enabled_default=False,
         )
 
     async def _adguard_update(self) -> None:

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -10,9 +10,9 @@ from homeassistant.components.adguard.const import (
     DATA_ADGUARD_VERION,
     DOMAIN,
 )
+from homeassistant.components.switch import SwitchDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,14 +45,16 @@ async def async_setup_entry(
     async_add_entities(switches, True)
 
 
-class AdGuardHomeSwitch(ToggleEntity, AdGuardHomeDeviceEntity):
+class AdGuardHomeSwitch(AdGuardHomeDeviceEntity, SwitchDevice):
     """Defines a AdGuard Home switch."""
 
-    def __init__(self, adguard, name: str, icon: str, key: str):
+    def __init__(
+        self, adguard, name: str, icon: str, key: str, enabled_default: bool = True
+    ):
         """Initialize AdGuard Home switch."""
         self._state = False
         self._key = key
-        super().__init__(adguard, name, icon)
+        super().__init__(adguard, name, icon, enabled_default)
 
     @property
     def unique_id(self) -> str:
@@ -204,7 +206,13 @@ class AdGuardHomeQueryLogSwitch(AdGuardHomeSwitch):
 
     def __init__(self, adguard) -> None:
         """Initialize AdGuard Home switch."""
-        super().__init__(adguard, "AdGuard Query Log", "mdi:shield-check", "querylog")
+        super().__init__(
+            adguard,
+            "AdGuard Query Log",
+            "mdi:shield-check",
+            "querylog",
+            enabled_default=False,
+        )
 
     async def _adguard_turn_off(self) -> None:
         """Turn off the switch."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds support for disabled entities to the AdGuard Home integration.
Disables by default: sensors for rule count and blocked queries count (ratio sensor is still there), and the query log switch.

![image](https://user-images.githubusercontent.com/195327/72988744-25445480-3ded-11ea-9201-712e1da06038.png)


It also changed the inherited class from `ToggleEntity` to `SwitchDevice` for switch entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
