### PR TITLE
Fix usage of deprecated attr option in auth models

### DIFF
--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -31,22 +31,28 @@ class User:
     """A user."""
 
     name = attr.ib(type=Optional[str])
-    perm_lookup = attr.ib(type=perm_mdl.PermissionLookup, cmp=False)
+    perm_lookup = attr.ib(type=perm_mdl.PermissionLookup, eq=False, order=False)
     id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
     is_owner = attr.ib(type=bool, default=False)
     is_active = attr.ib(type=bool, default=False)
     system_generated = attr.ib(type=bool, default=False)
 
-    groups = attr.ib(type=List[Group], factory=list, cmp=False)
+    groups = attr.ib(type=List[Group], factory=list, eq=False, order=False)
 
     # List of credentials of a user.
-    credentials = attr.ib(type=List["Credentials"], factory=list, cmp=False)
+    credentials = attr.ib(type=List["Credentials"], factory=list, eq=False, order=False)
 
     # Tokens associated with a user.
-    refresh_tokens = attr.ib(type=Dict[str, "RefreshToken"], factory=dict, cmp=False)
+    refresh_tokens = attr.ib(
+        type=Dict[str, "RefreshToken"], factory=dict, eq=False, order=False
+    )
 
     _permissions = attr.ib(
-        type=Optional[perm_mdl.PolicyPermissions], init=False, cmp=False, default=None
+        type=Optional[perm_mdl.PolicyPermissions],
+        init=False,
+        eq=False,
+        order=False,
+        default=None,
     )
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Solve the following `attr` deprecation warning for the option `cmp` by replacing it with `eq` and `order`. See https://www.attrs.org/en/stable/api.html#attr.ib for reference.
```
homeassistant/auth/models.py:34
  /Users/paulus/dev/hass/home-assistant/homeassistant/auth/models.py:34: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
    perm_lookup = attr.ib(type=perm_mdl.PermissionLookup, cmp=False)

homeassistant/auth/models.py:40
  /Users/paulus/dev/hass/home-assistant/homeassistant/auth/models.py:40: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
    groups = attr.ib(type=List[Group], factory=list, cmp=False)

homeassistant/auth/models.py:43
  /Users/paulus/dev/hass/home-assistant/homeassistant/auth/models.py:43: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
    credentials = attr.ib(type=List["Credentials"], factory=list, cmp=False)

homeassistant/auth/models.py:46
  /Users/paulus/dev/hass/home-assistant/homeassistant/auth/models.py:46: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
    refresh_tokens = attr.ib(type=Dict[str, "RefreshToken"], factory=dict, cmp=False)

homeassistant/auth/models.py:49
  /Users/paulus/dev/hass/home-assistant/homeassistant/auth/models.py:49: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
    type=Optional[perm_mdl.PolicyPermissions], init=False, cmp=False, default=None
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
N/A
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31341
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
