### PR TITLE
Bump iCloud to 0.9.2 + fix setup log

### DIFF
--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -122,6 +122,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         hass, username, password, icloud_dir, max_interval, gps_accuracy_threshold,
     )
     await hass.async_add_executor_job(account.setup)
+    if not account.devices:
+        return False
+
     hass.data[DOMAIN][username] = account
 
     for component in ICLOUD_COMPONENTS:
@@ -207,3 +210,5 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     hass.services.async_register(
         DOMAIN, SERVICE_ICLOUD_UPDATE, update_account, schema=SERVICE_SCHEMA
     )
+
+    return True

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -98,7 +98,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors[CONF_USERNAME] = "login"
             return await self._show_setup_form(user_input, errors)
 
-        if self.api.requires_2fa:
+        if self.api.requires_2sa:
             return await self.async_step_trusted_device()
 
         return self.async_create_entry(

--- a/homeassistant/components/icloud/manifest.json
+++ b/homeassistant/components/icloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "Apple iCloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/icloud",
-  "requirements": ["pyicloud==0.9.1"],
+  "requirements": ["pyicloud==0.9.2"],
   "dependencies": [],
   "codeowners": ["@Quentame"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1294,7 +1294,7 @@ pyhomeworks==0.0.6
 pyialarm==0.3
 
 # homeassistant.components.icloud
-pyicloud==0.9.1
+pyicloud==0.9.2
 
 # homeassistant.components.intesishome
 pyintesishome==1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -451,7 +451,7 @@ pyheos==0.6.0
 pyhomematic==0.1.63
 
 # homeassistant.components.icloud
-pyicloud==0.9.1
+pyicloud==0.9.2
 
 # homeassistant.components.ipma
 pyipma==2.0.2

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -39,7 +39,7 @@ def mock_controller_service():
     with patch(
         "homeassistant.components.icloud.config_flow.PyiCloudService"
     ) as service_mock:
-        service_mock.return_value.requires_2fa = True
+        service_mock.return_value.requires_2sa = True
         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
         service_mock.return_value.send_verification_code = Mock(return_value=True)
         service_mock.return_value.validate_verification_code = Mock(return_value=True)
@@ -52,7 +52,7 @@ def mock_controller_service_with_cookie():
     with patch(
         "homeassistant.components.icloud.config_flow.PyiCloudService"
     ) as service_mock:
-        service_mock.return_value.requires_2fa = False
+        service_mock.return_value.requires_2sa = False
         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
         service_mock.return_value.send_verification_code = Mock(return_value=True)
         service_mock.return_value.validate_verification_code = Mock(return_value=True)
@@ -65,7 +65,7 @@ def mock_controller_service_send_verification_code_failed():
     with patch(
         "homeassistant.components.icloud.config_flow.PyiCloudService"
     ) as service_mock:
-        service_mock.return_value.requires_2fa = True
+        service_mock.return_value.requires_2sa = True
         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
         service_mock.return_value.send_verification_code = Mock(return_value=False)
         yield service_mock
@@ -77,7 +77,7 @@ def mock_controller_service_validate_verification_code_failed():
     with patch(
         "homeassistant.components.icloud.config_flow.PyiCloudService"
     ) as service_mock:
-        service_mock.return_value.requires_2fa = True
+        service_mock.return_value.requires_2sa = True
         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
         service_mock.return_value.send_verification_code = Mock(return_value=True)
         service_mock.return_value.validate_verification_code = Mock(return_value=False)
@@ -324,7 +324,7 @@ async def test_verification_code_success(hass: HomeAssistantType, service: Magic
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_TRUSTED_DEVICE: 0}
     )
-    service.return_value.requires_2fa = False
+    service.return_value.requires_2sa = False
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_VERIFICATION_CODE: "0"}


### PR DESCRIPTION
##  Proposed change
- Bump pyicloud to 0.9.2
- fix log `ERROR (MainThread) [homeassistant.config_entries] icloud.async_setup_entry did not return boolean`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
