### PR TITLE
Add support for rangeValueDeltaDefault in Alexa AdjustRangeValue directive

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1237,7 +1237,9 @@ async def async_api_adjust_range(hass, config, directive, context):
         service = SERVICE_SET_COVER_TILT_POSITION
         current = entity.attributes.get(cover.ATTR_TILT_POSITION)
         if not current:
-            msg = "Unable to determine {} current position".format(entity.entity_id)
+            msg = "Unable to determine {} current tilt position".format(
+                entity.entity_id
+            )
             raise AlexaInvalidValueError(msg)
         tilt_position = response_value = min(100, max(0, range_delta + current))
         if tilt_position == 100:

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1191,6 +1191,7 @@ async def async_api_adjust_range(hass, config, directive, context):
     service = None
     data = {ATTR_ENTITY_ID: entity.entity_id}
     range_delta = directive.payload["rangeValueDelta"]
+    range_delta_default = bool(directive.payload["rangeValueDeltaDefault"])
     response_value = 0
 
     # Fan Speed
@@ -1216,9 +1217,12 @@ async def async_api_adjust_range(hass, config, directive, context):
 
     # Cover Position
     elif instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
-        range_delta = int(range_delta)
+        range_delta = int(range_delta * 20) if range_delta_default else int(range_delta)
         service = SERVICE_SET_COVER_POSITION
         current = entity.attributes.get(cover.ATTR_POSITION)
+        if not current:
+            msg = "Unable to determine {} current position".format(entity.entity_id)
+            raise AlexaInvalidValueError(msg)
         position = response_value = min(100, max(0, range_delta + current))
         if position == 100:
             service = cover.SERVICE_OPEN_COVER
@@ -1229,9 +1233,12 @@ async def async_api_adjust_range(hass, config, directive, context):
 
     # Cover Tilt
     elif instance == f"{cover.DOMAIN}.tilt":
-        range_delta = int(range_delta)
+        range_delta = int(range_delta * 20) if range_delta_default else int(range_delta)
         service = SERVICE_SET_COVER_TILT_POSITION
         current = entity.attributes.get(cover.ATTR_TILT_POSITION)
+        if not current:
+            msg = "Unable to determine {} current position".format(entity.entity_id)
+            raise AlexaInvalidValueError(msg)
         tilt_position = response_value = min(100, max(0, range_delta + current))
         if tilt_position == 100:
             service = cover.SERVICE_OPEN_COVER_TILT

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1586,7 +1586,7 @@ async def test_cover_position_range(hass):
 
     await assert_range_changes(
         hass,
-        [(25, -5, False), (35, 5, False)],
+        [(25, -5, False), (35, 5, False), (50, 1, True), (10, -1, True)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_range",
@@ -2831,7 +2831,7 @@ async def test_cover_tilt_position_range(hass):
 
     await assert_range_changes(
         hass,
-        [(25, -5, False), (35, 5, False)],
+        [(25, -5, False), (35, 5, False), (50, 1, True), (10, -1, True)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_tilt_range",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -753,7 +753,7 @@ async def test_fan_range(hass):
         "fan#test_5",
         "fan.set_speed",
         hass,
-        payload={"rangeValue": "1"},
+        payload={"rangeValue": 1},
         instance="fan.speed",
     )
     assert call.data["speed"] == "low"
@@ -764,14 +764,14 @@ async def test_fan_range(hass):
         "fan#test_5",
         "fan.set_speed",
         hass,
-        payload={"rangeValue": "5"},
+        payload={"rangeValue": 5},
         instance="fan.speed",
     )
     assert call.data["speed"] == "warp_speed"
 
     await assert_range_changes(
         hass,
-        [("low", "-1"), ("high", "1"), ("medium", "0"), ("warp_speed", "99")],
+        [("low", -1), ("high", 1), ("medium", 0), ("warp_speed", 99)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "fan#test_5",
@@ -802,14 +802,14 @@ async def test_fan_range_off(hass):
         "fan#test_6",
         "fan.turn_off",
         hass,
-        payload={"rangeValue": "0"},
+        payload={"rangeValue": 0},
         instance="fan.speed",
     )
     assert call.data["speed"] == "off"
 
     await assert_range_changes(
         hass,
-        [("off", "-3"), ("off", "-99")],
+        [("off", -3), ("off", -99)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "fan#test_6",
@@ -1520,7 +1520,7 @@ async def test_cover_position_range(hass):
         "cover#test_range",
         "cover.set_cover_position",
         hass,
-        payload={"rangeValue": "50"},
+        payload={"rangeValue": 50},
         instance="cover.position",
     )
     assert call.data["position"] == 50
@@ -1531,7 +1531,7 @@ async def test_cover_position_range(hass):
         "cover#test_range",
         "cover.close_cover",
         hass,
-        payload={"rangeValue": "0"},
+        payload={"rangeValue": 0},
         instance="cover.position",
     )
     properties = msg["context"]["properties"][0]
@@ -1545,7 +1545,7 @@ async def test_cover_position_range(hass):
         "cover#test_range",
         "cover.open_cover",
         hass,
-        payload={"rangeValue": "100"},
+        payload={"rangeValue": 100},
         instance="cover.position",
     )
     properties = msg["context"]["properties"][0]
@@ -1559,7 +1559,7 @@ async def test_cover_position_range(hass):
         "cover#test_range",
         "cover.open_cover",
         hass,
-        payload={"rangeValueDelta": "99"},
+        payload={"rangeValueDelta": 99, "rangeValueDeltaDefault": False},
         instance="cover.position",
     )
     properties = msg["context"]["properties"][0]
@@ -1573,7 +1573,7 @@ async def test_cover_position_range(hass):
         "cover#test_range",
         "cover.close_cover",
         hass,
-        payload={"rangeValueDelta": "-99"},
+        payload={"rangeValueDelta": -99, "rangeValueDeltaDefault": False},
         instance="cover.position",
     )
     properties = msg["context"]["properties"][0]
@@ -1583,7 +1583,7 @@ async def test_cover_position_range(hass):
 
     await assert_range_changes(
         hass,
-        [(25, "-5"), (35, "5")],
+        [(25, -5), (35, 5)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_range",
@@ -2484,7 +2484,7 @@ async def test_range_unsupported_domain(hass):
 
     context = Context()
     request = get_new_request("Alexa.RangeController", "SetRangeValue", "switch#test")
-    request["directive"]["payload"] = {"rangeValue": "1"}
+    request["directive"]["payload"] = {"rangeValue": 1}
     request["directive"]["header"]["instance"] = "switch.speed"
 
     msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
@@ -2813,7 +2813,7 @@ async def test_cover_tilt_position_range(hass):
         "cover#test_tilt_range",
         "cover.open_cover_tilt",
         hass,
-        payload={"rangeValueDelta": 99},
+        payload={"rangeValueDelta": 99, "rangeValueDeltaDefault": False},
         instance="cover.tilt",
     )
     properties = msg["context"]["properties"][0]
@@ -2827,7 +2827,7 @@ async def test_cover_tilt_position_range(hass):
         "cover#test_tilt_range",
         "cover.close_cover_tilt",
         hass,
-        payload={"rangeValueDelta": -99},
+        payload={"rangeValueDelta": -99, "rangeValueDeltaDefault": False},
         instance="cover.tilt",
     )
     properties = msg["context"]["properties"][0]
@@ -2837,7 +2837,7 @@ async def test_cover_tilt_position_range(hass):
 
     await assert_range_changes(
         hass,
-        [(25, "-5"), (35, "5")],
+        [(25, -5), (35, 5)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_tilt_range",
@@ -2992,14 +2992,14 @@ async def test_input_number(hass):
         "input_number#test_slider",
         "input_number.set_value",
         hass,
-        payload={"rangeValue": "10"},
+        payload={"rangeValue": 10},
         instance="input_number.value",
     )
     assert call.data["value"] == 10
 
     await assert_range_changes(
         hass,
-        [(25, "-5"), (35, "5"), (-20, "-100"), (35, "100")],
+        [(25, -5), (35, 5), (-20, -100), (35, 100)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "input_number#test_slider",
@@ -3078,14 +3078,14 @@ async def test_input_number_float(hass):
         "input_number#test_slider_float",
         "input_number.set_value",
         hass,
-        payload={"rangeValue": "0.333"},
+        payload={"rangeValue": 0.333},
         instance="input_number.value",
     )
     assert call.data["value"] == 0.333
 
     await assert_range_changes(
         hass,
-        [(0.4, "-0.1"), (0.6, "0.1"), (0, "-100"), (1, "100"), (0.51, "0.01")],
+        [(0.4, -0.1), (0.6, 0.1), (0, -100), (1, 100), (0.51, 0.01)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "input_number#test_slider_float",
@@ -3386,7 +3386,7 @@ async def test_vacuum_fan_speed(hass):
         "vacuum#test_2",
         "vacuum.set_fan_speed",
         hass,
-        payload={"rangeValue": "1"},
+        payload={"rangeValue": 1},
         instance="vacuum.fan_speed",
     )
     assert call.data["fan_speed"] == "low"
@@ -3397,14 +3397,14 @@ async def test_vacuum_fan_speed(hass):
         "vacuum#test_2",
         "vacuum.set_fan_speed",
         hass,
-        payload={"rangeValue": "5"},
+        payload={"rangeValue": 5},
         instance="vacuum.fan_speed",
     )
     assert call.data["fan_speed"] == "super_sucker"
 
     await assert_range_changes(
         hass,
-        [("low", "-1"), ("high", "1"), ("medium", "0"), ("super_sucker", "99")],
+        [("low", -1), ("high", 1), ("medium", 0), ("super_sucker", 99)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "vacuum#test_2",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -771,11 +771,15 @@ async def test_fan_range(hass):
 
     await assert_range_changes(
         hass,
-        [("low", -1), ("high", 1), ("medium", 0), ("warp_speed", 99)],
+        [
+            ("low", -1, False),
+            ("high", 1, False),
+            ("medium", 0, False),
+            ("warp_speed", 99, False),
+        ],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "fan#test_5",
-        False,
         "fan.set_speed",
         "speed",
         instance="fan.speed",
@@ -809,11 +813,10 @@ async def test_fan_range_off(hass):
 
     await assert_range_changes(
         hass,
-        [("off", -3), ("off", -99)],
+        [("off", -3, False), ("off", -99, False)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "fan#test_6",
-        False,
         "fan.turn_off",
         "speed",
         instance="fan.speed",
@@ -1583,11 +1586,10 @@ async def test_cover_position_range(hass):
 
     await assert_range_changes(
         hass,
-        [(25, -5), (35, 5)],
+        [(25, -5, False), (35, 5, False)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_range",
-        False,
         "cover.set_cover_position",
         "position",
         instance="cover.position",
@@ -1614,21 +1616,13 @@ async def assert_percentage_changes(
 
 
 async def assert_range_changes(
-    hass,
-    adjustments,
-    namespace,
-    name,
-    endpoint,
-    delta_default,
-    service,
-    changed_parameter,
-    instance,
+    hass, adjustments, namespace, name, endpoint, service, changed_parameter, instance
 ):
     """Assert an API request making range changes works.
 
     AdjustRangeValue are examples of such requests.
     """
-    for result_range, adjustment in adjustments:
+    for result_range, adjustment, delta_default in adjustments:
         payload = {
             "rangeValueDelta": adjustment,
             "rangeValueDeltaDefault": delta_default,
@@ -2837,11 +2831,10 @@ async def test_cover_tilt_position_range(hass):
 
     await assert_range_changes(
         hass,
-        [(25, -5), (35, 5)],
+        [(25, -5, False), (35, 5, False)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "cover#test_tilt_range",
-        False,
         "cover.set_cover_tilt_position",
         "tilt_position",
         instance="cover.tilt",
@@ -2999,11 +2992,10 @@ async def test_input_number(hass):
 
     await assert_range_changes(
         hass,
-        [(25, -5), (35, 5), (-20, -100), (35, 100)],
+        [(25, -5, False), (35, 5, False), (-20, -100, False), (35, 100, False)],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "input_number#test_slider",
-        False,
         "input_number.set_value",
         "value",
         instance="input_number.value",
@@ -3085,11 +3077,16 @@ async def test_input_number_float(hass):
 
     await assert_range_changes(
         hass,
-        [(0.4, -0.1), (0.6, 0.1), (0, -100), (1, 100), (0.51, 0.01)],
+        [
+            (0.4, -0.1, False),
+            (0.6, 0.1, False),
+            (0, -100, False),
+            (1, 100, False),
+            (0.51, 0.01, False),
+        ],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "input_number#test_slider_float",
-        False,
         "input_number.set_value",
         "value",
         instance="input_number.value",
@@ -3404,11 +3401,15 @@ async def test_vacuum_fan_speed(hass):
 
     await assert_range_changes(
         hass,
-        [("low", -1), ("high", 1), ("medium", 0), ("super_sucker", 99)],
+        [
+            ("low", -1, False),
+            ("high", 1, False),
+            ("medium", 0, False),
+            ("super_sucker", 99, False),
+        ],
         "Alexa.RangeController",
         "AdjustRangeValue",
         "vacuum#test_2",
-        False,
         "vacuum.set_fan_speed",
         "fan_speed",
         instance="vacuum.fan_speed",


### PR DESCRIPTION
## Proposed change
- Adds support for when Alexa returns `"rangeValueDeltaDefault": "true"` for the `AdjustRangeValue` directive. When a user says _"Alexa, increase/decrease the cover position/tilt"_ without specifying a value. The Alexa API returns a default `rangeValue` based on the configured precision, which is 1% for covers position and tilt. This PR multiplies the default by 20, to provide a more significant change.
- This PR also protects for an error when the current cover position is `None`.
- Updates to tests for `RangeController`.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31244
- This PR is related to issue: #31244
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.



The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
