### PR TITLE
Use SCAN_INTERVAL instead of Throttle for google travel time

### DIFF
--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
 from homeassistant.helpers import location
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,7 +31,7 @@ CONF_TRAVEL_MODE = "travel_mode"
 
 DEFAULT_NAME = "Google Travel Time"
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
+SCAN_INTERVAL = timedelta(minutes=5)
 
 ALL_LANGUAGES = [
     "ar",
@@ -255,7 +254,6 @@ class GoogleTravelTimeSensor(Entity):
         """Return the unit this state is expressed in."""
         return self._unit_of_measurement
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from Google."""
         options_copy = self._options.copy()


### PR DESCRIPTION
## Proposed change

The documentation for google_travel_time was at odds with the implementation. The documentation stated a default scan time of 5 minutes, but the implementation was using Throttle which resulted in the sensor updating at a maximum rate of one API call every 5 minutes. This was especially at odds with a given example at the end of the documentation, which showed updating the sensor every 2 minutes during commute times.

This change brings the implementation in line with the docs by adopting the `SCAN_INTERVAL` constant set to the stated default of 5 minutes and removing the Throttle.

This PR maintains the current default of 5 minutes, but fixes the bug where lower `scan_interval`s would not be respected.

In fixing this issue I also looked at #31167 which adds `scan_interval` support for the NUT integration. I'm unclear if this, or that approach is the preferred implementation method.

Also of note is that I've completely removed the `Throttle` here. Given that this uses a Google Cloud platform API which could result in user charges, I considered keeping a Throttle set to 15 seconds or so to limit potential damage. This can be easily added if requested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

This code snippet will now work- updating once a minute.

```yaml
sensor:
  - platform: google_travel_time
    name: Home to Work
    api_key: #big secret
    origin: Address
    destination: Another address
    scan_interval: 60
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31384
- This PR is related to issue: #31384
- Link to documentation pull request: [The documentation found here is now correct](https://www.home-assistant.io/integrations/google_travel_time/)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

No tests exist for this integration.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

As this PR brings the code up to matching the documentation, docs did not need updating.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
