### PR TITLE
Add new tag !include_dir_merge_recursive

### DIFF
--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -56,9 +56,12 @@ def load_yaml(fname: str) -> JSON_TYPE:
     """Load a YAML file."""
     try:
         with open(fname, encoding="utf-8") as conf_file:
-            # If configuration file is empty YAML returns None
-            # We convert that to an empty dict
-            return yaml.load(conf_file, Loader=SafeLineLoader) or OrderedDict()
+            content = yaml.load(conf_file, Loader=SafeLineLoader)
+            if content is None:
+                # If configuration file is empty YAML returns None
+                # We convert that to an empty dict
+                return OrderedDict()
+            return content
     except yaml.YAMLError as exc:
         _LOGGER.error(str(exc))
         raise HomeAssistantError(exc)


### PR DESCRIPTION
## Proposed change
Enable the user to split up the configuration files in a way, that allows for the complete context to be present in every file. Also enable the user to group all configuration for a single device in one file even if it contains configuration for multiple domains, e.g. switches, sensors and home-assistant.customize customization.
At the moment with the existing include tags the configuration for different domains (sensor, switch, component specific) needs to be split between different folders / files.
One may attempt something similar using the existing !include_dir_merge_named tag, by using one folder per device containing files like sensor.yaml and switch.yaml, but the last file for every domain that is loaded will shadow all previous contents with the same dict key (without any message in the logs).
This also allows to drop in configuration examples from the documentation that modify multiple domains in a single file instead of splitting it to multiple files.

Add a new include tag "!include_dir_merge_recursive"
The tag will merge dicts recursively (if two or more files contain a dict with a mapping that has an identical key, both values will be merged). Dicts will be merged by applying the merge algorithm to the values of identical keys, lists will be merged by extending the existing lists. All other types lead to an exception. Recursion is stopped when hitting a value that is not a dict.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
!include_dir_merge_recursive configuration/
```

```yaml
# Example configuration/automation.yaml
automation: !include ../automations.yaml
```
```yaml
# Example configuration/devices/tp-link.yaml
tplink:
  discovery: true
  switch:
    - host: '10.13.37.1'
sensor:
  - platform: template
    sensors:
      plug_amps:
        friendly_name_template: "{{ states.switch.plug.name}} Current"
        value_template: '{{ states.switch.plug.attributes["current_a"] | float }}'
        unit_of_measurement: 'A'
recorder:
  exclude:
    entities:
      - switch.plug
```


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This is kind of a request for comments at the moment, The PR works as is, but may need some improvements. For example I am considering adding references to all strings that are added to a dict from a merge. File-References are kind of wonky in check_config otherwise.

I will also do a separate pull request to add documentation if merging this PR is considered.

<!-- TODO: - Link to documentation pull request:  -->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
