### PR TITLE
Add support for opening and closing states to Homekit GarageDoor

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -83,7 +83,7 @@ class GarageDoorOpener(HomeAccessory):
     def update_state(self, new_state):
         """Update cover state after state changed."""
         hass_state = new_state.state
-        if hass_state in (STATE_OPEN, STATE_OPENING, STATE_CLOSED, STATE_CLOSING):
+        if hass_state in self.HASS_TO_HK_STATE:
             self.char_current_state.set_value(self.HASS_TO_HK_STATE[hass_state])
             if not self._flag_state:
                 self.char_target_state.set_value(
@@ -94,7 +94,9 @@ class GarageDoorOpener(HomeAccessory):
     def target_state_for_hass_state(self, hass_state):
         """Return the target state for the current state.
 
-        If the current state is opening, the target state should be open in order for Homekit to detect the opening state. The same goes for the cloosing state.
+        If the current state is opening, the target state
+        should be open in order for Homekit to detect the
+        opening state. The same goes for the closing state.
         """
         if hass_state == STATE_OPENING:
             return self.HASS_TO_HK_STATE[STATE_OPEN]

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -123,6 +123,26 @@ async def test_garage_door_open_close(hass, hk_driver, cls, events):
     assert len(events) == 4
     assert events[-1].data[ATTR_VALUE] is None
 
+    hass.states.async_set(entity_id, STATE_OPENING)
+    await hass.async_block_till_done()
+    assert acc.char_current_state.value == 2
+    assert acc.char_target_state.value == 0
+
+    hass.states.async_set(entity_id, STATE_OPEN)
+    await hass.async_block_till_done()
+    assert acc.char_current_state.value == 0
+    assert acc.char_target_state.value == 0
+
+    hass.states.async_set(entity_id, STATE_CLOSING)
+    await hass.async_block_till_done()
+    assert acc.char_current_state.value == 3
+    assert acc.char_target_state.value == 1
+
+    hass.states.async_set(entity_id, STATE_CLOSED)
+    await hass.async_block_till_done()
+    assert acc.char_current_state.value == 1
+    assert acc.char_target_state.value == 1
+
 
 async def test_window_set_cover_position(hass, hk_driver, cls, events):
     """Test if accessory and HA are updated accordingly."""


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Home assistant has support for the `opening` and `closing` states for cover's with the `garage` device class. Currently the `opening` and `closing` states are implicitly handled by Homekit, if the cover is open and you press close, it is considered that the cover is closing. However currently it's not possible to set the `opening` or `closing` state manually, for situations where the operation was not triggered by Homekit (e.g. a Home assistant automation or perhaps an analog input using a physical button on the garage door).

I've also added these states to the MQTT component in https://github.com/home-assistant/home-assistant/pull/31259. Together this will allow you to proactively report whether a `GarageDoor` is moving without having triggered the action from Homekit itself. However I think both PR's also make sense apart from each other. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
