### PR TITLE
Add smarter API usage for RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -288,15 +288,12 @@ class RainMachine:
         elif api_category == RESTRICTIONS_UNIVERSAL:
             data = await self.client.restrictions.universal()
 
-        _LOGGER.debug('Fetched "%s" API with result: %s', api_category, data)
-
         self.data[api_category] = data
 
     @callback
     def async_deregister_api_interest(self, api_category):
         """Decrement the number of entities with data needs from an API category."""
         if self._api_category_count[api_category] == 0:
-            _LOGGER.debug("No more entities require API: %s", api_category)
             if self._async_unsub_dispatcher_connect:
                 self._async_unsub_dispatcher_connect()
                 self._async_unsub_dispatcher_connect = None
@@ -307,7 +304,6 @@ class RainMachine:
         """Increment the number of entities with data needs from an API category."""
         # If this is the first registration we have, start a time interval:
         if not self._async_unsub_dispatcher_connect:
-            _LOGGER.debug("Registering time interval for API: %s", api_category)
             self._async_unsub_dispatcher_connect = async_track_time_interval(
                 self.hass,
                 self.async_update,
@@ -327,8 +323,6 @@ class RainMachine:
             if count == 0:
                 continue
             tasks[category] = self._async_fetch_from_api(category)
-
-        _LOGGER.debug("Updating data: %s", tasks)
 
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)
         for category, result in zip(tasks, results):

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -267,7 +267,6 @@ class RainMachine:
         """Initialize."""
         self._async_unsub_dispatcher_connect = None
         self._scan_interval_seconds = scan_interval
-        self._lock = asyncio.Lock()
         self.client = client
         self.data = {}
         self.default_zone_runtime = default_zone_runtime
@@ -278,6 +277,11 @@ class RainMachine:
             PROVISION_SETTINGS: 0,
             RESTRICTIONS_CURRENT: 0,
             RESTRICTIONS_UNIVERSAL: 0,
+        }
+        self._api_category_locks = {
+            PROVISION_SETTINGS: asyncio.Lock(),
+            RESTRICTIONS_CURRENT: asyncio.Lock(),
+            RESTRICTIONS_UNIVERSAL: asyncio.Lock(),
         }
 
     async def _async_fetch_from_api(self, api_category):
@@ -317,7 +321,7 @@ class RainMachine:
 
         # Lock API updates in case multiple entities are trying to call the same API
         # endpoint at once:
-        async with self._lock:
+        async with self._api_category_locks[api_category]:
             if api_category not in self.data:
                 self.data[api_category] = await self._async_fetch_from_api(api_category)
 

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -318,9 +318,8 @@ class RainMachine:
         # Lock API updates in case multiple entities are trying to call the same API
         # endpoint at once:
         async with self._lock:
-            if api_category in self.data:
-                return
-            self.data[api_category] = await self._async_fetch_from_api(api_category)
+            if api_category not in self.data:
+                self.data[api_category] = await self._async_fetch_from_api(api_category)
 
     async def async_update(self):
         """Update sensor/binary sensor data."""

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -293,7 +293,9 @@ class RainMachine:
     @callback
     def async_deregister_api_interest(self, api_category):
         """Decrement the number of entities with data needs from an API category."""
-        if self._api_category_count[api_category] == 0:
+        # If this deregistration should leave us with no registration at all, remove the
+        # time interval:
+        if sum(self._api_category_count.values()) == 0:
             if self._async_unsub_dispatcher_connect:
                 self._async_unsub_dispatcher_connect()
                 self._async_unsub_dispatcher_connect = None

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_SSL,
 )
+from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -127,7 +128,6 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up RainMachine as config entry."""
-
     _verify_domain_control = verify_domain_control(hass, DOMAIN)
 
     websession = aiohttp_client.async_get_clientsession(hass)
@@ -141,9 +141,11 @@ async def async_setup_entry(hass, config_entry):
             ssl=config_entry.data[CONF_SSL],
         )
         rainmachine = RainMachine(
-            client, config_entry.data.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN),
+            hass,
+            client,
+            config_entry.data.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN),
+            config_entry.data[CONF_SCAN_INTERVAL],
         )
-        await rainmachine.async_update()
     except RainMachineError as err:
         _LOGGER.error("An error occurred: %s", err)
         raise ConfigEntryNotReady
@@ -154,16 +156,6 @@ async def async_setup_entry(hass, config_entry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
-
-    async def refresh(event_time):
-        """Refresh RainMachine sensor data."""
-        _LOGGER.debug("Updating RainMachine sensor data")
-        await rainmachine.async_update()
-        async_dispatcher_send(hass, SENSOR_UPDATE_TOPIC)
-
-    hass.data[DOMAIN][DATA_LISTENER][config_entry.entry_id] = async_track_time_interval(
-        hass, refresh, timedelta(seconds=config_entry.data[CONF_SCAN_INTERVAL])
-    )
 
     @_verify_domain_control
     async def disable_program(call):
@@ -271,30 +263,81 @@ async def async_unload_entry(hass, config_entry):
 class RainMachine:
     """Define a generic RainMachine object."""
 
-    def __init__(self, client, default_zone_runtime):
+    def __init__(self, hass, client, default_zone_runtime, scan_interval):
         """Initialize."""
+        self._async_unsub_dispatcher_connect = None
+        self._scan_interval_seconds = scan_interval
         self.client = client
         self.data = {}
         self.default_zone_runtime = default_zone_runtime
         self.device_mac = self.client.mac
+        self.hass = hass
+
+        self._api_category_count = {
+            PROVISION_SETTINGS: 0,
+            RESTRICTIONS_CURRENT: 0,
+            RESTRICTIONS_UNIVERSAL: 0,
+        }
+
+    async def _async_fetch_from_api(self, api_category):
+        """Execute the appropriate coroutine to fetch particular data from the API."""
+        if api_category == PROVISION_SETTINGS:
+            data = await self.client.provisioning.settings()
+        elif api_category == RESTRICTIONS_CURRENT:
+            data = await self.client.restrictions.current()
+        elif api_category == RESTRICTIONS_UNIVERSAL:
+            data = await self.client.restrictions.universal()
+
+        _LOGGER.debug('Fetched "%s" API with result: %s', api_category, data)
+
+        self.data[api_category] = data
+
+    @callback
+    def async_deregister_api_interest(self, api_category):
+        """Decrement the number of entities with data needs from an API category."""
+        if self._api_category_count[api_category] == 0:
+            _LOGGER.debug("No more entities require API: %s", api_category)
+            if self._async_unsub_dispatcher_connect:
+                self._async_unsub_dispatcher_connect()
+                self._async_unsub_dispatcher_connect = None
+            return
+        self._api_category_count[api_category] += 1
+
+    async def async_register_api_interest(self, api_category):
+        """Increment the number of entities with data needs from an API category."""
+        # If this is the first registration we have, start a time interval:
+        if not self._async_unsub_dispatcher_connect:
+            _LOGGER.debug("Registering time interval for API: %s", api_category)
+            self._async_unsub_dispatcher_connect = async_track_time_interval(
+                self.hass,
+                self.async_update,
+                timedelta(seconds=self._scan_interval_seconds),
+            )
+
+        self._api_category_count[api_category] += 1
+
+        # If the data hasn't been fetched for a particular category yet, do it:
+        if api_category not in self.data:
+            await self._async_fetch_from_api(api_category)
 
     async def async_update(self):
         """Update sensor/binary sensor data."""
-        tasks = {
-            PROVISION_SETTINGS: self.client.provisioning.settings(),
-            RESTRICTIONS_CURRENT: self.client.restrictions.current(),
-            RESTRICTIONS_UNIVERSAL: self.client.restrictions.universal(),
-        }
+        tasks = {}
+        for category, count in self._api_category_count.items():
+            if count == 0:
+                continue
+            tasks[category] = self._async_fetch_from_api(category)
+
+        _LOGGER.debug("Updating data: %s", tasks)
 
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)
-        for operation, result in zip(tasks, results):
+        for category, result in zip(tasks, results):
             if isinstance(result, RainMachineError):
                 _LOGGER.error(
-                    "There was an error while updating %s: %s", operation, result
+                    "There was an error while updating %s: %s", category, result
                 )
-                continue
 
-            self.data[operation] = result
+        async_dispatcher_send(self.hass, SENSOR_UPDATE_TOPIC)
 
 
 class RainMachineEntity(Entity):

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -131,7 +131,7 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
             async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, update)
         )
         await self.rainmachine.async_register_api_interest(self._api_category)
-        update()
+        await self.async_update()
 
     async def async_update(self):
         """Update the state."""

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -158,7 +158,7 @@ class RainMachineSensor(RainMachineEntity):
             async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, update)
         )
         await self.rainmachine.async_register_api_interest(self._api_category)
-        update()
+        await self.async_update()
 
     async def async_update(self):
         """Update the sensor's state."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on #31066 (which removed monitored conditions from RainMachine and made some of its entities disabled by default), this PR smartens up the integration's internal API object. Now, when an entity is enabled, it registers its "interest" in receiving data from specific API calls and updates accordingly. If no entities exist for a particular API call, the API object won't call it. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
rainmachine:
  controllers:
    - ip_address: 192.168.1.100
      password: YOUR_PASSWORD
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
