### PR TITLE
Add memo text service

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -6,13 +6,13 @@ import velbus
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_PORT
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PORT
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import ATTR_MEMO_TEXT, ATTR_MODULE_ADDRESS, DOMAIN
+from .const import CONF_MEMO_TEXT, DOMAIN, SERVICE_SET_MEMO_TEXT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,10 +82,10 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     def set_memo_text(service):
         """Handle Memo Text service call."""
-        memo_text = service.data[ATTR_MEMO_TEXT]
+        memo_text = service.data[CONF_MEMO_TEXT]
         memo_text.hass = hass
         try:
-            controller.get_module(service.data[ATTR_MODULE_ADDRESS]).set_memo_text(
+            controller.get_module(service.data[CONF_ADDRESS]).set_memo_text(
                 memo_text.async_render()
             )
         except velbus.util.VelbusException as err:
@@ -93,14 +93,14 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     hass.services.async_register(
         DOMAIN,
-        "set_memo_text",
+        SERVICE_SET_MEMO_TEXT,
         set_memo_text,
         vol.Schema(
             {
-                vol.Required(ATTR_MODULE_ADDRESS): vol.All(
+                vol.Required(CONF_ADDRESS): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=255)
                 ),
-                vol.Optional(ATTR_MEMO_TEXT, default=""): cv.template,
+                vol.Optional(CONF_MEMO_TEXT, default=""): cv.template,
             }
         ),
     )

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN
+from .const import ATTR_MEMO_TEXT, ATTR_MODULE_ADDRESS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,6 +79,29 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
             _LOGGER.error("An error occurred: %s", err)
 
     hass.services.async_register(DOMAIN, "sync_clock", syn_clock, schema=vol.Schema({}))
+
+    def set_memo_text(service):
+        """Handle Memo Text service call."""
+        try:
+            controller.get_module(service.data[ATTR_MODULE_ADDRESS]).set_memo_text(
+                service.data[ATTR_MEMO_TEXT]
+            )
+        except velbus.util.VelbusException as err:
+            _LOGGER.error("An error occurred: %s", err)
+
+    hass.services.async_register(
+        DOMAIN,
+        "set_memo_text",
+        set_memo_text,
+        vol.Schema(
+            {
+                vol.Required(ATTR_MODULE_ADDRESS): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=255)
+                ),
+                vol.Optional(ATTR_MEMO_TEXT, default=""): cv.string,
+            }
+        ),
+    )
 
     return True
 

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -82,14 +82,15 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     def set_memo_text(service):
         """Handle Memo Text service call."""
+        module_address service.data[CONF_ADDRESS]
         memo_text = service.data[CONF_MEMO_TEXT]
         memo_text.hass = hass
         try:
-            controller.get_module(service.data[CONF_ADDRESS]).set_memo_text(
+            controller.get_module(module_address).set_memo_text(
                 memo_text.async_render()
             )
         except velbus.util.VelbusException as err:
-            _LOGGER.error("An error occurred: %s", err)
+            _LOGGER.error("An error occurred while setting memo text: %s", err)
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -82,7 +82,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     def set_memo_text(service):
         """Handle Memo Text service call."""
-        module_address service.data[CONF_ADDRESS]
+        module_address = service.data[CONF_ADDRESS]
         memo_text = service.data[CONF_MEMO_TEXT]
         memo_text.hass = hass
         try:

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -82,9 +82,11 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     def set_memo_text(service):
         """Handle Memo Text service call."""
+        memo_text = service.data[ATTR_MEMO_TEXT]
+        memo_text.hass = hass
         try:
             controller.get_module(service.data[ATTR_MODULE_ADDRESS]).set_memo_text(
-                service.data[ATTR_MEMO_TEXT]
+                memo_text.async_render()
             )
         except velbus.util.VelbusException as err:
             _LOGGER.error("An error occurred: %s", err)
@@ -98,7 +100,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
                 vol.Required(ATTR_MODULE_ADDRESS): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=255)
                 ),
-                vol.Optional(ATTR_MEMO_TEXT, default=""): cv.string,
+                vol.Optional(ATTR_MEMO_TEXT, default=""): cv.template,
             }
         ),
     )

--- a/homeassistant/components/velbus/const.py
+++ b/homeassistant/components/velbus/const.py
@@ -1,6 +1,7 @@
 """Const for Velbus."""
 
-ATTR_MEMO_TEXT = "memo_text"
-ATTR_MODULE_ADDRESS = "address"
-
 DOMAIN = "velbus"
+
+CONF_MEMO_TEXT = "memo_text"
+
+SERVICE_SET_MEMO_TEXT = "set_memo_text"

--- a/homeassistant/components/velbus/const.py
+++ b/homeassistant/components/velbus/const.py
@@ -1,3 +1,6 @@
 """Const for Velbus."""
 
+ATTR_MEMO_TEXT = "memo_text"
+ATTR_MODULE_ADDRESS = "address"
+
 DOMAIN = "velbus"

--- a/homeassistant/components/velbus/services.yaml
+++ b/homeassistant/components/velbus/services.yaml
@@ -1,2 +1,18 @@
 sync_clock:
   description: Sync the velbus modules clock to the Home Assistant clock, this is the same as the 'sync clock' from VelbusLink
+
+set_memo_text:
+  description: >
+    Set the memo text to the display of modules like VMBGPO, VMBGPOD
+    Be sure the page(s) of the module is configured to display the memo text.
+  fields:
+    address:
+      description: >
+        The module address in decimal format.
+        The decimal addresses are displayed in front of the modules listed at the integration page.
+      example: '11'
+    memo_text:
+      description: >
+        The actual text to be displayed.
+        Text is limited to 64 characters.
+      example: 'Do not forget trash'


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add service to set the memo text to be displayed at Velbus glass control modules like [VMBGPO(D)](https://www.velbus.eu/products/view/?id=416302) and [VMBELO](https://www.velbus.eu/products/view/?id=439040)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Updates the python-velbus lib to version 2.0.37 to support "Memo text" feature.
- Link to documentation pull request: [#11892](https://github.com/home-assistant/home-assistant.io/pull/11892)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
