### PR TITLE
Revert "Bump alarmdecoder to 1.13.9"

### DIFF
--- a/homeassistant/components/alarmdecoder/manifest.json
+++ b/homeassistant/components/alarmdecoder/manifest.json
@@ -2,7 +2,9 @@
   "domain": "alarmdecoder",
   "name": "AlarmDecoder",
   "documentation": "https://www.home-assistant.io/integrations/alarmdecoder",
-  "requirements": ["alarmdecoder==1.13.9"],
+  "requirements": [
+    "alarmdecoder==1.13.2"
+  ],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -208,7 +208,7 @@ airly==0.0.2
 aladdin_connect==0.3
 
 # homeassistant.components.alarmdecoder
-alarmdecoder==1.13.9
+alarmdecoder==1.13.2
 
 # homeassistant.components.alpha_vantage
 alpha_vantage==2.1.2


### PR DESCRIPTION
Reverts home-assistant/home-assistant#30303

Fixes #30892

Description:
- alarmdecoder was falsly bumped by me without user validation, which has broken the integration entirely
- since no errors are given out, debugging is troublesome and someone with a alarmdecoder device will need to investigate the changes before it can be bumped again