### PR TITLE
Let core resolve entity_id for lastfm from username

### DIFF
--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class LastfmSensor(Entity):
         self._unique_id = hashlib.sha256(user.encode("utf-8")).hexdigest()
         self._user = lastfm_api.get_user(user)
         self._name = user
-        self._entity_id = user
+        self._entity_id = slugify(user)
         self._lastfm = lastfm_api
         self._state = "Not Scrobbling"
         self._playcount = None

--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -59,7 +59,6 @@ class LastfmSensor(Entity):
         self._unique_id = hashlib.sha256(user.encode("utf-8")).hexdigest()
         self._user = lastfm_api.get_user(user)
         self._name = user
-        self._entity_id = slugify(user)
         self._lastfm = lastfm_api
         self._state = "Not Scrobbling"
         self._playcount = None
@@ -76,11 +75,6 @@ class LastfmSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
-
-    @property
-    def entity_id(self):
-        """Return the entity ID."""
-        return f"sensor.lastfm_{self._entity_id}"
 
     @property
     def state(self):

--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is the actual fix for #31162 that leads on from the initial work done in https://github.com/home-assistant/home-assistant/pull/31163 to ensure that entity IDs are unique.

The first PR was merged and should be released in `0.105` which will allow users that use the integration to have the unique ID set and avoid BC.

**This one must be merged into the `0.106` release cycle.**



