### PR TITLE
clean up setup taskwhen component failed to initialize

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -188,12 +188,18 @@ async def _async_setup_component(
 
     if result is False:
         log_error("Integration failed to initialize.")
+        # Cleanup
+        if domain in hass.data[DATA_SETUP]:
+            hass.data[DATA_SETUP].pop(domain)
         return False
     if result is not True:
         log_error(
             f"Integration {domain!r} did not return boolean if setup was "
             "successful. Disabling component."
         )
+        # Cleanup
+        if domain in hass.data[DATA_SETUP]:
+            hass.data[DATA_SETUP].pop(domain)
         return False
 
     if hass.config_entries:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a component fails to initialize in HA start up phase there still will be a "setup task entry" leaked in hass.data[DATA_SETUP] in setup.py. This will prevent any further attempt from setting up the component again later if triggered by discovery. (in async_setup_component() in setup.py:45 if there's an entry already in hass.data[DATA_SETUP] for a component it doesnt run the setup again.)

So the component will only have one time opportunity to setup. If they missed the short HA starting up period for whatever reason, even if the component supports auto discovery and triggers the setup later in discovery they won't be set up as the entry in hass.data[DATA_SETUP] is not removed. This is not flexible and fault-tolerant enough. I think a good design should not have any requirement on the availability of a device. Device can be sometimes unavailable and sometimes available again later. HA should always be able to add the device back through discovery mechanism when they become available later.

The issue we ran into is: in some of our client's environment xiaomi gateway device and raspeberry pi running HA are powered by the same power outlet. They are powered off and powered back on every day. When they are powered on, the xiaomi gateway device always takes longer time to start up. So in the setup of xiaomi gateway component in HA startup phase it would fail as the hardware is not fully started yet. Then an entry in hass.data[DATA_SETUP] in setup.py will leak. Xiaomi gateway component supports auto discovery. When later the device is ready and the discovery mechanism found the device and trigger the setup of the component, it won't be able to run as there's a leaked entry in hass.data[DATA_SETUP].

I'm adding clean up logic when the setup of component failed to give the component an opportunity to be add back later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
