### PR TITLE
Mark device unavailable when it leaves Zigbee network

### DIFF
--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -12,6 +12,8 @@ import logging
 import os
 import traceback
 
+import zigpy.device as zigpy_dev
+
 from homeassistant.components.system_log import LogEntry, _figure_out_source
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import (
@@ -176,9 +178,9 @@ class ZHAGateway:
         """Handle device joined and basic information discovered."""
         self._hass.async_create_task(self.async_device_initialized(device))
 
-    def device_left(self, device):
+    def device_left(self, device: zigpy_dev.Device):
         """Handle device leaving the network."""
-        pass
+        self.async_update_device(device, False)
 
     async def _async_remove_device(self, device, entity_refs):
         if entity_refs is not None:
@@ -315,13 +317,13 @@ class ZHAGateway:
         self.async_update_device(sender)
 
     @callback
-    def async_update_device(self, sender):
+    def async_update_device(self, sender: zigpy_dev.Device, available: bool = True):
         """Update device that has just become available."""
         if sender.ieee in self.devices:
             device = self.devices[sender.ieee]
             # avoid a race condition during new joins
             if device.status is DeviceStatus.INITIALIZED:
-                device.update_available(True)
+                device.update_available(available)
 
     async def async_update_device_storage(self):
         """Update the devices in the store."""

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -1,0 +1,29 @@
+"""Test ZHA Gateway."""
+import zigpy.zcl.clusters.general as general
+
+import homeassistant.components.zha.core.const as zha_const
+
+from .common import async_enable_traffic, async_init_zigpy_device
+
+
+async def test_device_left(hass, config_entry, zha_gateway):
+    """Test zha fan platform."""
+
+    # create zigpy device
+    zigpy_device = await async_init_zigpy_device(
+        hass, [general.Basic.cluster_id], [], None, zha_gateway
+    )
+
+    # load up fan domain
+    await hass.config_entries.async_forward_entry_setup(config_entry, zha_const.SENSOR)
+    await hass.async_block_till_done()
+
+    zha_device = zha_gateway.get_device(zigpy_device.ieee)
+
+    assert zha_device.available is False
+
+    await async_enable_traffic(hass, zha_gateway, [zha_device])
+    assert zha_device.available is True
+
+    zha_gateway.device_left(zigpy_device)
+    assert zha_device.available is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
No

## Proposed change
When a Zigbee device voluntarily leaves the network, mark it as unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
