### PR TITLE
deCONZ - Revert from using disabled_by when setting options

### DIFF
--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -37,7 +37,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for sensor in sensors:
 
-            if new and sensor.type in Thermostat.ZHATYPE:
+            if (
+                new
+                and sensor.type in Thermostat.ZHATYPE
+                and (
+                    gateway.option_allow_clip_sensor
+                    or not sensor.type.startswith("CLIP")
+                )
+            ):
                 entities.append(DeconzThermostat(sensor, gateway))
 
         async_add_entities(entities, True)

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -63,17 +63,6 @@ class DeconzDevice(DeconzBase, Entity):
 
         Daylight is a virtual sensor from deCONZ that should never be enabled by default.
         """
-        if not self.gateway.option_allow_clip_sensor and self._device.type.startswith(
-            "CLIP"
-        ):
-            return False
-
-        if (
-            not self.gateway.option_allow_deconz_groups
-            and self._device.type == "LightGroup"
-        ):
-            return False
-
         if self._device.type == "Daylight":
             return False
 

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -10,7 +10,6 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.entity_registry import async_get_registry
 
 from .const import (
     CONF_ALLOW_CLIP_SENSOR,
@@ -110,7 +109,6 @@ class DeconzGateway:
         self.api.start()
 
         self.config_entry.add_update_listener(self.async_new_address)
-        self.config_entry.add_update_listener(self.async_options_updated)
 
         return True
 
@@ -137,19 +135,6 @@ class DeconzGateway:
         """Handle signals of gateway connection status."""
         self.available = available
         async_dispatcher_send(self.hass, self.signal_reachable, True)
-
-    @property
-    def signal_options_update(self) -> str:
-        """Event specific per deCONZ entry to signal new options."""
-        return f"deconz-options-{self.bridgeid}"
-
-    @staticmethod
-    async def async_options_updated(hass, entry) -> None:
-        """Triggered by config entry options updates."""
-        gateway = get_gateway_from_config_entry(hass, entry)
-
-        registry = await async_get_registry(hass)
-        async_dispatcher_send(hass, gateway.signal_options_update, registry)
 
     @callback
     def async_signal_new_device(self, device_type) -> str:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -61,10 +61,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     @callback
     def async_add_group(groups):
         """Add group from deCONZ."""
+        if not gateway.option_allow_deconz_groups:
+            return
+
         entities = []
 
         for group in groups:
-            if group.lights and gateway.option_allow_deconz_groups:
+            if group.lights:
                 entities.append(DeconzGroup(group, gateway))
 
         async_add_entities(entities, True)

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -30,7 +30,7 @@ from .const import (
     SWITCH_TYPES,
 )
 from .deconz_device import DeconzDevice
-from .gateway import DeconzEntityHandler, get_gateway_from_config_entry
+from .gateway import get_gateway_from_config_entry
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -40,8 +40,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ lights and groups from a config entry."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
-
-    entity_handler = DeconzEntityHandler(gateway)
 
     @callback
     def async_add_light(lights):
@@ -66,10 +64,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
 
         for group in groups:
-            if group.lights:
-                new_group = DeconzGroup(group, gateway)
-                entity_handler.add_entity(new_group)
-                entities.append(new_group)
+            if group.lights and gateway.option_allow_deconz_groups:
+                entities.append(DeconzGroup(group, gateway))
 
         async_add_entities(entities, True)
 

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.dispatcher import (
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .deconz_event import DeconzEvent
-from .gateway import DeconzEntityHandler, get_gateway_from_config_entry
+from .gateway import get_gateway_from_config_entry
 
 ATTR_CURRENT = "current"
 ATTR_POWER = "power"
@@ -37,7 +37,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     batteries = set()
     battery_handler = DeconzBatteryHandler(gateway)
-    entity_handler = DeconzEntityHandler(gateway)
 
     @callback
     def async_add_sensor(sensors, new=True):
@@ -65,11 +64,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 new
                 and sensor.BINARY is False
                 and sensor.type not in Battery.ZHATYPE + Thermostat.ZHATYPE
+                and (
+                    gateway.option_allow_clip_sensor
+                    or not sensor.type.startswith("CLIP")
+                )
             ):
-
-                new_sensor = DeconzSensor(sensor, gateway)
-                entity_handler.add_entity(new_sensor)
-                entities.append(new_sensor)
+                entities.append(DeconzSensor(sensor, gateway))
 
             if sensor.battery is not None:
                 new_battery = DeconzBattery(sensor, gateway)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following direction changes from https://github.com/home-assistant/developers.home-assistant/pull/396
Need to figure out a better way of enabling and readding devices from deconz and disabling and removing entities from entity registry


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
