### PR TITLE
Update BraviaRC to use a new backend library

### DIFF
--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["braviarc-homeassistant==0.3.7.dev0", "getmac==0.8.1"],
+  "requirements": ["bravia-tv==1.0", "getmac==0.8.1"],
   "dependencies": ["configurator"],
   "codeowners": ["@robbiet480"]
 }

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -2,7 +2,7 @@
 import ipaddress
 import logging
 
-from braviarc.braviarc import BraviaRC
+from bravia_tv import BraviaRC
 from getmac import get_mac_address
 import voluptuous as vol
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -334,7 +334,7 @@ bomradarloop==0.1.3
 boto3==1.9.252
 
 # homeassistant.components.braviatv
-braviarc-homeassistant==0.3.7.dev0
+bravia-tv==1.0
 
 # homeassistant.components.broadlink
 broadlink==0.12.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR swaps: [braviarc-homeassistant/0.3.7.dev0](https://pypi.org/project/braviarc-homeassistant/0.3.7.dev0/) to [bravia-tv](https://pypi.org/project/bravia-tv/1.0/)

BraviaRC is currently unmaintained for home-assistant. This commit swaps it out with a new fork of BraviaRC called python-bravia-tv. This captures all bug fixes from BraviaRC release 3.7 (previously linked backend) to right before BraviaRC breaks when used by home-assistant. The intent of forking is to be able to continue supporting home-assistant. This is not intended to be a one off solution; this new fork will have future updates and be maintain as needed.

This initial commit of python-bravia-tv improves the import process, however overall preserves the original API. Other fixes include:

    * Fix set-volume slider
    * Better error handling
    * Increase input options

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Refer to [https://www.home-assistant.io/integrations/braviatv/](https://www.home-assistant.io/integrations/braviatv/). No changes to external API have been made

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26351, fixes #30964
- This PR is related to issue: #12577, #14843, #17345, #18245
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
