### PR TITLE
Update StepSpeaker and Speaker interfaces in Alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -676,12 +676,12 @@ class AlexaSpeaker(AlexaCapability):
                 current = 0
             return current
 
-        elif name == "muted":
+        if name == "muted":
             return bool(
                 self.entity.attributes.get(media_player.ATTR_MEDIA_VOLUME_MUTED)
             )
-        else:
-            raise UnsupportedProperty(name)
+
+        return None
 
 
 class AlexaStepSpeaker(AlexaCapability):

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1,5 +1,6 @@
 """Alexa capabilities."""
 import logging
+import math
 
 from homeassistant.components import (
     cover,
@@ -644,6 +645,43 @@ class AlexaSpeaker(AlexaCapability):
     def name(self):
         """Return the Alexa API name of this interface."""
         return "Alexa.Speaker"
+
+    def properties_supported(self):
+        """Return what properties this entity supports."""
+        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        properties = [{"name": "volume"}]
+
+        if supported & media_player.SUPPORT_VOLUME_MUTE:
+            properties.append({"name": "muted"})
+
+        return properties
+
+    def properties_proactively_reported(self):
+        """Return True if properties asynchronously reported."""
+        return True
+
+    def properties_retrievable(self):
+        """Return True if properties can be retrieved."""
+        return True
+
+    def get_property(self, name):
+        """Read and return a property."""
+        if name == "volume":
+            current_level = self.entity.attributes.get(
+                media_player.ATTR_MEDIA_VOLUME_LEVEL
+            )
+            try:
+                current = math.floor(int(current_level * 100))
+            except ZeroDivisionError:
+                current = 0
+            return current
+
+        elif name == "muted":
+            return bool(
+                self.entity.attributes.get(media_player.ATTR_MEDIA_VOLUME_MUTED)
+            )
+        else:
+            raise UnsupportedProperty(name)
 
 
 class AlexaStepSpeaker(AlexaCapability):

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -648,9 +648,9 @@ class AlexaSpeaker(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         properties = [{"name": "volume"}]
 
+        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & media_player.SUPPORT_VOLUME_MUTE:
             properties.append({"name": "muted"})
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -508,12 +508,7 @@ class MediaPlayerCapabilities(AlexaEntity):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & media_player.const.SUPPORT_VOLUME_SET:
             yield AlexaSpeaker(self.entity)
-
-        step_volume_features = (
-            media_player.const.SUPPORT_VOLUME_MUTE
-            | media_player.const.SUPPORT_VOLUME_STEP
-        )
-        if supported & step_volume_features:
+        elif supported & media_player.const.SUPPORT_VOLUME_STEP:
             yield AlexaStepSpeaker(self.entity)
 
         playback_features = (

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -503,13 +503,9 @@ class MediaPlayerCapabilities(AlexaEntity):
 
     def interfaces(self):
         """Yield the supported interfaces."""
+        yield AlexaPowerController(self.entity)
+
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-
-        if supported & (
-            media_player.const.SUPPORT_TURN_OFF | media_player.const.SUPPORT_TURN_ON
-        ):
-            yield AlexaPowerController(self.entity)
-
         if supported & media_player.const.SUPPORT_VOLUME_SET:
             yield AlexaSpeaker(self.entity)
         elif supported & media_player.const.SUPPORT_VOLUME_STEP:

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -503,9 +503,13 @@ class MediaPlayerCapabilities(AlexaEntity):
 
     def interfaces(self):
         """Yield the supported interfaces."""
-        yield AlexaPowerController(self.entity)
-
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+
+        if supported & (
+            media_player.const.SUPPORT_TURN_OFF | media_player.const.SUPPORT_TURN_ON
+        ):
+            yield AlexaPowerController(self.entity)
+
         if supported & media_player.const.SUPPORT_VOLUME_SET:
             yield AlexaSpeaker(self.entity)
         elif supported & media_player.const.SUPPORT_VOLUME_STEP:

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -16,6 +16,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_STEP,
 )
 import homeassistant.components.vacuum as vacuum
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
@@ -904,7 +905,6 @@ async def test_media_player(hass):
         "Alexa.PlaybackStateReporter",
         "Alexa.PowerController",
         "Alexa.Speaker",
-        "Alexa.StepSpeaker",
     )
 
     playback_capability = get_capability(capabilities, "Alexa.PlaybackController")
@@ -958,93 +958,6 @@ async def test_media_player(hass):
         hass,
     )
 
-    call, _ = await assert_request_calls_service(
-        "Alexa.Speaker",
-        "SetVolume",
-        "media_player#test",
-        "media_player.volume_set",
-        hass,
-        payload={"volume": 50},
-    )
-    assert call.data["volume_level"] == 0.5
-
-    call, _ = await assert_request_calls_service(
-        "Alexa.Speaker",
-        "SetMute",
-        "media_player#test",
-        "media_player.volume_mute",
-        hass,
-        payload={"mute": True},
-    )
-    assert call.data["is_volume_muted"]
-
-    call, _, = await assert_request_calls_service(
-        "Alexa.Speaker",
-        "SetMute",
-        "media_player#test",
-        "media_player.volume_mute",
-        hass,
-        payload={"mute": False},
-    )
-    assert not call.data["is_volume_muted"]
-
-    await assert_percentage_changes(
-        hass,
-        [(0.7, "-5"), (0.8, "5"), (0, "-80")],
-        "Alexa.Speaker",
-        "AdjustVolume",
-        "media_player#test",
-        "volume",
-        "media_player.volume_set",
-        "volume_level",
-    )
-
-    call, _ = await assert_request_calls_service(
-        "Alexa.StepSpeaker",
-        "SetMute",
-        "media_player#test",
-        "media_player.volume_mute",
-        hass,
-        payload={"mute": True},
-    )
-    assert call.data["is_volume_muted"]
-
-    call, _, = await assert_request_calls_service(
-        "Alexa.StepSpeaker",
-        "SetMute",
-        "media_player#test",
-        "media_player.volume_mute",
-        hass,
-        payload={"mute": False},
-    )
-    assert not call.data["is_volume_muted"]
-
-    call, _ = await assert_request_calls_service(
-        "Alexa.StepSpeaker",
-        "AdjustVolume",
-        "media_player#test",
-        "media_player.volume_up",
-        hass,
-        payload={"volumeSteps": 1, "volumeStepsDefault": False},
-    )
-
-    call, _ = await assert_request_calls_service(
-        "Alexa.StepSpeaker",
-        "AdjustVolume",
-        "media_player#test",
-        "media_player.volume_down",
-        hass,
-        payload={"volumeSteps": -1, "volumeStepsDefault": False},
-    )
-
-    call, _ = await assert_request_calls_service(
-        "Alexa.StepSpeaker",
-        "AdjustVolume",
-        "media_player#test",
-        "media_player.volume_up",
-        hass,
-        payload={"volumeSteps": 10, "volumeStepsDefault": True},
-    )
     call, _ = await assert_request_calls_service(
         "Alexa.ChannelController",
         "ChangeChannel",
@@ -1140,7 +1053,6 @@ async def test_media_player_power(hass):
         "Alexa.PowerController",
         "Alexa.SeekController",
         "Alexa.Speaker",
-        "Alexa.StepSpeaker",
     )
 
     await assert_request_calls_service(
@@ -1265,22 +1177,141 @@ async def test_media_player_inputs(hass):
 
 
 async def test_media_player_speaker(hass):
-    """Test media player discovery with device class speaker."""
+    """Test media player with speaker interface."""
     device = (
-        "media_player.test",
+        "media_player.test_speaker",
         "off",
         {
-            "friendly_name": "Test media player",
-            "supported_features": 51765,
+            "friendly_name": "Test media player speaker",
+            "supported_features": SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET,
             "volume_level": 0.75,
             "device_class": "speaker",
         },
     )
     appliance = await discovery_test(device, hass)
 
-    assert appliance["endpointId"] == "media_player#test"
+    assert appliance["endpointId"] == "media_player#test_speaker"
     assert appliance["displayCategories"][0] == "SPEAKER"
-    assert appliance["friendlyName"] == "Test media player"
+    assert appliance["friendlyName"] == "Test media player speaker"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa",
+        "Alexa.EndpointHealth",
+        "Alexa.PowerController",
+        "Alexa.Speaker",
+    )
+
+    speaker_capability = get_capability(capabilities, "Alexa.Speaker")
+    properties = speaker_capability["properties"]
+    assert {"name": "volume"} in properties["supported"]
+    assert {"name": "muted"} in properties["supported"]
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.Speaker",
+        "SetVolume",
+        "media_player#test_speaker",
+        "media_player.volume_set",
+        hass,
+        payload={"volume": 50},
+    )
+    assert call.data["volume_level"] == 0.5
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.Speaker",
+        "SetMute",
+        "media_player#test_speaker",
+        "media_player.volume_mute",
+        hass,
+        payload={"mute": True},
+    )
+    assert call.data["is_volume_muted"]
+
+    call, _, = await assert_request_calls_service(
+        "Alexa.Speaker",
+        "SetMute",
+        "media_player#test_speaker",
+        "media_player.volume_mute",
+        hass,
+        payload={"mute": False},
+    )
+    assert not call.data["is_volume_muted"]
+
+    await assert_percentage_changes(
+        hass,
+        [(0.7, "-5"), (0.8, "5"), (0, "-80")],
+        "Alexa.Speaker",
+        "AdjustVolume",
+        "media_player#test_speaker",
+        "volume",
+        "media_player.volume_set",
+        "volume_level",
+    )
+
+
+async def test_media_player_step_speaker(hass):
+    """Test media player with step speaker interface."""
+    device = (
+        "media_player.test_step_speaker",
+        "off",
+        {
+            "friendly_name": "Test media player step speaker",
+            "supported_features": SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP,
+            "device_class": "speaker",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "media_player#test_step_speaker"
+    assert appliance["displayCategories"][0] == "SPEAKER"
+    assert appliance["friendlyName"] == "Test media player step speaker"
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.StepSpeaker",
+        "SetMute",
+        "media_player#test_step_speaker",
+        "media_player.volume_mute",
+        hass,
+        payload={"mute": True},
+    )
+    assert call.data["is_volume_muted"]
+
+    call, _, = await assert_request_calls_service(
+        "Alexa.StepSpeaker",
+        "SetMute",
+        "media_player#test_step_speaker",
+        "media_player.volume_mute",
+        hass,
+        payload={"mute": False},
+    )
+    assert not call.data["is_volume_muted"]
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.StepSpeaker",
+        "AdjustVolume",
+        "media_player#test_step_speaker",
+        "media_player.volume_up",
+        hass,
+        payload={"volumeSteps": 1, "volumeStepsDefault": False},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.StepSpeaker",
+        "AdjustVolume",
+        "media_player#test_step_speaker",
+        "media_player.volume_down",
+        hass,
+        payload={"volumeSteps": -1, "volumeStepsDefault": False},
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.StepSpeaker",
+        "AdjustVolume",
+        "media_player#test_step_speaker",
+        "media_player.volume_up",
+        hass,
+        payload={"volumeSteps": 10, "volumeStepsDefault": True},
+    )
 
 
 async def test_media_player_seek(hass):


### PR DESCRIPTION
## Proposed change
- Yields only one of `Alexa.Speaker` or `Alexa.StepSpeaker` interface for `media_player` based on the support features. 
- Adds missing properties to the `Alexa.Speaker` interface.
- Enables `proactivelyReported` properties for `Alexa.Speaker` interface.
- Enables `retrievable` properties for `Alexa.Speaker` interface.
- Refactors tests, breaking out tests for each of the speaker interfaces. 
- Fixes a bug when both Speaker interfaces are yielded for the same device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
I'm checking 2 boxes :stuck_out_tongue_winking_eye:
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
