### PR TITLE
Keep track of the derivative for unit_time

### DIFF
--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -30,7 +30,16 @@ CONF_UNIT = "unit"
 CONF_TIME_WINDOW = "time_window"
 
 # SI Metric prefixes
-UNIT_PREFIXES = {None: 1, "k": 10 ** 3, "G": 10 ** 6, "T": 10 ** 9}
+UNIT_PREFIXES = {
+    None: 1,
+    "n": 1e-9,
+    "µ": 1e-6,
+    "m": 1e-3,
+    "k": 1e3,
+    "M": 1e6,
+    "G": 1e9,
+    "T": 1e12,
+}
 
 # SI Time prefixes
 UNIT_TIME = {"s": 1, "min": 60, "h": 60 * 60, "d": 24 * 60 * 60}

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_UNIT_PREFIX, default=None): vol.In(UNIT_PREFIXES),
         vol.Optional(CONF_UNIT_TIME, default="h"): vol.In(UNIT_TIME),
         vol.Optional(CONF_UNIT): cv.string,
-        vol.Optional(CONF_TIME_WINDOW): vol.Coerce(float),
+        vol.Optional(CONF_TIME_WINDOW): cv.time_period,
     }
 )
 
@@ -101,7 +101,7 @@ class DerivativeSensor(RestoreEntity):
         if time_window is None:
             self._time_window = 0
         else:
-            self._time_window = time_window * self._unit_time
+            self._time_window = time_window * _unit_time
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -126,7 +126,7 @@ class DerivativeSensor(RestoreEntity):
             now = new_state.last_updated
             self._state_list.append((now, new_state.state))
 
-            # Get indices of tuples that are older than `unit_time`
+            # Get indices of tuples that are older than `time_window`
             to_remove = []
             for i, (timestamp, _) in enumerate(self._state_list[:-1]):
                 if (now - timestamp).total_seconds() > self._time_window:

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -124,7 +124,7 @@ class DerivativeSensor(RestoreEntity):
             now = new_state.last_updated
             self._state_list.append((now, new_state.state))
 
-            # Get indices of tuples that are older than `time_window`
+            # Get indices of tuples that are older than (and outside of the) `time_window`
             to_remove = []
             for i, (timestamp, _) in enumerate(self._state_list[:-1]):
                 if (now - timestamp).total_seconds() > self._time_window:

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -99,7 +99,7 @@ class DerivativeSensor(RestoreEntity):
 
         self._unit_prefix = UNIT_PREFIXES[unit_prefix]
         self._unit_time = UNIT_TIME[unit_time]
-        self._time_window = time_window * _unit_time
+        self._time_window = time_window.total_seconds()
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -142,7 +142,6 @@ class DerivativeSensor(RestoreEntity):
             if len(self._state_list) == 0:
                 self._state_list.append((old_state.last_updated, old_state.state))
             self._state_list.append((new_state.last_updated, new_state.state))
-            _LOGGER.debug("Current state_list for %s: %s", self._name, self._state_list)
 
             if self._unit_of_measurement is None:
                 unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -162,13 +161,6 @@ class DerivativeSensor(RestoreEntity):
                     / Decimal(elapsed_time)
                     / Decimal(self._unit_prefix)
                     * Decimal(self._unit_time)
-                )
-
-                _LOGGER.debug(
-                    "Δy is %s and Δx is %s, so Δy/Δx is %s (in the correct unit)",
-                    delta_value,
-                    elapsed_time,
-                    derivative,
                 )
                 assert isinstance(derivative, Decimal)
             except ValueError as err:

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -38,6 +38,7 @@ UNIT_TIME = {"s": 1, "min": 60, "h": 60 * 60, "d": 24 * 60 * 60}
 ICON = "mdi:chart-line"
 
 DEFAULT_ROUND = 3
+DEFAULT_TIME_WINDOW = 0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -47,7 +48,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_UNIT_PREFIX, default=None): vol.In(UNIT_PREFIXES),
         vol.Optional(CONF_UNIT_TIME, default="h"): vol.In(UNIT_TIME),
         vol.Optional(CONF_UNIT): cv.string,
-        vol.Optional(CONF_TIME_WINDOW): cv.time_period,
+        vol.Optional(CONF_TIME_WINDOW, default=DEFAULT_TIME_WINDOW): cv.time_period,
     }
 )
 
@@ -61,7 +62,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         config[CONF_UNIT_PREFIX],
         config[CONF_UNIT_TIME],
         config.get(CONF_UNIT),
-        config.get(CONF_TIME_WINDOW),
+        config[CONF_TIME_WINDOW],
     )
 
     async_add_entities([derivative])
@@ -98,10 +99,7 @@ class DerivativeSensor(RestoreEntity):
 
         self._unit_prefix = UNIT_PREFIXES[unit_prefix]
         self._unit_time = UNIT_TIME[unit_time]
-        if time_window is None:
-            self._time_window = 0
-        else:
-            self._time_window = time_window * _unit_time
+        self._time_window = time_window * _unit_time
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -157,8 +157,11 @@ class DerivativeSensor(RestoreEntity):
 
                 elapsed_time = (last_time - first_time).total_seconds()
                 delta_value = Decimal(last_value) - Decimal(first_value)
-                derivative = delta_value / (
-                    Decimal(elapsed_time) * Decimal(self._unit_prefix * self._unit_time)
+                derivative = (
+                    delta_value
+                    / Decimal(elapsed_time)
+                    / Decimal(self._unit_prefix)
+                    * Decimal(self._unit_time)
                 )
 
                 _LOGGER.debug(

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -129,6 +129,11 @@ class DerivativeSensor(RestoreEntity):
             for i in reversed(to_remove):
                 self._state_list.pop(i)
 
+            # It can happen that the list only has one entry, in that case
+            # we use the old_state, because we cannot do anything better.
+            if len(self._state_list) == 1:
+                self._state_list.insert(0, (old_state.last_updated, old_state.state))
+
             if self._unit_of_measurement is None:
                 unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
                 self._unit_of_measurement = self._unit_template.format(

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -108,7 +108,6 @@ class DerivativeSensor(RestoreEntity):
         @callback
         def calc_derivative(entity, old_state, new_state):
             """Handle the sensor state changes."""
-
             if (
                 old_state is None
                 or old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
@@ -120,11 +119,12 @@ class DerivativeSensor(RestoreEntity):
             self._state_list.append((now, new_state.state))
 
             # Get indices of tuples that are older than `unit_time`
-            to_remove = [
-                i
-                for i, (timestamp, _) in enumerate(self._state_list)
-                if (now - timestamp).total_seconds() > self._unit_time
-            ]
+            to_remove = []
+            for i, (timestamp, _) in enumerate(self._state_list):
+                if (now - timestamp).total_seconds() > self._unit_time:
+                    to_remove.append(i)
+                else:
+                    break
             # Delete those tuples from the list
             for i in reversed(to_remove):
                 self._state_list.pop(i)

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -77,21 +77,26 @@ async def setup_tests(hass, config, times, values, expected_state):
 
 async def test_dataSet1(hass):
     """Test derivative sensor state."""
-    times, values = zip(*[(20, 10), (30, 30), (40, 5), (50, 0)])
-    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=-0.5)
+    await setup_tests(
+        hass,
+        {"unit_time": "s"},
+        times=[20, 30, 40, 50],
+        values=[10, 30, 5, 0],
+        expected_state=-0.5,
+    )
 
 
 async def test_dataSet2(hass):
     """Test derivative sensor state."""
-    times, values = zip(*[(20, 5), (30, 0)])
-    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=-0.5)
+    await setup_tests(
+        hass, {"unit_time": "s"}, times=[20, 30], values=[5, 0], expected_state=-0.5
+    )
 
 
 async def test_dataSet3(hass):
     """Test derivative sensor state."""
-    times, values = zip(*[(20, 5), (30, 10)])
     state = await setup_tests(
-        hass, {"unit_time": "s"}, times, values, expected_state=0.5
+        hass, {"unit_time": "s"}, times=[20, 30], values=[5, 10], expected_state=0.5
     )
 
     assert state.attributes.get("unit_of_measurement") == "/s"
@@ -99,20 +104,21 @@ async def test_dataSet3(hass):
 
 async def test_dataSet4(hass):
     """Test derivative sensor state."""
-    times, values = zip(*[(20, 5), (30, 5)])
-    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=0)
+    await setup_tests(
+        hass, {"unit_time": "s"}, times=[20, 30], values=[5, 5], expected_state=0
+    )
 
 
 async def test_dataSet5(hass):
     """Test derivative sensor state."""
-    times, values = zip(*[(20, 10), (30, -10)])
-    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=-2)
+    await setup_tests(
+        hass, {"unit_time": "s"}, times=[20, 30], values=[10, -10], expected_state=-2
+    )
 
 
 async def test_dataSet6(hass):
     """Test derivative sensor state."""
-    times, values = zip(*[(0, 0), (60, 1 / 60)])
-    await setup_tests(hass, {}, times, values, expected_state=1)
+    await setup_tests(hass, {}, times=[0, 60], values=[0, 1 / 60], expected_state=1)
 
 
 async def test_data_moving_average_for_discrete_sensor(hass):
@@ -142,7 +148,7 @@ async def test_data_moving_average_for_discrete_sensor(hass):
             state = hass.states.get("sensor.power")
             derivative = round(float(state.state), config["sensor"]["round"])
             # Test that the error is never more than
-            # (time_window_in_minutes / true_derivative * 100) =10%
+            # (time_window_in_minutes / true_derivative * 100) = 10%
             assert abs(1 - derivative) <= 0.1
 
 

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -124,9 +124,11 @@ async def test_dataSet6(hass):
 async def test_data_moving_average_for_discrete_sensor(hass):
     """Test derivative sensor state."""
     # We simulate the following situation:
-    # The temperature rises 1 degree per minute, for 1 hour long.
-    # There is a data point every second. However, the sensor returns
+    # The temperature rises 1 °C per minute for 1 hour long.
+    # There is a data point every second, however, the sensor returns
     # the temperature rounded down to an integer value.
+    # We use a time window of 10 minutes and therefore we can expect
+    # (because the true derivative is 1 °C/min) an error of less than 10%.
 
     temperature_values = []
     for temperature in range(60):

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -38,9 +38,9 @@ async def test_state(hass):
     assert state.attributes.get("unit_of_measurement") == "kW"
 
 
-async def test_dataSet1(hass):
+async def setup_tests(hass, config, times, values, expected_state):
     """Test derivative sensor state."""
-    config = {
+    default_config = {
         "sensor": {
             "platform": "derivative",
             "name": "power",
@@ -49,7 +49,7 @@ async def test_dataSet1(hass):
             "round": 2,
         }
     }
-
+    config = dict(default_config, **config)
     assert await async_setup_component(hass, "sensor", config)
 
     entity_id = config["sensor"]["source"]
@@ -57,7 +57,7 @@ async def test_dataSet1(hass):
     await hass.async_block_till_done()
 
     # Testing a energy sensor with non-monotonic intervals and values
-    for time, value in [(20, 10), (30, 30), (40, 5), (50, 0)]:
+    for time, value in zip(times, values):
         now = dt_util.utcnow() + timedelta(seconds=time)
         with patch("homeassistant.util.dt.utcnow", return_value=now):
             hass.states.async_set(entity_id, value, {}, force_update=True)
@@ -66,163 +66,47 @@ async def test_dataSet1(hass):
     state = hass.states.get("sensor.power")
     assert state is not None
 
-    assert round(float(state.state), config["sensor"]["round"]) == -0.5
+    assert round(float(state.state), config["sensor"]["round"]) == expected_state
+
+    return state
+
+
+async def test_dataSet1(hass):
+    """Test derivative sensor state."""
+    times, values = zip(*[(20, 10), (30, 30), (40, 5), (50, 0)])
+    await setup_tests(hass, {}, times, values, expected_state=-0.5)
 
 
 async def test_dataSet2(hass):
     """Test derivative sensor state."""
-    config = {
-        "sensor": {
-            "platform": "derivative",
-            "name": "power",
-            "source": "sensor.energy",
-            "unit_time": "s",
-            "round": 2,
-        }
-    }
-
-    assert await async_setup_component(hass, "sensor", config)
-
-    entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 0, {})
-    await hass.async_block_till_done()
-
-    # Testing a energy sensor with non-monotonic intervals and values
-    for time, value in [(20, 5), (30, 0)]:
-        now = dt_util.utcnow() + timedelta(seconds=time)
-        with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
-            await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.power")
-    assert state is not None
-
-    assert round(float(state.state), config["sensor"]["round"]) == -0.5
+    times, values = zip(*[(20, 5), (30, 0)])
+    await setup_tests(hass, {}, times, values, expected_state=-0.5)
 
 
 async def test_dataSet3(hass):
     """Test derivative sensor state."""
-    config = {
-        "sensor": {
-            "platform": "derivative",
-            "name": "power",
-            "source": "sensor.energy",
-            "unit_time": "s",
-            "round": 2,
-        }
-    }
-
-    assert await async_setup_component(hass, "sensor", config)
-
-    entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 0, {})
-    await hass.async_block_till_done()
-
-    # Testing a energy sensor with non-monotonic intervals and values
-    for time, value in [(20, 5), (30, 10)]:
-        now = dt_util.utcnow() + timedelta(seconds=time)
-        with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
-            await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.power")
-    assert state is not None
-
-    assert round(float(state.state), config["sensor"]["round"]) == 0.5
+    times, values = zip(*[(20, 5), (30, 10)])
+    state = await setup_tests(hass, {}, times, values, expected_state=0.5)
 
     assert state.attributes.get("unit_of_measurement") == "/s"
 
 
 async def test_dataSet4(hass):
     """Test derivative sensor state."""
-    config = {
-        "sensor": {
-            "platform": "derivative",
-            "name": "power",
-            "source": "sensor.energy",
-            "unit_time": "s",
-            "round": 2,
-        }
-    }
-
-    assert await async_setup_component(hass, "sensor", config)
-
-    entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 0, {})
-    await hass.async_block_till_done()
-
-    # Testing a energy sensor with non-monotonic intervals and values
-    for time, value in [(20, 5), (30, 5)]:
-        now = dt_util.utcnow() + timedelta(seconds=time)
-        with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
-            await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.power")
-    assert state is not None
-
-    assert round(float(state.state), config["sensor"]["round"]) == 0
+    times, values = zip(*[(20, 5), (30, 5)])
+    await setup_tests(hass, {}, times, values, expected_state=0)
 
 
 async def test_dataSet5(hass):
     """Test derivative sensor state."""
-    config = {
-        "sensor": {
-            "platform": "derivative",
-            "name": "power",
-            "source": "sensor.energy",
-            "unit_time": "s",
-            "round": 2,
-        }
-    }
-
-    assert await async_setup_component(hass, "sensor", config)
-
-    entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 0, {})
-    await hass.async_block_till_done()
-
-    # Testing a energy sensor with non-monotonic intervals and values
-    for time, value in [(20, 10), (30, -10)]:
-        now = dt_util.utcnow() + timedelta(seconds=time)
-        with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
-            await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.power")
-    assert state is not None
-
-    assert round(float(state.state), config["sensor"]["round"]) == -2
+    times, values = zip(*[(20, 10), (30, -10)])
+    await setup_tests(hass, {}, times, values, expected_state=-2)
 
 
 async def test_dataSet6(hass):
     """Test derivative sensor state."""
-    config = {
-        "sensor": {
-            "platform": "derivative",
-            "name": "power",
-            "source": "sensor.energy",
-            "round": 2,
-        }
-    }
-
-    assert await async_setup_component(hass, "sensor", config)
-
-    entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 0, {})
-    await hass.async_block_till_done()
-
-    # Testing a energy sensor with non-monotonic intervals and values
-    for time, value in [(20, 0), (30, 36000)]:
-        now = dt_util.utcnow() + timedelta(seconds=time)
-        with patch("homeassistant.util.dt.utcnow", return_value=now):
-            hass.states.async_set(entity_id, value, {}, force_update=True)
-            await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.power")
-    assert state is not None
-
-    assert round(float(state.state), config["sensor"]["round"]) == 1
+    times, values = zip(*[(20, 0), (30, 36000)])
+    await setup_tests(hass, {}, times, values, expected_state=1)
 
 
 async def test_prefix(hass):

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -43,7 +43,6 @@ async def _setup_sensor(hass, config):
         "platform": "derivative",
         "name": "power",
         "source": "sensor.energy",
-        "unit_time": "s",
         "round": 2,
     }
 
@@ -79,19 +78,21 @@ async def setup_tests(hass, config, times, values, expected_state):
 async def test_dataSet1(hass):
     """Test derivative sensor state."""
     times, values = zip(*[(20, 10), (30, 30), (40, 5), (50, 0)])
-    await setup_tests(hass, {}, times, values, expected_state=-0.5)
+    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=-0.5)
 
 
 async def test_dataSet2(hass):
     """Test derivative sensor state."""
     times, values = zip(*[(20, 5), (30, 0)])
-    await setup_tests(hass, {}, times, values, expected_state=-0.5)
+    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=-0.5)
 
 
 async def test_dataSet3(hass):
     """Test derivative sensor state."""
     times, values = zip(*[(20, 5), (30, 10)])
-    state = await setup_tests(hass, {}, times, values, expected_state=0.5)
+    state = await setup_tests(
+        hass, {"unit_time": "s"}, times, values, expected_state=0.5
+    )
 
     assert state.attributes.get("unit_of_measurement") == "/s"
 
@@ -99,18 +100,18 @@ async def test_dataSet3(hass):
 async def test_dataSet4(hass):
     """Test derivative sensor state."""
     times, values = zip(*[(20, 5), (30, 5)])
-    await setup_tests(hass, {}, times, values, expected_state=0)
+    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=0)
 
 
 async def test_dataSet5(hass):
     """Test derivative sensor state."""
     times, values = zip(*[(20, 10), (30, -10)])
-    await setup_tests(hass, {}, times, values, expected_state=-2)
+    await setup_tests(hass, {"unit_time": "s"}, times, values, expected_state=-2)
 
 
 async def test_dataSet6(hass):
     """Test derivative sensor state."""
-    times, values = zip(*[(20, 0), (30, 36000)])
+    times, values = zip(*[(0, 0), (60, 1 / 60)])
     await setup_tests(hass, {}, times, values, expected_state=1)
 
 
@@ -122,9 +123,10 @@ async def test_data_moving_average_for_discrete_sensor(hass):
     # the temperature rounded down to an integer value.
 
     temperature_values = []
-    for minute in range(60):
-        temperature_values += [minute] * 60
+    for temperature in range(60):
+        temperature_values += [temperature] * 60
     time_window = 600
+
     times = list(range(len(temperature_values)))
     config, entity_id = await _setup_sensor(
         hass, {"time_window": {"seconds": time_window}, "unit_time": "min", "round": 1}
@@ -136,10 +138,11 @@ async def test_data_moving_average_for_discrete_sensor(hass):
             hass.states.async_set(entity_id, value, {}, force_update=True)
             await hass.async_block_till_done()
 
-        if time_window < time < len(times) - time_window:
+        if time_window < time < times[-1] - time_window:
             state = hass.states.get("sensor.power")
             derivative = round(float(state.state), config["sensor"]["round"])
-            # Test that the error is never more than 10%
+            # Test that the error is never more than
+            # (time_window_in_minutes / true_derivative * 100) =10%
             assert abs(1 - derivative) <= 0.1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The derivative component is still in beta.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With this implementation, we will get a better estimate of the derivate during the timescale that is relevant to the sensor (indicated by the new option `time_window`).

This solves a problem where sensors have a low output resolution.
For example, a temperature sensor that can only report integer numbers (or half-integer).
It might report values every few seconds that are the same (e.g. 18 deg) and then suddenly go up one value (to 19 deg).
**Only** at that moment (with the current implementation) the derivative will be finite, otherwise, it will be zero. This instantaneous derivative isn't a good estimate of the true derivative.

The problem is captured by the following plot:
```python
import matplotlib.pyplot as plt
import numpy as np
xs = np.linspace(0, 2 * np.pi)
true_sensor = 4 * np.sin(xs)
sensor_output = np.round(true_sensor, 0)
plt.plot(xs, true_sensor, label='true sensor')
plt.plot(xs, sensor_output, label='sensor value')
plt.scatter(xs, sensor_output, c="C1")
plt.plot(xs, np.gradient(sensor_output), label='calculated derivative (with current method)')
plt.plot(xs, 5*np.cos(xs), label='true derivative')
plt.legend()
```

![image](https://user-images.githubusercontent.com/6897215/73616114-8e0ea680-460f-11ea-92c2-2391c673bf48.png)

With my proposed implementation, this problem will not occur, because it takes the average derivative of `time_window`.

I have added a `time_window` option, if you leave it out or if you set it to 0, the behavior is as it is in the `dev` branch.

Config example:
```
sensor:
  - platform: derivative
    source: sensor.gas_consumption
    name: Gas per hour
    unit: m³/h
    unit_time: h
    time_window: "00:30:00"
```
will average over the last half hour.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/11963

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for https://github.com/home-assistant/home-assistant.io/pull/11963
If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
