### PR TITLE
improvements to zha cover

### DIFF
--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -96,6 +96,16 @@ class ZhaCover(ZhaEntity, CoverDevice):
         return self.current_cover_position == 0
 
     @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return self._state == STATE_OPENING
+
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return self._state == STATE_CLOSING
+
+    @property
     def current_cover_position(self):
         """Return the current position of ZHA cover.
 
@@ -133,7 +143,7 @@ class ZhaCover(ZhaEntity, CoverDevice):
 
     async def async_set_cover_position(self, **kwargs):
         """Move the roller shutter to a specific position."""
-        new_pos = kwargs.get(ATTR_POSITION)
+        new_pos = kwargs[ATTR_POSITION]
         res = await self._cover_channel.go_to_lift_percentage(100 - new_pos)
         if isinstance(res, list) and res[1] is Status.SUCCESS:
             self.async_set_state(


### PR DESCRIPTION
## Proposed change
Supports `is_closing` and `is_opening`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

