### PR TITLE
Add color to light template

### DIFF
--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -4,7 +4,11 @@ import logging
 import pytest
 
 from homeassistant import setup
-from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
+)
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import callback
 
@@ -815,6 +819,123 @@ class TestTemplateLight:
         state = self.hass.states.get("light.test_template_light")
 
         assert state.attributes["entity_picture"] == "/local/light.png"
+
+    def test_color_action_no_template(self):
+        """Test setting color with optimistic template."""
+        assert setup.setup_component(
+            self.hass,
+            "light",
+            {
+                "light": {
+                    "platform": "template",
+                    "lights": {
+                        "test_template_light": {
+                            "value_template": "{{1 == 1}}",
+                            "turn_on": {
+                                "service": "light.turn_on",
+                                "entity_id": "light.test_state",
+                            },
+                            "turn_off": {
+                                "service": "light.turn_off",
+                                "entity_id": "light.test_state",
+                            },
+                            "set_color": [
+                                {
+                                    "service": "test.automation",
+                                    "data_template": {
+                                        "entity_id": "test.test_state",
+                                        "h": "{{h}}",
+                                        "s": "{{s}}",
+                                    },
+                                },
+                                {
+                                    "service": "test.automation",
+                                    "data_template": {
+                                        "entity_id": "test.test_state",
+                                        "s": "{{s}}",
+                                        "h": "{{h}}",
+                                    },
+                                },
+                            ],
+                        }
+                    },
+                }
+            },
+        )
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("light.test_template_light")
+        assert state.attributes.get("hs_color") is None
+
+        common.turn_on(
+            self.hass, "light.test_template_light", **{ATTR_HS_COLOR: (40, 50)}
+        )
+        self.hass.block_till_done()
+        assert len(self.calls) == 2
+        assert self.calls[0].data["h"] == "40"
+        assert self.calls[0].data["s"] == "50"
+        assert self.calls[1].data["h"] == "40"
+        assert self.calls[1].data["s"] == "50"
+
+        state = self.hass.states.get("light.test_template_light")
+        _LOGGER.info(str(state.attributes))
+        assert state is not None
+        assert self.calls[0].data["h"] == "40"
+        assert self.calls[0].data["s"] == "50"
+        assert self.calls[1].data["h"] == "40"
+        assert self.calls[1].data["s"] == "50"
+
+    @pytest.mark.parametrize(
+        "expected_hs,template",
+        [
+            ((360, 100), "{{(360, 100)}}"),
+            ((359.9, 99.9), "{{(359.9, 99.9)}}"),
+            (None, "{{(361, 100)}}"),
+            (None, "{{(360, 101)}}"),
+            (None, "{{x - 12}}"),
+        ],
+    )
+    def test_color_template(self, expected_hs, template):
+        """Test the template for the color."""
+        with assert_setup_component(1, "light"):
+            assert setup.setup_component(
+                self.hass,
+                "light",
+                {
+                    "light": {
+                        "platform": "template",
+                        "lights": {
+                            "test_template_light": {
+                                "value_template": "{{ 1 == 1 }}",
+                                "turn_on": {
+                                    "service": "light.turn_on",
+                                    "entity_id": "light.test_state",
+                                },
+                                "turn_off": {
+                                    "service": "light.turn_off",
+                                    "entity_id": "light.test_state",
+                                },
+                                "set_color": [
+                                    {
+                                        "service": "input_number.set_value",
+                                        "data_template": {
+                                            "entity_id": "input_number.h",
+                                            "color_temp": "{{h}}",
+                                        },
+                                    }
+                                ],
+                                "color_template": template,
+                            }
+                        },
+                    }
+                },
+            )
+        self.hass.start()
+        self.hass.block_till_done()
+        state = self.hass.states.get("light.test_template_light")
+        assert state is not None
+        assert state.attributes.get("hs_color") == expected_hs
 
 
 async def test_available_template_with_entities(hass):


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, light template supports brightness and temperature. This PR adds temperature support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
input_boolean:
  foo_bool_input:

input_number:
  brightness_input:
    min: 0
    max: 255
  temperature_input:
    min: 0
    max: 500

light:
  - platform: template
    lights:
      foo:
        turn_on:
          service: input_boolean.turn_on
          entity_id: input_boolean.brightness_input
        turn_off:
          service: input_boolean.turn_off
          entity_id: input_boolean.brightness_input
        level_template: "{{states('input_number.brightness_input') | int }}"
        value_template: "{{states('input_number.brightness_input') | int > 0}}"
        set_level:
          service: input_number.set_value
          data_template:
            value: "{{ brightness }}"
            entity_id: input_number.brightness_input
        color_template: "({{states('input_number.h_input') | int}}, {{states('input_number.s_input') | int}})"
        set_color:
          - service: input_number.set_value
            data_template:
              value: "{{ h }}"
              entity_id: input_number.h_input
          - service: input_number.set_value
            data_template:
              value: "{{ s }}"
              entity_id: input_number.s_input
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~This PR fixes or closes issue: fixes #~
- ~This PR is related to issue:~
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/11958

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
