### PR TITLE
Implement 'volume_set' service for Android TV devices

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
     "adb-shell==0.1.1",
-    "androidtv==0.0.38",
+    "androidtv==0.0.39",
     "pure-python-adb==0.2.2.dev0"
   ],
   "dependencies": [],

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -26,6 +26,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.const import (
@@ -59,6 +60,7 @@ SUPPORT_ANDROIDTV = (
     | SUPPORT_SELECT_SOURCE
     | SUPPORT_STOP
     | SUPPORT_VOLUME_MUTE
+    | SUPPORT_VOLUME_SET
     | SUPPORT_VOLUME_STEP
 )
 
@@ -630,6 +632,11 @@ class AndroidTVDevice(ADBDevice):
     def mute_volume(self, mute):
         """Mute the volume."""
         self.aftv.mute_volume()
+
+    @adb_decorator()
+    def set_volume_level(self, volume):
+        """Set the volume level."""
+        self.aftv.set_volume_level(volume)
 
     @adb_decorator()
     def volume_down(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -220,7 +220,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.38
+androidtv==0.0.39
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -87,7 +87,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.38
+androidtv==0.0.39
 
 # homeassistant.components.apns
 apns2==0.3.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implement the `media_player.volume_set` service for Android TV devices (excludes Fire TV devices).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31033
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver **see the next section**
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

### [Silver](https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html#silver-%F0%9F%A5%88) Checklist

- [ ] Connection/configuration is handled via a component.
- [x] Set an appropriate SCAN_INTERVAL (if a polling integration) **handled by the `media_player` domain**
- [x] Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
- [x] ~~Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.~~
- [x] ~~Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.~~  **Doesn't rely on external internet**
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
    https://github.com/home-assistant/home-assistant/blob/c481a48e3a85b6bed55b5898a66502f0ea3d732d/tests/components/androidtv/test_media_player.py#L98-L105
- [x] Set available property to False if appropriate (docs)
- [x] Entities have unique ID (if available) (docs)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
