### PR TITLE
Bump pyvizio version and add additional device info

### DIFF
--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "Vizio SmartCast TV",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.1.16"],
+  "requirements": ["pyvizio==0.1.19"],
   "dependencies": [],
   "codeowners": ["@raman325"],
   "config_flow": true,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.16
+pyvizio==0.1.19
 
 # homeassistant.components.velux
 pyvlx==0.2.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -567,7 +567,7 @@ pyvera==0.3.7
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.16
+pyvizio==0.1.19
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -3,7 +3,7 @@ from asynctest import patch
 import pytest
 from pyvizio.const import DEVICE_CLASS_SPEAKER, MAX_VOLUME
 
-from .const import CURRENT_INPUT, INPUT_LIST, UNIQUE_ID
+from .const import CURRENT_INPUT, INPUT_LIST, MODEL, UNIQUE_ID, VERSION
 
 
 class MockInput:
@@ -97,5 +97,11 @@ def vizio_update_fixture():
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
         return_value=True,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_model",
+        return_value=MODEL,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_version",
+        return_value=VERSION,
     ):
         yield

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -1,8 +1,7 @@
 """Configure py.test."""
 from asynctest import patch
 import pytest
-from pyvizio.const import DEVICE_CLASS_SPEAKER
-from pyvizio.vizio import MAX_VOLUME
+from pyvizio.const import DEVICE_CLASS_SPEAKER, MAX_VOLUME
 
 from .const import CURRENT_INPUT, INPUT_LIST, UNIQUE_ID
 
@@ -91,9 +90,9 @@ def vizio_update_fixture():
         return_value=int(MAX_VOLUME[DEVICE_CLASS_SPEAKER] / 2),
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_current_input",
-        return_value=MockInput(CURRENT_INPUT),
+        return_value=CURRENT_INPUT,
     ), patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.get_inputs",
+        "homeassistant.components.vizio.media_player.VizioAsync.get_inputs_list",
         return_value=get_mock_inputs(INPUT_LIST),
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -26,6 +26,8 @@ HOST2 = "192.168.1.2:9000"
 ACCESS_TOKEN = "deadbeef"
 VOLUME_STEP = 2
 UNIQUE_ID = "testid"
+MODEL = "model"
+VERSION = "version"
 
 MOCK_USER_VALID_TV_CONFIG = {
     CONF_NAME: NAME,

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -7,8 +7,8 @@ import pytest
 from pyvizio.const import (
     DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
     DEVICE_CLASS_TV as VIZIO_DEVICE_CLASS_TV,
+    MAX_VOLUME,
 )
-from pyvizio.vizio import MAX_VOLUME
 
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
@@ -107,6 +107,7 @@ async def _test_setup_failure(hass: HomeAssistantType, config: str) -> None:
         assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0
 
 
+# pylint: disable=keyword-arg-before-vararg
 async def _test_service(
     hass: HomeAssistantType,
     vizio_func_name: str,
@@ -203,7 +204,7 @@ async def test_services(
         hass, "mute_off", SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: False}
     )
     await _test_service(
-        hass, "input_switch", SERVICE_SELECT_SOURCE, {ATTR_INPUT_SOURCE: "USB"}, "USB"
+        hass, "set_input", SERVICE_SELECT_SOURCE, {ATTR_INPUT_SOURCE: "USB"}, "USB"
     )
     await _test_service(hass, "vol_up", SERVICE_VOLUME_UP)
     await _test_service(hass, "vol_down", SERVICE_VOLUME_DOWN)

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -107,12 +107,11 @@ async def _test_setup_failure(hass: HomeAssistantType, config: str) -> None:
         assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0
 
 
-# pylint: disable=keyword-arg-before-vararg
 async def _test_service(
     hass: HomeAssistantType,
     vizio_func_name: str,
     ha_service_name: str,
-    additional_service_data: dict = None,
+    additional_service_data: dict,
     *args,
     **kwargs,
 ) -> None:
@@ -195,8 +194,8 @@ async def test_services(
     """Test all Vizio media player entity services."""
     await _test_setup(hass, DEVICE_CLASS_TV, True)
 
-    await _test_service(hass, "pow_on", SERVICE_TURN_ON)
-    await _test_service(hass, "pow_off", SERVICE_TURN_OFF)
+    await _test_service(hass, "pow_on", SERVICE_TURN_ON, None)
+    await _test_service(hass, "pow_off", SERVICE_TURN_OFF, None)
     await _test_service(
         hass, "mute_on", SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: True}
     )
@@ -206,16 +205,16 @@ async def test_services(
     await _test_service(
         hass, "set_input", SERVICE_SELECT_SOURCE, {ATTR_INPUT_SOURCE: "USB"}, "USB"
     )
-    await _test_service(hass, "vol_up", SERVICE_VOLUME_UP)
-    await _test_service(hass, "vol_down", SERVICE_VOLUME_DOWN)
+    await _test_service(hass, "vol_up", SERVICE_VOLUME_UP, None)
+    await _test_service(hass, "vol_down", SERVICE_VOLUME_DOWN, None)
     await _test_service(
         hass, "vol_up", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 1}
     )
     await _test_service(
         hass, "vol_down", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 0}
     )
-    await _test_service(hass, "ch_up", SERVICE_MEDIA_NEXT_TRACK)
-    await _test_service(hass, "ch_down", SERVICE_MEDIA_PREVIOUS_TRACK)
+    await _test_service(hass, "ch_up", SERVICE_MEDIA_NEXT_TRACK, None)
+    await _test_service(hass, "ch_down", SERVICE_MEDIA_PREVIOUS_TRACK, None)
 
 
 async def test_options_update(
@@ -232,7 +231,7 @@ async def test_options_update(
         entry=config_entry, options=new_options,
     )
     assert config_entry.options == updated_options
-    await _test_service(hass, "vol_up", SERVICE_VOLUME_UP, num=VOLUME_STEP)
+    await _test_service(hass, "vol_up", SERVICE_VOLUME_UP, None, num=VOLUME_STEP)
 
 
 async def _test_update_availability_switch(


### PR DESCRIPTION
## Proposed change
`pyvizio` has support for two more device properties so this update bumps the dependent version for `vizio` and adds those two properties to the `device_info` property. There were also some slight changes to how existing `pyvizio` functions were named and functioned so those changes were applied in parallel to the integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
