### PR TITLE
Actually enable alarmdecoder to see open/close state of bypassed RF zones when armed

### DIFF
--- a/homeassistant/components/alarmdecoder/binary_sensor.py
+++ b/homeassistant/components/alarmdecoder/binary_sensor.py
@@ -138,7 +138,7 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
 
     def _restore_callback(self, zone):
         """Update the zone's state, if needed."""
-        if zone is None or int(zone) == self._zone_number:
+        if zone is None or (int(zone) == self._zone_number and not self._loop):
             self._state = 0
             self.schedule_update_ha_state()
 


### PR DESCRIPTION
…"loop" specified can now "correctly show a bypassed RF zone as open or closed when the alarm is armed" as per specifications.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
According to the AlarmDecoder integration documentation [here](https://www.home-assistant.io/integrations/alarmdecoder/), specifying the `rfid` and `loop` variables "allows Home Assistant to read open/closed status from the raw sensor data **in addition to from the panel display**" and that "it can correctly show a bypassed RF zone as open or closed when the alarm is armed". This was integrated with PR #18477.

However, once the alarm panel tells the integration that the zone is closed, that's that. It doesn't override this using the raw sensor data as it's supposed to. When a zone is bypassed and the alarm is armed, the alarm panel will falsely assert that all zones (even RF) are closed. Perhaps hours or days after the system is armed, when the RF sensor may send its periodic supervisory data, at which point (I assume) HA will recognize this zone as open and overwrite the fake panel off status for it. But that's pretty useless.

My solution that fulfills the specifications of the documentation is: if the `loop` variable is set, then HA should not listen to fault restorations from the panel for that zone. It should hold the RFID messages paramount. That's the whole point of setting `loop`, as the documentation says. Otherwise, just setting `rfid` without `loop` would provide the loop data without instructing HA to use it as the main state. If there is no `loop` data readily available like when HA restarts, my fix ensures that the system will default to the alarm panel's status for the zone. I only changed the fault restore logic since this is only relevant to zones falsely becoming restored upon bypassed arming, not the other way around.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [✓] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
alarmdecoder:
  device:
    type: socket
    host: alarm.yuksel
    port: 10000
  panel_display: false
  autobypass: true
  zones:
    01:
      name: 'Front Door'
      type: 'door'
    02:
      name: 'Back Door'
      type: 'door'
    09:
      name: 'Some Door'
      type: 'garage_door'
      rfid: '0283147'
      loop: 3
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to PR: #18477

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [✓] The code change is tested and works locally.
- [✓] Local tests pass. **Your PR cannot be merged unless tests pass**
- [✓] There is no commented out code in this PR.
- [✓] I have followed the [development checklist][dev-checklist]
- [✓] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
