### PR TITLE
Add optimistic mode for somfy covers that do not support position

### DIFF
--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -60,9 +60,7 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    hass.data[DOMAIN][CONF_OPTIMISTIC] = False
-    if CONF_OPTIMISTIC in config[DOMAIN]:
-        hass.data[DOMAIN][CONF_OPTIMISTIC] = config[DOMAIN][CONF_OPTIMISTIC]
+    hass.data[DOMAIN][CONF_OPTIMISTIC] = config[DOMAIN][CONF_OPTIMISTIC]
 
     config_flow.SomfyFlowHandler.async_register_implementation(
         hass,

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -32,7 +32,7 @@ DOMAIN = "somfy"
 
 CONF_CLIENT_ID = "client_id"
 CONF_CLIENT_SECRET = "client_secret"
-CONF_SHADOW = "shadow_cover"
+CONF_OPTIMISTIC = "optimisitic"
 
 SOMFY_AUTH_CALLBACK_PATH = "/auth/somfy/callback"
 SOMFY_AUTH_START = "/auth/somfy"
@@ -43,7 +43,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Required(CONF_CLIENT_SECRET): cv.string,
-                vol.Optional(CONF_SHADOW): cv.boolean,
+                vol.Optional(CONF_OPTIMISTIC): cv.boolean,
             }
         )
     },
@@ -60,9 +60,9 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    hass.data[DOMAIN][CONF_SHADOW] = False
-    if CONF_SHADOW in config[DOMAIN].keys():
-        hass.data[DOMAIN][CONF_SHADOW] = config[DOMAIN][CONF_SHADOW]
+    hass.data[DOMAIN][CONF_OPTIMISTIC] = False
+    if CONF_OPTIMISTIC in config[DOMAIN].keys():
+        hass.data[DOMAIN][CONF_OPTIMISTIC] = config[DOMAIN][CONF_OPTIMISTIC]
 
     config_flow.SomfyFlowHandler.async_register_implementation(
         hass,

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -43,7 +43,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Required(CONF_CLIENT_SECRET): cv.string,
-                vol.Optional(CONF_OPTIMISTIC): cv.boolean,
+                vol.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
             }
         )
     },
@@ -61,7 +61,7 @@ async def async_setup(hass, config):
         return True
 
     hass.data[DOMAIN][CONF_OPTIMISTIC] = False
-    if CONF_OPTIMISTIC in config[DOMAIN].keys():
+    if CONF_OPTIMISTIC in config[DOMAIN]:
         hass.data[DOMAIN][CONF_OPTIMISTIC] = config[DOMAIN][CONF_OPTIMISTIC]
 
     config_flow.SomfyFlowHandler.async_register_implementation(

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -32,6 +32,7 @@ DOMAIN = "somfy"
 
 CONF_CLIENT_ID = "client_id"
 CONF_CLIENT_SECRET = "client_secret"
+CONF_SHADOW = "shadow_cover"
 
 SOMFY_AUTH_CALLBACK_PATH = "/auth/somfy/callback"
 SOMFY_AUTH_START = "/auth/somfy"
@@ -42,6 +43,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Required(CONF_CLIENT_SECRET): cv.string,
+                vol.Optional(CONF_SHADOW): cv.boolean,
             }
         )
     },
@@ -57,6 +59,10 @@ async def async_setup(hass, config):
 
     if DOMAIN not in config:
         return True
+
+    hass.data[DOMAIN][CONF_SHADOW] = False
+    if CONF_SHADOW in config[DOMAIN].keys():
+        hass.data[DOMAIN][CONF_SHADOW] = config[DOMAIN][CONF_SHADOW]
 
     config_flow.SomfyFlowHandler.async_register_implementation(
         hass,

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -8,7 +8,7 @@ from homeassistant.components.cover import (
     CoverDevice,
 )
 
-from . import API, CONF_SHADOW, DEVICES, DOMAIN, SomfyEntity
+from . import API, CONF_OPTIMISTIC, DEVICES, DOMAIN, SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -24,13 +24,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         devices = hass.data[DOMAIN][DEVICES]
 
-        if CONF_SHADOW in hass.data[DOMAIN].keys():
-            shadow = hass.data[DOMAIN][CONF_SHADOW]
-        else:
-            shadow = False
-
         return [
-            SomfyCover(cover, hass.data[DOMAIN][API], shadow)
+            SomfyCover(cover, hass.data[DOMAIN][API], hass.data[DOMAIN][CONF_OPTIMISTIC])
             for cover in devices
             if categories & set(cover.categories)
         ]

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -38,11 +38,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class SomfyCover(SomfyEntity, CoverDevice):
     """Representation of a Somfy cover device."""
 
-    def __init__(self, device, api, shadow):
+    def __init__(self, device, api, optimistic):
         """Initialize the Somfy device."""
         super().__init__(device, api)
         self.cover = Blind(self.device, self.api)
-        self.shadow = shadow
+        self.optimistic = optimistic
         self._closed = None
 
     async def async_update(self):
@@ -52,13 +52,13 @@ class SomfyCover(SomfyEntity, CoverDevice):
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        if self.shadow:
+        if self.optimistic:
             self._closed = True
         self.cover.close()
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        if self.shadow:
+        if self.optimistic:
             self._closed = False
         self.cover.open()
 
@@ -84,7 +84,7 @@ class SomfyCover(SomfyEntity, CoverDevice):
         is_closed = None
         if self.has_capability("position"):
             is_closed = self.cover.is_closed()
-        elif self.shadow:
+        elif self.optimistic:
             is_closed = self._closed
         return is_closed
 

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -25,7 +25,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         devices = hass.data[DOMAIN][DEVICES]
 
         return [
-            SomfyCover(cover, hass.data[DOMAIN][API], hass.data[DOMAIN][CONF_OPTIMISTIC])
+            SomfyCover(
+                cover, hass.data[DOMAIN][API], hass.data[DOMAIN][CONF_OPTIMISTIC]
+            )
             for cover in devices
             if categories & set(cover.categories)
         ]

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -8,7 +8,7 @@ from homeassistant.components.cover import (
     CoverDevice,
 )
 
-from . import API, DEVICES, DOMAIN, SomfyEntity
+from . import API, CONF_SHADOW, DEVICES, DOMAIN, SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -24,8 +24,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         devices = hass.data[DOMAIN][DEVICES]
 
+        if CONF_SHADOW in hass.data[DOMAIN].keys():
+            shadow = hass.data[DOMAIN][CONF_SHADOW]
+        else:
+            shadow = False
+
         return [
-            SomfyCover(cover, hass.data[DOMAIN][API])
+            SomfyCover(cover, hass.data[DOMAIN][API], shadow)
             for cover in devices
             if categories & set(cover.categories)
         ]
@@ -36,10 +41,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class SomfyCover(SomfyEntity, CoverDevice):
     """Representation of a Somfy cover device."""
 
-    def __init__(self, device, api):
+    def __init__(self, device, api, shadow):
         """Initialize the Somfy device."""
         super().__init__(device, api)
         self.cover = Blind(self.device, self.api)
+        self.shadow = shadow
+        self._closed = None
 
     async def async_update(self):
         """Update the device with the latest data."""
@@ -48,10 +55,14 @@ class SomfyCover(SomfyEntity, CoverDevice):
 
     def close_cover(self, **kwargs):
         """Close the cover."""
+        if self.shadow:
+            self._closed = True
         self.cover.close()
 
     def open_cover(self, **kwargs):
         """Open the cover."""
+        if self.shadow:
+            self._closed = False
         self.cover.open()
 
     def stop_cover(self, **kwargs):
@@ -76,6 +87,8 @@ class SomfyCover(SomfyEntity, CoverDevice):
         is_closed = None
         if self.has_capability("position"):
             is_closed = self.cover.is_closed()
+        elif self.shadow:
+            is_closed = self._closed
         return is_closed
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

This adds a shadow (optimistic mode) to Somfy blinds that do not support the position function.
I.e., if "position" is not supported, track the state of the blind via the open/close commands.
This is needed, as otherwise the status is set to "undefined".   While this is OK in Lovelace, when the cover is presented in Homekit, homekit will mark the blind as Closed.    



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
To use the feature add the line ```optimistic: true``` as follows.
It's optional, and defaults to False
```yaml
# Example configuration.yaml
somfy:
  client_id: !secret somfy_id
  client_secret: !secret somfy_secret
  optimistic: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/12019
If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
