### PR TITLE
Update media_player and add tests to qualify vizio integration for platinum quality score

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -782,9 +782,6 @@ omit =
     homeassistant/components/viaggiatreno/sensor.py
     homeassistant/components/vicare/*
     homeassistant/components/vivotek/camera.py
-    homeassistant/components/vizio/__init__.py
-    homeassistant/components/vizio/const.py
-    homeassistant/components/vizio/media_player.py
     homeassistant/components/vlc/media_player.py
     homeassistant/components/vlc_telnet/media_player.py
     homeassistant/components/volkszaehler/sensor.py

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": [],
   "codeowners": ["@raman325"],
   "config_flow": true,
-  "zeroconf": ["_viziocast._tcp.local."]
+  "zeroconf": ["_viziocast._tcp.local."],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -39,8 +39,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-
-PARALLEL_UPDATES = 0
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -55,13 +54,13 @@ async def async_setup_entry(
     device_class = config_entry.data[CONF_DEVICE_CLASS]
 
     # If config entry options not set up, set them up, otherwise assign values managed in options
+    volume_step = config_entry.options.get(
+        CONF_VOLUME_STEP, config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+    )
     if not config_entry.options:
-        volume_step = config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
         hass.config_entries.async_update_entry(
             config_entry, options={CONF_VOLUME_STEP: volume_step}
         )
-    else:
-        volume_step = config_entry.options[CONF_VOLUME_STEP]
 
     device = VizioAsync(
         DEVICE_ID,

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -39,8 +39,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PARALLEL_UPDATES = 0
 SCAN_INTERVAL = MIN_TIME_BETWEEN_SCANS
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -6,7 +6,7 @@ from typing import Callable, List
 from pyvizio import VizioAsync
 
 from homeassistant import util
-from homeassistant.components.media_player import DOMAIN as MP_DOMAIN, MediaPlayerDevice
+from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
@@ -24,7 +24,6 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.util import slugify
 
 from .const import (
     CONF_VOLUME_STEP,
@@ -76,18 +75,7 @@ async def async_setup_entry(
     )
 
     if not await device.can_connect():
-        fail_auth_msg = ""
-        if token:
-            fail_auth_msg = f"and auth token are correct"
-        else:
-            fail_auth_msg = "is correct"
-        _LOGGER.warning(
-            "Unable to connect to device, check if host '%s' is valid "
-            "and available. Also check if device class '%s' %s",
-            host,
-            device_class,
-            fail_auth_msg,
-        )
+        _LOGGER.warning("Failed to connect to %s", host)
         raise PlatformNotReady
 
     entity = VizioDevice(config_entry, device, name, volume_step, device_class)
@@ -131,18 +119,14 @@ class VizioDevice(MediaPlayerDevice):
         if is_on is None:
             if self._available:
                 _LOGGER.warning(
-                    "Lost connection to %s (%s)",
-                    self._config_entry.data[CONF_HOST],
-                    f"{MP_DOMAIN}.{slugify(self._name)}",
+                    "Lost connection to %s", self._config_entry.data[CONF_HOST]
                 )
                 self._available = False
             return
 
         if not self._available:
             _LOGGER.info(
-                "Restored connection to %s (%s)",
-                self._config_entry.data[CONF_HOST],
-                f"{MP_DOMAIN}.{slugify(self._name)}",
+                "Restored connection to %s", self._config_entry.data[CONF_HOST]
             )
             self._available = True
 
@@ -171,7 +155,7 @@ class VizioDevice(MediaPlayerDevice):
     async def _async_send_update_options_signal(
         hass: HomeAssistantType, config_entry: ConfigEntry
     ) -> None:
-        """Send update event when when Vizio config entry is updated."""
+        """Send update event when Vizio config entry is updated."""
         # Move this method to component level if another entity ever gets added for a single config entry.
         # See here: https://github.com/home-assistant/home-assistant/pull/30653#discussion_r366426121
         async_dispatcher_send(hass, config_entry.entry_id, config_entry)
@@ -290,7 +274,7 @@ class VizioDevice(MediaPlayerDevice):
         await self._device.input_switch(source)
 
     async def async_volume_up(self) -> None:
-        """Increasing volume of the device."""
+        """Increase volume of the device."""
         await self._device.vol_up(num=self._volume_step)
 
         if self._volume_level is not None:
@@ -299,7 +283,7 @@ class VizioDevice(MediaPlayerDevice):
             )
 
     async def async_volume_down(self) -> None:
-        """Decreasing volume of the device."""
+        """Decrease volume of the device."""
         await self._device.vol_down(num=self._volume_step)
 
         if self._volume_level is not None:

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -5,7 +5,7 @@ from typing import Callable, List
 from pyvizio import VizioAsync
 
 from homeassistant import util
-from homeassistant.components.media_player import MediaPlayerDevice
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN, MediaPlayerDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
@@ -23,6 +23,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.util import slugify
 
 from .const import (
     CONF_VOLUME_STEP,
@@ -76,12 +77,12 @@ async def async_setup_entry(
     if not await device.can_connect():
         fail_auth_msg = ""
         if token:
-            fail_auth_msg = f"and auth token '{token}' are correct"
+            fail_auth_msg = f"and auth token are correct"
         else:
             fail_auth_msg = "is correct"
         _LOGGER.warning(
-            "Failed to connect to Vizio device, please check if host '%s' "
-            "is valid and available. Also check if device class '%s' %s",
+            "Unable to connect to device, check if host '%s' is valid "
+            "and available. Also check if device class '%s' %s",
             host,
             device_class,
             fail_auth_msg,
@@ -129,19 +130,18 @@ class VizioDevice(MediaPlayerDevice):
         if is_on is None:
             if self._available:
                 _LOGGER.warning(
-                    "Can't connect to device '%s - %s'. Entity will be unavailable "
-                    "until connection is restored",
-                    self._name,
+                    "Lost connection to %s (%s)",
                     self._config_entry.data[CONF_HOST],
+                    f"{MP_DOMAIN}.{slugify(self._name)}",
                 )
                 self._available = False
             return
 
         if not self._available:
             _LOGGER.info(
-                "Connection to device '%s - %s' restored",
-                self._name,
+                "Restored connection to %s (%s)",
                 self._config_entry.data[CONF_HOST],
+                f"{MP_DOMAIN}.{slugify(self._name)}",
             )
             self._available = True
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -1,4 +1,5 @@
 """Vizio SmartCast Device support."""
+from datetime import timedelta
 import logging
 from typing import Callable, List
 
@@ -40,7 +41,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = MIN_TIME_BETWEEN_SCANS
+SCAN_INTERVAL = timedelta(seconds=10)
 PARALLEL_UPDATES = 0
 
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -76,9 +76,9 @@ async def async_setup_entry(
     if not await device.can_connect():
         fail_auth_msg = ""
         if token:
-            fail_auth_msg = f"and auth token '{token}' are correct."
+            fail_auth_msg = f"and auth token '{token}' are correct"
         else:
-            fail_auth_msg = "is correct."
+            fail_auth_msg = "is correct"
         _LOGGER.warning(
             "Failed to connect to Vizio device, please check if host '%s' "
             "is valid and available. Also check if device class '%s' %s",
@@ -130,7 +130,7 @@ class VizioDevice(MediaPlayerDevice):
             if self._available:
                 _LOGGER.warning(
                     "Can't connect to device '%s - %s'. Entity will be unavailable "
-                    "until connection is restored.",
+                    "until connection is restored",
                     self._name,
                     self._config_entry.data[CONF_HOST],
                 )
@@ -139,7 +139,7 @@ class VizioDevice(MediaPlayerDevice):
 
         if not self._available:
             _LOGGER.info(
-                "Connection to device '%s - %s' restored!",
+                "Connection to device '%s - %s' restored",
                 self._name,
                 self._config_entry.data[CONF_HOST],
             )
@@ -255,11 +255,6 @@ class VizioDevice(MediaPlayerDevice):
             "name": self.name,
             "manufacturer": "VIZIO",
         }
-
-    @property
-    def entity_registry_enabled_default(self):
-        """Return whether entity should be enabled or disabled when first added."""
-        return True
 
     @property
     def device_class(self):

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -1,0 +1,55 @@
+"""Configure py.test."""
+from asynctest import patch
+import pytest
+
+from .const import UNIQUE_ID
+
+
+@pytest.fixture(name="vizio_connect", autouse=False)
+def vizio_connect_fixture():
+    """Mock valid vizio device and entry setup."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
+        return_value=UNIQUE_ID,
+    ):
+        yield
+
+
+@pytest.fixture(name="vizio_bypass_setup", autouse=False)
+def vizio_bypass_setup_fixture():
+    """Mock component setup."""
+    with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
+        yield
+
+
+@pytest.fixture(name="vizio_bypass_update", autouse=False)
+def vizio_bypass_update_fixture():
+    """Mock component update."""
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=True,
+    ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
+        yield
+
+
+@pytest.fixture(name="vizio_guess_device_type", autouse=False)
+def vizio_guess_device_type_fixture():
+    """Mock vizio async_guess_device_type function."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.async_guess_device_type",
+        return_value="speaker",
+    ):
+        yield
+
+
+@pytest.fixture(name="vizio_cant_connect", autouse=False)
+def vizio_cant_connect_fixture():
+    """Mock vizio device cant connect."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+        return_value=False,
+    ):
+        yield

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from .const import UNIQUE_ID
 
 
-@pytest.fixture(name="vizio_connect", autouse=False)
+@pytest.fixture(name="vizio_connect")
 def vizio_connect_fixture():
     """Mock valid vizio device and entry setup."""
     with patch(
@@ -18,14 +18,14 @@ def vizio_connect_fixture():
         yield
 
 
-@pytest.fixture(name="vizio_bypass_setup", autouse=False)
+@pytest.fixture(name="vizio_bypass_setup")
 def vizio_bypass_setup_fixture():
     """Mock component setup."""
     with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
         yield
 
 
-@pytest.fixture(name="vizio_bypass_update", autouse=False)
+@pytest.fixture(name="vizio_bypass_update")
 def vizio_bypass_update_fixture():
     """Mock component update."""
     with patch(
@@ -35,7 +35,7 @@ def vizio_bypass_update_fixture():
         yield
 
 
-@pytest.fixture(name="vizio_guess_device_type", autouse=False)
+@pytest.fixture(name="vizio_guess_device_type")
 def vizio_guess_device_type_fixture():
     """Mock vizio async_guess_device_type function."""
     with patch(
@@ -45,7 +45,7 @@ def vizio_guess_device_type_fixture():
         yield
 
 
-@pytest.fixture(name="vizio_cant_connect", autouse=False)
+@pytest.fixture(name="vizio_cant_connect")
 def vizio_cant_connect_fixture():
     """Mock vizio device cant connect."""
     with patch(

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -5,6 +5,15 @@ import pytest
 from .const import UNIQUE_ID
 
 
+@pytest.fixture(name="skip_notifications", autouse=True)
+def skip_notifications_fixture():
+    """Skip notification calls."""
+    with patch("homeassistant.components.persistent_notification.async_create"), patch(
+        "homeassistant.components.persistent_notification.async_dismiss"
+    ):
+        yield
+
+
 @pytest.fixture(name="vizio_connect")
 def vizio_connect_fixture():
     """Mock valid vizio device and entry setup."""

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -1,8 +1,24 @@
 """Configure py.test."""
 from asynctest import patch
 import pytest
+from pyvizio.const import DEVICE_CLASS_SPEAKER
+from pyvizio.vizio import MAX_VOLUME
 
-from .const import UNIQUE_ID
+from .const import CURRENT_INPUT, INPUT_LIST, UNIQUE_ID
+
+
+class MockInput:
+    """Mock Vizio device input."""
+
+    def __init__(self, name):
+        """Initialize mock Vizio device input."""
+        self.meta_name = name
+        self.name = name
+
+
+def get_mock_inputs(input_list):
+    """Return list of MockInput."""
+    return [MockInput(input) for input in input_list]
 
 
 @pytest.fixture(name="skip_notifications", autouse=True)
@@ -60,5 +76,27 @@ def vizio_cant_connect_fixture():
     with patch(
         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
         return_value=False,
+    ):
+        yield
+
+
+@pytest.fixture(name="vizio_update")
+def vizio_update_fixture():
+    """Mock valid updates to vizio device."""
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_volume",
+        return_value=int(MAX_VOLUME[DEVICE_CLASS_SPEAKER] / 2),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_input",
+        return_value=MockInput(CURRENT_INPUT),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_inputs",
+        return_value=get_mock_inputs(INPUT_LIST),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
+        return_value=True,
     ):
         yield

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -1,0 +1,85 @@
+"""Constants for the Vizio integration tests."""
+import logging
+
+from homeassistant.components.media_player import (
+    DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV,
+    DOMAIN as MP_DOMAIN,
+)
+from homeassistant.components.vizio.const import CONF_VOLUME_STEP, DOMAIN
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_DEVICE_CLASS,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TYPE,
+)
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+NAME = "Vizio"
+NAME2 = "Vizio2"
+HOST = "192.168.1.1:9000"
+HOST2 = "192.168.1.2:9000"
+ACCESS_TOKEN = "deadbeef"
+VOLUME_STEP = 2
+UNIQUE_ID = "testid"
+
+MOCK_USER_VALID_TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
+}
+
+MOCK_OPTIONS = {
+    CONF_VOLUME_STEP: VOLUME_STEP,
+}
+
+MOCK_IMPORT_VALID_TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
+    CONF_VOLUME_STEP: VOLUME_STEP,
+}
+
+MOCK_INVALID_TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+}
+
+MOCK_SPEAKER_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
+}
+
+VIZIO_ZEROCONF_SERVICE_TYPE = "_viziocast._tcp.local."
+ZEROCONF_NAME = f"{NAME}.{VIZIO_ZEROCONF_SERVICE_TYPE}"
+ZEROCONF_HOST = HOST.split(":")[0]
+ZEROCONF_PORT = HOST.split(":")[1]
+
+MOCK_ZEROCONF_ENTRY = {
+    CONF_TYPE: VIZIO_ZEROCONF_SERVICE_TYPE,
+    CONF_NAME: ZEROCONF_NAME,
+    CONF_HOST: ZEROCONF_HOST,
+    CONF_PORT: ZEROCONF_PORT,
+    "properties": {"name": "SB4031-D5"},
+}
+
+MOCK_SPEAKER_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
+)
+MOCK_TV_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
+)
+
+CURRENT_INPUT = "HDMI"
+INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
+
+ENTITY_ID = f"{MP_DOMAIN.lower()}.{NAME.lower()}"

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -6,7 +6,7 @@ from homeassistant.components.media_player import (
     DEVICE_CLASS_TV,
     DOMAIN as MP_DOMAIN,
 )
-from homeassistant.components.vizio.const import CONF_VOLUME_STEP, DOMAIN
+from homeassistant.components.vizio.const import CONF_VOLUME_STEP
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_DEVICE_CLASS,
@@ -15,8 +15,6 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_TYPE,
 )
-
-from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,20 +62,13 @@ ZEROCONF_NAME = f"{NAME}.{VIZIO_ZEROCONF_SERVICE_TYPE}"
 ZEROCONF_HOST = HOST.split(":")[0]
 ZEROCONF_PORT = HOST.split(":")[1]
 
-MOCK_ZEROCONF_ENTRY = {
+MOCK_ZEROCONF_SERVICE_INFO = {
     CONF_TYPE: VIZIO_ZEROCONF_SERVICE_TYPE,
     CONF_NAME: ZEROCONF_NAME,
     CONF_HOST: ZEROCONF_HOST,
     CONF_PORT: ZEROCONF_PORT,
     "properties": {"name": "SB4031-D5"},
 }
-
-MOCK_SPEAKER_CONFIG_ENTRY = MockConfigEntry(
-    domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
-)
-MOCK_TV_CONFIG_ENTRY = MockConfigEntry(
-    domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
-)
 
 CURRENT_INPUT = "HDMI"
 INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -82,4 +82,4 @@ MOCK_TV_CONFIG_ENTRY = MockConfigEntry(
 CURRENT_INPUT = "HDMI"
 INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
 
-ENTITY_ID = f"{MP_DOMAIN.lower()}.{NAME.lower()}"
+ENTITY_ID = f"{MP_DOMAIN}.{NAME.lower()}"

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_TYPE,
 )
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,4 +74,4 @@ MOCK_ZEROCONF_SERVICE_INFO = {
 CURRENT_INPUT = "HDMI"
 INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
 
-ENTITY_ID = f"{MP_DOMAIN}.{NAME.lower()}"
+ENTITY_ID = f"{MP_DOMAIN}.{slugify(NAME)}"

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -44,6 +44,10 @@ MOCK_USER_VALID_TV_CONFIG = {
     CONF_ACCESS_TOKEN: ACCESS_TOKEN,
 }
 
+MOCK_OPTIONS = {
+    CONF_VOLUME_STEP: VOLUME_STEP,
+}
+
 MOCK_IMPORT_VALID_TV_CONFIG = {
     CONF_NAME: NAME,
     CONF_HOST: HOST,
@@ -128,6 +132,18 @@ def vizio_cant_connect_fixture():
         yield
 
 
+async def test_unload(
+    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+) -> None:
+    """Test loading with options and unloading config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
+    )
+    assert await result["result"].async_unload(hass)
+
+
 async def test_user_flow_minimum_fields(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,
@@ -142,12 +158,7 @@ async def test_user_flow_minimum_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_NAME: NAME,
-            CONF_HOST: HOST,
-            CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
-        },
+        result["flow_id"], user_input=MOCK_SPEAKER_CONFIG,
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -172,13 +183,7 @@ async def test_user_flow_all_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_NAME: NAME,
-            CONF_HOST: HOST,
-            CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-            CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-        },
+        result["flow_id"], user_input=MOCK_USER_VALID_TV_CONFIG,
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -1,6 +1,4 @@
 """Tests for Vizio config flow."""
-
-from asynctest import patch
 import pytest
 import voluptuous as vol
 
@@ -39,55 +37,54 @@ from .const import (
 
 from tests.common import MockConfigEntry
 
-
-@pytest.fixture(name="vizio_connect")
-def vizio_connect_fixture():
-    """Mock valid vizio device and entry setup."""
-    with patch(
-        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
-        return_value=UNIQUE_ID,
-    ):
-        yield
-
-
-@pytest.fixture(name="vizio_bypass_setup")
-def vizio_bypass_setup_fixture():
-    """Mock component setup."""
-    with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
-        yield
+# @pytest.fixture(name="vizio_connect")
+# def vizio_connect_fixture():
+#     """Mock valid vizio device and entry setup."""
+#     with patch(
+#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+#         return_value=True,
+#     ), patch(
+#         "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
+#         return_value=UNIQUE_ID,
+#     ):
+#         yield
 
 
-@pytest.fixture(name="vizio_bypass_update")
-def vizio_bypass_update_fixture():
-    """Mock component update."""
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
-        return_value=True,
-    ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
-        yield
+# @pytest.fixture(name="vizio_bypass_setup")
+# def vizio_bypass_setup_fixture():
+#     """Mock component setup."""
+#     with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
+#         yield
 
 
-@pytest.fixture(name="vizio_guess_device_type")
-def vizio_guess_device_type_fixture():
-    """Mock vizio async_guess_device_type function."""
-    with patch(
-        "homeassistant.components.vizio.config_flow.async_guess_device_type",
-        return_value="speaker",
-    ):
-        yield
+# @pytest.fixture(name="vizio_bypass_update")
+# def vizio_bypass_update_fixture():
+#     """Mock component update."""
+#     with patch(
+#         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+#         return_value=True,
+#     ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
+#         yield
 
 
-@pytest.fixture(name="vizio_cant_connect")
-def vizio_cant_connect_fixture():
-    """Mock vizio device cant connect."""
-    with patch(
-        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-        return_value=False,
-    ):
-        yield
+# @pytest.fixture(name="vizio_guess_device_type")
+# def vizio_guess_device_type_fixture():
+#     """Mock vizio async_guess_device_type function."""
+#     with patch(
+#         "homeassistant.components.vizio.config_flow.async_guess_device_type",
+#         return_value="speaker",
+#     ):
+#         yield
+
+
+# @pytest.fixture(name="vizio_cant_connect")
+# def vizio_cant_connect_fixture():
+#     """Mock vizio device cant connect."""
+#     with patch(
+#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+#         return_value=False,
+#     ):
+#         yield
 
 
 async def test_unload(

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -38,18 +38,6 @@ from .const import (
 from tests.common import MockConfigEntry
 
 
-async def test_unload(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
-) -> None:
-    """Test loading with options and unloading config entry."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
-    )
-    assert await result["result"].async_unload(hass)
-
-
 async def test_user_flow_minimum_fields(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -37,55 +37,6 @@ from .const import (
 
 from tests.common import MockConfigEntry
 
-# @pytest.fixture(name="vizio_connect")
-# def vizio_connect_fixture():
-#     """Mock valid vizio device and entry setup."""
-#     with patch(
-#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-#         return_value=True,
-#     ), patch(
-#         "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
-#         return_value=UNIQUE_ID,
-#     ):
-#         yield
-
-
-# @pytest.fixture(name="vizio_bypass_setup")
-# def vizio_bypass_setup_fixture():
-#     """Mock component setup."""
-#     with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
-#         yield
-
-
-# @pytest.fixture(name="vizio_bypass_update")
-# def vizio_bypass_update_fixture():
-#     """Mock component update."""
-#     with patch(
-#         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
-#         return_value=True,
-#     ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
-#         yield
-
-
-# @pytest.fixture(name="vizio_guess_device_type")
-# def vizio_guess_device_type_fixture():
-#     """Mock vizio async_guess_device_type function."""
-#     with patch(
-#         "homeassistant.components.vizio.config_flow.async_guess_device_type",
-#         return_value="speaker",
-#     ):
-#         yield
-
-
-# @pytest.fixture(name="vizio_cant_connect")
-# def vizio_cant_connect_fixture():
-#     """Mock vizio device cant connect."""
-#     with patch(
-#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-#         return_value=False,
-#     ):
-#         yield
-
 
 async def test_unload(
     hass: HomeAssistantType, vizio_connect, vizio_bypass_setup

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for Vizio config flow."""
-import logging
 
 from asynctest import patch
 import pytest
@@ -20,66 +19,25 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_HOST,
     CONF_NAME,
-    CONF_PORT,
-    CONF_TYPE,
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
+from .const import (
+    ACCESS_TOKEN,
+    HOST,
+    HOST2,
+    MOCK_IMPORT_VALID_TV_CONFIG,
+    MOCK_INVALID_TV_CONFIG,
+    MOCK_SPEAKER_CONFIG,
+    MOCK_USER_VALID_TV_CONFIG,
+    MOCK_ZEROCONF_ENTRY,
+    NAME,
+    NAME2,
+    UNIQUE_ID,
+    VOLUME_STEP,
+)
+
 from tests.common import MockConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
-
-NAME = "Vizio"
-NAME2 = "Vizio2"
-HOST = "192.168.1.1:9000"
-HOST2 = "192.168.1.2:9000"
-ACCESS_TOKEN = "deadbeef"
-VOLUME_STEP = 2
-UNIQUE_ID = "testid"
-
-MOCK_USER_VALID_TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-}
-
-MOCK_OPTIONS = {
-    CONF_VOLUME_STEP: VOLUME_STEP,
-}
-
-MOCK_IMPORT_VALID_TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-    CONF_VOLUME_STEP: VOLUME_STEP,
-}
-
-MOCK_INVALID_TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-}
-
-MOCK_SPEAKER_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
-}
-
-VIZIO_ZEROCONF_SERVICE_TYPE = "_viziocast._tcp.local."
-ZEROCONF_NAME = f"{NAME}.{VIZIO_ZEROCONF_SERVICE_TYPE}"
-ZEROCONF_HOST = HOST.split(":")[0]
-ZEROCONF_PORT = HOST.split(":")[1]
-
-MOCK_ZEROCONF_ENTRY = {
-    CONF_TYPE: VIZIO_ZEROCONF_SERVICE_TYPE,
-    CONF_NAME: ZEROCONF_NAME,
-    CONF_HOST: ZEROCONF_HOST,
-    CONF_PORT: ZEROCONF_PORT,
-    "properties": {"name": "SB4031-D5"},
-}
 
 
 @pytest.fixture(name="vizio_connect")
@@ -158,7 +116,7 @@ async def test_user_flow_minimum_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_SPEAKER_CONFIG,
+        result["flow_id"], user_input=MOCK_SPEAKER_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -183,7 +141,7 @@ async def test_user_flow_all_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_USER_VALID_TV_CONFIG,
+        result["flow_id"], user_input=MOCK_USER_VALID_TV_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -28,7 +28,7 @@ from .const import (
     MOCK_INVALID_TV_CONFIG,
     MOCK_SPEAKER_CONFIG,
     MOCK_USER_VALID_TV_CONFIG,
-    MOCK_ZEROCONF_ENTRY,
+    MOCK_ZEROCONF_SERVICE_INFO,
     NAME,
     NAME2,
     UNIQUE_ID,
@@ -307,7 +307,7 @@ async def test_zeroconf_flow(
     vizio_guess_device_type: pytest.fixture,
 ) -> None:
     """Test zeroconf config flow."""
-    discovery_info = MOCK_ZEROCONF_ENTRY.copy()
+    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -343,7 +343,7 @@ async def test_zeroconf_flow_already_configured(
     entry.add_to_hass(hass)
 
     # Try rediscovering same device
-    discovery_info = MOCK_ZEROCONF_ENTRY.copy()
+    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -1,0 +1,22 @@
+"""Tests for Vizio init."""
+import pytest
+
+from homeassistant.components.vizio.const import DOMAIN
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.setup import async_setup_component
+
+from .const import MOCK_SPEAKER_CONFIG
+
+
+async def test_unload(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
+) -> None:
+    """Test loading component and unloading entry."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: MOCK_SPEAKER_CONFIG})
+    await hass.async_block_till_done()
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    for entry in entries:
+        assert await entry.async_unload(hass)

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -2,21 +2,41 @@
 import pytest
 
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
+from homeassistant.components.vizio.const import DOMAIN
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.setup import async_setup_component
 
-from .const import MOCK_SPEAKER_CONFIG_ENTRY
+from .const import MOCK_USER_VALID_TV_CONFIG, UNIQUE_ID
+
+from tests.common import MockConfigEntry
 
 
-async def test_unload(
+async def test_setup_component(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_update: pytest.fixture,
+) -> None:
+    """Test component setup."""
+    assert await async_setup_component(
+        hass, DOMAIN, {DOMAIN: MOCK_USER_VALID_TV_CONFIG}
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
+
+
+async def test_load_and_unload(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,
     vizio_update: pytest.fixture,
 ) -> None:
     """Test loading component and unloading entry."""
-    await hass.config_entries.async_add(MOCK_SPEAKER_CONFIG_ENTRY)
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
+    )
+    await hass.config_entries.async_add(config_entry)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
 
-    assert await hass.config_entries.async_unload(MOCK_SPEAKER_CONFIG_ENTRY.entry_id)
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -1,7 +1,7 @@
 """Tests for Vizio init."""
 import pytest
 
-from homeassistant.components.media_player.const import DOMAIN
+from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import _LOGGER, MOCK_SPEAKER_CONFIG_ENTRY
@@ -17,8 +17,8 @@ async def test_unload(
     await hass.config_entries.async_add(MOCK_SPEAKER_CONFIG_ENTRY)
     await hass.async_block_till_done()
     _LOGGER.error(hass.states.async_entity_ids())
-    assert len(hass.states.async_entity_ids(DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
 
     assert await hass.config_entries.async_unload(MOCK_SPEAKER_CONFIG_ENTRY.entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import _LOGGER, MOCK_SPEAKER_CONFIG_ENTRY
+from .const import MOCK_SPEAKER_CONFIG_ENTRY
 
 
 async def test_unload(
@@ -13,10 +13,8 @@ async def test_unload(
     vizio_update: pytest.fixture,
 ) -> None:
     """Test loading component and unloading entry."""
-    _LOGGER.error(MOCK_SPEAKER_CONFIG_ENTRY.state)
     await hass.config_entries.async_add(MOCK_SPEAKER_CONFIG_ENTRY)
     await hass.async_block_till_done()
-    _LOGGER.error(hass.states.async_entity_ids())
     assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
 
     assert await hass.config_entries.async_unload(MOCK_SPEAKER_CONFIG_ENTRY.entry_id)

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -1,22 +1,24 @@
 """Tests for Vizio init."""
 import pytest
 
-from homeassistant.components.vizio.const import DOMAIN
+from homeassistant.components.media_player.const import DOMAIN
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.setup import async_setup_component
 
-from .const import MOCK_SPEAKER_CONFIG
+from .const import _LOGGER, MOCK_SPEAKER_CONFIG_ENTRY
 
 
 async def test_unload(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
+    vizio_update: pytest.fixture,
 ) -> None:
     """Test loading component and unloading entry."""
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: MOCK_SPEAKER_CONFIG})
+    _LOGGER.error(MOCK_SPEAKER_CONFIG_ENTRY.state)
+    await hass.config_entries.async_add(MOCK_SPEAKER_CONFIG_ENTRY)
     await hass.async_block_till_done()
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(entries) == 1
-    for entry in entries:
-        assert await hass.config_entries.async_unload(entry.entry_id)
+    _LOGGER.error(hass.states.async_entity_ids())
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 1
+
+    assert await hass.config_entries.async_unload(MOCK_SPEAKER_CONFIG_ENTRY.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 0

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -33,7 +33,8 @@ async def test_load_and_unload(
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
     )
-    await hass.config_entries.async_add(config_entry)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
 

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -29,7 +29,7 @@ async def test_load_and_unload(
     vizio_connect: pytest.fixture,
     vizio_update: pytest.fixture,
 ) -> None:
-    """Test loading component and unloading entry."""
+    """Test loading and unloading entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
     )

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -19,4 +19,4 @@ async def test_unload(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     for entry in entries:
-        assert await entry.async_unload(hass)
+        assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,6 +1,4 @@
 """Tests for Vizio config flow."""
-import logging
-
 from asynctest import patch
 from pyvizio.const import (
     DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
@@ -27,53 +25,22 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.vizio.const import DOMAIN
 from homeassistant.components.vizio.media_player import async_setup_entry
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    CONF_ACCESS_TOKEN,
-    CONF_DEVICE_CLASS,
-    CONF_HOST,
-    CONF_NAME,
-    STATE_OFF,
-    STATE_ON,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
-
-NAME = "Vizio"
-HOST = "192.168.1.1:9000"
-ACCESS_TOKEN = "deadbeef"
-VOLUME_STEP = 2
-TIMEOUT = 3
-UNIQUE_ID = "testid"
-
-CURRENT_INPUT = "HDMI"
-INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
-
-TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-}
-
-ENTITY_ID = f"{MP_DOMAIN.lower()}.{NAME.lower()}"
-
-SPEAKER_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
-}
-
-SPEAKER_CONFIG_ENTRY = MockConfigEntry(
-    domain=DOMAIN, data=SPEAKER_CONFIG, unique_id=UNIQUE_ID
+from .const import (
+    CURRENT_INPUT,
+    ENTITY_ID,
+    INPUT_LIST,
+    MOCK_SPEAKER_CONFIG,
+    MOCK_SPEAKER_CONFIG_ENTRY,
+    MOCK_TV_CONFIG_ENTRY,
+    MOCK_USER_VALID_TV_CONFIG,
+    NAME,
+    UNIQUE_ID,
 )
-TV_CONFIG_ENTRY = MockConfigEntry(domain=DOMAIN, data=TV_CONFIG, unique_id=UNIQUE_ID)
 
 
 class MockInput:
@@ -141,7 +108,7 @@ async def test_vizio_speaker_on(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when on."""
     await _test_vizio_init(
         hass,
-        SPEAKER_CONFIG,
+        MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
         DEVICE_CLASS_SPEAKER,
         True,
@@ -153,7 +120,7 @@ async def test_vizio_speaker_off(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when off."""
     await _test_vizio_init(
         hass,
-        SPEAKER_CONFIG,
+        MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
         DEVICE_CLASS_SPEAKER,
         False,
@@ -165,7 +132,7 @@ async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when unavailable."""
     await _test_vizio_init(
         hass,
-        SPEAKER_CONFIG,
+        MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
         DEVICE_CLASS_SPEAKER,
         None,
@@ -176,21 +143,36 @@ async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
 async def test_vizio_init_tv_on(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when on."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        True,
+        STATE_ON,
     )
 
 
 async def test_vizio_init_tv_off(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when off."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, False, STATE_OFF
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        False,
+        STATE_OFF,
     )
 
 
 async def test_vizio_init_tv_unavailable(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when unavailable."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, None, STATE_UNAVAILABLE
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        None,
+        STATE_UNAVAILABLE,
     )
 
 
@@ -201,12 +183,12 @@ async def test_setup_failure(hass: HomeAssistantType) -> None:
         return_value=False,
     ):
         try:
-            await async_setup_entry(hass, SPEAKER_CONFIG_ENTRY, None)
+            await async_setup_entry(hass, MOCK_SPEAKER_CONFIG_ENTRY, None)
         except Exception as e:
             assert isinstance(e, PlatformNotReady)
 
         try:
-            await async_setup_entry(hass, TV_CONFIG_ENTRY, None)
+            await async_setup_entry(hass, MOCK_TV_CONFIG_ENTRY, None)
         except Exception as e:
             assert isinstance(e, PlatformNotReady)
 
@@ -214,7 +196,12 @@ async def test_setup_failure(hass: HomeAssistantType) -> None:
 async def test_services(hass: HomeAssistantType) -> None:
     """Test media player entity services."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON,
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        True,
+        STATE_ON,
     )
 
     with patch("homeassistant.components.vizio.media_player.VizioAsync.pow_on"):

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,0 +1,302 @@
+"""Tests for Vizio config flow."""
+import logging
+
+from asynctest import patch
+from pyvizio.const import (
+    DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV as VIZIO_DEVICE_CLASS_TV,
+)
+from pyvizio.vizio import MAX_VOLUME
+
+from homeassistant.components.media_player import (
+    ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+    DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV,
+    DOMAIN as MP_DOMAIN,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_SELECT_SOURCE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
+)
+from homeassistant.components.vizio.const import DOMAIN
+from homeassistant.components.vizio.media_player import async_setup_entry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ACCESS_TOKEN,
+    CONF_DEVICE_CLASS,
+    CONF_HOST,
+    CONF_NAME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+NAME = "Vizio"
+HOST = "192.168.1.1:9000"
+ACCESS_TOKEN = "deadbeef"
+VOLUME_STEP = 2
+TIMEOUT = 3
+UNIQUE_ID = "testid"
+
+CURRENT_INPUT = "HDMI"
+INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
+
+TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
+}
+
+ENTITY_ID = f"{MP_DOMAIN.lower()}.{NAME.lower()}"
+
+SPEAKER_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
+}
+
+SPEAKER_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN, data=SPEAKER_CONFIG, unique_id=UNIQUE_ID
+)
+TV_CONFIG_ENTRY = MockConfigEntry(domain=DOMAIN, data=TV_CONFIG, unique_id=UNIQUE_ID)
+
+
+class MockInput:
+    """Mock Vizio device input."""
+
+    def __init__(self, name):
+        """Initialize mock Vizio device input."""
+        self.meta_name = name
+        self.name = name
+
+
+def get_mock_inputs(input_list):
+    """Return list of MockInput."""
+    return [MockInput(input) for input in input_list]
+
+
+async def _test_vizio_init(
+    hass: HomeAssistantType,
+    config: dict,
+    vizio_device_class: str,
+    ha_device_class: str,
+    vizio_power_state: bool,
+    ha_power_state: str,
+) -> None:
+    """Test initialization of Vizio Device entity with device class `speaker`."""
+
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_unique_id",
+        return_value=UNIQUE_ID,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_volume",
+        return_value=int(MAX_VOLUME[vizio_device_class] / 2),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_input",
+        return_value=MockInput(CURRENT_INPUT),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_inputs",
+        return_value=get_mock_inputs(INPUT_LIST),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
+        return_value=vizio_power_state,
+    ):
+        await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        await hass.async_block_till_done()
+
+        attr = hass.states.get(ENTITY_ID).attributes
+        assert attr["friendly_name"] == NAME
+        assert attr["device_class"] == ha_device_class
+
+        assert hass.states.get(ENTITY_ID).state == ha_power_state
+        if ha_power_state == STATE_ON:
+            assert attr["source_list"] == INPUT_LIST
+            assert attr["source"] == CURRENT_INPUT
+            assert (
+                attr["volume_level"]
+                == float(int(MAX_VOLUME[vizio_device_class] / 2))
+                / MAX_VOLUME[vizio_device_class]
+            )
+
+
+async def test_vizio_speaker_on(hass: HomeAssistantType) -> None:
+    """Test for Vizio Speaker entity when on."""
+    await _test_vizio_init(
+        hass,
+        SPEAKER_CONFIG,
+        VIZIO_DEVICE_CLASS_SPEAKER,
+        DEVICE_CLASS_SPEAKER,
+        True,
+        STATE_ON,
+    )
+
+
+async def test_vizio_speaker_off(hass: HomeAssistantType) -> None:
+    """Test for Vizio Speaker entity when off."""
+    await _test_vizio_init(
+        hass,
+        SPEAKER_CONFIG,
+        VIZIO_DEVICE_CLASS_SPEAKER,
+        DEVICE_CLASS_SPEAKER,
+        False,
+        STATE_OFF,
+    )
+
+
+async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
+    """Test for Vizio Speaker entity when unavailable."""
+    await _test_vizio_init(
+        hass,
+        SPEAKER_CONFIG,
+        VIZIO_DEVICE_CLASS_SPEAKER,
+        DEVICE_CLASS_SPEAKER,
+        None,
+        STATE_UNAVAILABLE,
+    )
+
+
+async def test_vizio_init_tv_on(hass: HomeAssistantType) -> None:
+    """Test for Vizio TV entity when on."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON
+    )
+
+
+async def test_vizio_init_tv_off(hass: HomeAssistantType) -> None:
+    """Test for Vizio TV entity when off."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, False, STATE_OFF
+    )
+
+
+async def test_vizio_init_tv_unavailable(hass: HomeAssistantType) -> None:
+    """Test for Vizio TV entity when unavailable."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, None, STATE_UNAVAILABLE
+    )
+
+
+async def test_setup_failure(hass: HomeAssistantType) -> None:
+    """Test media player entity setup failure."""
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=False,
+    ):
+        try:
+            await async_setup_entry(hass, SPEAKER_CONFIG_ENTRY, None)
+        except Exception as e:
+            assert isinstance(e, PlatformNotReady)
+
+        try:
+            await async_setup_entry(hass, TV_CONFIG_ENTRY, None)
+        except Exception as e:
+            assert isinstance(e, PlatformNotReady)
+
+
+async def test_services(hass: HomeAssistantType) -> None:
+    """Test media player entity services."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON,
+    )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.pow_on"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_TURN_ON,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.pow_off"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_TURN_OFF,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.mute_on"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_MUTE,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.mute_off"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_MUTE,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: False},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.input_switch"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_SELECT_SOURCE,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "USB"},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.vol_up"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_UP,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_SET,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 1},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.vol_down"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_DOWN,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_SET,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.ch_up"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_MEDIA_NEXT_TRACK,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.ch_down"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_MEDIA_PREVIOUS_TRACK,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -96,9 +96,7 @@ async def _test_setup_failure(hass: HomeAssistantType, config: str) -> None:
         return_value=False,
     ):
         await hass.config_entries.async_add(
-            MockConfigEntry(
-                domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
-            )
+            MockConfigEntry(domain=DOMAIN, data=config, unique_id=UNIQUE_ID)
         )
         await hass.async_block_till_done()
         assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -43,14 +43,26 @@ from tests.common import MockConfigEntry
 
 
 async def _test_init(
-    hass: HomeAssistantType,
-    config_entry: MockConfigEntry,
-    vizio_device_class: str,
-    ha_device_class: str,
-    vizio_power_state: bool,
-    ha_power_state: str,
+    hass: HomeAssistantType, ha_device_class: str, vizio_power_state: bool,
 ) -> None:
-    """Test initialization of Vizio Device entity with device class `speaker`."""
+    """Test initialization of generic Vizio Device entity."""
+    if vizio_power_state:
+        ha_power_state = STATE_ON
+    elif vizio_power_state is False:
+        ha_power_state = STATE_OFF
+    else:
+        ha_power_state = STATE_UNAVAILABLE
+
+    if ha_device_class == DEVICE_CLASS_SPEAKER:
+        vizio_device_class = VIZIO_DEVICE_CLASS_SPEAKER
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
+        )
+    else:
+        vizio_device_class = VIZIO_DEVICE_CLASS_TV
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
+        )
 
     with patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_current_volume",
@@ -81,90 +93,42 @@ async def test_speaker_on(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test for Vizio Speaker entity when on."""
-    await _test_init(
-        hass,
-        MockConfigEntry(domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID),
-        VIZIO_DEVICE_CLASS_SPEAKER,
-        DEVICE_CLASS_SPEAKER,
-        True,
-        STATE_ON,
-    )
+    await _test_init(hass, DEVICE_CLASS_SPEAKER, True)
 
 
 async def test_speaker_off(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test for Vizio Speaker entity when off."""
-    await _test_init(
-        hass,
-        MockConfigEntry(domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID),
-        VIZIO_DEVICE_CLASS_SPEAKER,
-        DEVICE_CLASS_SPEAKER,
-        False,
-        STATE_OFF,
-    )
+    await _test_init(hass, DEVICE_CLASS_SPEAKER, False)
 
 
 async def test_speaker_unavailable(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test for Vizio Speaker entity when unavailable."""
-    await _test_init(
-        hass,
-        MockConfigEntry(domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID),
-        VIZIO_DEVICE_CLASS_SPEAKER,
-        DEVICE_CLASS_SPEAKER,
-        None,
-        STATE_UNAVAILABLE,
-    )
+    await _test_init(hass, DEVICE_CLASS_SPEAKER, None)
 
 
 async def test_init_tv_on(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test for Vizio TV entity when on."""
-    await _test_init(
-        hass,
-        MockConfigEntry(
-            domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
-        ),
-        VIZIO_DEVICE_CLASS_TV,
-        DEVICE_CLASS_TV,
-        True,
-        STATE_ON,
-    )
+    await _test_init(hass, DEVICE_CLASS_TV, True)
 
 
 async def test_init_tv_off(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test for Vizio TV entity when off."""
-    await _test_init(
-        hass,
-        MockConfigEntry(
-            domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
-        ),
-        VIZIO_DEVICE_CLASS_TV,
-        DEVICE_CLASS_TV,
-        False,
-        STATE_OFF,
-    )
+    await _test_init(hass, DEVICE_CLASS_TV, False)
 
 
 async def test_init_tv_unavailable(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test for Vizio TV entity when unavailable."""
-    await _test_init(
-        hass,
-        MockConfigEntry(
-            domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
-        ),
-        VIZIO_DEVICE_CLASS_TV,
-        DEVICE_CLASS_TV,
-        None,
-        STATE_UNAVAILABLE,
-    )
+    await _test_init(hass, DEVICE_CLASS_TV, None)
 
 
 async def test_setup_failure_speaker(
@@ -205,16 +169,7 @@ async def test_services(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test media player entity services."""
-    await _test_init(
-        hass,
-        MockConfigEntry(
-            domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
-        ),
-        VIZIO_DEVICE_CLASS_TV,
-        DEVICE_CLASS_TV,
-        True,
-        STATE_ON,
-    )
+    await _test_init(hass, DEVICE_CLASS_TV, True)
 
     with patch(
         "homeassistant.components.vizio.media_player.VizioAsync.pow_on"
@@ -336,18 +291,8 @@ async def test_options_update(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test for when config entry update event fires."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
-    )
-    await _test_init(
-        hass,
-        config_entry,
-        VIZIO_DEVICE_CLASS_SPEAKER,
-        DEVICE_CLASS_SPEAKER,
-        True,
-        STATE_ON,
-    )
-
+    await _test_init(hass, DEVICE_CLASS_SPEAKER, True)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert config_entry.options
     new_options = config_entry.options.copy()
     updated_options = {CONF_VOLUME_STEP: VOLUME_STEP}

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,5 +1,4 @@
 """Tests for Vizio config flow."""
-from datetime import timedelta
 from unittest.mock import call
 
 from asynctest import patch
@@ -29,12 +28,9 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.vizio.const import CONF_VOLUME_STEP, DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
-from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.util import dt as dt_util
 
 from .const import (
-    _LOGGER,
     CURRENT_INPUT,
     ENTITY_ID,
     INPUT_LIST,
@@ -45,7 +41,7 @@ from .const import (
     VOLUME_STEP,
 )
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 
 async def _test_init(
@@ -234,20 +230,3 @@ async def test_options_update(
     )
     assert config_entry.options == updated_options
     await _test_service(hass, "vol_up", SERVICE_VOLUME_UP, num=VOLUME_STEP)
-
-
-async def test_update_unavailable_to_available(
-    hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
-) -> None:
-    """Test that device will successfully become available after period of unavailability."""
-    await _test_init(hass, DEVICE_CLASS_SPEAKER, None)
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
-        return_value=True,
-    ):
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
-        await hass.async_block_till_done()
-        await async_update_entity(hass, ENTITY_ID)
-        await hass.async_block_till_done()
-        _LOGGER.error(hass.states.get(ENTITY_ID).state)
-        assert False

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -165,126 +165,53 @@ async def test_setup_failure_tv(
         assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0
 
 
+async def _test_service(
+    hass: HomeAssistantType,
+    vizio_func_name: str,
+    ha_service_name: str,
+    additional_service_data: dict = None,
+):
+    """Test a media player entity service."""
+    service_data = {ATTR_ENTITY_ID: ENTITY_ID}
+    if additional_service_data:
+        service_data.update(additional_service_data)
+
+    with patch(
+        f"homeassistant.components.vizio.media_player.VizioAsync.{vizio_func_name}"
+    ) as service_call:
+        await hass.services.async_call(
+            MP_DOMAIN, ha_service_name, service_data=service_data, blocking=True,
+        )
+        assert service_call.call_count == 1
+
+
 async def test_services(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
     """Test media player entity services."""
     await _test_init(hass, DEVICE_CLASS_TV, True)
 
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.pow_on"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_TURN_ON,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.pow_off"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_TURN_OFF,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.mute_on"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_VOLUME_MUTE,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.mute_off"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_VOLUME_MUTE,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: False},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.input_switch"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "USB"},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.vol_up"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_VOLUME_UP,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_VOLUME_SET,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 1},
-            blocking=True,
-        )
-        assert service_call.call_count == 2
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.vol_down"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_VOLUME_DOWN,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_VOLUME_SET,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0},
-            blocking=True,
-        )
-        assert service_call.call_count == 2
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.ch_up"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_MEDIA_NEXT_TRACK,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
-
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.ch_down"
-    ) as service_call:
-        await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_MEDIA_PREVIOUS_TRACK,
-            service_data={ATTR_ENTITY_ID: ENTITY_ID},
-            blocking=True,
-        )
-        assert service_call.call_count == 1
+    await _test_service(hass, "pow_on", SERVICE_TURN_ON)
+    await _test_service(hass, "pow_off", SERVICE_TURN_OFF)
+    await _test_service(
+        hass, "mute_on", SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: True}
+    )
+    await _test_service(
+        hass, "mute_off", SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: False}
+    )
+    await _test_service(
+        hass, "input_switch", SERVICE_SELECT_SOURCE, {ATTR_INPUT_SOURCE: "USB"}
+    )
+    await _test_service(hass, "vol_up", SERVICE_VOLUME_UP)
+    await _test_service(hass, "vol_down", SERVICE_VOLUME_DOWN)
+    await _test_service(
+        hass, "vol_up", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 1}
+    )
+    await _test_service(
+        hass, "vol_down", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 0}
+    )
+    await _test_service(hass, "ch_up", SERVICE_MEDIA_NEXT_TRACK)
+    await _test_service(hass, "ch_down", SERVICE_MEDIA_PREVIOUS_TRACK)
 
 
 async def test_options_update(

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -348,8 +348,9 @@ async def test_options_update(
         STATE_ON,
     )
 
-    updated_options = {CONF_VOLUME_STEP: VOLUME_STEP}
+    assert config_entry.options
     new_options = config_entry.options.copy()
+    updated_options = {CONF_VOLUME_STEP: VOLUME_STEP}
     new_options.update(updated_options)
     hass.config_entries.async_update_entry(
         entry=config_entry, options=new_options,

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -54,7 +54,7 @@ def get_mock_inputs(input_list):
     return [MockInput(input) for input in input_list]
 
 
-async def _test_vizio_init(
+async def _test_init(
     hass: HomeAssistantType,
     config: dict,
     vizio_device_class: str,
@@ -101,9 +101,9 @@ async def _test_vizio_init(
             )
 
 
-async def test_vizio_speaker_on(hass: HomeAssistantType) -> None:
+async def test_speaker_on(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when on."""
-    await _test_vizio_init(
+    await _test_init(
         hass,
         MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
@@ -113,9 +113,9 @@ async def test_vizio_speaker_on(hass: HomeAssistantType) -> None:
     )
 
 
-async def test_vizio_speaker_off(hass: HomeAssistantType) -> None:
+async def test_speaker_off(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when off."""
-    await _test_vizio_init(
+    await _test_init(
         hass,
         MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
@@ -125,9 +125,9 @@ async def test_vizio_speaker_off(hass: HomeAssistantType) -> None:
     )
 
 
-async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
+async def test_speaker_unavailable(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when unavailable."""
-    await _test_vizio_init(
+    await _test_init(
         hass,
         MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
@@ -137,9 +137,9 @@ async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
     )
 
 
-async def test_vizio_init_tv_on(hass: HomeAssistantType) -> None:
+async def test_init_tv_on(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when on."""
-    await _test_vizio_init(
+    await _test_init(
         hass,
         MOCK_USER_VALID_TV_CONFIG,
         VIZIO_DEVICE_CLASS_TV,
@@ -149,9 +149,9 @@ async def test_vizio_init_tv_on(hass: HomeAssistantType) -> None:
     )
 
 
-async def test_vizio_init_tv_off(hass: HomeAssistantType) -> None:
+async def test_init_tv_off(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when off."""
-    await _test_vizio_init(
+    await _test_init(
         hass,
         MOCK_USER_VALID_TV_CONFIG,
         VIZIO_DEVICE_CLASS_TV,
@@ -161,9 +161,9 @@ async def test_vizio_init_tv_off(hass: HomeAssistantType) -> None:
     )
 
 
-async def test_vizio_init_tv_unavailable(hass: HomeAssistantType) -> None:
+async def test_init_tv_unavailable(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when unavailable."""
-    await _test_vizio_init(
+    await _test_init(
         hass,
         MOCK_USER_VALID_TV_CONFIG,
         VIZIO_DEVICE_CLASS_TV,
@@ -173,10 +173,10 @@ async def test_vizio_init_tv_unavailable(hass: HomeAssistantType) -> None:
     )
 
 
-async def test_setup_failure(
+async def test_setup_failure_speaker(
     hass: HomeAssistantType, vizio_connect: pytest.fixture
 ) -> None:
-    """Test media player entity setup failure."""
+    """Test speaker entity setup failure."""
     with patch(
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
         return_value=False,
@@ -185,6 +185,15 @@ async def test_setup_failure(
         await hass.async_block_till_done()
         assert len(hass.states.async_entity_ids(DOMAIN)) == 0
 
+
+async def test_setup_failure_tv(
+    hass: HomeAssistantType, vizio_connect: pytest.fixture
+) -> None:
+    """Test TV entity setup failure."""
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=False,
+    ):
         assert await async_setup_component(
             hass, DOMAIN, {DOMAIN: MOCK_USER_VALID_TV_CONFIG}
         )
@@ -194,7 +203,7 @@ async def test_setup_failure(
 
 async def test_services(hass: HomeAssistantType) -> None:
     """Test media player entity services."""
-    await _test_vizio_init(
+    await _test_init(
         hass,
         MOCK_USER_VALID_TV_CONFIG,
         VIZIO_DEVICE_CLASS_TV,

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -126,7 +126,7 @@ async def _test_service(
         )
         assert service_call.called
 
-        if len(args) + len(kwargs) > 0:
+        if args or kwargs:
             assert service_call.call_args == call(*args, **kwargs)
 
 

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -132,8 +132,8 @@ async def _test_service(
             arg_vals = [arg_vals]
 
         if len(args) == len(arg_vals):
-            # For each argument and argument value pair, make sure pair match what was
-            # passed to function
+            # For each argument and argument value pair, assert that pair matches what
+            # was passed to function
             for arg in args:
                 assert (
                     service_call.call_args[args.index(arg) + 1][arg]

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -171,7 +171,7 @@ async def _test_service(
     ha_service_name: str,
     additional_service_data: dict = None,
 ):
-    """Test a media player entity service."""
+    """Test a generic Vizio media player entity service."""
     service_data = {ATTR_ENTITY_ID: ENTITY_ID}
     if additional_service_data:
         service_data.update(additional_service_data)
@@ -188,7 +188,7 @@ async def _test_service(
 async def test_services(
     hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
 ) -> None:
-    """Test media player entity services."""
+    """Test all Vizio media player entity services."""
     await _test_init(hass, DEVICE_CLASS_TV, True)
 
     await _test_service(hass, "pow_on", SERVICE_TURN_ON)

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -24,7 +24,7 @@ from homeassistant.components.media_player import (
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
 )
-from homeassistant.components.vizio.const import DOMAIN
+from homeassistant.components.vizio.const import CONF_VOLUME_STEP, DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -36,6 +36,7 @@ from .const import (
     MOCK_USER_VALID_TV_CONFIG,
     NAME,
     UNIQUE_ID,
+    VOLUME_STEP,
 )
 
 from tests.common import MockConfigEntry
@@ -329,3 +330,28 @@ async def test_services(
             blocking=True,
         )
         assert service_call.call_count == 1
+
+
+async def test_options_update(
+    hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
+) -> None:
+    """Test for when config entry update event fires."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
+    )
+    await _test_init(
+        hass,
+        config_entry,
+        VIZIO_DEVICE_CLASS_SPEAKER,
+        DEVICE_CLASS_SPEAKER,
+        True,
+        STATE_ON,
+    )
+
+    updated_options = {CONF_VOLUME_STEP: VOLUME_STEP}
+    new_options = config_entry.options.copy()
+    new_options.update(updated_options)
+    hass.config_entries.async_update_entry(
+        entry=config_entry, options=new_options,
+    )
+    assert config_entry.options == updated_options

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -98,9 +98,9 @@ async def _test_setup_failure(hass: HomeAssistantType, config: str) -> None:
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
         return_value=False,
     ):
-        await hass.config_entries.async_add(
-            MockConfigEntry(domain=DOMAIN, data=config, unique_id=UNIQUE_ID)
-        )
+        config_entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id=UNIQUE_ID)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0
 

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,4 +1,5 @@
 """Tests for Vizio config flow."""
+from datetime import timedelta
 from unittest.mock import call
 
 from asynctest import patch
@@ -28,9 +29,12 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.vizio.const import CONF_VOLUME_STEP, DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.util import dt as dt_util
 
 from .const import (
+    _LOGGER,
     CURRENT_INPUT,
     ENTITY_ID,
     INPUT_LIST,
@@ -41,7 +45,7 @@ from .const import (
     VOLUME_STEP,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def _test_init(
@@ -230,3 +234,20 @@ async def test_options_update(
     )
     assert config_entry.options == updated_options
     await _test_service(hass, "vol_up", SERVICE_VOLUME_UP, num=VOLUME_STEP)
+
+
+async def test_update_unavailable_to_available(
+    hass: HomeAssistantType, vizio_connect: pytest.fixture, vizio_update: pytest.fixture
+) -> None:
+    """Test that device will successfully become available after period of unavailability."""
+    await _test_init(hass, DEVICE_CLASS_SPEAKER, None)
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
+        return_value=True,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+        await hass.async_block_till_done()
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
+        _LOGGER.error(hass.states.get(ENTITY_ID).state)
+        assert False

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -29,29 +29,18 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVA
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
 
+from .conftest import MockInput, get_mock_inputs
 from .const import (
     CURRENT_INPUT,
     ENTITY_ID,
     INPUT_LIST,
     MOCK_SPEAKER_CONFIG,
+    MOCK_SPEAKER_CONFIG_ENTRY,
+    MOCK_TV_CONFIG_ENTRY,
     MOCK_USER_VALID_TV_CONFIG,
     NAME,
     UNIQUE_ID,
 )
-
-
-class MockInput:
-    """Mock Vizio device input."""
-
-    def __init__(self, name):
-        """Initialize mock Vizio device input."""
-        self.meta_name = name
-        self.name = name
-
-
-def get_mock_inputs(input_list):
-    """Return list of MockInput."""
-    return [MockInput(input) for input in input_list]
 
 
 async def _test_init(
@@ -181,9 +170,9 @@ async def test_setup_failure_speaker(
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
         return_value=False,
     ):
-        assert await async_setup_component(hass, DOMAIN, {DOMAIN: MOCK_SPEAKER_CONFIG})
+        await hass.config_entries.async_add(MOCK_SPEAKER_CONFIG_ENTRY)
         await hass.async_block_till_done()
-        assert len(hass.states.async_entity_ids(DOMAIN)) == 0
+        assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0
 
 
 async def test_setup_failure_tv(
@@ -194,11 +183,9 @@ async def test_setup_failure_tv(
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
         return_value=False,
     ):
-        assert await async_setup_component(
-            hass, DOMAIN, {DOMAIN: MOCK_USER_VALID_TV_CONFIG}
-        )
+        await hass.config_entries.async_add(MOCK_TV_CONFIG_ENTRY)
         await hass.async_block_till_done()
-        assert len(hass.states.async_entity_ids(DOMAIN)) == 0
+        assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0
 
 
 async def test_services(hass: HomeAssistantType) -> None:

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -43,7 +43,7 @@ from tests.common import MockConfigEntry
 
 
 async def _test_init(
-    hass: HomeAssistantType, ha_device_class: str, vizio_power_state: bool,
+    hass: HomeAssistantType, ha_device_class: str, vizio_power_state: bool
 ) -> None:
     """Test initialization of generic Vizio Device entity."""
     if vizio_power_state:

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,5 +1,6 @@
 """Tests for Vizio config flow."""
 from asynctest import patch
+import pytest
 from pyvizio.const import (
     DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
     DEVICE_CLASS_TV as VIZIO_DEVICE_CLASS_TV,
@@ -172,7 +173,9 @@ async def test_vizio_init_tv_unavailable(hass: HomeAssistantType) -> None:
     )
 
 
-async def test_setup_failure(hass: HomeAssistantType) -> None:
+async def test_setup_failure(
+    hass: HomeAssistantType, vizio_connect: pytest.fixture
+) -> None:
     """Test media player entity setup failure."""
     with patch(
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mainly added missing tests for `vizio` integration to get 95+% code coverage on tests for the integration. I also simplified logic for entry setup when setting up config entry options, added logging when a device first becomes available or unavailable per https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html, and moved test constants into a separate file so they could be shared across all tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
