### PR TITLE
Add service to openhome to invoke a pin

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -564,7 +564,9 @@ omit =
     homeassistant/components/openevse/sensor.py
     homeassistant/components/openexchangerates/sensor.py
     homeassistant/components/opengarage/cover.py
+    homeassistant/components/openhome/__init__.py
     homeassistant/components/openhome/media_player.py
+    homeassistant/components/openhome/const.py
     homeassistant/components/opensensemap/air_quality.py
     homeassistant/components/opensky/sensor.py
     homeassistant/components/opentherm_gw/__init__.py

--- a/homeassistant/components/openhome/const.py
+++ b/homeassistant/components/openhome/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Openhome component."""
+DOMAIN = "openhome"
+SERVICE_INVOKE_PIN = "invoke_pin"
+ATTR_PIN_INDEX = "pin"
+DATA_OPENHOME = "openhome"

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -2,6 +2,6 @@
   "domain": "openhome",
   "name": "Linn / OpenHome",
   "documentation": "https://www.home-assistant.io/integrations/openhome",
-  "requirements": ["openhomedevice==0.6.3"],
+  "requirements": ["openhomedevice==0.7.2"],
   "codeowners": []
 }

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -2,6 +2,7 @@
 import logging
 
 from openhomedevice.Device import Device
+import voluptuous as vol
 
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
@@ -20,35 +21,45 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.const import STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING
+from homeassistant.helpers import config_validation as cv, entity_platform
+
+from .const import ATTR_PIN_INDEX, DATA_OPENHOME, SERVICE_INVOKE_PIN
 
 SUPPORT_OPENHOME = SUPPORT_SELECT_SOURCE | SUPPORT_TURN_OFF | SUPPORT_TURN_ON
 
 _LOGGER = logging.getLogger(__name__)
 
-DEVICES = []
 
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Openhome platform."""
 
     if not discovery_info:
-        return True
+        return
+
+    openhome_data = hass.data.setdefault(DATA_OPENHOME, set())
 
     name = discovery_info.get("name")
     description = discovery_info.get("ssdp_description")
+
     _LOGGER.info("Openhome device found: %s", name)
-    device = Device(description)
+    device = await hass.async_add_executor_job(Device, description)
 
     # if device has already been discovered
-    if device.Uuid() in [x.unique_id for x in DEVICES]:
+    if device.Uuid() in openhome_data:
         return True
 
-    device = OpenhomeDevice(hass, device)
+    entity = OpenhomeDevice(hass, device)
 
-    add_entities([device], True)
-    DEVICES.append(device)
+    async_add_entities([entity])
+    openhome_data.add(device.Uuid())
 
-    return True
+    platform = entity_platform.current_platform.get()
+
+    platform.async_register_entity_service(
+        SERVICE_INVOKE_PIN,
+        {vol.Required(ATTR_PIN_INDEX): cv.positive_int},
+        "invoke_pin",
+    )
 
 
 class OpenhomeDevice(MediaPlayerEntity):
@@ -161,6 +172,10 @@ class OpenhomeDevice(MediaPlayerEntity):
     def select_source(self, source):
         """Select input source."""
         self._device.SetSource(self._source_index[source])
+
+    def invoke_pin(self, pin):
+        """Invoke pin."""
+        self._device.InvokePin(pin)
 
     @property
     def name(self):

--- a/homeassistant/components/openhome/services.yaml
+++ b/homeassistant/components/openhome/services.yaml
@@ -1,0 +1,11 @@
+# Describes the format for available openhome services
+
+invoke_pin:
+  description: Invoke a pin on the specified device.
+  fields:
+    entity_id:
+      description: The name of the openhome device to invoke the pin on
+      example: media_player.main_room
+    pin:
+      description: Which pin to invoke
+      example: 4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1012,7 +1012,7 @@ openerz-api==0.1.0
 openevsewifi==0.4
 
 # homeassistant.components.openhome
-openhomedevice==0.6.3
+openhomedevice==0.7.2
 
 # homeassistant.components.opensensemap
 opensensemap-api==0.1.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Recent Linn hifi products include a feature called 'pins' which is very similar to a preset functionality where a playlist, radio station or source can be pinned to a button (see https://docs.linn.co.uk/wiki/index.php/Linn_DS/DSM_control#PINS).

The underlying library now supports the capability to invoke a pin and this PR introduces a new service `openhome.invoke_pin` which invokes a pin by index on the specified device. 

Example data:
```
{
  entity_id: media_player.kitchen
  pin: 4
}
```

This would allow automations and scripts to invoke the specified pin (4 in my example). I imagine it wouldn’t take much to generalise this into a `media_player.invoke_preset` service - but I see many existing integrations use the name of the preset rather than an index and there's a variety of ways to actually active the presets, so more evidence is required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
discovery:
media_player:
  - platform: openhome
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

https://github.com/home-assistant/home-assistant.io/pull/11855

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
