### PR TITLE
Register on HA stop event to gracefully shutdown HomematicIP Cloud connections

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -328,15 +328,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         _LOGGER.info("No matching access point found for access point id %s", hapid)
         return None
 
-    async def async_reset_hap_connections():
-        """Reset all hmip hap connections."""
-        for hap in hass.data[DOMAIN].values():
-            await hap.async_reset()
-            _LOGGER.info("Shut down access point id %s", hap.config_entry.unique_id)
-
-    # Register on HA stop event to gracefully shutdown HomematicIP Cloud connections
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_reset_hap_connections())
-
     return True
 
 
@@ -356,6 +347,14 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     if not await hap.async_setup():
         return False
+    
+    async def async_reset_hap_connection():
+        """Reset hmip hap connections."""
+        await hap.async_reset()
+        _LOGGER.debug("Shut down access point id %s", hap.config_entry.unique_id)
+
+    # Register on HA stop event to gracefully shutdown HomematicIP Cloud connection
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_reset_hap_connection())
 
     # Register hap as device in registry.
     device_registry = await dr.async_get_registry(hass)

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -350,11 +350,11 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     async def async_reset_hap_connection():
         """Reset hmip hap connection."""
-        await async_unload_entry(hass, entry)
+        await hap.async_reset()
         _LOGGER.debug("Reset connection to access point id %s", entry.unique_id)
 
     # Register on HA stop event to gracefully shutdown HomematicIP Cloud connection
-    hap.shutdown_listener = hass.bus.async_listen_once(
+    hap.reset_connection_listener = hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP, async_reset_hap_connection()
     )
 
@@ -377,5 +377,5 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     hap = hass.data[DOMAIN].pop(entry.unique_id)
-    hap.shutdown_listener()
+    hap.reset_connection_listener()
     return await hap.async_reset()

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -349,9 +349,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         return False
 
     async def async_reset_hap_connection():
-        """Reset hmip hap connections."""
-        await hap.async_reset()
-        _LOGGER.debug("Shut down access point id %s", hap.config_entry.unique_id)
+        """Reset hmip hap connection."""
+        await async_unload_entry(hass, entry)
+        _LOGGER.debug("Reset connection to access point id %s", entry.unique_id)
 
     # Register on HA stop event to gracefully shutdown HomematicIP Cloud connection
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_reset_hap_connection())

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -347,7 +347,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     if not await hap.async_setup():
         return False
-    
+
     async def async_reset_hap_connection():
         """Reset hmip hap connections."""
         await hap.async_reset()

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME
+from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import comp_entity_ids
@@ -327,6 +327,15 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
 
         _LOGGER.info("No matching access point found for access point id %s", hapid)
         return None
+
+    async def async_reset_hap_connections():
+        """Reset all hmip hap connections."""
+        for hap in hass.data[DOMAIN].values():
+            await hap.async_reset()
+            _LOGGER.info("Shut down access point id %s", hap.config_entry.unique_id)
+
+    # Register on HA stop event to gracefully shutdown HomematicIP Cloud connections
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_reset_hap_connections())
 
     return True
 

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -354,7 +354,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         _LOGGER.debug("Reset connection to access point id %s", entry.unique_id)
 
     # Register on HA stop event to gracefully shutdown HomematicIP Cloud connection
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_reset_hap_connection())
+    hap.shutdown_listener = hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP, async_reset_hap_connection()
+    )
 
     # Register hap as device in registry.
     device_registry = await dr.async_get_registry(hass)
@@ -375,4 +377,5 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     hap = hass.data[DOMAIN].pop(entry.unique_id)
+    hap.shutdown_listener()
     return await hap.async_reset()

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -81,6 +81,7 @@ class HomematicipHAP:
         self._tries = 0
         self._accesspoint_connected = True
         self.hmip_device_by_entity_id = {}
+        self.shutdown_listener = None
 
     async def async_setup(self, tries: int = 0) -> bool:
         """Initialize connection."""

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -81,7 +81,7 @@ class HomematicipHAP:
         self._tries = 0
         self._accesspoint_connected = True
         self.hmip_device_by_entity_id = {}
-        self.shutdown_listener = None
+        self.reset_connection_listener = None
 
     async def async_setup(self, tries: int = 0) -> bool:
         """Initialize connection."""


### PR DESCRIPTION
## Proposed change
Register on HA stop event to gracefully shutdown HomematicIP Cloud connections

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
