### PR TITLE
Validate coveragerc with hassfest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,6 @@ omit =
     homeassistant/helpers/signal.py
     homeassistant/helpers/typing.py
     homeassistant/scripts/*.py
-    homeassistant/util/async.py
 
     # omit pieces of code that rely on external devices being present
     homeassistant/components/abode/__init__.py
@@ -32,7 +31,6 @@ omit =
     homeassistant/components/airly/const.py
     homeassistant/components/airvisual/sensor.py
     homeassistant/components/aladdin_connect/cover.py
-    homeassistant/components/alarm_control_panel/manual_mqtt.py
     homeassistant/components/alarmdecoder/*
     homeassistant/components/alarmdotcom/alarm_control_panel.py
     homeassistant/components/alpha_vantage/sensor.py
@@ -261,7 +259,6 @@ omit =
     homeassistant/components/geizhals/sensor.py
     homeassistant/components/gios/__init__.py
     homeassistant/components/gios/air_quality.py
-    homeassistant/components/gios/consts.py
     homeassistant/components/github/sensor.py
     homeassistant/components/gitlab_ci/sensor.py
     homeassistant/components/gitter/sensor.py
@@ -533,7 +530,6 @@ omit =
     homeassistant/components/plex/media_player.py
     homeassistant/components/plex/sensor.py
     homeassistant/components/plex/server.py
-    homeassistant/components/plex/websockets.py
     homeassistant/components/plugwise/*
     homeassistant/components/plum_lightpad/*
     homeassistant/components/pocketcasts/sensor.py
@@ -726,7 +722,6 @@ omit =
     homeassistant/components/torque/sensor.py
     homeassistant/components/totalconnect/*
     homeassistant/components/touchline/climate.py
-    homeassistant/components/tplink/device_tracker.py
     homeassistant/components/tplink/switch.py
     homeassistant/components/tplink_lte/*
     homeassistant/components/traccar/device_tracker.py
@@ -828,7 +823,6 @@ omit =
     homeassistant/components/zestimate/sensor.py
     homeassistant/components/zha/__init__.py
     homeassistant/components/zha/api.py
-    homeassistant/components/zha/const.py
     homeassistant/components/zha/core/channels/*
     homeassistant/components/zha/core/const.py
     homeassistant/components/zha/core/device.py
@@ -836,7 +830,6 @@ omit =
     homeassistant/components/zha/core/helpers.py
     homeassistant/components/zha/core/patches.py
     homeassistant/components/zha/core/registries.py
-    homeassistant/components/zha/device_entity.py
     homeassistant/components/zha/entity.py
     homeassistant/components/zha/light.py
     homeassistant/components/zha/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -306,7 +306,6 @@ omit =
     homeassistant/components/homematic/notify.py
     homeassistant/components/homeworks/*
     homeassistant/components/honeywell/climate.py
-    homeassistant/components/hook/switch.py
     homeassistant/components/horizon/media_player.py
     homeassistant/components/hp_ilo/sensor.py
     homeassistant/components/htu21d/sensor.py
@@ -752,7 +751,6 @@ omit =
     homeassistant/components/twitch/sensor.py
     homeassistant/components/twitter/notify.py
     homeassistant/components/ubee/device_tracker.py
-    homeassistant/components/uber/sensor.py
     homeassistant/components/ubus/device_tracker.py
     homeassistant/components/ue_smart_radio/media_player.py
     homeassistant/components/unifiled/*

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -1,6 +1,7 @@
 """Validate manifests."""
 import pathlib
 import sys
+from time import monotonic
 
 from . import (
     codeowners,
@@ -51,8 +52,14 @@ def main():
 
     for plugin in PLUGINS:
         try:
+            start = monotonic()
+            print(f"Validating {plugin.__name__.split('.')[-1]}...", end="")
             plugin.validate(integrations, config)
+            print(" done in {:.2f}s".format(monotonic() - start))
         except RuntimeError as err:
+            print()
+            print()
+            print("Error!")
             print(err)
             return 1
 

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -53,7 +53,7 @@ def main():
     for plugin in PLUGINS:
         try:
             start = monotonic()
-            print(f"Validating {plugin.__name__.split('.')[-1]}...", end="")
+            print(f"Validating {plugin.__name__.split('.')[-1]}...", end="", flush=True)
             plugin.validate(integrations, config)
             print(" done in {:.2f}s".format(monotonic() - start))
         except RuntimeError as err:

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -5,6 +5,7 @@ import sys
 from . import (
     codeowners,
     config_flow,
+    coverage,
     dependencies,
     json,
     manifest,
@@ -18,6 +19,7 @@ PLUGINS = [
     json,
     codeowners,
     config_flow,
+    coverage,
     dependencies,
     manifest,
     services,
@@ -48,7 +50,11 @@ def main():
     integrations = Integration.load_dir(pathlib.Path("homeassistant/components"))
 
     for plugin in PLUGINS:
-        plugin.validate(integrations, config)
+        try:
+            plugin.validate(integrations, config)
+        except RuntimeError as err:
+            print(err)
+            return 1
 
     # When we generate, all errors that are fixable will be ignored,
     # as generating them will be fixed.

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -1,0 +1,28 @@
+"""Validate coverage files."""
+from typing import Dict
+
+from .model import Config, Integration
+
+
+def validate(integrations: Dict[str, Integration], config: Config):
+    """Validate coverage."""
+    codeowners_path = config.root / ".coveragerc"
+
+    referenced = set()
+
+    with codeowners_path.open("rt") as fp:
+        for line in fp:
+            line = line.strip()
+
+            if not line.startswith("homeassistant/components/"):
+                continue
+
+            referenced.add(line.split("/")[2])
+
+    for domain in integrations:
+        referenced.discard(domain)
+
+    if referenced:
+        raise RuntimeError(
+            f".coveragerc references invalid integrations: {', '.join(referenced)}"
+        )


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate that all referenced integrations in `.coveragerc` exist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
