### PR TITLE
Fix light.turn_on for emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -351,8 +351,9 @@ class HueOneLightChangeView(HomeAssistantView):
 
         if HUE_API_STATE_BRI in request_json:
             if entity.domain == light.DOMAIN:
-                parsed[STATE_ON] = parsed[STATE_BRIGHTNESS] > 0
-                if not entity_features & SUPPORT_BRIGHTNESS:
+                if entity_features & SUPPORT_BRIGHTNESS:
+                    parsed[STATE_ON] = parsed[STATE_BRIGHTNESS] > 0
+                else:
                     parsed[STATE_BRIGHTNESS] = None
 
             elif entity.domain == scene.DOMAIN:

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -32,10 +32,20 @@ from homeassistant.components.emulated_hue.hue_api import (
     HueOneLightStateView,
     HueUsernameView,
 )
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed, get_test_instance_port
+from tests.common import (
+    async_fire_time_changed,
+    async_mock_service,
+    get_test_instance_port,
+)
 
 HTTP_SERVER_PORT = get_test_instance_port()
 BRIDGE_SERVER_PORT = get_test_instance_port()
@@ -229,6 +239,64 @@ async def test_light_without_brightness_supported(hass_hue, hue_client):
 
     assert light_without_brightness_json["state"][HUE_API_STATE_ON] is True
     assert light_without_brightness_json["type"] == "On/off light"
+
+
+async def test_light_without_brightness_can_be_turned_off(hass_hue, hue_client):
+    """Test that light without brightness can be turned off."""
+    hass_hue.states.async_set("light.no_brightness", "on", {})
+
+    # Check if light can be turned off
+    turn_off_calls = async_mock_service(hass_hue, light.DOMAIN, SERVICE_TURN_OFF)
+
+    no_brightness_result = await perform_put_light_state(
+        hass_hue, hue_client, "light.no_brightness", False
+    )
+    no_brightness_result_json = await no_brightness_result.json()
+
+    assert no_brightness_result.status == 200
+    assert "application/json" in no_brightness_result.headers["content-type"]
+    assert len(no_brightness_result_json) == 1
+
+    # Verify that SERVICE_TURN_OFF has been called
+    await hass_hue.async_block_till_done()
+    assert 1 == len(turn_off_calls)
+    call = turn_off_calls[-1]
+
+    assert light.DOMAIN == call.domain
+    assert SERVICE_TURN_OFF == call.service
+    assert "light.no_brightness" in call.data[ATTR_ENTITY_ID]
+
+
+async def test_light_without_brightness_can_be_turned_on(hass_hue, hue_client):
+    """Test that light without brightness can be turned on."""
+    hass_hue.states.async_set("light.no_brightness", "off", {})
+
+    # Check if light can be turned on
+    turn_on_calls = async_mock_service(hass_hue, light.DOMAIN, SERVICE_TURN_ON)
+
+    no_brightness_result = await perform_put_light_state(
+        hass_hue,
+        hue_client,
+        "light.no_brightness",
+        True,
+        # Some remotes, like HarmonyHub send brightness value regardless of light's features
+        brightness=0,
+    )
+
+    no_brightness_result_json = await no_brightness_result.json()
+
+    assert no_brightness_result.status == 200
+    assert "application/json" in no_brightness_result.headers["content-type"]
+    assert len(no_brightness_result_json) == 1
+
+    # Verify that SERVICE_TURN_ON has been called
+    await hass_hue.async_block_till_done()
+    assert 1 == len(turn_on_calls)
+    call = turn_on_calls[-1]
+
+    assert light.DOMAIN == call.domain
+    assert SERVICE_TURN_ON == call.service
+    assert "light.no_brightness" in call.data[ATTR_ENTITY_ID]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
HarmonyHub sends `{'xy': [0, 0], 'on': True, 'bri': 0}` when turning on lights that do not support brightness control. Unfortunately current logic always uses  brightness value to control on/off state, which in this case results in overriding `'on': False` and in turn, results in light not turning on at all.
This change fixes that behavior, making light without brightness control usable with HarmonyHub (and probably some other remotes) by simply ignoring brightness value. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
