### PR TITLE
Fix Plugwise climate issues

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -13,6 +13,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_OFF,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -66,7 +67,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Add the Plugwise (Anna) Thermostate."""
+    """Add the Plugwise (Anna) Thermostat."""
     api = haanna.Haanna(
         config[CONF_USERNAME],
         config[CONF_PASSWORD],
@@ -88,7 +89,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class ThermostatDevice(ClimateDevice):
-    """Representation of an Plugwise thermostat."""
+    """Representation of the Plugwise thermostat."""
 
     def __init__(self, api, name, min_temp, max_temp):
         """Set up the Plugwise API."""
@@ -96,14 +97,18 @@ class ThermostatDevice(ClimateDevice):
         self._min_temp = min_temp
         self._max_temp = max_temp
         self._name = name
+        self._direct_objects = None
         self._domain_objects = None
         self._outdoor_temperature = None
         self._selected_schema = None
+        self._last_active_schema = None
         self._preset_mode = None
         self._presets = None
         self._presets_list = None
+        self._boiler_status = None
         self._heating_status = None
         self._cooling_status = None
+        self._dhw_status = None
         self._schema_names = None
         self._schema_status = None
         self._current_temperature = None
@@ -115,8 +120,8 @@ class ThermostatDevice(ClimateDevice):
 
     @property
     def hvac_action(self):
-        """Return the current action."""
-        if self._heating_status:
+        """Return the current hvac action."""
+        if self._heating_status or self._boiler_status or self._dhw_status:
             return CURRENT_HVAC_HEAT
         if self._cooling_status:
             return CURRENT_HVAC_COOL
@@ -143,8 +148,12 @@ class ThermostatDevice(ClimateDevice):
         attributes = {}
         if self._outdoor_temperature:
             attributes["outdoor_temperature"] = self._outdoor_temperature
-        attributes["available_schemas"] = self._schema_names
-        attributes["selected_schema"] = self._selected_schema
+        if self._schema_names:
+            attributes["available_schemas"] = self._schema_names
+        else:
+            attributes["available_schemas"] = "None"
+        if self._selected_schema:
+            attributes["selected_schema"] = self._selected_schema
         if self._boiler_temperature:
             attributes["boiler_temperature"] = self._boiler_temperature
         if self._water_pressure:
@@ -162,7 +171,7 @@ class ThermostatDevice(ClimateDevice):
     @property
     def hvac_modes(self):
         """Return the available hvac modes list."""
-        if self._heating_status is not None:
+        if self._heating_status is not None or self._boiler_status is not None:
             if self._cooling_status is not None:
                 return HVAC_MODES_2
             return HVAC_MODES_1
@@ -173,11 +182,11 @@ class ThermostatDevice(ClimateDevice):
         """Return current active hvac state."""
         if self._schema_status:
             return HVAC_MODE_AUTO
-        if self._heating_status:
+        if self._heating_status or self._boiler_status or self._dhw_status:
             if self._cooling_status:
                 return HVAC_MODE_HEAT_COOL
             return HVAC_MODE_HEAT
-        return None
+        return HVAC_MODE_OFF
 
     @property
     def target_temperature(self):
@@ -193,9 +202,9 @@ class ThermostatDevice(ClimateDevice):
     def preset_mode(self):
         """Return the active selected schedule-name.
 
-        Or return the active preset, or return Temporary in case of a manual change
-        in the set-temperature with a weekschedule active,
-        or return Manual in case of a manual change and no weekschedule active.
+        Or, return the active preset, or return Temporary in case of a manual change
+        in the set-temperature with a weekschedule active.
+        Or return Manual in case of a manual change and no weekschedule active.
         """
         if self._presets:
             presets = self._presets
@@ -248,7 +257,7 @@ class ThermostatDevice(ClimateDevice):
         if hvac_mode == HVAC_MODE_AUTO:
             schema_mode = "true"
         self._api.set_schema_state(
-            self._domain_objects, self._selected_schema, schema_mode
+            self._domain_objects, self._last_active_schema, schema_mode
         )
 
     def set_preset_mode(self, preset_mode):
@@ -259,16 +268,22 @@ class ThermostatDevice(ClimateDevice):
     def update(self):
         """Update the data from the thermostat."""
         _LOGGER.debug("Update called")
+        self._direct_objects = self._api.get_direct_objects()
         self._domain_objects = self._api.get_domain_objects()
         self._outdoor_temperature = self._api.get_outdoor_temperature(
             self._domain_objects
         )
         self._selected_schema = self._api.get_active_schema_name(self._domain_objects)
+        self._last_active_schema = self._api.get_last_active_schema_name(
+            self._domain_objects
+        )
         self._preset_mode = self._api.get_current_preset(self._domain_objects)
         self._presets = self._api.get_presets(self._domain_objects)
         self._presets_list = list(self._api.get_presets(self._domain_objects))
-        self._heating_status = self._api.get_heating_status(self._domain_objects)
-        self._cooling_status = self._api.get_cooling_status(self._domain_objects)
+        self._boiler_status = self._api.get_boiler_status(self._direct_objects)
+        self._heating_status = self._api.get_heating_status(self._direct_objects)
+        self._cooling_status = self._api.get_cooling_status(self._direct_objects)
+        self._dhw_status = self._api.get_domestic_hot_water_status(self._direct_objects)
         self._schema_names = self._api.get_schema_names(self._domain_objects)
         self._schema_status = self._api.get_schema_state(self._domain_objects)
         self._current_temperature = self._api.get_current_temperature(

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -150,8 +150,6 @@ class ThermostatDevice(ClimateDevice):
             attributes["outdoor_temperature"] = self._outdoor_temperature
         if self._schema_names:
             attributes["available_schemas"] = self._schema_names
-        else:
-            attributes["available_schemas"] = "None"
         if self._selected_schema:
             attributes["selected_schema"] = self._selected_schema
         if self._boiler_temperature:

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
   "dependencies": [],
   "codeowners": ["@laetificat", "@CoMPaTech", "@bouwew"],
-  "requirements": ["haanna==0.13.5"]
+  "requirements": ["haanna==0.14.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -637,7 +637,7 @@ ha-ffmpeg==2.0
 ha-philipsjs==0.0.8
 
 # homeassistant.components.plugwise
-haanna==0.13.5
+haanna==0.14.1
 
 # homeassistant.components.habitica
 habitipy==0.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump Haanna to 0.14.1, fixing the reported Home Assistant issues:
fixes #28815
fixes #28947
fixes #30714
and the error reported in haanna issue fixes  #14.
Also, the proposed fix for the issue reported by fwestenberg, related to 2 Annas in one HA system, is included.

Update to climate.py, fixes #28947: add detection of the heating_state for on/off-type heaters via the boiler_state parameter.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
fixes #28815, fixes #28947, fixes #30714 and fixes #28947
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
