### PR TITLE
Refactor RainMachine switch platform

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -31,18 +31,17 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SSL,
     DOMAIN,
+    PROGRAM_UPDATE_TOPIC,
     PROVISION_SETTINGS,
     RESTRICTIONS_CURRENT,
     RESTRICTIONS_UNIVERSAL,
+    SENSOR_UPDATE_TOPIC,
+    ZONE_UPDATE_TOPIC,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 DATA_LISTENER = "listener"
-
-PROGRAM_UPDATE_TOPIC = f"{DOMAIN}_program_update"
-SENSOR_UPDATE_TOPIC = f"{DOMAIN}_data_update"
-ZONE_UPDATE_TOPIC = f"{DOMAIN}_zone_update"
 
 CONF_CONTROLLERS = "controllers"
 CONF_PROGRAM_ID = "program_id"

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -375,8 +375,6 @@ class RainMachine:
 
         Program and zone updates always go together because of how linked they are:
         programs affect zones and certain combinations of zones affect programs.
-        :wa
-
 
         Note that this call does not take into account interested entities when making
         the API calls; we make the reasonable assumption that switches will always be

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -166,38 +166,37 @@ async def async_setup_entry(hass, config_entry):
     async def disable_program(call):
         """Disable a program."""
         await rainmachine.client.programs.disable(call.data[CONF_PROGRAM_ID])
-        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def disable_zone(call):
         """Disable a zone."""
         await rainmachine.client.zones.disable(call.data[CONF_ZONE_ID])
-        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def enable_program(call):
         """Enable a program."""
         await rainmachine.client.programs.enable(call.data[CONF_PROGRAM_ID])
-        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def enable_zone(call):
         """Enable a zone."""
         await rainmachine.client.zones.enable(call.data[CONF_ZONE_ID])
-        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def pause_watering(call):
         """Pause watering for a set number of seconds."""
         await rainmachine.client.watering.pause_all(call.data[CONF_SECONDS])
-        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
-        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def start_program(call):
         """Start a particular program."""
         await rainmachine.client.programs.start(call.data[CONF_PROGRAM_ID])
-        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def start_zone(call):
@@ -205,33 +204,31 @@ async def async_setup_entry(hass, config_entry):
         await rainmachine.client.zones.start(
             call.data[CONF_ZONE_ID], call.data[CONF_ZONE_RUN_TIME]
         )
-        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def stop_all(call):
         """Stop all watering."""
         await rainmachine.client.watering.stop_all()
-        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
-        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def stop_program(call):
         """Stop a program."""
         await rainmachine.client.programs.stop(call.data[CONF_PROGRAM_ID])
-        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def stop_zone(call):
         """Stop a zone."""
         await rainmachine.client.zones.stop(call.data[CONF_ZONE_ID])
-        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     @_verify_domain_control
     async def unpause_watering(call):
         """Unpause watering."""
         await rainmachine.client.watering.unpause_all()
-        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
-        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
+        await rainmachine.async_update_programs_and_zones()
 
     for service, method, schema in [
         ("disable_program", disable_program, SERVICE_ALTER_PROGRAM),

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -27,14 +27,14 @@ from homeassistant.helpers.service import verify_domain_control
 from .config_flow import configured_instances
 from .const import (
     DATA_CLIENT,
+    DATA_PROVISION_SETTINGS,
+    DATA_RESTRICTIONS_CURRENT,
+    DATA_RESTRICTIONS_UNIVERSAL,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SSL,
     DOMAIN,
     PROGRAM_UPDATE_TOPIC,
-    PROVISION_SETTINGS,
-    RESTRICTIONS_CURRENT,
-    RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC,
     ZONE_UPDATE_TOPIC,
 )
@@ -273,9 +273,9 @@ class RainMachine:
         self.hass = hass
 
         self._api_category_count = {
-            PROVISION_SETTINGS: 0,
-            RESTRICTIONS_CURRENT: 0,
-            RESTRICTIONS_UNIVERSAL: 0,
+            DATA_PROVISION_SETTINGS: 0,
+            DATA_RESTRICTIONS_CURRENT: 0,
+            DATA_RESTRICTIONS_UNIVERSAL: 0,
         }
         self._api_category_locks = {
             PROVISION_SETTINGS: asyncio.Lock(),
@@ -285,11 +285,11 @@ class RainMachine:
 
     async def _async_fetch_from_api(self, api_category):
         """Execute the appropriate coroutine to fetch particular data from the API."""
-        if api_category == PROVISION_SETTINGS:
+        if api_category == DATA_PROVISION_SETTINGS:
             data = await self.client.provisioning.settings()
-        elif api_category == RESTRICTIONS_CURRENT:
+        elif api_category == DATA_RESTRICTIONS_CURRENT:
             data = await self.client.restrictions.current()
-        elif api_category == RESTRICTIONS_UNIVERSAL:
+        elif api_category == DATA_RESTRICTIONS_UNIVERSAL:
             data = await self.client.restrictions.universal()
 
         return data

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -306,6 +306,7 @@ class RainMachine:
                 self._async_cancel_time_interval_listener()
                 self._async_cancel_time_interval_listener = None
             return
+
         self._api_category_count[api_category] -= 1
 
     async def async_fetch_from_api(self, api_category):

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -348,14 +348,14 @@ class RainMachine:
         _LOGGER.debug("Updating data for RainMachine")
 
         # Always update program data and zone data (since we should reasonably
-        # anticipate that the user wants switches to control the device):
+        # anticipate that the user won't disable the switch entities):
         tasks = {
             DATA_PROGRAMS: self._async_fetch_from_api(DATA_PROGRAMS),
             DATA_ZONES: self._async_fetch_from_api(DATA_ZONES),
             DATA_ZONES_DETAILS: self._async_fetch_from_api(DATA_ZONES_DETAILS),
         }
 
-        # Add an API task only if there is at least one "interested" entity:
+        # Add an task for any API call if there is at least one interested entity:
         for category, count in self._api_category_count.items():
             if count == 0:
                 continue

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -373,6 +373,11 @@ class RainMachine:
     async def async_update_programs_and_zones(self):
         """Update program and zone data.
 
+        Program and zone updates always go together because of how linked they are:
+        programs affect zones and certain combinations of zones affect programs.
+        :wa
+
+
         Note that this call does not take into account interested entities when making
         the API calls; we make the reasonable assumption that switches will always be
         enabled.

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -346,7 +346,6 @@ class RainMachine:
     async def async_update(self):
         """Update all RainMachine data."""
         tasks = [self.async_update_programs_and_zones(), self.async_update_sensors()]
-
         await asyncio.gather(*tasks)
 
     async def async_update_sensors(self):

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -394,7 +394,6 @@ class RainMachine:
                 _LOGGER.error(
                     "There was an error while updating %s: %s", api_category, result
                 )
-                continue
 
         async_dispatcher_send(self.hass, PROGRAM_UPDATE_TOPIC)
         async_dispatcher_send(self.hass, ZONE_UPDATE_TOPIC)

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -306,7 +306,7 @@ class RainMachine:
                 self._async_cancel_time_interval_listener()
                 self._async_cancel_time_interval_listener = None
             return
-        self._api_category_count[api_category] += 1
+        self._api_category_count[api_category] -= 1
 
     async def async_fetch_from_api(self, api_category):
         """Execute the appropriate coroutine to fetch particular data from the API."""

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -191,6 +191,7 @@ async def async_setup_entry(hass, config_entry):
         """Pause watering for a set number of seconds."""
         await rainmachine.client.watering.pause_all(call.data[CONF_SECONDS])
         async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
 
     @_verify_domain_control
     async def start_program(call):
@@ -211,6 +212,7 @@ async def async_setup_entry(hass, config_entry):
         """Stop all watering."""
         await rainmachine.client.watering.stop_all()
         async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
 
     @_verify_domain_control
     async def stop_program(call):
@@ -229,6 +231,7 @@ async def async_setup_entry(hass, config_entry):
         """Unpause watering."""
         await rainmachine.client.watering.unpause_all()
         async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+        async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
 
     for service, method, schema in [
         ("disable_program", disable_program, SERVICE_ALTER_PROGRAM),

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -8,10 +8,10 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from . import RainMachineEntity
 from .const import (
     DATA_CLIENT,
+    DATA_PROVISION_SETTINGS,
+    DATA_RESTRICTIONS_CURRENT,
+    DATA_RESTRICTIONS_UNIVERSAL,
     DOMAIN as RAINMACHINE_DOMAIN,
-    PROVISION_SETTINGS,
-    RESTRICTIONS_CURRENT,
-    RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC,
 )
 
@@ -28,35 +28,45 @@ TYPE_RAINSENSOR = "rainsensor"
 TYPE_WEEKDAY = "weekday"
 
 BINARY_SENSORS = {
-    TYPE_FLOW_SENSOR: ("Flow Sensor", "mdi:water-pump", True, PROVISION_SETTINGS),
-    TYPE_FREEZE: ("Freeze Restrictions", "mdi:cancel", True, RESTRICTIONS_CURRENT),
+    TYPE_FLOW_SENSOR: ("Flow Sensor", "mdi:water-pump", True, DATA_PROVISION_SETTINGS),
+    TYPE_FREEZE: ("Freeze Restrictions", "mdi:cancel", True, DATA_RESTRICTIONS_CURRENT),
     TYPE_FREEZE_PROTECTION: (
         "Freeze Protection",
         "mdi:weather-snowy",
         True,
-        RESTRICTIONS_UNIVERSAL,
+        DATA_RESTRICTIONS_UNIVERSAL,
     ),
     TYPE_HOT_DAYS: (
         "Extra Water on Hot Days",
         "mdi:thermometer-lines",
         True,
-        RESTRICTIONS_UNIVERSAL,
+        DATA_RESTRICTIONS_UNIVERSAL,
     ),
-    TYPE_HOURLY: ("Hourly Restrictions", "mdi:cancel", False, RESTRICTIONS_CURRENT),
-    TYPE_MONTH: ("Month Restrictions", "mdi:cancel", False, RESTRICTIONS_CURRENT),
+    TYPE_HOURLY: (
+        "Hourly Restrictions",
+        "mdi:cancel",
+        False,
+        DATA_RESTRICTIONS_CURRENT,
+    ),
+    TYPE_MONTH: ("Month Restrictions", "mdi:cancel", False, DATA_RESTRICTIONS_CURRENT),
     TYPE_RAINDELAY: (
         "Rain Delay Restrictions",
         "mdi:cancel",
         False,
-        RESTRICTIONS_CURRENT,
+        DATA_RESTRICTIONS_CURRENT,
     ),
     TYPE_RAINSENSOR: (
         "Rain Sensor Restrictions",
         "mdi:cancel",
         False,
-        RESTRICTIONS_CURRENT,
+        DATA_RESTRICTIONS_CURRENT,
     ),
-    TYPE_WEEKDAY: ("Weekday Restrictions", "mdi:cancel", False, RESTRICTIONS_CURRENT),
+    TYPE_WEEKDAY: (
+        "Weekday Restrictions",
+        "mdi:cancel",
+        False,
+        DATA_RESTRICTIONS_CURRENT,
+    ),
 }
 
 
@@ -136,29 +146,29 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
     async def async_update(self):
         """Update the state."""
         if self._sensor_type == TYPE_FLOW_SENSOR:
-            self._state = self.rainmachine.data[PROVISION_SETTINGS]["system"].get(
+            self._state = self.rainmachine.data[DATA_PROVISION_SETTINGS]["system"].get(
                 "useFlowSensor"
             )
         elif self._sensor_type == TYPE_FREEZE:
-            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]["freeze"]
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_CURRENT]["freeze"]
         elif self._sensor_type == TYPE_FREEZE_PROTECTION:
-            self._state = self.rainmachine.data[RESTRICTIONS_UNIVERSAL][
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_UNIVERSAL][
                 "freezeProtectEnabled"
             ]
         elif self._sensor_type == TYPE_HOT_DAYS:
-            self._state = self.rainmachine.data[RESTRICTIONS_UNIVERSAL][
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_UNIVERSAL][
                 "hotDaysExtraWatering"
             ]
         elif self._sensor_type == TYPE_HOURLY:
-            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]["hourly"]
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_CURRENT]["hourly"]
         elif self._sensor_type == TYPE_MONTH:
-            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]["month"]
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_CURRENT]["month"]
         elif self._sensor_type == TYPE_RAINDELAY:
-            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]["rainDelay"]
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_CURRENT]["rainDelay"]
         elif self._sensor_type == TYPE_RAINSENSOR:
-            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]["rainSensor"]
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_CURRENT]["rainSensor"]
         elif self._sensor_type == TYPE_WEEKDAY:
-            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]["weekDay"]
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_CURRENT]["weekDay"]
 
     async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listeners and deregister API interest."""

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -5,14 +5,14 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import (
+from . import RainMachineEntity
+from .const import (
     DATA_CLIENT,
     DOMAIN as RAINMACHINE_DOMAIN,
     PROVISION_SETTINGS,
     RESTRICTIONS_CURRENT,
     RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC,
-    RainMachineEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -2,7 +2,6 @@
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import RainMachineEntity
@@ -118,11 +117,6 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
         return self._state
 
     @property
-    def should_poll(self):
-        """Disable polling."""
-        return False
-
-    @property
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return "{0}_{1}".format(
@@ -131,14 +125,8 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-
-        @callback
-        def update():
-            """Update the state."""
-            self.async_schedule_update_ha_state(True)
-
         self._dispatcher_handlers.append(
-            async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, update)
+            async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, self._update_state)
         )
         await self.rainmachine.async_register_api_interest(self._api_category)
         await self.async_update()

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -128,7 +128,7 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
         self._dispatcher_handlers.append(
             async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, self._update_state)
         )
-        await self.rainmachine.async_register_api_interest(self._api_category)
+        await self.rainmachine.async_register_sensor_api_interest(self._api_category)
         await self.async_update()
 
     async def async_update(self):
@@ -161,4 +161,4 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
     async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listeners and deregister API interest."""
         super().async_will_remove_from_hass()
-        self.rainmachine.async_deregister_api_interest(self._api_category)
+        self.rainmachine.async_deregister_sensor_api_interest(self._api_category)

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -7,14 +7,13 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "rainmachine"
 
 DATA_CLIENT = "client"
+DATA_PROVISION_SETTINGS = "provision.settings"
+DATA_RESTRICTIONS_CURRENT = "restrictions.current"
+DATA_RESTRICTIONS_UNIVERSAL = "restrictions.universal"
 
 DEFAULT_PORT = 8080
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 DEFAULT_SSL = True
-
-PROVISION_SETTINGS = "provision.settings"
-RESTRICTIONS_CURRENT = "restrictions.current"
-RESTRICTIONS_UNIVERSAL = "restrictions.universal"
 
 PROGRAM_UPDATE_TOPIC = f"{DOMAIN}_program_update"
 SENSOR_UPDATE_TOPIC = f"{DOMAIN}_data_update"

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -16,4 +16,6 @@ PROVISION_SETTINGS = "provision.settings"
 RESTRICTIONS_CURRENT = "restrictions.current"
 RESTRICTIONS_UNIVERSAL = "restrictions.universal"
 
-TOPIC_UPDATE = "update_{0}"
+PROGRAM_UPDATE_TOPIC = f"{DOMAIN}_program_update"
+SENSOR_UPDATE_TOPIC = f"{DOMAIN}_data_update"
+ZONE_UPDATE_TOPIC = f"{DOMAIN}_zone_update"

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -7,9 +7,12 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "rainmachine"
 
 DATA_CLIENT = "client"
+DATA_PROGRAMS = "programs"
 DATA_PROVISION_SETTINGS = "provision.settings"
 DATA_RESTRICTIONS_CURRENT = "restrictions.current"
 DATA_RESTRICTIONS_UNIVERSAL = "restrictions.universal"
+DATA_ZONES = "zones"
+DATA_ZONES_DETAILS = "zones_details"
 
 DEFAULT_PORT = 8080
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -7,9 +7,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from . import RainMachineEntity
 from .const import (
     DATA_CLIENT,
+    DATA_PROVISION_SETTINGS,
+    DATA_RESTRICTIONS_UNIVERSAL,
     DOMAIN as RAINMACHINE_DOMAIN,
-    PROVISION_SETTINGS,
-    RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC,
 )
 
@@ -28,7 +28,7 @@ SENSORS = {
         "clicks/m^3",
         None,
         False,
-        PROVISION_SETTINGS,
+        DATA_PROVISION_SETTINGS,
     ),
     TYPE_FLOW_SENSOR_CONSUMED_LITERS: (
         "Flow Sensor Consumed Liters",
@@ -36,7 +36,7 @@ SENSORS = {
         "liter",
         None,
         False,
-        PROVISION_SETTINGS,
+        DATA_PROVISION_SETTINGS,
     ),
     TYPE_FLOW_SENSOR_START_INDEX: (
         "Flow Sensor Start Index",
@@ -44,7 +44,7 @@ SENSORS = {
         "index",
         None,
         False,
-        PROVISION_SETTINGS,
+        DATA_PROVISION_SETTINGS,
     ),
     TYPE_FLOW_SENSOR_WATERING_CLICKS: (
         "Flow Sensor Clicks",
@@ -52,7 +52,7 @@ SENSORS = {
         "clicks",
         None,
         False,
-        PROVISION_SETTINGS,
+        DATA_PROVISION_SETTINGS,
     ),
     TYPE_FREEZE_TEMP: (
         "Freeze Protect Temperature",
@@ -60,7 +60,7 @@ SENSORS = {
         "°C",
         "temperature",
         True,
-        RESTRICTIONS_UNIVERSAL,
+        DATA_RESTRICTIONS_UNIVERSAL,
     ),
 }
 
@@ -163,31 +163,31 @@ class RainMachineSensor(RainMachineEntity):
     async def async_update(self):
         """Update the sensor's state."""
         if self._sensor_type == TYPE_FLOW_SENSOR_CLICK_M3:
-            self._state = self.rainmachine.data[PROVISION_SETTINGS]["system"].get(
+            self._state = self.rainmachine.data[DATA_PROVISION_SETTINGS]["system"].get(
                 "flowSensorClicksPerCubicMeter"
             )
         elif self._sensor_type == TYPE_FLOW_SENSOR_CONSUMED_LITERS:
-            clicks = self.rainmachine.data[PROVISION_SETTINGS]["system"].get(
+            clicks = self.rainmachine.data[DATA_PROVISION_SETTINGS]["system"].get(
                 "flowSensorWateringClicks"
             )
-            clicks_per_m3 = self.rainmachine.data[PROVISION_SETTINGS]["system"].get(
-                "flowSensorClicksPerCubicMeter"
-            )
+            clicks_per_m3 = self.rainmachine.data[DATA_PROVISION_SETTINGS][
+                "system"
+            ].get("flowSensorClicksPerCubicMeter")
 
             if clicks and clicks_per_m3:
                 self._state = (clicks * 1000) / clicks_per_m3
             else:
                 self._state = None
         elif self._sensor_type == TYPE_FLOW_SENSOR_START_INDEX:
-            self._state = self.rainmachine.data[PROVISION_SETTINGS]["system"].get(
+            self._state = self.rainmachine.data[DATA_PROVISION_SETTINGS]["system"].get(
                 "flowSensorStartIndex"
             )
         elif self._sensor_type == TYPE_FLOW_SENSOR_WATERING_CLICKS:
-            self._state = self.rainmachine.data[PROVISION_SETTINGS]["system"].get(
+            self._state = self.rainmachine.data[DATA_PROVISION_SETTINGS]["system"].get(
                 "flowSensorWateringClicks"
             )
         elif self._sensor_type == TYPE_FREEZE_TEMP:
-            self._state = self.rainmachine.data[RESTRICTIONS_UNIVERSAL][
+            self._state = self.rainmachine.data[DATA_RESTRICTIONS_UNIVERSAL][
                 "freezeProtectTemp"
             ]
 

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -4,13 +4,13 @@ import logging
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import (
+from . import RainMachineEntity
+from .const import (
     DATA_CLIENT,
     DOMAIN as RAINMACHINE_DOMAIN,
     PROVISION_SETTINGS,
     RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC,
-    RainMachineEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -145,7 +145,7 @@ class RainMachineSensor(RainMachineEntity):
         self._dispatcher_handlers.append(
             async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, self._update_state)
         )
-        await self.rainmachine.async_register_api_interest(self._api_category)
+        await self.rainmachine.async_register_sensor_api_interest(self._api_category)
         await self.async_update()
 
     async def async_update(self):
@@ -182,4 +182,4 @@ class RainMachineSensor(RainMachineEntity):
     async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listeners and deregister API interest."""
         super().async_will_remove_from_hass()
-        self.rainmachine.async_deregister_api_interest(self._api_category)
+        self.rainmachine.async_deregister_sensor_api_interest(self._api_category)

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -1,7 +1,6 @@
 """This platform provides support for sensor data from RainMachine."""
 import logging
 
-from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import RainMachineEntity
@@ -125,11 +124,6 @@ class RainMachineSensor(RainMachineEntity):
         return self._icon
 
     @property
-    def should_poll(self):
-        """Disable polling."""
-        return False
-
-    @property
     def state(self) -> str:
         """Return the name of the entity."""
         return self._state
@@ -148,14 +142,8 @@ class RainMachineSensor(RainMachineEntity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-
-        @callback
-        def update():
-            """Update the state."""
-            self.async_schedule_update_ha_state(True)
-
         self._dispatcher_handlers.append(
-            async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, update)
+            async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, self._update_state)
         )
         await self.rainmachine.async_register_api_interest(self._api_category)
         await self.async_update()

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -156,7 +156,7 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
                 'Unable to turn off %s "%s": %s',
                 self._switch_type,
                 self.unique_id,
-                str(err),
+                err,
             )
             return
 
@@ -177,10 +177,7 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
             resp = await api_coro
         except RequestError as err:
             _LOGGER.error(
-                'Unable to turn on %s "%s": %s',
-                self._switch_type,
-                self.unique_id,
-                str(err),
+                'Unable to turn on %s "%s": %s', self._switch_type, self.unique_id, err,
             )
             return
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -12,12 +12,12 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 
-from . import (
+from . import RainMachineEntity
+from .const import (
     DATA_CLIENT,
     DOMAIN as RAINMACHINE_DOMAIN,
     PROGRAM_UPDATE_TOPIC,
     ZONE_UPDATE_TOPIC,
-    RainMachineEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -178,7 +178,6 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the program off."""
-
         try:
             await self.rainmachine.client.programs.stop(self._rainmachine_entity_id)
             async_dispatcher_send(self.hass, PROGRAM_UPDATE_TOPIC)
@@ -189,7 +188,6 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the program on."""
-
         try:
             await self.rainmachine.client.programs.start(self._rainmachine_entity_id)
             async_dispatcher_send(self.hass, PROGRAM_UPDATE_TOPIC)
@@ -200,7 +198,6 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_update(self) -> None:
         """Update info for the program."""
-
         try:
             self._obj = await self.rainmachine.client.programs.get(
                 self._rainmachine_entity_id
@@ -259,7 +256,6 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the zone off."""
-
         try:
             await self.rainmachine.client.zones.stop(self._rainmachine_entity_id)
         except RequestError as err:
@@ -267,7 +263,6 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the zone on."""
-
         try:
             await self.rainmachine.client.zones.start(
                 self._rainmachine_entity_id, self._run_time
@@ -277,7 +272,6 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_update(self) -> None:
         """Update info for the zone."""
-
         try:
             self._obj = await self.rainmachine.client.zones.get(
                 self._rainmachine_entity_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
(this is a redo – and expansion – of https://github.com/home-assistant/home-assistant/pull/31125)

The RainMachine switch platform was quite outdated compared to the rest of the component; most notably, switches would individually poll the API (which caused excess, unnecessary traffic and could sometimes cause the device to time out if too many requests hit it at the same time) and their state updates were tied directly to that polling (meaning it would often take until the next update interval to properly reflect the state).

To that end, this PR accomplishes a few things:

* Updates the internal RainMachine data object to handle the periodic retrieval of switch data.
* In accordance with the above, removes polling from RainMachine switches.
* Cleans up various cruft within the RainMachine switch classes.
* Centralizes more functionality with the `RainMachine` and `RainMachineEntity` classes.
* Renames some internal constants to better reflect their purpose.
* Cleans up some constants that lived outside of `const.py`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
rainmachine:
  controllers:
    - ip_address: 192.168.1.100
      password: YOUR_PASSWORD
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
