### PR TITLE
Upgrade dsmr_parser to 0.18, re-enable tests

### DIFF
--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dsmr",
   "name": "DSMR Slimme Meter",
   "documentation": "https://www.home-assistant.io/integrations/dsmr",
-  "requirements": ["dsmr_parser==0.12"],
+  "requirements": ["dsmr_parser==0.18"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -447,7 +447,7 @@ doorbirdpy==2.0.8
 dovado==0.4.1
 
 # homeassistant.components.dsmr
-dsmr_parser==0.12
+dsmr_parser==0.18
 
 # homeassistant.components.dweet
 dweepy==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -162,7 +162,7 @@ directpy==0.5
 distro==1.4.0
 
 # homeassistant.components.dsmr
-dsmr_parser==0.12
+dsmr_parser==0.18
 
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -14,15 +14,9 @@ import asynctest
 import pytest
 
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.components.dsmr.sensor import DerivativeDSMREntity
 
 from tests.common import assert_setup_component
-
-# Imports disabled due to missing PyCRC on PyPi
-# Also disabled pylint/flake8 where this is used below
-# from homeassistant.components.dsmr.sensor import DerivativeDSMREntity
-
-
-pytest.skip("Dependency missing on PyPi", allow_module_level=True)
 
 
 @pytest.fixture
@@ -103,9 +97,7 @@ async def test_derivative():
 
     config = {"platform": "dsmr"}
 
-    # Disabled to satisfy pylint & flake8 caused by disabled import
-    # pylint: disable=undefined-variable
-    entity = DerivativeDSMREntity("test", "1.0.0", config)  # noqa: F821
+    entity = DerivativeDSMREntity("test", "1.0.0", config)
     await entity.async_update()
 
     assert entity.state is None, "initial state not unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This reverts a PR I did earlier to fix our CI.

`dsmr_parser` has been updated upstream, to deal with the deleted package on PyPi.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
