### PR TITLE
Fix ps4 errors if pin begins with a 0

### DIFF
--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -30,6 +30,8 @@ UDP_PORT = 987
 TCP_PORT = 997
 PORT_MSG = {UDP_PORT: "port_987_bind_error", TCP_PORT: "port_997_bind_error"}
 
+PIN_LENGTH = 8
+
 
 @config_entries.HANDLERS.register(DOMAIN)
 class PlayStation4FlowHandler(config_entries.ConfigFlow):
@@ -143,7 +145,8 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
         if user_input is not None:
             self.region = user_input[CONF_REGION]
             self.name = user_input[CONF_NAME]
-            self.pin = str(user_input[CONF_CODE])
+            # Assume pin had leading zeros, before coercing to int.
+            self.pin = str(user_input[CONF_CODE]).zfill(PIN_LENGTH)
             self.host = user_input[CONF_IP_ADDRESS]
 
             is_ready, is_login = await self.hass.async_add_executor_job(
@@ -184,7 +187,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             list(regions)
         )
         link_schema[vol.Required(CONF_CODE)] = vol.All(
-            vol.Strip, vol.Length(min=8, max=8), vol.Coerce(int)
+            vol.Strip, vol.Length(max=PIN_LENGTH), vol.Coerce(int)
         )
         link_schema[vol.Required(CONF_NAME, default=DEFAULT_NAME)] = str
 

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -5,7 +5,11 @@ from pyps4_2ndscreen.errors import CredentialTimeout
 
 from homeassistant import data_entry_flow
 from homeassistant.components import ps4
-from homeassistant.components.ps4.const import DEFAULT_NAME, DEFAULT_REGION
+from homeassistant.components.ps4.const import (
+    DEFAULT_ALIAS,
+    DEFAULT_NAME,
+    DEFAULT_REGION,
+)
 from homeassistant.const import (
     CONF_CODE,
     CONF_HOST,
@@ -19,7 +23,9 @@ from homeassistant.util import location
 from tests.common import MockConfigEntry
 
 MOCK_TITLE = "PlayStation 4"
-MOCK_CODE = "12345678"
+MOCK_CODE = 12345678
+MOCK_CODE_LEAD_0 = 1234567
+MOCK_CODE_LEAD_0_STR = "01234567"
 MOCK_CREDS = "000aa000"
 MOCK_HOST = "192.0.0.0"
 MOCK_HOST_ADDITIONAL = "192.0.0.1"
@@ -291,6 +297,27 @@ async def test_additional_device(hass):
 
     # Check that there are 2 entries
     assert len(manager.async_entries()) == 2
+
+
+async def test_0_pin(hass):
+    """Test Pin leading with 0."""
+    flow = ps4.PlayStation4FlowHandler()
+    flow.hass = hass
+    flow.location = MOCK_LOCATION
+    flow.creds = MOCK_CREDS
+
+    mock_config = MOCK_CONFIG
+    mock_config[CONF_CODE] = MOCK_CODE_LEAD_0
+
+    with patch(
+        "pyps4_2ndscreen.Helper.link", return_value=(True, True)
+    ) as mock_call, patch(
+        "pyps4_2ndscreen.Helper.has_devices", return_value=[{"host-ip": MOCK_HOST}]
+    ):
+        await flow.async_step_link(mock_config)
+    mock_call.assert_called_once_with(
+        MOCK_HOST, MOCK_CREDS, MOCK_CODE_LEAD_0_STR, DEFAULT_ALIAS
+    )
 
 
 async def test_no_devices_found_abort(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes errors with config flow, where the numeric PIN given to the user begins with 0.

We coerce the input as an int to validate it is numeric. But if the input is '01234567' it becomes int(1234567).

- Remove min param from vol.Length(). The example will pass the schema validation.
- When we cast to str we also call zfill() to add back leading zeros.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31151
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
