### PR TITLE
Add PowerController to covers in Alexa

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -400,6 +400,7 @@ class CoverCapabilities(AlexaEntity):
 
     def interfaces(self):
         """Yield the supported interfaces."""
+        yield AlexaPowerController(self.entity)
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & cover.SUPPORT_SET_POSITION:
             yield AlexaRangeController(

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -119,7 +119,9 @@ async def async_api_turn_on(hass, config, directive, context):
         domain = ha.DOMAIN
 
     service = SERVICE_TURN_ON
-    if domain == media_player.DOMAIN:
+    if domain == cover.DOMAIN:
+        service = cover.SERVICE_OPEN_COVER
+    elif domain == media_player.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         power_features = media_player.SUPPORT_TURN_ON | media_player.SUPPORT_TURN_OFF
         if not supported & power_features:
@@ -145,7 +147,9 @@ async def async_api_turn_off(hass, config, directive, context):
         domain = ha.DOMAIN
 
     service = SERVICE_TURN_OFF
-    if domain == media_player.DOMAIN:
+    if entity.domain == cover.DOMAIN:
+        service = cover.SERVICE_CLOSE_COVER
+    elif domain == media_player.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         power_features = media_player.SUPPORT_TURN_ON | media_player.SUPPORT_TURN_OFF
         if not supported & power_features:

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2520,7 +2520,7 @@ async def test_mode_unsupported_domain(hass):
 
 
 async def test_cover(hass):
-    """Test cover discovery."""
+    """Test cover discovery and powerController """
     device = (
         "cover.test",
         "off",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -131,7 +131,7 @@ async def discovery_test(device, hass, expected_endpoints=1):
 def get_capability(capabilities, capability_name, instance=None):
     """Search a set of capabilities for a specific one."""
     for capability in capabilities:
-        if instance and capability["instance"] == instance:
+        if instance and capability.get("instance") == instance:
             return capability
         if not instance and capability["interface"] == capability_name:
             return capability
@@ -1452,7 +1452,11 @@ async def test_cover_position_range(hass):
     assert appliance["friendlyName"] == "Test cover range"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.RangeController", "Alexa.EndpointHealth", "Alexa"
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.RangeController",
+        "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     range_capability = get_capability(capabilities, "Alexa.RangeController")
@@ -2515,6 +2519,32 @@ async def test_mode_unsupported_domain(hass):
     assert msg["payload"]["type"] == "INVALID_DIRECTIVE"
 
 
+async def test_cover(hass):
+    """Test cover discovery."""
+    device = (
+        "cover.test",
+        "off",
+        {"friendly_name": "Test cover", "supported_features": 3, "position": 30},
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "cover#test"
+    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["friendlyName"] == "Test cover"
+
+    assert_endpoint_capabilities(
+        appliance,
+        "Alexa.ModeController",
+        "Alexa.PowerController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    await assert_power_controller_works(
+        "cover#test", "cover.open_cover", "cover.close_cover", hass
+    )
+
+
 async def test_cover_position_mode(hass):
     """Test cover discovery and position using modeController."""
     device = (
@@ -2533,7 +2563,11 @@ async def test_cover_position_mode(hass):
     assert appliance["friendlyName"] == "Test cover mode"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa", "Alexa.ModeController", "Alexa.EndpointHealth"
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.ModeController",
+        "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     mode_capability = get_capability(capabilities, "Alexa.ModeController")
@@ -2752,7 +2786,11 @@ async def test_cover_tilt_position_range(hass):
     assert appliance["friendlyName"] == "Test cover tilt range"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.RangeController", "Alexa.EndpointHealth", "Alexa"
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.RangeController",
+        "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     range_capability = get_capability(capabilities, "Alexa.RangeController")
@@ -2868,7 +2906,11 @@ async def test_cover_semantics_position_and_tilt(hass):
     assert appliance["friendlyName"] == "Test cover semantics"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.RangeController", "Alexa.EndpointHealth", "Alexa"
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.RangeController",
+        "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     # Assert for Position Semantics

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2520,7 +2520,7 @@ async def test_mode_unsupported_domain(hass):
 
 
 async def test_cover(hass):
-    """Test cover discovery and powerController """
+    """Test garage cover discovery and powerController."""
     device = (
         "cover.test",
         "off",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2524,12 +2524,16 @@ async def test_cover(hass):
     device = (
         "cover.test",
         "off",
-        {"friendly_name": "Test cover", "supported_features": 3, "position": 30},
+        {
+            "friendly_name": "Test cover",
+            "supported_features": 3,
+            "device_class": "garage",
+        },
     )
     appliance = await discovery_test(device, hass)
 
     assert appliance["endpointId"] == "cover#test"
-    assert appliance["displayCategories"][0] == "OTHER"
+    assert appliance["displayCategories"][0] == "GARAGE_DOOR"
     assert appliance["friendlyName"] == "Test cover"
 
     assert_endpoint_capabilities(


### PR DESCRIPTION
## Proposed change
This restores the PowerController for covers in Alexa. 

Not all languages support open/close/raise/lower semantics therefore this restores support for _"turn on"_ _"turn off"_ utterances that are supported for all languages.

Honestly, I can't remember why it was removed :confused:


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31244
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
