### PR TITLE
Fix device name Google Assistant when using aliases

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -399,7 +399,7 @@ class GoogleEntity:
         # use aliases
         aliases = entity_config.get(CONF_ALIASES)
         if aliases:
-            device["name"]["nicknames"] = aliases
+            device["name"]["nicknames"] = [name] + aliases
 
         if self.config.is_local_sdk_active:
             device["otherDeviceIds"] = [{"deviceId": self.entity_id}]

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -121,7 +121,7 @@ async def test_handler_google_actions(hass):
     device = devices[0]
     assert device["id"] == "switch.test"
     assert device["name"]["name"] == "Config name"
-    assert device["name"]["nicknames"] == ["Config alias"]
+    assert device["name"]["nicknames"] == ["Config name", "Config alias"]
     assert device["type"] == "action.devices.types.SWITCH"
     assert device["roomHint"] == "living room"
 

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -104,7 +104,10 @@ DEMO_DEVICES = [
     },
     {
         "id": "light.ceiling_lights",
-        "name": {"name": "Roof Lights", "nicknames": ["top lights", "ceiling lights"]},
+        "name": {
+            "name": "Roof Lights",
+            "nicknames": ["Roof Lights", "top lights", "ceiling lights"],
+        },
         "traits": [
             "action.devices.traits.OnOff",
             "action.devices.traits.Brightness",

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -92,7 +92,10 @@ async def test_sync_message(hass):
             "devices": [
                 {
                     "id": "light.demo_light",
-                    "name": {"name": "Demo Light", "nicknames": ["Hello", "World"]},
+                    "name": {
+                        "name": "Demo Light",
+                        "nicknames": ["Demo Light", "Hello", "World"],
+                    },
                     "traits": [
                         trait.TRAIT_BRIGHTNESS,
                         trait.TRAIT_ONOFF,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Entities exposed to Google Assistant, that have aliases configured, will now expose the configured name, instead of the first configured alias.
Because of that, it might be that entities that have a name and aliases set for Google Assistant, may show up with a "new" name.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

During the set up of my new main/production system, I noticed something weird happening inside my Google Home app when adding devices that have a name, but also provides aliases.

Google seems to ignore the provided `name` when providing `nicknames` (which we call aliases). I have not found any documentation on this, but I was able to reproduce the issue consistently.

See the example config below in this PR for the used test configuration.

Before:

![IMG_31FFC64BFD39-1](https://user-images.githubusercontent.com/195327/73612287-c51e9100-45ea-11ea-9b4b-e0f04a2c0494.jpeg)

After this PR:

![IMG_16AB0EFDD36B-1](https://user-images.githubusercontent.com/195327/73612292-cc459f00-45ea-11ea-9a02-a47cbf92ab37.jpeg)


This PR provides I guess a thing that should be called a workaround? I'm not sure, since I could not find references, but it adds the configured device `name` to the `nicknames` list, if aliases are provided.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
cloud:
  google_actions:
    entity_config:
      climate.bedroom_flynn:
        name: Thermostaat Flynn
        aliases:
          - flynn slaapkamer thermostaat
          - bedroom flynn
          - bedroom flynn thermostat
          - flynn thermostaat
          - flynn thermostat
        room: Slaapkamer Flynn
    filter:
      include_entities:
        - climate.bedroom_flynn
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
