### PR TITLE
Filter int in fan speed_list when yielding RangeController in Alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1393,7 +1393,9 @@ class AlexaRangeController(AlexaCapability):
                     labels.append(AlexaGlobalCatalog.VALUE_MINIMUM)
                 if index == max_value:
                     labels.append(AlexaGlobalCatalog.VALUE_MAXIMUM)
-                self._resource.add_preset(value=index, labels=labels)
+
+                if len(labels) > 0:
+                    self._resource.add_preset(value=index, labels=labels)
 
             return self._resource.serialize_capability_resources()
 

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1386,7 +1386,9 @@ class AlexaRangeController(AlexaCapability):
                 precision=1,
             )
             for index, speed in enumerate(speed_list):
-                labels = [speed.replace("_", " ")]
+                labels = []
+                if isinstance(speed, str):
+                    labels.append(speed.replace("_", " "))
                 if index == 1:
                     labels.append(AlexaGlobalCatalog.VALUE_MINIMUM)
                 if index == max_value:

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -737,6 +737,8 @@ async def test_fan_range(hass):
         },
     } in presets
 
+    assert {"rangeValue": 5} not in presets
+
     assert {
         "rangeValue": 6,
         "presetResources": {

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -669,7 +669,7 @@ async def test_fan_range(hass):
         {
             "friendly_name": "Test fan 5",
             "supported_features": 1,
-            "speed_list": ["off", "low", "medium", "high", "turbo", "warp_speed"],
+            "speed_list": ["off", "low", "medium", "high", "turbo", 5, "warp_speed"],
             "speed": "medium",
         },
     )
@@ -705,7 +705,7 @@ async def test_fan_range(hass):
 
     supported_range = configuration["supportedRange"]
     assert supported_range["minimumValue"] == 0
-    assert supported_range["maximumValue"] == 5
+    assert supported_range["maximumValue"] == 6
     assert supported_range["precision"] == 1
 
     presets = configuration["presets"]
@@ -738,7 +738,7 @@ async def test_fan_range(hass):
     } in presets
 
     assert {
-        "rangeValue": 5,
+        "rangeValue": 6,
         "presetResources": {
             "friendlyNames": [
                 {"@type": "text", "value": {"text": "warp speed", "locale": "en-US"}},
@@ -765,6 +765,17 @@ async def test_fan_range(hass):
         "fan.set_speed",
         hass,
         payload={"rangeValue": 5},
+        instance="fan.speed",
+    )
+    assert call.data["speed"] == 5
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "fan#test_5",
+        "fan.set_speed",
+        hass,
+        payload={"rangeValue": 6},
         instance="fan.speed",
     )
     assert call.data["speed"] == "warp_speed"


### PR DESCRIPTION
## Proposed change

Filters int values from the friendly names when building the RangeController fan speed list in Alexa.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31340
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
