### PR TITLE
Update media_player and add tests to qualify vizio integration for platinum quality score

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -776,9 +776,6 @@ omit =
     homeassistant/components/viaggiatreno/sensor.py
     homeassistant/components/vicare/*
     homeassistant/components/vivotek/camera.py
-    homeassistant/components/vizio/__init__.py
-    homeassistant/components/vizio/const.py
-    homeassistant/components/vizio/media_player.py
     homeassistant/components/vlc/media_player.py
     homeassistant/components/vlc_telnet/media_player.py
     homeassistant/components/volkszaehler/sensor.py

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": [],
   "codeowners": ["@raman325"],
   "config_flow": true,
-  "zeroconf": ["_viziocast._tcp.local."]
+  "zeroconf": ["_viziocast._tcp.local."],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -39,8 +39,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-
-PARALLEL_UPDATES = 0
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -55,13 +54,13 @@ async def async_setup_entry(
     device_class = config_entry.data[CONF_DEVICE_CLASS]
 
     # If config entry options not set up, set them up, otherwise assign values managed in options
+    volume_step = config_entry.options.get(
+        CONF_VOLUME_STEP, config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+    )
     if not config_entry.options:
-        volume_step = config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
         hass.config_entries.async_update_entry(
             config_entry, options={CONF_VOLUME_STEP: volume_step}
         )
-    else:
-        volume_step = config_entry.options[CONF_VOLUME_STEP]
 
     device = VizioAsync(
         DEVICE_ID,

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -39,8 +39,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PARALLEL_UPDATES = 0
 SCAN_INTERVAL = MIN_TIME_BETWEEN_SCANS
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -1,0 +1,55 @@
+"""Configure py.test."""
+from asynctest import patch
+import pytest
+
+from .const import UNIQUE_ID
+
+
+@pytest.fixture(name="vizio_connect", autouse=False)
+def vizio_connect_fixture():
+    """Mock valid vizio device and entry setup."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
+        return_value=UNIQUE_ID,
+    ):
+        yield
+
+
+@pytest.fixture(name="vizio_bypass_setup", autouse=False)
+def vizio_bypass_setup_fixture():
+    """Mock component setup."""
+    with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
+        yield
+
+
+@pytest.fixture(name="vizio_bypass_update", autouse=False)
+def vizio_bypass_update_fixture():
+    """Mock component update."""
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=True,
+    ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
+        yield
+
+
+@pytest.fixture(name="vizio_guess_device_type", autouse=False)
+def vizio_guess_device_type_fixture():
+    """Mock vizio async_guess_device_type function."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.async_guess_device_type",
+        return_value="speaker",
+    ):
+        yield
+
+
+@pytest.fixture(name="vizio_cant_connect", autouse=False)
+def vizio_cant_connect_fixture():
+    """Mock vizio device cant connect."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+        return_value=False,
+    ):
+        yield

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -1,0 +1,85 @@
+"""Constants for the Vizio integration tests."""
+import logging
+
+from homeassistant.components.media_player import (
+    DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV,
+    DOMAIN as MP_DOMAIN,
+)
+from homeassistant.components.vizio.const import CONF_VOLUME_STEP, DOMAIN
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_DEVICE_CLASS,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TYPE,
+)
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+NAME = "Vizio"
+NAME2 = "Vizio2"
+HOST = "192.168.1.1:9000"
+HOST2 = "192.168.1.2:9000"
+ACCESS_TOKEN = "deadbeef"
+VOLUME_STEP = 2
+UNIQUE_ID = "testid"
+
+MOCK_USER_VALID_TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
+}
+
+MOCK_OPTIONS = {
+    CONF_VOLUME_STEP: VOLUME_STEP,
+}
+
+MOCK_IMPORT_VALID_TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
+    CONF_VOLUME_STEP: VOLUME_STEP,
+}
+
+MOCK_INVALID_TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+}
+
+MOCK_SPEAKER_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
+}
+
+VIZIO_ZEROCONF_SERVICE_TYPE = "_viziocast._tcp.local."
+ZEROCONF_NAME = f"{NAME}.{VIZIO_ZEROCONF_SERVICE_TYPE}"
+ZEROCONF_HOST = HOST.split(":")[0]
+ZEROCONF_PORT = HOST.split(":")[1]
+
+MOCK_ZEROCONF_ENTRY = {
+    CONF_TYPE: VIZIO_ZEROCONF_SERVICE_TYPE,
+    CONF_NAME: ZEROCONF_NAME,
+    CONF_HOST: ZEROCONF_HOST,
+    CONF_PORT: ZEROCONF_PORT,
+    "properties": {"name": "SB4031-D5"},
+}
+
+MOCK_SPEAKER_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
+)
+MOCK_TV_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
+)
+
+CURRENT_INPUT = "HDMI"
+INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
+
+ENTITY_ID = f"{MP_DOMAIN.lower()}.{NAME.lower()}"

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -44,6 +44,10 @@ MOCK_USER_VALID_TV_CONFIG = {
     CONF_ACCESS_TOKEN: ACCESS_TOKEN,
 }
 
+MOCK_OPTIONS = {
+    CONF_VOLUME_STEP: VOLUME_STEP,
+}
+
 MOCK_IMPORT_VALID_TV_CONFIG = {
     CONF_NAME: NAME,
     CONF_HOST: HOST,
@@ -128,6 +132,18 @@ def vizio_cant_connect_fixture():
         yield
 
 
+async def test_unload(
+    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
+) -> None:
+    """Test loading with options and unloading config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
+    )
+    assert await result["result"].async_unload(hass)
+
+
 async def test_user_flow_minimum_fields(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,
@@ -142,12 +158,7 @@ async def test_user_flow_minimum_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_NAME: NAME,
-            CONF_HOST: HOST,
-            CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
-        },
+        result["flow_id"], user_input=MOCK_SPEAKER_CONFIG,
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -172,13 +183,7 @@ async def test_user_flow_all_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_NAME: NAME,
-            CONF_HOST: HOST,
-            CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-            CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-        },
+        result["flow_id"], user_input=MOCK_USER_VALID_TV_CONFIG,
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -1,6 +1,4 @@
 """Tests for Vizio config flow."""
-
-from asynctest import patch
 import pytest
 import voluptuous as vol
 
@@ -39,55 +37,54 @@ from .const import (
 
 from tests.common import MockConfigEntry
 
-
-@pytest.fixture(name="vizio_connect")
-def vizio_connect_fixture():
-    """Mock valid vizio device and entry setup."""
-    with patch(
-        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
-        return_value=UNIQUE_ID,
-    ):
-        yield
-
-
-@pytest.fixture(name="vizio_bypass_setup")
-def vizio_bypass_setup_fixture():
-    """Mock component setup."""
-    with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
-        yield
+# @pytest.fixture(name="vizio_connect")
+# def vizio_connect_fixture():
+#     """Mock valid vizio device and entry setup."""
+#     with patch(
+#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+#         return_value=True,
+#     ), patch(
+#         "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
+#         return_value=UNIQUE_ID,
+#     ):
+#         yield
 
 
-@pytest.fixture(name="vizio_bypass_update")
-def vizio_bypass_update_fixture():
-    """Mock component update."""
-    with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
-        return_value=True,
-    ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
-        yield
+# @pytest.fixture(name="vizio_bypass_setup")
+# def vizio_bypass_setup_fixture():
+#     """Mock component setup."""
+#     with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
+#         yield
 
 
-@pytest.fixture(name="vizio_guess_device_type")
-def vizio_guess_device_type_fixture():
-    """Mock vizio async_guess_device_type function."""
-    with patch(
-        "homeassistant.components.vizio.config_flow.async_guess_device_type",
-        return_value="speaker",
-    ):
-        yield
+# @pytest.fixture(name="vizio_bypass_update")
+# def vizio_bypass_update_fixture():
+#     """Mock component update."""
+#     with patch(
+#         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+#         return_value=True,
+#     ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
+#         yield
 
 
-@pytest.fixture(name="vizio_cant_connect")
-def vizio_cant_connect_fixture():
-    """Mock vizio device cant connect."""
-    with patch(
-        "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-        return_value=False,
-    ):
-        yield
+# @pytest.fixture(name="vizio_guess_device_type")
+# def vizio_guess_device_type_fixture():
+#     """Mock vizio async_guess_device_type function."""
+#     with patch(
+#         "homeassistant.components.vizio.config_flow.async_guess_device_type",
+#         return_value="speaker",
+#     ):
+#         yield
+
+
+# @pytest.fixture(name="vizio_cant_connect")
+# def vizio_cant_connect_fixture():
+#     """Mock vizio device cant connect."""
+#     with patch(
+#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
+#         return_value=False,
+#     ):
+#         yield
 
 
 async def test_unload(

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -38,18 +38,6 @@ from .const import (
 from tests.common import MockConfigEntry
 
 
-async def test_unload(
-    hass: HomeAssistantType, vizio_connect, vizio_bypass_setup
-) -> None:
-    """Test loading with options and unloading config entry."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
-    )
-    assert await result["result"].async_unload(hass)
-
-
 async def test_user_flow_minimum_fields(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -37,55 +37,6 @@ from .const import (
 
 from tests.common import MockConfigEntry
 
-# @pytest.fixture(name="vizio_connect")
-# def vizio_connect_fixture():
-#     """Mock valid vizio device and entry setup."""
-#     with patch(
-#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-#         return_value=True,
-#     ), patch(
-#         "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
-#         return_value=UNIQUE_ID,
-#     ):
-#         yield
-
-
-# @pytest.fixture(name="vizio_bypass_setup")
-# def vizio_bypass_setup_fixture():
-#     """Mock component setup."""
-#     with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
-#         yield
-
-
-# @pytest.fixture(name="vizio_bypass_update")
-# def vizio_bypass_update_fixture():
-#     """Mock component update."""
-#     with patch(
-#         "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
-#         return_value=True,
-#     ), patch("homeassistant.components.vizio.media_player.VizioDevice.async_update"):
-#         yield
-
-
-# @pytest.fixture(name="vizio_guess_device_type")
-# def vizio_guess_device_type_fixture():
-#     """Mock vizio async_guess_device_type function."""
-#     with patch(
-#         "homeassistant.components.vizio.config_flow.async_guess_device_type",
-#         return_value="speaker",
-#     ):
-#         yield
-
-
-# @pytest.fixture(name="vizio_cant_connect")
-# def vizio_cant_connect_fixture():
-#     """Mock vizio device cant connect."""
-#     with patch(
-#         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
-#         return_value=False,
-#     ):
-#         yield
-
 
 async def test_unload(
     hass: HomeAssistantType, vizio_connect, vizio_bypass_setup

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for Vizio config flow."""
-import logging
 
 from asynctest import patch
 import pytest
@@ -20,66 +19,25 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_HOST,
     CONF_NAME,
-    CONF_PORT,
-    CONF_TYPE,
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
+from .const import (
+    ACCESS_TOKEN,
+    HOST,
+    HOST2,
+    MOCK_IMPORT_VALID_TV_CONFIG,
+    MOCK_INVALID_TV_CONFIG,
+    MOCK_SPEAKER_CONFIG,
+    MOCK_USER_VALID_TV_CONFIG,
+    MOCK_ZEROCONF_ENTRY,
+    NAME,
+    NAME2,
+    UNIQUE_ID,
+    VOLUME_STEP,
+)
+
 from tests.common import MockConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
-
-NAME = "Vizio"
-NAME2 = "Vizio2"
-HOST = "192.168.1.1:9000"
-HOST2 = "192.168.1.2:9000"
-ACCESS_TOKEN = "deadbeef"
-VOLUME_STEP = 2
-UNIQUE_ID = "testid"
-
-MOCK_USER_VALID_TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-}
-
-MOCK_OPTIONS = {
-    CONF_VOLUME_STEP: VOLUME_STEP,
-}
-
-MOCK_IMPORT_VALID_TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-    CONF_VOLUME_STEP: VOLUME_STEP,
-}
-
-MOCK_INVALID_TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-}
-
-MOCK_SPEAKER_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
-}
-
-VIZIO_ZEROCONF_SERVICE_TYPE = "_viziocast._tcp.local."
-ZEROCONF_NAME = f"{NAME}.{VIZIO_ZEROCONF_SERVICE_TYPE}"
-ZEROCONF_HOST = HOST.split(":")[0]
-ZEROCONF_PORT = HOST.split(":")[1]
-
-MOCK_ZEROCONF_ENTRY = {
-    CONF_TYPE: VIZIO_ZEROCONF_SERVICE_TYPE,
-    CONF_NAME: ZEROCONF_NAME,
-    CONF_HOST: ZEROCONF_HOST,
-    CONF_PORT: ZEROCONF_PORT,
-    "properties": {"name": "SB4031-D5"},
-}
 
 
 @pytest.fixture(name="vizio_connect")
@@ -158,7 +116,7 @@ async def test_user_flow_minimum_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_SPEAKER_CONFIG,
+        result["flow_id"], user_input=MOCK_SPEAKER_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -183,7 +141,7 @@ async def test_user_flow_all_fields(
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_USER_VALID_TV_CONFIG,
+        result["flow_id"], user_input=MOCK_USER_VALID_TV_CONFIG
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -1,0 +1,22 @@
+"""Tests for Vizio init."""
+import pytest
+
+from homeassistant.components.vizio.const import DOMAIN
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.setup import async_setup_component
+
+from .const import MOCK_SPEAKER_CONFIG
+
+
+async def test_unload(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
+) -> None:
+    """Test loading component and unloading entry."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: MOCK_SPEAKER_CONFIG})
+    await hass.async_block_till_done()
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    for entry in entries:
+        assert await entry.async_unload(hass)

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,6 +1,4 @@
 """Tests for Vizio config flow."""
-import logging
-
 from asynctest import patch
 from pyvizio.const import (
     DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
@@ -27,53 +25,22 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.vizio.const import DOMAIN
 from homeassistant.components.vizio.media_player import async_setup_entry
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    CONF_ACCESS_TOKEN,
-    CONF_DEVICE_CLASS,
-    CONF_HOST,
-    CONF_NAME,
-    STATE_OFF,
-    STATE_ON,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
-
-NAME = "Vizio"
-HOST = "192.168.1.1:9000"
-ACCESS_TOKEN = "deadbeef"
-VOLUME_STEP = 2
-TIMEOUT = 3
-UNIQUE_ID = "testid"
-
-CURRENT_INPUT = "HDMI"
-INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
-
-TV_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
-    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
-}
-
-ENTITY_ID = f"{MP_DOMAIN.lower()}.{NAME.lower()}"
-
-SPEAKER_CONFIG = {
-    CONF_NAME: NAME,
-    CONF_HOST: HOST,
-    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
-}
-
-SPEAKER_CONFIG_ENTRY = MockConfigEntry(
-    domain=DOMAIN, data=SPEAKER_CONFIG, unique_id=UNIQUE_ID
+from .const import (
+    CURRENT_INPUT,
+    ENTITY_ID,
+    INPUT_LIST,
+    MOCK_SPEAKER_CONFIG,
+    MOCK_SPEAKER_CONFIG_ENTRY,
+    MOCK_TV_CONFIG_ENTRY,
+    MOCK_USER_VALID_TV_CONFIG,
+    NAME,
+    UNIQUE_ID,
 )
-TV_CONFIG_ENTRY = MockConfigEntry(domain=DOMAIN, data=TV_CONFIG, unique_id=UNIQUE_ID)
 
 
 class MockInput:
@@ -141,7 +108,7 @@ async def test_vizio_speaker_on(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when on."""
     await _test_vizio_init(
         hass,
-        SPEAKER_CONFIG,
+        MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
         DEVICE_CLASS_SPEAKER,
         True,
@@ -153,7 +120,7 @@ async def test_vizio_speaker_off(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when off."""
     await _test_vizio_init(
         hass,
-        SPEAKER_CONFIG,
+        MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
         DEVICE_CLASS_SPEAKER,
         False,
@@ -165,7 +132,7 @@ async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
     """Test for Vizio Speaker entity when unavailable."""
     await _test_vizio_init(
         hass,
-        SPEAKER_CONFIG,
+        MOCK_SPEAKER_CONFIG,
         VIZIO_DEVICE_CLASS_SPEAKER,
         DEVICE_CLASS_SPEAKER,
         None,
@@ -176,21 +143,36 @@ async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
 async def test_vizio_init_tv_on(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when on."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        True,
+        STATE_ON,
     )
 
 
 async def test_vizio_init_tv_off(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when off."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, False, STATE_OFF
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        False,
+        STATE_OFF,
     )
 
 
 async def test_vizio_init_tv_unavailable(hass: HomeAssistantType) -> None:
     """Test for Vizio TV entity when unavailable."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, None, STATE_UNAVAILABLE
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        None,
+        STATE_UNAVAILABLE,
     )
 
 
@@ -201,12 +183,12 @@ async def test_setup_failure(hass: HomeAssistantType) -> None:
         return_value=False,
     ):
         try:
-            await async_setup_entry(hass, SPEAKER_CONFIG_ENTRY, None)
+            await async_setup_entry(hass, MOCK_SPEAKER_CONFIG_ENTRY, None)
         except Exception as e:
             assert isinstance(e, PlatformNotReady)
 
         try:
-            await async_setup_entry(hass, TV_CONFIG_ENTRY, None)
+            await async_setup_entry(hass, MOCK_TV_CONFIG_ENTRY, None)
         except Exception as e:
             assert isinstance(e, PlatformNotReady)
 
@@ -214,7 +196,12 @@ async def test_setup_failure(hass: HomeAssistantType) -> None:
 async def test_services(hass: HomeAssistantType) -> None:
     """Test media player entity services."""
     await _test_vizio_init(
-        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON,
+        hass,
+        MOCK_USER_VALID_TV_CONFIG,
+        VIZIO_DEVICE_CLASS_TV,
+        DEVICE_CLASS_TV,
+        True,
+        STATE_ON,
     )
 
     with patch("homeassistant.components.vizio.media_player.VizioAsync.pow_on"):

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,0 +1,302 @@
+"""Tests for Vizio config flow."""
+import logging
+
+from asynctest import patch
+from pyvizio.const import (
+    DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV as VIZIO_DEVICE_CLASS_TV,
+)
+from pyvizio.vizio import MAX_VOLUME
+
+from homeassistant.components.media_player import (
+    ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+    DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV,
+    DOMAIN as MP_DOMAIN,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_SELECT_SOURCE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
+)
+from homeassistant.components.vizio.const import DOMAIN
+from homeassistant.components.vizio.media_player import async_setup_entry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ACCESS_TOKEN,
+    CONF_DEVICE_CLASS,
+    CONF_HOST,
+    CONF_NAME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+NAME = "Vizio"
+HOST = "192.168.1.1:9000"
+ACCESS_TOKEN = "deadbeef"
+VOLUME_STEP = 2
+TIMEOUT = 3
+UNIQUE_ID = "testid"
+
+CURRENT_INPUT = "HDMI"
+INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
+
+TV_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TV,
+    CONF_ACCESS_TOKEN: ACCESS_TOKEN,
+}
+
+ENTITY_ID = f"{MP_DOMAIN.lower()}.{NAME.lower()}"
+
+SPEAKER_CONFIG = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_SPEAKER,
+}
+
+SPEAKER_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN, data=SPEAKER_CONFIG, unique_id=UNIQUE_ID
+)
+TV_CONFIG_ENTRY = MockConfigEntry(domain=DOMAIN, data=TV_CONFIG, unique_id=UNIQUE_ID)
+
+
+class MockInput:
+    """Mock Vizio device input."""
+
+    def __init__(self, name):
+        """Initialize mock Vizio device input."""
+        self.meta_name = name
+        self.name = name
+
+
+def get_mock_inputs(input_list):
+    """Return list of MockInput."""
+    return [MockInput(input) for input in input_list]
+
+
+async def _test_vizio_init(
+    hass: HomeAssistantType,
+    config: dict,
+    vizio_device_class: str,
+    ha_device_class: str,
+    vizio_power_state: bool,
+    ha_power_state: str,
+) -> None:
+    """Test initialization of Vizio Device entity with device class `speaker`."""
+
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_unique_id",
+        return_value=UNIQUE_ID,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_volume",
+        return_value=int(MAX_VOLUME[vizio_device_class] / 2),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_input",
+        return_value=MockInput(CURRENT_INPUT),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_inputs",
+        return_value=get_mock_inputs(INPUT_LIST),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
+        return_value=vizio_power_state,
+    ):
+        await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        await hass.async_block_till_done()
+
+        attr = hass.states.get(ENTITY_ID).attributes
+        assert attr["friendly_name"] == NAME
+        assert attr["device_class"] == ha_device_class
+
+        assert hass.states.get(ENTITY_ID).state == ha_power_state
+        if ha_power_state == STATE_ON:
+            assert attr["source_list"] == INPUT_LIST
+            assert attr["source"] == CURRENT_INPUT
+            assert (
+                attr["volume_level"]
+                == float(int(MAX_VOLUME[vizio_device_class] / 2))
+                / MAX_VOLUME[vizio_device_class]
+            )
+
+
+async def test_vizio_speaker_on(hass: HomeAssistantType) -> None:
+    """Test for Vizio Speaker entity when on."""
+    await _test_vizio_init(
+        hass,
+        SPEAKER_CONFIG,
+        VIZIO_DEVICE_CLASS_SPEAKER,
+        DEVICE_CLASS_SPEAKER,
+        True,
+        STATE_ON,
+    )
+
+
+async def test_vizio_speaker_off(hass: HomeAssistantType) -> None:
+    """Test for Vizio Speaker entity when off."""
+    await _test_vizio_init(
+        hass,
+        SPEAKER_CONFIG,
+        VIZIO_DEVICE_CLASS_SPEAKER,
+        DEVICE_CLASS_SPEAKER,
+        False,
+        STATE_OFF,
+    )
+
+
+async def test_vizio_speaker_unavailable(hass: HomeAssistantType) -> None:
+    """Test for Vizio Speaker entity when unavailable."""
+    await _test_vizio_init(
+        hass,
+        SPEAKER_CONFIG,
+        VIZIO_DEVICE_CLASS_SPEAKER,
+        DEVICE_CLASS_SPEAKER,
+        None,
+        STATE_UNAVAILABLE,
+    )
+
+
+async def test_vizio_init_tv_on(hass: HomeAssistantType) -> None:
+    """Test for Vizio TV entity when on."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON
+    )
+
+
+async def test_vizio_init_tv_off(hass: HomeAssistantType) -> None:
+    """Test for Vizio TV entity when off."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, False, STATE_OFF
+    )
+
+
+async def test_vizio_init_tv_unavailable(hass: HomeAssistantType) -> None:
+    """Test for Vizio TV entity when unavailable."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, None, STATE_UNAVAILABLE
+    )
+
+
+async def test_setup_failure(hass: HomeAssistantType) -> None:
+    """Test media player entity setup failure."""
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.can_connect",
+        return_value=False,
+    ):
+        try:
+            await async_setup_entry(hass, SPEAKER_CONFIG_ENTRY, None)
+        except Exception as e:
+            assert isinstance(e, PlatformNotReady)
+
+        try:
+            await async_setup_entry(hass, TV_CONFIG_ENTRY, None)
+        except Exception as e:
+            assert isinstance(e, PlatformNotReady)
+
+
+async def test_services(hass: HomeAssistantType) -> None:
+    """Test media player entity services."""
+    await _test_vizio_init(
+        hass, TV_CONFIG, VIZIO_DEVICE_CLASS_TV, DEVICE_CLASS_TV, True, STATE_ON,
+    )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.pow_on"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_TURN_ON,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.pow_off"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_TURN_OFF,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.mute_on"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_MUTE,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.mute_off"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_MUTE,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: False},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.input_switch"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_SELECT_SOURCE,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "USB"},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.vol_up"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_UP,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_SET,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 1},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.vol_down"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_DOWN,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_VOLUME_SET,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.ch_up"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_MEDIA_NEXT_TRACK,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    with patch("homeassistant.components.vizio.media_player.VizioAsync.ch_down"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_MEDIA_PREVIOUS_TRACK,
+            service_data={ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mainly added missing tests for `vizio` integration to get 95+% code coverage on tests for the integration. I also simplified logic for entry setup when setting up config entry options, added logging when a device first becomes available or unavailable per https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html, and moved test constants into a separate file so they could be shared across all tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
