### PR TITLE
Add webostv sound_output capability

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException, WebOsClient
+from const import ATTR_SOUND_OUTPUT
 import voluptuous as vol
 from websockets.exceptions import ConnectionClosed
 
@@ -16,8 +17,6 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-
-from const import ATTR_SOUND_OUTPUT
 
 DOMAIN = "webostv"
 

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from .media_player import ATTR_SOUND_OUTPUT
 
 DOMAIN = "webostv"
 
@@ -31,7 +32,6 @@ SERVICE_COMMAND = "command"
 ATTR_COMMAND = "command"
 
 SERVICE_SELECT_SOUND_OUTPUT = "select_sound_output"
-ATTR_SOUND_OUTPUT = "sound_output"
 
 CUSTOMIZE_SCHEMA = vol.Schema(
     {vol.Optional(CONF_SOURCES, default=[]): vol.All(cv.ensure_list, [cv.string])}

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -68,7 +68,10 @@ SOUND_OUTPUT_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_SOUND_OUTPUT): cv.st
 SERVICE_TO_METHOD = {
     SERVICE_BUTTON: {"method": "async_button", "schema": BUTTON_SCHEMA},
     SERVICE_COMMAND: {"method": "async_command", "schema": COMMAND_SCHEMA},
-    SERVICE_SELECT_SOUND_OUTPUT: {"method": "async_select_sound_output", "schema": SOUND_OUTPUT_SCHEMA},
+    SERVICE_SELECT_SOUND_OUTPUT: {
+        "method": "async_select_sound_output",
+        "schema": SOUND_OUTPUT_SCHEMA
+    },
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException, WebOsClient
-from const import ATTR_SOUND_OUTPUT
+from .const import ATTR_SOUND_OUTPUT
 import voluptuous as vol
 from websockets.exceptions import ConnectionClosed
 

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -30,6 +30,9 @@ ATTR_BUTTON = "button"
 SERVICE_COMMAND = "command"
 ATTR_COMMAND = "command"
 
+SERVICE_SELECT_SOUND_OUTPUT = "select_sound_output"
+ATTR_SOUND_OUTPUT = "sound_output"
+
 CUSTOMIZE_SCHEMA = vol.Schema(
     {vol.Optional(CONF_SOURCES, default=[]): vol.All(cv.ensure_list, [cv.string])}
 )
@@ -60,9 +63,12 @@ BUTTON_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_BUTTON): cv.string})
 
 COMMAND_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_COMMAND): cv.string})
 
+SOUND_OUTPUT_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_SOUND_OUTPUT): cv.string})
+
 SERVICE_TO_METHOD = {
     SERVICE_BUTTON: {"method": "async_button", "schema": BUTTON_SCHEMA},
     SERVICE_COMMAND: {"method": "async_command", "schema": COMMAND_SCHEMA},
+    SERVICE_SELECT_SOUND_OUTPUT: {"method": "async_select_sound_output", "schema": SOUND_OUTPUT_SCHEMA},
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .media_player import ATTR_SOUND_OUTPUT
+from const import ATTR_SOUND_OUTPUT
 
 DOMAIN = "webostv"
 

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -70,7 +70,7 @@ SERVICE_TO_METHOD = {
     SERVICE_COMMAND: {"method": "async_command", "schema": COMMAND_SCHEMA},
     SERVICE_SELECT_SOUND_OUTPUT: {
         "method": "async_select_sound_output",
-        "schema": SOUND_OUTPUT_SCHEMA
+        "schema": SOUND_OUTPUT_SCHEMA,
     },
 }
 

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException, WebOsClient
-from .const import ATTR_SOUND_OUTPUT
 import voluptuous as vol
 from websockets.exceptions import ConnectionClosed
 
@@ -17,6 +16,8 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import ATTR_SOUND_OUTPUT
 
 DOMAIN = "webostv"
 

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+
 from .media_player import ATTR_SOUND_OUTPUT
 
 DOMAIN = "webostv"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,0 +1,3 @@
+LIVE_TV_APP_ID = "com.webos.app.livetv"
+
+ATTR_SOUND_OUTPUT = "sound_output"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,3 +1,4 @@
-LIVE_TV_APP_ID = "com.webos.app.livetv"
+"""Constants used for WebOS TV."""
+IVE_TV_APP_ID = "com.webos.app.livetv"
 
 ATTR_SOUND_OUTPUT = "sound_output"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,4 +1,4 @@
 """Constants used for WebOS TV."""
-IVE_TV_APP_ID = "com.webos.app.livetv"
+LIVE_TV_APP_ID = "com.webos.app.livetv"
 
 ATTR_SOUND_OUTPUT = "sound_output"

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -61,6 +61,7 @@ MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
 
 LIVE_TV_APP_ID = "com.webos.app.livetv"
 
+ATTR_SOUND_OUTPUT = "sound_output"
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the LG WebOS TV platform."""
@@ -290,6 +291,17 @@ class LgWebOSMediaPlayerEntity(MediaPlayerDevice):
             return SUPPORT_WEBOSTV | SUPPORT_TURN_ON
         return SUPPORT_WEBOSTV
 
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        attributes = {}
+        if (
+            self._client.sound_output is not None
+            and self.state != STATE_OFF
+        ):
+            attributes[ATTR_SOUND_OUTPUT] = self._client.sound_output
+        return attributes
+
     @cmd
     async def async_turn_off(self):
         """Turn off media player."""
@@ -320,6 +332,11 @@ class LgWebOSMediaPlayerEntity(MediaPlayerDevice):
     async def async_mute_volume(self, mute):
         """Send mute command."""
         await self._client.set_mute(mute)
+
+    @cmd
+    async def async_select_sound_output(self, sound_output):
+        """Select the sound output."""
+        await self._client.change_sound_output(sound_output)
 
     @cmd
     async def async_media_play_pause(self):

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -5,7 +5,6 @@ from functools import wraps
 import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException
-from .const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
 from websockets.exceptions import ConnectionClosed
 
 from homeassistant import util
@@ -37,6 +36,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.script import Script
 
 from . import CONF_ON_ACTION, CONF_SOURCES, DOMAIN
+from .const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -63,6 +63,7 @@ LIVE_TV_APP_ID = "com.webos.app.livetv"
 
 ATTR_SOUND_OUTPUT = "sound_output"
 
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the LG WebOS TV platform."""
 
@@ -295,10 +296,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerDevice):
     def device_state_attributes(self):
         """Return device specific state attributes."""
         attributes = {}
-        if (
-            self._client.sound_output is not None
-            and self.state != STATE_OFF
-        ):
+        if self._client.sound_output is not None and self.state != STATE_OFF:
             attributes[ATTR_SOUND_OUTPUT] = self._client.sound_output
         return attributes
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -5,7 +5,7 @@ from functools import wraps
 import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException
-from const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
+from .const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
 from websockets.exceptions import ConnectionClosed
 
 from homeassistant import util

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -5,6 +5,7 @@ from functools import wraps
 import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException
+from const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
 from websockets.exceptions import ConnectionClosed
 
 from homeassistant import util
@@ -36,10 +37,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.script import Script
 
 from . import CONF_ON_ACTION, CONF_SOURCES, DOMAIN
-
-
-from const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -37,10 +37,11 @@ from homeassistant.helpers.script import Script
 
 from . import CONF_ON_ACTION, CONF_SOURCES, DOMAIN
 
+
+from const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
+
+
 _LOGGER = logging.getLogger(__name__)
-
-
-LIVETV_APP_ID = "com.webos.app.livetv"
 
 
 SUPPORT_WEBOSTV = (
@@ -58,10 +59,6 @@ SUPPORT_WEBOSTV = (
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
-
-LIVE_TV_APP_ID = "com.webos.app.livetv"
-
-ATTR_SOUND_OUTPUT = "sound_output"
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -412,7 +409,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerDevice):
     async def async_media_next_track(self):
         """Send next track command."""
         current_input = self._client.get_input()
-        if current_input == LIVETV_APP_ID:
+        if current_input == LIVE_TV_APP_ID:
             await self._client.channel_up()
         else:
             await self._client.fast_forward()
@@ -421,7 +418,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerDevice):
     async def async_media_previous_track(self):
         """Send the previous track command."""
         current_input = self._client.get_input()
-        if current_input == LIVETV_APP_ID:
+        if current_input == LIVE_TV_APP_ID:
             await self._client.channel_down()
         else:
             await self._client.rewind()

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -36,7 +36,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.script import Script
 
 from . import CONF_ON_ACTION, CONF_SOURCES, DOMAIN
-from .const import LIVE_TV_APP_ID, ATTR_SOUND_OUTPUT
+from .const import ATTR_SOUND_OUTPUT, LIVE_TV_APP_ID
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/webostv/services.yaml
+++ b/homeassistant/components/webostv/services.yaml
@@ -24,3 +24,12 @@ command:
         https://github.com/TheRealLink/pylgtv/blob/master/pylgtv/endpoints.py
       example: 'media.controls/rewind'
 
+select_sound_output:
+  description: 'Send the TV the command to change sound output.'
+  fields:
+    entity_id:
+      description: Name(s) of the webostv entities to change sound output on.
+      example: 'media_player.living_room_tv'
+    sound_output:
+      description: Name of the sound output to switch to.
+      example: 'external_speaker'


### PR DESCRIPTION
## Proposed change
Add the ability to read and set the sound_output


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/11854

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
