### PR TITLE
Axis - config flow use new helper functions

### DIFF
--- a/homeassistant/components/axis/__init__.py
+++ b/homeassistant/components/axis/__init__.py
@@ -1,14 +1,22 @@
 """Support for Axis devices."""
 
+import logging
+
 from homeassistant.const import (
     CONF_DEVICE,
+    CONF_HOST,
     CONF_MAC,
+    CONF_PASSWORD,
+    CONF_PORT,
     CONF_TRIGGER_TIME,
+    CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
 )
 
 from .const import CONF_CAMERA, CONF_EVENTS, DEFAULT_TRIGGER_TIME, DOMAIN
 from .device import AxisNetworkDevice, get_device
+
+LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass, config):
@@ -35,7 +43,7 @@ async def async_setup_entry(hass, config_entry):
             config_entry, unique_id=device.api.vapix.params.system_serialnumber
         )
 
-    hass.data[DOMAIN][device.serial] = device
+    hass.data[DOMAIN][config_entry.unique_id] = device
 
     await device.async_update_device_registry()
 
@@ -52,7 +60,13 @@ async def async_unload_entry(hass, config_entry):
 
 async def async_populate_options(hass, config_entry):
     """Populate default options for device."""
-    device = await get_device(hass, config_entry.data[CONF_DEVICE])
+    device = await get_device(
+        hass,
+        host=config_entry.data[CONF_HOST],
+        port=config_entry.data[CONF_PORT],
+        username=config_entry.data[CONF_USERNAME],
+        password=config_entry.data[CONF_PASSWORD],
+    )
 
     supported_formats = device.vapix.params.image_format
     camera = bool(supported_formats)
@@ -64,3 +78,19 @@ async def async_populate_options(hass, config_entry):
     }
 
     hass.config_entries.async_update_entry(config_entry, options=options)
+
+
+async def async_migrate_entry(hass, config_entry):
+    """Migrate old entry."""
+    LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+        device = config_entry.data.pop(CONF_DEVICE)
+        config_entry.data = {**config_entry.data, **device}
+
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry)
+
+    LOGGER.info("Migration to version %s successful", config_entry.version)
+
+    return True

--- a/homeassistant/components/axis/__init__.py
+++ b/homeassistant/components/axis/__init__.py
@@ -84,12 +84,11 @@ async def async_migrate_entry(hass, config_entry):
     """Migrate old entry."""
     LOGGER.debug("Migrating from version %s", config_entry.version)
 
+    #  Flatten configuration but keep old data if user rollbacks HASS
     if config_entry.version == 1:
-        device = config_entry.data.pop(CONF_DEVICE)
-        config_entry.data = {**config_entry.data, **device}
+        config_entry.data = {**config_entry.data, **config_entry.data[CONF_DEVICE]}
 
         config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry)
 
     LOGGER.info("Migration to version %s successful", config_entry.version)
 

--- a/homeassistant/components/axis/camera.py
+++ b/homeassistant/components/axis/camera.py
@@ -9,7 +9,6 @@ from homeassistant.components.mjpeg.camera import (
 )
 from homeassistant.const import (
     CONF_AUTHENTICATION,
-    CONF_DEVICE,
     CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
@@ -35,15 +34,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config = {
         CONF_NAME: config_entry.data[CONF_NAME],
-        CONF_USERNAME: config_entry.data[CONF_DEVICE][CONF_USERNAME],
-        CONF_PASSWORD: config_entry.data[CONF_DEVICE][CONF_PASSWORD],
+        CONF_USERNAME: config_entry.data[CONF_USERNAME],
+        CONF_PASSWORD: config_entry.data[CONF_PASSWORD],
         CONF_MJPEG_URL: AXIS_VIDEO.format(
-            config_entry.data[CONF_DEVICE][CONF_HOST],
-            config_entry.data[CONF_DEVICE][CONF_PORT],
+            config_entry.data[CONF_HOST], config_entry.data[CONF_PORT],
         ),
         CONF_STILL_IMAGE_URL: AXIS_IMAGE.format(
-            config_entry.data[CONF_DEVICE][CONF_HOST],
-            config_entry.data[CONF_DEVICE][CONF_PORT],
+            config_entry.data[CONF_HOST], config_entry.data[CONF_PORT],
         ),
         CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
     }
@@ -76,14 +73,14 @@ class AxisCamera(AxisEntityBase, MjpegCamera):
     async def stream_source(self):
         """Return the stream source."""
         return AXIS_STREAM.format(
-            self.device.config_entry.data[CONF_DEVICE][CONF_USERNAME],
-            self.device.config_entry.data[CONF_DEVICE][CONF_PASSWORD],
+            self.device.config_entry.data[CONF_USERNAME],
+            self.device.config_entry.data[CONF_PASSWORD],
             self.device.host,
         )
 
     def _new_address(self):
         """Set new device address for video stream."""
-        port = self.device.config_entry.data[CONF_DEVICE][CONF_PORT]
+        port = self.device.config_entry.data[CONF_PORT]
         self._mjpeg_url = AXIS_VIDEO.format(self.device.host, port)
         self._still_image_url = AXIS_IMAGE.format(self.device.host, port)
 

--- a/homeassistant/components/axis/strings.json
+++ b/homeassistant/components/axis/strings.json
@@ -23,8 +23,7 @@
             "already_configured": "Device is already configured",
             "bad_config_file": "Bad data from config file",
             "link_local_address": "Link local addresses are not supported",
-            "not_axis_device": "Discovered device not an Axis device",
-            "updated_configuration": "Updated device configuration with new host address"
+            "not_axis_device": "Discovered device not an Axis device"
         }
     }
 }

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 from homeassistant.components import axis
 from homeassistant.components.axis import config_flow
 
-from .test_device import MAC, setup_axis_integration
+from .test_device import MAC, MODEL, NAME, setup_axis_integration
 
 from tests.common import MockConfigEntry, mock_coro
 
@@ -54,12 +54,10 @@ async def test_flow_manual_configuration(hass):
     assert result["type"] == "create_entry"
     assert result["title"] == f"prodnbr - {MAC}"
     assert result["data"] == {
-        axis.CONF_DEVICE: {
-            config_flow.CONF_HOST: "1.2.3.4",
-            config_flow.CONF_USERNAME: "user",
-            config_flow.CONF_PASSWORD: "pass",
-            config_flow.CONF_PORT: 80,
-        },
+        config_flow.CONF_HOST: "1.2.3.4",
+        config_flow.CONF_USERNAME: "user",
+        config_flow.CONF_PASSWORD: "pass",
+        config_flow.CONF_PORT: 80,
         config_flow.CONF_MAC: MAC,
         config_flow.CONF_MODEL: "prodnbr",
         config_flow.CONF_NAME: "prodnbr 0",
@@ -95,11 +93,8 @@ async def test_manual_configuration_update_configuration(hass):
         )
 
     assert result["type"] == "abort"
-    assert result["reason"] == "updated_configuration"
-    assert (
-        device.config_entry.data[config_flow.CONF_DEVICE][config_flow.CONF_HOST]
-        == "2.3.4.5"
-    )
+    assert result["reason"] == "already_configured"
+    assert device.config_entry.data[config_flow.CONF_HOST] == "2.3.4.5"
 
 
 async def test_flow_fails_already_configured(hass):
@@ -223,12 +218,10 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(hass):
     assert result["type"] == "create_entry"
     assert result["title"] == f"prodnbr - {MAC}"
     assert result["data"] == {
-        axis.CONF_DEVICE: {
-            config_flow.CONF_HOST: "1.2.3.4",
-            config_flow.CONF_USERNAME: "user",
-            config_flow.CONF_PASSWORD: "pass",
-            config_flow.CONF_PORT: 80,
-        },
+        config_flow.CONF_HOST: "1.2.3.4",
+        config_flow.CONF_USERNAME: "user",
+        config_flow.CONF_PASSWORD: "pass",
+        config_flow.CONF_PORT: 80,
         config_flow.CONF_MAC: MAC,
         config_flow.CONF_MODEL: "prodnbr",
         config_flow.CONF_NAME: "prodnbr 2",
@@ -271,12 +264,10 @@ async def test_zeroconf_flow(hass):
     assert result["type"] == "create_entry"
     assert result["title"] == f"prodnbr - {MAC}"
     assert result["data"] == {
-        axis.CONF_DEVICE: {
-            config_flow.CONF_HOST: "1.2.3.4",
-            config_flow.CONF_USERNAME: "user",
-            config_flow.CONF_PASSWORD: "pass",
-            config_flow.CONF_PORT: 80,
-        },
+        config_flow.CONF_HOST: "1.2.3.4",
+        config_flow.CONF_USERNAME: "user",
+        config_flow.CONF_PASSWORD: "pass",
+        config_flow.CONF_PORT: 80,
         config_flow.CONF_MAC: MAC,
         config_flow.CONF_MODEL: "prodnbr",
         config_flow.CONF_NAME: "prodnbr 0",
@@ -310,6 +301,15 @@ async def test_zeroconf_flow_updated_configuration(hass):
     """Test that zeroconf update configuration with new parameters."""
     device = await setup_axis_integration(hass)
     assert device.host == "1.2.3.4"
+    assert device.config_entry.data == {
+        config_flow.CONF_HOST: "1.2.3.4",
+        config_flow.CONF_PORT: 80,
+        config_flow.CONF_USERNAME: "username",
+        config_flow.CONF_PASSWORD: "password",
+        config_flow.CONF_MAC: MAC,
+        config_flow.CONF_MODEL: MODEL,
+        config_flow.CONF_NAME: NAME,
+    }
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
@@ -323,11 +323,16 @@ async def test_zeroconf_flow_updated_configuration(hass):
     )
 
     assert result["type"] == "abort"
-    assert result["reason"] == "updated_configuration"
-    assert device.host == "2.3.4.5"
-    assert (
-        device.config_entry.data[config_flow.CONF_DEVICE][config_flow.CONF_PORT] == 8080
-    )
+    assert result["reason"] == "already_configured"
+    assert device.config_entry.data == {
+        config_flow.CONF_HOST: "2.3.4.5",
+        config_flow.CONF_PORT: 8080,
+        config_flow.CONF_USERNAME: "username",
+        config_flow.CONF_PASSWORD: "password",
+        config_flow.CONF_MAC: MAC,
+        config_flow.CONF_MODEL: MODEL,
+        config_flow.CONF_NAME: NAME,
+    }
 
 
 async def test_zeroconf_flow_ignore_non_axis_device(hass):

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -14,18 +14,14 @@ MAC = "00408C12345"
 MODEL = "model"
 NAME = "name"
 
-DEVICE_DATA = {
-    axis.device.CONF_HOST: "1.2.3.4",
-    axis.device.CONF_USERNAME: "username",
-    axis.device.CONF_PASSWORD: "password",
-    axis.device.CONF_PORT: 80,
-}
-
-ENTRY_OPTIONS = {axis.device.CONF_CAMERA: True, axis.device.CONF_EVENTS: True}
+ENTRY_OPTIONS = {axis.CONF_CAMERA: True, axis.CONF_EVENTS: True}
 
 ENTRY_CONFIG = {
-    axis.device.CONF_DEVICE: DEVICE_DATA,
-    axis.device.CONF_MAC: MAC,
+    axis.CONF_HOST: "1.2.3.4",
+    axis.CONF_USERNAME: "username",
+    axis.CONF_PASSWORD: "password",
+    axis.CONF_PORT: 80,
+    axis.CONF_MAC: MAC,
     axis.device.CONF_MODEL: MODEL,
     axis.device.CONF_NAME: NAME,
 }
@@ -76,6 +72,7 @@ async def setup_axis_integration(
         connection_class=config_entries.CONN_CLASS_LOCAL_PUSH,
         options=deepcopy(options),
         entry_id="1",
+        version=2,
     )
     config_entry.add_to_hass(hass)
 
@@ -116,10 +113,10 @@ async def test_device_setup(hass):
     assert forward_entry_setup.mock_calls[1][1] == (entry, "binary_sensor")
     assert forward_entry_setup.mock_calls[2][1] == (entry, "switch")
 
-    assert device.host == DEVICE_DATA[axis.device.CONF_HOST]
+    assert device.host == ENTRY_CONFIG[axis.CONF_HOST]
     assert device.model == ENTRY_CONFIG[axis.device.CONF_MODEL]
     assert device.name == ENTRY_CONFIG[axis.device.CONF_NAME]
-    assert device.serial == ENTRY_CONFIG[axis.device.CONF_MAC]
+    assert device.serial == ENTRY_CONFIG[axis.CONF_MAC]
 
 
 async def test_update_address(hass):
@@ -204,7 +201,7 @@ async def test_get_device_fails(hass):
     with patch(
         "axis.param_cgi.Params.update_brand", side_effect=axislib.Unauthorized
     ), pytest.raises(axis.errors.AuthenticationRequired):
-        await axis.device.get_device(hass, DEVICE_DATA)
+        await axis.device.get_device(hass, host="", port="", username="", password="")
 
 
 async def test_get_device_device_unavailable(hass):
@@ -212,7 +209,7 @@ async def test_get_device_device_unavailable(hass):
     with patch(
         "axis.param_cgi.Params.update_brand", side_effect=axislib.RequestError
     ), pytest.raises(axis.errors.CannotConnect):
-        await axis.device.get_device(hass, DEVICE_DATA)
+        await axis.device.get_device(hass, host="", port="", username="", password="")
 
 
 async def test_get_device_unknown_error(hass):
@@ -220,4 +217,4 @@ async def test_get_device_unknown_error(hass):
     with patch(
         "axis.param_cgi.Params.update_brand", side_effect=axislib.AxisException
     ), pytest.raises(axis.errors.AuthenticationRequired):
-        await axis.device.get_device(hass, DEVICE_DATA)
+        await axis.device.get_device(hass, host="", port="", username="", password="")

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 from homeassistant.components import axis
 from homeassistant.setup import async_setup_component
 
-from .test_device import MAC, setup_axis_integration
+from .test_device import ENTRY_CONFIG, MAC, setup_axis_integration
 
 from tests.common import MockConfigEntry, mock_coro
 
@@ -16,7 +16,7 @@ async def test_setup_device_already_configured(hass):
         assert await async_setup_component(
             hass,
             axis.DOMAIN,
-            {axis.DOMAIN: {"device_name": {axis.config_flow.CONF_HOST: "1.2.3.4"}}},
+            {axis.DOMAIN: {"device_name": {axis.CONF_HOST: "1.2.3.4"}}},
         )
 
     assert not mock_config_entries.flow.mock_calls
@@ -38,7 +38,7 @@ async def test_setup_entry(hass):
 async def test_setup_entry_fails(hass):
     """Test successful setup of entry."""
     entry = MockConfigEntry(
-        domain=axis.DOMAIN, data={axis.device.CONF_MAC: "0123"}, options=True
+        domain=axis.DOMAIN, data={axis.CONF_MAC: "0123"}, options=True
     )
 
     mock_device = Mock()
@@ -63,7 +63,7 @@ async def test_unload_entry(hass):
 
 async def test_populate_options(hass):
     """Test successful populate options."""
-    entry = MockConfigEntry(domain=axis.DOMAIN, data={"device": {}})
+    entry = MockConfigEntry(domain=axis.DOMAIN, data=ENTRY_CONFIG)
     entry.add_to_hass(hass)
 
     with patch.object(axis, "get_device", return_value=mock_coro(Mock())):
@@ -75,3 +75,36 @@ async def test_populate_options(hass):
         axis.CONF_EVENTS: True,
         axis.CONF_TRIGGER_TIME: axis.DEFAULT_TRIGGER_TIME,
     }
+
+
+async def test_migrate_entry(hass):
+    """Test successful migration of entry data."""
+    legacy_config = {
+        axis.CONF_DEVICE: {
+            axis.CONF_HOST: "1.2.3.4",
+            axis.CONF_USERNAME: "username",
+            axis.CONF_PASSWORD: "password",
+            axis.CONF_PORT: 80,
+        },
+        axis.CONF_MAC: "mac",
+        axis.device.CONF_MODEL: "model",
+        axis.device.CONF_NAME: "name",
+    }
+    entry = MockConfigEntry(domain=axis.DOMAIN, data=legacy_config)
+
+    assert entry.data == legacy_config
+    assert entry.version == 1
+
+    await axis.async_migrate_entry(hass, entry)
+
+    assert entry.data == {
+        axis.CONF_HOST: "1.2.3.4",
+        axis.CONF_USERNAME: "username",
+        axis.CONF_PASSWORD: "password",
+        axis.CONF_PORT: 80,
+        axis.CONF_MAC: "mac",
+        axis.device.CONF_MODEL: "model",
+        axis.device.CONF_NAME: "name",
+    }
+    assert entry.version == 2
+    assert axis.CONF_DEVICE not in entry.data

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -98,6 +98,12 @@ async def test_migrate_entry(hass):
     await axis.async_migrate_entry(hass, entry)
 
     assert entry.data == {
+        axis.CONF_DEVICE: {
+            axis.CONF_HOST: "1.2.3.4",
+            axis.CONF_USERNAME: "username",
+            axis.CONF_PASSWORD: "password",
+            axis.CONF_PORT: 80,
+        },
         axis.CONF_HOST: "1.2.3.4",
         axis.CONF_USERNAME: "username",
         axis.CONF_PASSWORD: "password",
@@ -107,4 +113,3 @@ async def test_migrate_entry(hass):
         axis.device.CONF_NAME: "name",
     }
     assert entry.version == 2
-    assert axis.CONF_DEVICE not in entry.data


### PR DESCRIPTION
Simplify Axis entry config to work with config flow helpers

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
