### PR TITLE
Clean up RainMachine switch platform

### DIFF
--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -3,7 +3,7 @@ import asyncio
 from datetime import datetime
 import logging
 
-from regenmaschine.errors import RequestError
+from regenmaschine.errors import RainMachineError
 
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import ATTR_ID
@@ -108,7 +108,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     results = await asyncio.gather(*tasks.values(), return_exceptions=True)
     for kind, result in zip(tasks, results):
-        if isinstance(result, RequestError):
+        if isinstance(result, RainMachineError):
             _LOGGER.error("There was an error while retrieving %s: %s", kind, result)
             continue
 
@@ -192,7 +192,7 @@ class RainMachineProgram(RainMachineSwitch):
         try:
             await self.rainmachine.client.programs.stop(self._rainmachine_entity_id)
             async_dispatcher_send(self.hass, PROGRAM_UPDATE_TOPIC)
-        except RequestError as err:
+        except RainMachineError as err:
             _LOGGER.error(
                 'Unable to turn off program "%s": %s', self.unique_id, str(err)
             )
@@ -202,7 +202,7 @@ class RainMachineProgram(RainMachineSwitch):
         try:
             await self.rainmachine.client.programs.start(self._rainmachine_entity_id)
             async_dispatcher_send(self.hass, PROGRAM_UPDATE_TOPIC)
-        except RequestError as err:
+        except RainMachineError as err:
             _LOGGER.error(
                 'Unable to turn on program "%s": %s', self.unique_id, str(err)
             )
@@ -231,7 +231,7 @@ class RainMachineProgram(RainMachineSwitch):
                     ATTR_ZONES: ", ".join(z["name"] for z in self.zones),
                 }
             )
-        except RequestError as err:
+        except RainMachineError as err:
             _LOGGER.error(
                 'Unable to update info for program "%s": %s', self.unique_id, str(err)
             )
@@ -269,7 +269,7 @@ class RainMachineZone(RainMachineSwitch):
         """Turn the zone off."""
         try:
             await self.rainmachine.client.zones.stop(self._rainmachine_entity_id)
-        except RequestError as err:
+        except RainMachineError as err:
             _LOGGER.error('Unable to turn off zone "%s": %s', self.unique_id, str(err))
 
     async def async_turn_on(self, **kwargs) -> None:
@@ -278,7 +278,7 @@ class RainMachineZone(RainMachineSwitch):
             await self.rainmachine.client.zones.start(
                 self._rainmachine_entity_id, self._run_time
             )
-        except RequestError as err:
+        except RainMachineError as err:
             _LOGGER.error('Unable to turn on zone "%s": %s', self.unique_id, str(err))
 
     async def async_update(self) -> None:
@@ -316,7 +316,7 @@ class RainMachineZone(RainMachineSwitch):
                     ATTR_VEGETATION_TYPE: VEGETATION_MAP.get(self._obj.get("type")),
                 }
             )
-        except RequestError as err:
+        except RainMachineError as err:
             _LOGGER.error(
                 'Unable to update info for zone "%s": %s', self.unique_id, str(err)
             )

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -178,7 +178,6 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the program off."""
-
         try:
             await self.rainmachine.client.programs.stop(self._rainmachine_entity_id)
             async_dispatcher_send(self.hass, PROGRAM_UPDATE_TOPIC)
@@ -189,7 +188,6 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the program on."""
-
         try:
             await self.rainmachine.client.programs.start(self._rainmachine_entity_id)
             async_dispatcher_send(self.hass, PROGRAM_UPDATE_TOPIC)
@@ -200,7 +198,6 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_update(self) -> None:
         """Update info for the program."""
-
         try:
             self._obj = await self.rainmachine.client.programs.get(
                 self._rainmachine_entity_id
@@ -259,7 +256,6 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the zone off."""
-
         try:
             await self.rainmachine.client.zones.stop(self._rainmachine_entity_id)
         except RequestError as err:
@@ -267,7 +263,6 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the zone on."""
-
         try:
             await self.rainmachine.client.zones.start(
                 self._rainmachine_entity_id, self._run_time
@@ -277,7 +272,6 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_update(self) -> None:
         """Update info for the zone."""
-
         try:
             self._obj = await self.rainmachine.client.zones.get(
                 self._rainmachine_entity_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR does some small cleanup to the RainMachine switch platform:

* During startup, the switch platform would run back-to-back coroutines to get programs and zones; this PR does those calls in parallel.
* Catch `RainMachineError` instead `RequestError` (more generic).
* Some gentle linting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
rainmachine:
  controllers:
    - ip_address: 192.168.1.100
      password: YOUR_PASSWORD
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
