### PR TITLE
Fix misspelled danfoss_air sensor names

### DIFF
--- a/homeassistant/components/danfoss_air/sensor.py
+++ b/homeassistant/components/danfoss_air/sensor.py
@@ -48,10 +48,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ["Danfoss Air Remaining Filter", "%", ReadCommand.filterPercent, None],
         ["Danfoss Air Humidity", "%", ReadCommand.humidity, DEVICE_CLASS_HUMIDITY],
         ["Danfoss Air Fan Step", "%", ReadCommand.fan_step, None],
-        ["Dandoss Air Exhaust Fan Speed", "RPM", ReadCommand.exhaust_fan_speed, None],
-        ["Dandoss Air Supply Fan Speed", "RPM", ReadCommand.supply_fan_speed, None],
+        ["Danfoss Air Exhaust Fan Speed", "RPM", ReadCommand.exhaust_fan_speed, None],
+        ["Danfoss Air Supply Fan Speed", "RPM", ReadCommand.supply_fan_speed, None],
         [
-            "Dandoss Air Dial Battery",
+            "Danfoss Air Dial Battery",
             "%",
             ReadCommand.battery_percent,
             DEVICE_CLASS_BATTERY,


### PR DESCRIPTION
## Breaking change
The names of some danfoss_air sensors include a misspelling of the word `danfoss`.
This typo has been corrected and you will need to adjust all occurrences respectively.
The following sensors are affected:
- `dandoss_air_dial_battery` -> `danfoss_air_dial_battery`
- `dandoss_air_exhaust_fan_speed` -> `danfoss_air_exhaust_fan_speed`
- `dandoss_air_supply_fan_speed` -> `danfoss_air_supply_fan_speed`



## Proposed change
Fix missspelled sensor names.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests