### PR TITLE
Make SimpliSafe integration more resilient to SimpliSafe cloud issues

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -332,10 +332,15 @@ class SimpliSafe:
             # apparently); so, if we detect that we're in such a situation, try a last-
             # ditch effort by re-authenticating with the stored token:
             if self._emergency_refresh_token:
-                # If we've already tried this, log the error and suggest a HASS restart:
+                # If we've already tried this, log the error, suggest a HASS restart,
+                # and stop the time tracker:
                 _LOGGER.error(
                     "SimpliSafe authentication disconnected. Please restart HASS."
                 )
+                remove_listener = self._hass.data[DOMAIN][DATA_LISTENER].pop(
+                    self._config_entry.entry_id
+                )
+                remove_listener()
                 return
 
             _LOGGER.warning("SimpliSafe cloud error; trying stored refresh token")

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -359,6 +359,11 @@ class SimpliSafe:
                 self._hass, self._config_entry, self._api.refresh_token
             )
 
+        if self._emergency_refresh_token:
+            # If we've reached this point using an emergency refresh token, we're in the
+            # clear and we can discard it:
+            self._emergency_refresh_token = None
+
     async def async_update(self):
         """Get updated data from SimpliSafe."""
         tasks = [self._update_system(system) for system in self.systems.values()]

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -370,6 +370,11 @@ class SimpliSafe:
 
         await asyncio.gather(*tasks)
 
+        if self._api.refresh_token_dirty:
+            _async_save_refresh_token(
+                self._hass, self._config_entry, self._api.refresh_token
+            )
+
 
 class SimpliSafeEntity(Entity):
     """Define a base SimpliSafe entity."""

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -359,14 +359,9 @@ class SimpliSafe:
 
         self.last_event_data[system.system_id] = latest_event
 
-        if self._api.refresh_token_dirty:
-            _async_save_refresh_token(
-                self._hass, self._config_entry, self._api.refresh_token
-            )
-
+        # If we've reached this point using an emergency refresh token, we're in the
+        # clear and we can discard it:
         if self._emergency_refresh_token:
-            # If we've reached this point using an emergency refresh token, we're in the
-            # clear and we can discard it:
             self._emergency_refresh_token = None
 
     async def async_update(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-up to https://github.com/home-assistant/home-assistant/pull/30456.

At times, SimpliSafe will do something in their cloud (producing a `500` or `502`) and the integration can't recover without a HASS restart. Today, I noticed another such incident in my HASS logs:

```
2020-01-23 11:54:50 ERROR (MainThread) [simplipy.system] Error while getting latest settings values: Error requesting data from ss3/subscriptions/SID/settings/normal: 502, message='Bad Gateway', url='https://api.simplisafe.com/v1/ss3/subscriptions/SID/settings/normal?forceUpdate=false
2020-01-23 11:54:50 ERROR (MainThread) [custom_components.simplisafe] SimpliSafe error while updating "MY ADDRESS": Repeated 401s despite refreshing access token
2020-01-23 11:55:21 ERROR (MainThread) [simplipy.system] Error while getting latest system values: Repeated 401s despite refreshing access token
2020-01-23 11:55:21 ERROR (MainThread) [simplipy.system] Error while getting latest settings values: Repeated 401s despite refreshing access token
```

My supposition: at times, a 500 or 502 will seemingly harm `simplisafe-python`'s existing access token _and_ refresh token, thus preventing the integration from recovering. However, the refresh token stored in the config entry escapes unscathed (again, apparently); so, if we detect that we're in such a situation, we should try one last effort using that stored refresh token. This PR implements that.

By all accounts and because this is sporadic, this isn't an issue of how we're using the SimpliSafe's unpublished API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
simplisafe:
  accounts:
    username: !secret simplisafe_username
    password: !secret simplisafe_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant/issues/23669
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
