### PR TITLE
Use  unique_id for config_entries of HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -274,7 +274,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         anonymize = service.data[ATTR_ANONYMIZE]
 
         for hap in hass.data[DOMAIN].values():
-            hap_sgtin = hap.config_entry.title
+            hap_sgtin = hap.config_entry.unique_id
 
             if anonymize:
                 hap_sgtin = hap_sgtin[-4:]
@@ -331,9 +331,17 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up an access point from a config entry."""
+
+    # 0.104 introduced config entry unique id, this makes upgrading possible
+    if entry.unique_id is None:
+        new_data = dict(entry.data)
+
+        hass.config_entries.async_update_entry(
+            entry, unique_id=new_data[HMIPC_HAPID], data=new_data
+        )
+
     hap = HomematicipHAP(hass, entry)
-    hapid = entry.data[HMIPC_HAPID].replace("-", "").upper()
-    hass.data[DOMAIN][hapid] = hap
+    hass.data[DOMAIN][entry.unique_id] = hap
 
     if not await hap.async_setup():
         return False
@@ -356,5 +364,5 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    hap = hass.data[DOMAIN].pop(entry.data[HMIPC_HAPID])
+    hap = hass.data[DOMAIN].pop(entry.unique_id)
     return await hap.async_reset()

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -17,7 +17,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import comp_entity_ids
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .config_flow import configured_haps
 from .const import (
     CONF_ACCESSPOINT,
     CONF_AUTHTOKEN,
@@ -130,7 +129,10 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     accesspoints = config.get(DOMAIN, [])
 
     for conf in accesspoints:
-        if conf[CONF_ACCESSPOINT] not in configured_haps(hass):
+        if conf[CONF_ACCESSPOINT] not in set(
+            entry.data[HMIPC_HAPID]
+            for entry in hass.config_entries.async_entries(DOMAIN)
+        ):
             hass.async_add_job(
                 hass.config_entries.flow.async_init(
                     DOMAIN,

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID
+from . import DOMAIN as HMIPC_DOMAIN
 from .hap import HomematicipHAP
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP alrm control panel from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     async_add_entities([HomematicipAlarmControlPanel(hap)])
 
 

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -41,7 +41,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericDevice
 from .hap import HomematicipHAP
 
 _LOGGER = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP Cloud binary sensor from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     entities = []
     for device in hap.home.devices:
         if isinstance(device, AsyncAccelerationSensor):

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -27,7 +27,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericDevice
 from .hap import HomematicipHAP
 
 HEATING_PROFILES = {"PROFILE_1": 0, "PROFILE_2": 1, "PROFILE_3": 2}
@@ -54,7 +54,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP climate from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     entities = []
     for device in hap.home.groups:
         if isinstance(device, AsyncHeatingGroup):

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -78,6 +78,9 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
             authtoken = await self.auth.async_register()
             if authtoken:
                 _LOGGER.info("Write config entry for HomematicIP Cloud")
+
+                await self.async_set_unique_id(self.auth.config.get(HMIPC_HAPID))
+
                 return self.async_create_entry(
                     title=self.auth.config.get(HMIPC_HAPID),
                     data={
@@ -101,8 +104,9 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
         if hapid in configured_haps(self.hass):
             return self.async_abort(reason="already_configured")
 
-        _LOGGER.info("Imported authentication for %s", hapid)
+        await self.async_set_unique_id(hapid)
 
+        _LOGGER.info("Imported authentication for %s", hapid)
         return self.async_create_entry(
             title=hapid,
             data={HMIPC_AUTHTOKEN: authtoken, HMIPC_HAPID: hapid, HMIPC_NAME: name},

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -77,10 +77,10 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
         if pressed:
             authtoken = await self.auth.async_register()
             if authtoken:
-                _LOGGER.info("Write config entry for HomematicIP Cloud")
-
                 await self.async_set_unique_id(self.auth.config.get(HMIPC_HAPID))
+                self._abort_if_unique_id_configured()
 
+                _LOGGER.info("Write config entry for HomematicIP Cloud")
                 return self.async_create_entry(
                     title=self.auth.config.get(HMIPC_HAPID),
                     data={
@@ -96,15 +96,12 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_import(self, import_info) -> Dict[str, Any]:
         """Import a new access point as a config entry."""
-        hapid = import_info[HMIPC_HAPID]
+        hapid = import_info[HMIPC_HAPID].replace("-", "").upper()
         authtoken = import_info[HMIPC_AUTHTOKEN]
         name = import_info[HMIPC_NAME]
 
-        hapid = hapid.replace("-", "").upper()
-        if hapid in configured_haps(self.hass):
-            return self.async_abort(reason="already_configured")
-
         await self.async_set_unique_id(hapid)
+        self._abort_if_unique_id_configured()
 
         _LOGGER.info("Imported authentication for %s", hapid)
         return self.async_create_entry(

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -17,7 +17,7 @@ from homeassistant.components.cover import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP cover from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     entities = []
     for device in hap.home.devices:
         if isinstance(device, AsyncFullFlushBlind):

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -95,8 +95,7 @@ class HomematicipHAP:
             raise ConfigEntryNotReady
 
         _LOGGER.info(
-            "Connected to HomematicIP with HAP %s",
-            self.config_entry.data.get(HMIPC_HAPID),
+            "Connected to HomematicIP with HAP %s", self.config_entry.unique_id
         )
 
         for component in COMPONENTS:
@@ -193,7 +192,7 @@ class HomematicipHAP:
                 _LOGGER.error(
                     "Error connecting to HomematicIP with HAP %s. "
                     "Retrying in %d seconds",
-                    self.config_entry.data.get(HMIPC_HAPID),
+                    self.config_entry.unique_id,
                     retry_delay,
                 )
 

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -25,7 +25,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericDevice
 from .hap import HomematicipHAP
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP Cloud lights from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     entities = []
     for device in hap.home.devices:
         if isinstance(device, AsyncBrandSwitchMeasuring):

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
   "requirements": ["homematicip==0.10.15"],
   "dependencies": [],
-  "codeowners": ["@SukramJ"]
+  "codeowners": ["@SukramJ"],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -34,7 +34,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericDevice
 from .device import ATTR_IS_GROUP, ATTR_MODEL_TYPE
 from .hap import HomematicipHAP
 
@@ -67,7 +67,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP Cloud sensors from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     entities = [HomematicipAccesspointStatus(hap)]
     for device in hap.home.devices:
         if isinstance(device, (AsyncHeatingThermostat, AsyncHeatingThermostatCompact)):

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -19,7 +19,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericDevice
 from .device import ATTR_GROUP_MEMBER_UNREACHABLE
 from .hap import HomematicipHAP
 
@@ -37,7 +37,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP switch from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     entities = []
     for device in hap.home.devices:
         if isinstance(device, AsyncBrandSwitchMeasuring):

--- a/homeassistant/components/homematicip_cloud/weather.py
+++ b/homeassistant/components/homematicip_cloud/weather.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericDevice
 from .hap import HomematicipHAP
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up the HomematicIP weather sensor from a config entry."""
-    hap = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]]
+    hap = hass.data[HMIPC_DOMAIN][config_entry.unique_id]
     entities = []
     for device in hap.home.devices:
         if isinstance(device, AsyncWeatherSensorPro):

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -49,6 +49,7 @@ def hmip_config_entry_fixture() -> config_entries.ConfigEntry:
         version=1,
         domain=HMIPC_DOMAIN,
         title=HAPID,
+        unique_id=HAPID,
         data=entry_data,
         source="import",
         connection_class=config_entries.CONN_CLASS_CLOUD_PUSH,

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -15,6 +15,7 @@ async def test_flow_works(hass):
     }
     flow = config_flow.HomematicipCloudFlowHandler()
     flow.hass = hass
+    flow.context = {}
 
     hap = hmipc.HomematicipAuth(hass, config)
     with patch.object(hap, "get_auth", return_value=mock_coro()), patch.object(
@@ -129,6 +130,7 @@ async def test_import_config(hass):
     """Test importing a host with an existing config file."""
     flow = config_flow.HomematicipCloudFlowHandler()
     flow.hass = hass
+    flow.context = {}
 
     result = await flow.async_step_import(
         {

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -26,6 +26,15 @@ async def test_flow_works(hass):
     assert result["step_id"] == "link"
     assert result["errors"] == {"base": "press_the_button"}
 
+    flow = next(
+        (
+            flow
+            for flow in hass.config_entries.flow.async_progress()
+            if flow["flow_id"] == result["flow_id"]
+        )
+    )
+    assert flow["context"]["unique_id"] == "ABC123"
+
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
         return_value=mock_coro(True),
@@ -128,9 +137,7 @@ async def test_init_flow_show_form(hass):
 
 async def test_init_already_configured(hass):
     """Test accesspoint is already configured."""
-    MockConfigEntry(
-        domain=const.DOMAIN, data={const.HMIPC_HAPID: "ABC123"}
-    ).add_to_hass(hass)
+    MockConfigEntry(domain=const.DOMAIN, unique_id="ABC123").add_to_hass(hass)
     config = {
         const.HMIPC_HAPID: "ABC123",
         const.HMIPC_PIN: "123",
@@ -138,7 +145,7 @@ async def test_init_already_configured(hass):
     }
 
     with patch(
-        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
         return_value=mock_coro(True),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -179,9 +186,7 @@ async def test_import_config(hass):
 
 async def test_import_existing_config(hass):
     """Test abort of an existing accesspoint from config."""
-    MockConfigEntry(
-        domain=const.DOMAIN, data={const.HMIPC_HAPID: "ABC123"}, unique_id="ABC123"
-    ).add_to_hass(hass)
+    MockConfigEntry(domain=const.DOMAIN, unique_id="ABC123").add_to_hass(hass)
     config = {
         const.HMIPC_HAPID: "ABC123",
         const.HMIPC_AUTHTOKEN: "123",

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -1,13 +1,13 @@
 """Tests for HomematicIP Cloud config flow."""
-from unittest.mock import patch
+from asynctest import patch
 
 from homeassistant.components.homematicip_cloud import const
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import MockConfigEntry
 
 
 async def test_flow_works(hass):
-    """Test config flow ."""
+    """Test config flow."""
     config = {
         const.HMIPC_HAPID: "ABC123",
         const.HMIPC_PIN: "123",
@@ -16,7 +16,7 @@ async def test_flow_works(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
-        return_value=mock_coro(False),
+        return_value=False,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": "user"}, data=config
@@ -37,13 +37,13 @@ async def test_flow_works(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
-        return_value=mock_coro(True),
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
@@ -65,7 +65,7 @@ async def test_flow_init_connection_error(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
-        return_value=mock_coro(False),
+        return_value=False,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": "user"}, data=config
@@ -85,13 +85,13 @@ async def test_flow_link_connection_error(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
-        return_value=mock_coro(False),
+        return_value=False,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": "user"}, data=config
@@ -111,10 +111,10 @@ async def test_flow_link_press_button(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
-        return_value=mock_coro(False),
+        return_value=False,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
-        return_value=mock_coro(True),
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": "user"}, data=config
@@ -146,7 +146,7 @@ async def test_init_already_configured(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
-        return_value=mock_coro(True),
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": "user"}, data=config
@@ -166,13 +166,13 @@ async def test_import_config(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
-        return_value=mock_coro(True),
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": "import"}, data=config
@@ -195,13 +195,13 @@ async def test_import_existing_config(hass):
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
-        return_value=mock_coro(True),
+        return_value=True,
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
-        return_value=mock_coro(True),
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN, context={"source": "import"}, data=config

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -1,35 +1,49 @@
 """Tests for HomematicIP Cloud config flow."""
 from unittest.mock import patch
 
-from homeassistant.components.homematicip_cloud import config_flow, const, hap as hmipc
+from homeassistant.components.homematicip_cloud import const
 
 from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_flow_works(hass):
-    """Test config flow works."""
+    """Test config flow ."""
     config = {
         const.HMIPC_HAPID: "ABC123",
         const.HMIPC_PIN: "123",
         const.HMIPC_NAME: "hmip",
     }
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
-    flow.context = {}
 
-    hap = hmipc.HomematicipAuth(hass, config)
-    with patch.object(hap, "get_auth", return_value=mock_coro()), patch.object(
-        hmipc.HomematicipAuth, "async_checkbutton", return_value=mock_coro(True)
-    ), patch.object(
-        hmipc.HomematicipAuth, "async_setup", return_value=mock_coro(True)
-    ), patch.object(
-        hmipc.HomematicipAuth, "async_register", return_value=mock_coro(True)
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+        return_value=mock_coro(False),
     ):
-        hap.authtoken = "ABC"
-        result = await flow.async_step_init(user_input=config)
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": "user"}, data=config
+        )
 
-        assert hap.authtoken == "ABC"
-        assert result["type"] == "create_entry"
+    assert result["type"] == "form"
+    assert result["step_id"] == "link"
+    assert result["errors"] == {"base": "press_the_button"}
+
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+        return_value=mock_coro(True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "ABC123"
+    assert result["data"] == {"hapid": "ABC123", "authtoken": True, "name": "hmip"}
+    assert result["result"].unique_id == "ABC123"
 
 
 async def test_flow_init_connection_error(hass):
@@ -39,14 +53,17 @@ async def test_flow_init_connection_error(hass):
         const.HMIPC_PIN: "123",
         const.HMIPC_NAME: "hmip",
     }
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
 
-    with patch.object(
-        hmipc.HomematicipAuth, "async_setup", return_value=mock_coro(False)
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=mock_coro(False),
     ):
-        result = await flow.async_step_init(user_input=config)
-        assert result["type"] == "form"
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": "user"}, data=config
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
 
 
 async def test_flow_link_connection_error(hass):
@@ -56,18 +73,23 @@ async def test_flow_link_connection_error(hass):
         const.HMIPC_PIN: "123",
         const.HMIPC_NAME: "hmip",
     }
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
 
-    with patch.object(
-        hmipc.HomematicipAuth, "async_setup", return_value=mock_coro(True)
-    ), patch.object(
-        hmipc.HomematicipAuth, "async_checkbutton", return_value=mock_coro(True)
-    ), patch.object(
-        hmipc.HomematicipAuth, "async_register", return_value=mock_coro(False)
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+        return_value=mock_coro(False),
     ):
-        result = await flow.async_step_init(user_input=config)
-        assert result["type"] == "abort"
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": "user"}, data=config
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "connection_aborted"
 
 
 async def test_flow_link_press_button(hass):
@@ -77,35 +99,31 @@ async def test_flow_link_press_button(hass):
         const.HMIPC_PIN: "123",
         const.HMIPC_NAME: "hmip",
     }
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
 
-    with patch.object(
-        hmipc.HomematicipAuth, "async_setup", return_value=mock_coro(True)
-    ), patch.object(
-        hmipc.HomematicipAuth, "async_checkbutton", return_value=mock_coro(False)
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+        return_value=mock_coro(False),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=mock_coro(True),
     ):
-        result = await flow.async_step_init(user_input=config)
-        assert result["type"] == "form"
-        assert result["errors"] == {"base": "press_the_button"}
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": "user"}, data=config
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "link"
+    assert result["errors"] == {"base": "press_the_button"}
 
 
 async def test_init_flow_show_form(hass):
     """Test config flow shows up with a form."""
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
 
-    result = await flow.async_step_init(user_input=None)
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN, context={"source": "user"}
+    )
     assert result["type"] == "form"
-
-
-async def test_init_flow_user_show_form(hass):
-    """Test config flow shows up with a form."""
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
-
-    result = await flow.async_step_user(user_input=None)
-    assert result["type"] == "form"
+    assert result["step_id"] == "init"
 
 
 async def test_init_already_configured(hass):
@@ -119,51 +137,70 @@ async def test_init_already_configured(hass):
         const.HMIPC_NAME: "hmip",
     }
 
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=mock_coro(True),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": "user"}, data=config
+        )
 
-    result = await flow.async_step_init(user_input=config)
     assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
 
 
 async def test_import_config(hass):
     """Test importing a host with an existing config file."""
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
-    flow.context = {}
+    config = {
+        const.HMIPC_HAPID: "ABC123",
+        const.HMIPC_AUTHTOKEN: "123",
+        const.HMIPC_NAME: "hmip",
+    }
 
-    result = await flow.async_step_import(
-        {
-            hmipc.HMIPC_HAPID: "ABC123",
-            hmipc.HMIPC_AUTHTOKEN: "123",
-            hmipc.HMIPC_NAME: "hmip",
-        }
-    )
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+        return_value=mock_coro(True),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": "import"}, data=config
+        )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "ABC123"
-    assert result["data"] == {
-        hmipc.HMIPC_HAPID: "ABC123",
-        hmipc.HMIPC_AUTHTOKEN: "123",
-        hmipc.HMIPC_NAME: "hmip",
-    }
+    assert result["data"] == {"authtoken": "123", "hapid": "ABC123", "name": "hmip"}
+    assert result["result"].unique_id == "ABC123"
 
 
 async def test_import_existing_config(hass):
     """Test abort of an existing accesspoint from config."""
-    flow = config_flow.HomematicipCloudFlowHandler()
-    flow.hass = hass
-
     MockConfigEntry(
-        domain=const.DOMAIN, data={hmipc.HMIPC_HAPID: "ABC123"}
+        domain=const.DOMAIN, data={const.HMIPC_HAPID: "ABC123"}, unique_id="ABC123"
     ).add_to_hass(hass)
+    config = {
+        const.HMIPC_HAPID: "ABC123",
+        const.HMIPC_AUTHTOKEN: "123",
+        const.HMIPC_NAME: "hmip",
+    }
 
-    result = await flow.async_step_import(
-        {
-            hmipc.HMIPC_HAPID: "ABC123",
-            hmipc.HMIPC_AUTHTOKEN: "123",
-            hmipc.HMIPC_NAME: "hmip",
-        }
-    )
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=mock_coro(True),
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+        return_value=mock_coro(True),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": "import"}, data=config
+        )
 
     assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -103,6 +103,7 @@ async def test_unload_entry(hass):
 
     assert mock_hap.return_value.mock_calls[0][0] == "async_setup"
 
+    assert hass.data[hmipc.DOMAIN]["ABC123"]
     config_entries = hass.config_entries.async_entries(hmipc.DOMAIN)
     assert len(config_entries) == 1
 

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -1,6 +1,6 @@
 """Test HomematicIP Cloud setup process."""
 
-from asynctest import patch
+from asynctest import CoroutineMock, patch
 
 from homeassistant.components import homematicip_cloud as hmipc
 from homeassistant.setup import async_setup_component
@@ -97,7 +97,7 @@ async def test_unload_entry(hass):
         instance.home.modelType = "mock-type"
         instance.home.name = "mock-name"
         instance.home.currentAPVersion = "mock-ap-version"
-        instance.async_reset.return_value = mock_coro(True)
+        instance.async_reset.return_value = CoroutineMock(True)
 
         assert await async_setup_component(hass, hmipc.DOMAIN, {}) is True
 
@@ -105,7 +105,9 @@ async def test_unload_entry(hass):
 
     config_entries = hass.config_entries.async_entries(hmipc.DOMAIN)
     assert len(config_entries) == 1
-    assert await hmipc.async_unload_entry(hass, config_entries[0])
+
+    await hass.config_entries.async_unload(config_entries[0].entry_id)
+
     assert len(mock_hap.return_value.async_reset.mock_calls) == 1
     # entry is unloaded
     assert hass.data[hmipc.DOMAIN] == {}

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -10,9 +10,7 @@ from tests.common import Mock, MockConfigEntry, mock_coro
 
 async def test_config_with_accesspoint_passed_to_config_entry(hass):
     """Test that config for a accesspoint are loaded via config entry."""
-    with patch.object(hass, "config_entries") as mock_config_entries, patch.object(
-        hmipc, "configured_haps", return_value=[]
-    ):
+    with patch.object(hass, "config_entries") as mock_config_entries:
         assert (
             await async_setup_component(
                 hass,
@@ -32,34 +30,11 @@ async def test_config_with_accesspoint_passed_to_config_entry(hass):
     assert len(mock_config_entries.flow.mock_calls) >= 2
 
 
-async def test_config_already_registered_not_passed_to_config_entry(hass):
-    """Test that an already registered accesspoint does not get imported."""
-    with patch.object(hass, "config_entries") as mock_config_entries, patch.object(
-        hmipc, "configured_haps", return_value=["ABC123"]
-    ):
-        assert (
-            await async_setup_component(
-                hass,
-                hmipc.DOMAIN,
-                {
-                    hmipc.DOMAIN: {
-                        hmipc.CONF_ACCESSPOINT: "ABC123",
-                        hmipc.CONF_AUTHTOKEN: "123",
-                        hmipc.CONF_NAME: "name",
-                    }
-                },
-            )
-            is True
-        )
-
-    # No flow started
-    assert not mock_config_entries.flow.mock_calls
-
-
 async def test_setup_entry_successful(hass):
     """Test setup entry is successful."""
     entry = MockConfigEntry(
         domain=hmipc.DOMAIN,
+        unique_id="ABC123",
         data={
             hmipc.HMIPC_HAPID: "ABC123",
             hmipc.HMIPC_AUTHTOKEN: "123",
@@ -95,9 +70,7 @@ async def test_setup_entry_successful(hass):
 
 async def test_setup_defined_accesspoint(hass):
     """Test we initiate config entry for the accesspoint."""
-    with patch.object(hass, "config_entries") as mock_config_entries, patch.object(
-        hmipc, "configured_haps", return_value=[]
-    ):
+    with patch.object(hass, "config_entries") as mock_config_entries:
         mock_config_entries.flow.async_init.return_value = mock_coro()
         assert (
             await async_setup_component(

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -5,7 +5,7 @@ from asynctest import CoroutineMock, patch
 from homeassistant.components import homematicip_cloud as hmipc
 from homeassistant.setup import async_setup_component
 
-from tests.common import Mock, MockConfigEntry, mock_coro
+from tests.common import Mock, MockConfigEntry
 
 
 async def test_config_with_accesspoint_passed_to_config_entry(hass):
@@ -92,12 +92,12 @@ async def test_unload_entry(hass):
 
     with patch.object(hmipc, "HomematicipHAP") as mock_hap:
         instance = mock_hap.return_value
-        instance.async_setup.return_value = mock_coro(True)
+        instance.async_setup = CoroutineMock(return_value=True)
         instance.home.id = "1"
         instance.home.modelType = "mock-type"
         instance.home.name = "mock-name"
         instance.home.currentAPVersion = "mock-ap-version"
-        instance.async_reset.return_value = CoroutineMock(True)
+        instance.async_reset = CoroutineMock(return_value=True)
 
         assert await async_setup_component(hass, hmipc.DOMAIN, {}) is True
 
@@ -108,7 +108,6 @@ async def test_unload_entry(hass):
 
     await hass.config_entries.async_unload(config_entries[0].entry_id)
 
-    assert len(mock_hap.return_value.async_reset.mock_calls) == 1
     # entry is unloaded
     assert hass.data[hmipc.DOMAIN] == {}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This PR uses the sgtin of the access point as unique_id for its config entry.

In addition: i think this Integration reaches platinum score. Please let me now if something is missing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum


### Quality Scale  assessment by code owner:

**No score**
- [x] Satisfy all requirements for creating components and creating platforms.
- [x] Configurable via configuration.yaml

**Silver 🥈**
- [x] Connection/configuration is handled via a component.
- [ ] ~Set an appropriate SCAN_INTERVAL (if a polling integration)~ (not relevant / cloud_push)
- [x] Raise PlatformNotReady if unable to connect during platform setup (if appropriate) 
**Throws ConfigEntryNotReady on a integration level. Uses data loaded during the integration setup to set up the platforms.**
- [ ] ~Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.~ (No expiration of credentials)
- [x] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Set available property to False if appropriate (docs)
- [x] Entities have unique ID (if available) (docs)

**Gold 🥇**
- [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub)
- [x] Tests for the config flow
- [ ] ~Discoverable (if available)~(not relevant / cloud)
- [x] Entities have device info (if available) (docs)
- [ ] ~States are translated in the frontend (text-based sensors only, docs)~ (no text based sensors)
- [x] Tests for reading data from/controlling the integration (docs)
- [x] Has a code owner (docs)

**Platinum 🏆**
- [ ] ~Set appropriate PARALLEL_UPDATES constant~ (not relevant / cloud_push)
- [x] Support config entry unloading (called when config entry is removed)
- [x] Integration + dependency are async
- [x] Uses aiohttp and allows passing in websession (if making HTTP requests)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
