### PR TITLE
Serialize ipaddress objects (Address/Network) as strings by default in storage

### DIFF
--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -2,15 +2,16 @@
 import asyncio
 from datetime import timedelta
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
+from asynctest import patch
 import pytest
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import storage
 from homeassistant.util import dt
 
-from tests.common import async_fire_time_changed, mock_coro
+from tests.common import async_fire_time_changed
 
 MOCK_VERSION = 1
 MOCK_KEY = "storage-test"
@@ -140,7 +141,7 @@ async def test_writing_while_writing_delay(hass, store, hass_storage):
 async def test_migrator_no_existing_config(hass, store, hass_storage):
     """Test migrator with no existing config."""
     with patch("os.path.isfile", return_value=False), patch.object(
-        store, "async_load", return_value=mock_coro({"cur": "config"})
+        store, "async_load", return_value={"cur": "config"}
     ):
         data = await storage.async_migrator(hass, "old-path", store)
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -1,6 +1,7 @@
 """Tests for the storage helper."""
 import asyncio
 from datetime import timedelta
+from ipaddress import IPv4Address
 import json
 from unittest.mock import Mock
 
@@ -46,6 +47,15 @@ async def test_custom_encoder(hass):
     await store.async_save(Mock())
     data = await store.async_load()
     assert data == "9"
+
+
+async def test_save_ipaddress(hass):
+    """Test that default encoder can save ip addresses."""
+
+    store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
+    await store.async_save(IPv4Address("192.168.1.1"))
+    data = await store.async_load()
+    assert data == "192.168.1.1"
 
 
 async def test_loading_non_existing(hass, store):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes a problem where serializing http settings fails with a TypeError that e.g. 'Object of type IPv4Address is not JSON serializable.'

So, we create a simple default encoder wrapper that converts IPv4Address (etc.) to strings, and  delegates to json.JSONEncoder for everything else. We still keep the ability for clients of the storage API to provide their own encoders as before.

We also fix a broken unittest in tests/test_storage.py (test_migrator_no_existing_config)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes an issue introduced in #30723.
- **>>> MAINTAINERS <<<** Would you like me to file an issue and reference it here?

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
