### PR TITLE
Remove code from template alarm_control_panel

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import (
     ENTITY_ID_FORMAT,
-    FORMAT_NUMBER,
     PLATFORM_SCHEMA,
     AlarmControlPanel,
 )
@@ -49,7 +48,6 @@ CONF_ARM_HOME_ACTION = "arm_home"
 CONF_ARM_NIGHT_ACTION = "arm_night"
 CONF_DISARM_ACTION = "disarm"
 CONF_ALARM_CONTROL_PANELS = "panels"
-CONF_CODE_ARM_REQUIRED = "code_arm_required"
 
 ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
     {
@@ -58,7 +56,6 @@ ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
         vol.Optional(CONF_ARM_AWAY_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_ARM_HOME_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_ARM_NIGHT_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
         vol.Optional(CONF_NAME): cv.string,
     }
 )
@@ -83,7 +80,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         arm_away_action = device_config.get(CONF_ARM_AWAY_ACTION)
         arm_home_action = device_config.get(CONF_ARM_HOME_ACTION)
         arm_night_action = device_config.get(CONF_ARM_NIGHT_ACTION)
-        code_arm_required = device_config[CONF_CODE_ARM_REQUIRED]
 
         template_entity_ids = set()
 
@@ -107,7 +103,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 arm_away_action,
                 arm_home_action,
                 arm_night_action,
-                code_arm_required,
                 template_entity_ids,
             )
         )
@@ -128,7 +123,6 @@ class AlarmControlPanelTemplate(AlarmControlPanel):
         arm_away_action,
         arm_home_action,
         arm_night_action,
-        code_arm_required,
         template_entity_ids,
     ):
         """Initialize the panel."""
@@ -139,7 +133,7 @@ class AlarmControlPanelTemplate(AlarmControlPanel):
         self._name = name
         self._template = state_template
         self._disarm_script = None
-        self._code_arm_required = code_arm_required
+
         if disarm_action is not None:
             self._disarm_script = Script(hass, disarm_action)
         self._arm_away_script = None
@@ -191,12 +185,12 @@ class AlarmControlPanelTemplate(AlarmControlPanel):
     @property
     def code_format(self):
         """Return one or more digits/characters."""
-        return FORMAT_NUMBER
+        return None
 
     @property
     def code_arm_required(self):
         """Whether the code is required for arm actions."""
-        return self._code_arm_required
+        return False
 
     async def async_added_to_hass(self):
         """Register callbacks."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
There is no code functionality in the new template alarm_control_panel.  This PR makes the behavior consistent with that.

I suggest this be included in the 0.105.0 release as otherwise I think this will be a breaking change since an unused config option is removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
alarm_control_panel:
  - platform: template
    panels:
      test_panel:
        arm_home:
          service: persistent_notificarion
          data:
            message: "armed"
        disarm:
          service: persistent_notificarion
          data:
            message: "disarmed" 
```

## Additional information
Documentation needs to be fixed too.  TODO.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
