### PR TITLE
Include entries containing a period in their name for mqtt discovery

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -16,8 +16,8 @@ from .const import ATTR_DISCOVERY_HASH, CONF_STATE_TOPIC
 _LOGGER = logging.getLogger(__name__)
 
 TOPIC_MATCHER = re.compile(
-    r"(?P<component>\w+)/(?:(?P<node_id>[a-zA-Z0-9_-]+)/)"
-    r"?(?P<object_id>[a-zA-Z0-9_-]+)/config"
+    r"(?P<component>\w+)/(?:(?P<node_id>[a-zA-Z0-9\._-]+)/)"
+    r"?(?P<object_id>[a-zA-Z0-9\._-]+)/config"
 )
 
 SUPPORTED_COMPONENTS = [


### PR DESCRIPTION
Gentlemen,
this PR changes the patterns used to determine a valid entry for discovery.
On Tasmota firmware we have some sensors like the PMS 5003/7003 or the SDS0X1 adding a `.` (period) on sub-sensor name and are not identified correctly by Home Assistant. 
As a result, the entity will not be created.

Example:
An mqtt sensor created using YAML works:

```
sensor:
  - platform: mqtt
    name: "PM2.5"
    state_topic: "dom_PM2_2F8183/tele/SENSOR"
    value_template: "{{ value_json['SDS0X1']['PM2.5'] }}"
    availability_topic: "dom_PM2_2F8183/tele/LWT"
    payload_available: "Online"
    payload_not_available: "Offline" 
```
The same sensor created with discovery will not work:
```
{ 
   "name":"Wemos PM sensor SDS0X1 PM2.5",
   "stat_t":"~SENSOR",
   "avty_t":"~LWT",
   "frc_upd":true,
   "pl_avail":"Online",
   "pl_not_avail":"Offline",
   "uniq_id":"2F8183_SDS0X1_PM2.5",
   "device":{ 
      "identifiers":[ 
         "2F8183"
      ],
      "connections":[ 
         [ 
            "mac",
            "XX:XX:XX:XX:XX:XX"
         ]
      ]
   },
   "~":"dom_PM2_2F8183/tele/",
   "val_tpl":"{{value_json['SDS0X1']['PM2.5']}}"
}
```
If I force a creation with mosquitto using the very same json but omitting the period on `PM2.5` Home Assistant will accept the code and create the sensor on database.

Would you gently have a look on it?

Yours Truly,
Federico Leoni

Tasmota Support Information
See [Wiki](https://tasmota.github.io/docs) for more information.
See [Chat](https://discord.gg/Ks2Kzd4) for more user experience.
See [Community](https://groups.google.com/d/forum/sonoffusers) for forum.
See [Code of Conduct](https://github.com/arendst/Sonoff-Tasmota/blob/development/CODE_OF_CONDUCT.md)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
We are not aware of eventual issues with this change but we tested just with our firmware. 
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30940
- This PR is related to issue: https://github.com/arendst/Tasmota/issues/7548
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
