### PR TITLE
Fix Huawei LTE SMS recipient setting from options UI

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -506,6 +506,19 @@ async def async_signal_options_update(
     async_dispatcher_send(hass, UPDATE_OPTIONS_SIGNAL, config_entry)
 
 
+async def async_migrate_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
+    """Migrate config entry to new version."""
+    if config_entry.version == 1:
+        options = config_entry.options
+        recipient = options[CONF_RECIPIENT]
+        if isinstance(recipient, str):
+            options[CONF_RECIPIENT] = [x.strip() for x in recipient.split(",")]
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, options=options)
+        _LOGGER.info("Migrated config entry to version %d", config_entry.version)
+    return True
+
+
 @attr.s
 class HuaweiLteBaseEntity(Entity):
     """Huawei LTE entity base class."""

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -40,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle Huawei LTE config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     @staticmethod
@@ -247,9 +247,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
+
+        # Recipients are persisted as a list, but handled as comma separated string in UI
+
         if user_input is not None:
             # Preserve existing options, for example *_from_yaml markers
             data = {**self.config_entry.options, **user_input}
+            if not isinstance(data[CONF_RECIPIENT], list):
+                data[CONF_RECIPIENT] = [
+                    x.strip() for x in data[CONF_RECIPIENT].split(",")
+                ]
             return self.async_create_entry(title="", data=data)
 
         data_schema = vol.Schema(
@@ -262,7 +269,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): str,
                 vol.Optional(
                     CONF_RECIPIENT,
-                    default=self.config_entry.options.get(CONF_RECIPIENT, ""),
+                    default=", ".join(
+                        self.config_entry.options.get(CONF_RECIPIENT, [])
+                    ),
                 ): str,
             }
         )

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -181,13 +181,13 @@ async def test_options(flow):
     )
     config_entry.add_to_hass(flow.hass)
 
-    result = await flow.async_get_options_flow(config_entry).async_step_init()
+    result = await flow.hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
     recipient = "+15555550000"
-    result = await flow.async_get_options_flow(config_entry).async_step_init(
-        {CONF_RECIPIENT: recipient}
+    result = await flow.hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_RECIPIENT: recipient}
     )
     assert result["data"][CONF_NAME] == DOMAIN
     assert result["data"][CONF_RECIPIENT] == [recipient]


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Config entry SMS recipients saved from UI gets persisted as a string, but we need a list.
Fixes one of the issues reported in https://github.com/home-assistant/home-assistant/issues/30827 (not the main one though).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/home-assistant/issues/30827
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
