### PR TITLE
Change scan_interval settings for Tesla to allow automation flexibility

### DIFF
--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -26,7 +26,14 @@ from .config_flow import (
     configured_instances,
     validate_input,
 )
-from .const import DATA_LISTENER, DOMAIN, ICONS, TESLA_COMPONENTS
+from .const import (
+    DATA_LISTENER,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    ICONS,
+    MIN_SCAN_INTERVAL,
+    TESLA_COMPONENTS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,9 +43,9 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_SCAN_INTERVAL, default=300): vol.All(
-                    cv.positive_int, vol.Clamp(min=300)
-                ),
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
             }
         )
     },
@@ -63,7 +70,7 @@ async def async_setup(hass, base_config):
 
     def _update_entry(email, data=None, options=None):
         data = data or {}
-        options = options or {CONF_SCAN_INTERVAL: 300}
+        options = options or {CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL}
         for entry in hass.config_entries.async_entries(DOMAIN):
             if email != entry.title:
                 continue
@@ -119,7 +126,9 @@ async def async_setup_entry(hass, config_entry):
             websession,
             refresh_token=config[CONF_TOKEN],
             access_token=config[CONF_ACCESS_TOKEN],
-            update_interval=config_entry.options.get(CONF_SCAN_INTERVAL, 300),
+            update_interval=config_entry.options.get(
+                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+            ),
         )
         (refresh_token, access_token) = await controller.connect()
     except TeslaException as ex:

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import DOMAIN
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, MIN_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,8 +100,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             {
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
-                    default=self.config_entry.options.get(CONF_SCAN_INTERVAL, 300),
-                ): vol.All(cv.positive_int, vol.Clamp(min=300))
+                    default=self.config_entry.options.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    ),
+                ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL))
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)
@@ -120,7 +122,7 @@ async def validate_input(hass: core.HomeAssistant, data):
             websession,
             email=data[CONF_USERNAME],
             password=data[CONF_PASSWORD],
-            update_interval=300,
+            update_interval=DEFAULT_SCAN_INTERVAL,
         )
         (config[CONF_TOKEN], config[CONF_ACCESS_TOKEN]) = await controller.connect(
             test_login=True

--- a/homeassistant/components/tesla/const.py
+++ b/homeassistant/components/tesla/const.py
@@ -1,6 +1,8 @@
 """Const file for Tesla cars."""
 DOMAIN = "tesla"
 DATA_LISTENER = "listener"
+DEFAULT_SCAN_INTERVAL = 660
+MIN_SCAN_INTERVAL = 60
 TESLA_COMPONENTS = [
     "sensor",
     "lock",

--- a/tests/components/tesla/test_config_flow.py
+++ b/tests/components/tesla/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from teslajsonpy import TeslaException
 
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.tesla.const import DOMAIN
+from homeassistant.components.tesla.const import DOMAIN, MIN_SCAN_INTERVAL
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_PASSWORD,
@@ -40,8 +40,8 @@ async def test_form(hass):
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "test@email.com"
     assert result2["data"] == {
-        "token": "test-refresh-token",
-        "access_token": "test-access-token",
+        CONF_TOKEN: "test-refresh-token",
+        CONF_ACCESS_TOKEN: "test-access-token",
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -157,4 +157,4 @@ async def test_option_flow_input_floor(hass):
         result["flow_id"], user_input={CONF_SCAN_INTERVAL: 1}
     )
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_SCAN_INTERVAL: 300}
+    assert result["data"] == {CONF_SCAN_INTERVAL: MIN_SCAN_INTERVAL}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->Tesla default SCAN_INTERVAL has been raised to 660 seconds from 300 seconds. This is the result of new testing showing the prior default would not allow Tesla vehicles to fall asleep. You should reevaluate your SCAN_INTERVAL if you have changed it to avoid battery drain. The SCAN_INTERVAL has had the minimum lowered to 60.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SCAN_INTERVAL default has been changed to 660 and minimum set to 60. The new minimum allows those use automations to potentially create an adaptive refresh algorithm.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30778
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/11883

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
