### PR TITLE
Check that documentation urls are valid

### DIFF
--- a/homeassistant/components/solarlog/manifest.json
+++ b/homeassistant/components/solarlog/manifest.json
@@ -2,7 +2,7 @@
   "domain": "solarlog",
   "name": "Solar-Log",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integration/solarlog",
+  "documentation": "https://www.home-assistant.io/integrations/solarlog",
   "dependencies": [],
   "codeowners": ["@Ernst79"],
   "requirements": ["sunwatcher==0.2.1"]

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -6,12 +6,28 @@ from voluptuous.humanize import humanize_error
 
 from .model import Integration
 
+DOCUMENTATION_URL_PREFIX = "https://www.home-assistant.io/integrations/"
+DOCUMENTATION_URL_EXCEPTIONS = ["https://www.home-assistant.io/hassio"]
+
 SUPPORTED_QUALITY_SCALES = [
     "gold",
     "internal",
     "platinum",
     "silver",
 ]
+
+
+def documentation_url(value: str) -> str:
+    """Validate that a documentation url starts with the correct prefix."""
+    if (
+        not value.startswith(DOCUMENTATION_URL_PREFIX)
+        and value not in DOCUMENTATION_URL_EXCEPTIONS
+    ):
+        raise vol.Invalid(
+            "Documentation url didn't begin with %s".format(DOCUMENTATION_URL_PREFIX)
+        )
+    return value
+
 
 MANIFEST_SCHEMA = vol.Schema(
     {
@@ -23,9 +39,9 @@ MANIFEST_SCHEMA = vol.Schema(
             vol.All([vol.All(vol.Schema({}, extra=vol.ALLOW_EXTRA), vol.Length(min=1))])
         ),
         vol.Optional("homekit"): vol.Schema({vol.Optional("models"): [str]}),
-        vol.Required(
-            "documentation"
-        ): vol.Url(),  # pylint: disable=no-value-for-parameter
+        vol.Required("documentation"): vol.All(
+            vol.Url(), documentation_url
+        ),  # pylint: disable=no-value-for-parameter
         vol.Optional("quality_scale"): vol.In(SUPPORTED_QUALITY_SCALES),
         vol.Required("requirements"): [str],
         vol.Required("dependencies"): [str],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Builds on top of the basic URL validation introduced in #31143 by @frenck to include checking that documentation links in the manifest actually point to `www.home-assistant.io/integrations/`. Found one that is invalid and corrected that here as well.

Since there is a manifest for hassio and the documentation for that livest at `www.home-assistant.io/hassio`, I added a list of exceptions to the documentation check.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
