### PR TITLE
Add brightness_step to light.turn_on

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -1,5 +1,4 @@
 """Provides functionality to interact with lights."""
-import asyncio
 import csv
 from datetime import timedelta
 import logging
@@ -8,15 +7,12 @@ from typing import Dict, Optional, Tuple
 
 import voluptuous as vol
 
-from homeassistant.auth.permissions.const import POLICY_CONTROL
 from homeassistant.const import (
-    ATTR_ENTITY_ID,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_ON,
 )
-from homeassistant.exceptions import Unauthorized, UnknownUser
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -91,8 +87,8 @@ VALID_BRIGHTNESS_PCT = vol.All(vol.Coerce(float), vol.Range(min=0, max=100))
 LIGHT_TURN_ON_SCHEMA = {
     vol.Exclusive(ATTR_PROFILE, COLOR_GROUP): cv.string,
     ATTR_TRANSITION: VALID_TRANSITION,
-    ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
-    ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
+    vol.Exclusive(ATTR_BRIGHTNESS, ATTR_BRIGHTNESS): VALID_BRIGHTNESS,
+    vol.Exclusive(ATTR_BRIGHTNESS_PCT, ATTR_BRIGHTNESS): VALID_BRIGHTNESS_PCT,
     vol.Exclusive(ATTR_COLOR_NAME, COLOR_GROUP): cv.string,
     vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP): vol.All(
         vol.ExactSequence((cv.byte, cv.byte, cv.byte)), vol.Coerce(tuple)
@@ -169,7 +165,7 @@ def preprocess_turn_off(params):
     """Process data for turning light off if brightness is 0."""
     if ATTR_BRIGHTNESS in params and params[ATTR_BRIGHTNESS] == 0:
         # Zero brightness: Light will be turned off
-        params = {k: v for k, v in params.items() if k in [ATTR_TRANSITION, ATTR_FLASH]}
+        params = {k: v for k, v in params.items() if k in (ATTR_TRANSITION, ATTR_FLASH)}
         return (True, params)  # Light should be turned off
 
     return (False, None)  # Light should be turned on
@@ -187,70 +183,51 @@ async def async_setup(hass, config):
     if not profiles_valid:
         return False
 
-    async def async_handle_light_on_service(service):
-        """Handle a turn light on service call."""
-        # Get the validated data
-        params = service.data.copy()
+    def preprocess_data(data):
+        """Preprocess the service data."""
+        base = {}
 
-        # Convert the entity ids to valid light ids
-        target_lights = await component.async_extract_from_service(service)
-        params.pop(ATTR_ENTITY_ID, None)
+        for entity_field in cv.ENTITY_SERVICE_FIELDS:
+            if entity_field in data:
+                base[entity_field] = data.pop(entity_field)
 
-        if service.context.user_id:
-            user = await hass.auth.async_get_user(service.context.user_id)
-            if user is None:
-                raise UnknownUser(context=service.context)
+        preprocess_turn_on_alternatives(data)
+        turn_lights_off, off_params = preprocess_turn_off(data)
 
-            entity_perms = user.permissions.check_entity
+        base["params"] = data
+        base["turn_lights_off"] = turn_lights_off
+        base["off_params"] = off_params
 
-            for light in target_lights:
-                if not entity_perms(light, POLICY_CONTROL):
-                    raise Unauthorized(
-                        context=service.context,
-                        entity_id=light,
-                        permission=POLICY_CONTROL,
-                    )
+        return base
 
-        preprocess_turn_on_alternatives(params)
-        turn_lights_off, off_params = preprocess_turn_off(params)
+    async def async_handle_light_on_service(light, call):
+        """Handle turning a light on.
 
-        poll_lights = []
-        change_tasks = []
-        for light in target_lights:
-            light.async_set_context(service.context)
+        If brightness is set to 0, this service will turn the light off.
+        """
+        params = call.data["params"]
+        turn_light_off = call.data["turn_lights_off"]
+        off_params = call.data["off_params"]
 
-            pars = params
-            off_pars = off_params
-            turn_light_off = turn_lights_off
-            if not pars:
-                pars = params.copy()
-                pars[ATTR_PROFILE] = Profiles.get_default(light.entity_id)
-                preprocess_turn_on_alternatives(pars)
-                turn_light_off, off_pars = preprocess_turn_off(pars)
-            if turn_light_off:
-                task = light.async_request_call(light.async_turn_off(**off_pars))
-            else:
-                task = light.async_request_call(light.async_turn_on(**pars))
+        if not params:
+            default_profile = Profiles.get_default(light.entity_id)
 
-            change_tasks.append(task)
+            if default_profile is not None:
+                params = {ATTR_PROFILE: default_profile}
+                preprocess_turn_on_alternatives(params)
+                turn_light_off, off_params = preprocess_turn_off(params)
 
-            if light.should_poll:
-                poll_lights.append(light)
-
-        if change_tasks:
-            await asyncio.wait(change_tasks)
-
-        if poll_lights:
-            await asyncio.wait(
-                [light.async_update_ha_state(True) for light in poll_lights]
-            )
+        if turn_light_off:
+            await light.async_turn_off(**off_params)
+        else:
+            await light.async_turn_on(**params)
 
     # Listen for light on and light off service calls.
-    hass.services.async_register(
-        DOMAIN,
+
+    component.async_register_entity_service(
         SERVICE_TURN_ON,
+        vol.All(cv.make_entity_service_schema(LIGHT_TURN_ON_SCHEMA), preprocess_data),
         async_handle_light_on_service,
-        schema=cv.make_entity_service_schema(LIGHT_TURN_ON_SCHEMA),
     )
 
     component.async_register_entity_service(

--- a/homeassistant/components/light/intent.py
+++ b/homeassistant/components/light/intent.py
@@ -1,6 +1,7 @@
 """Intents for the light integration."""
 import voluptuous as vol
 
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
@@ -8,7 +9,6 @@ import homeassistant.util.color as color_util
 
 from . import (
     ATTR_BRIGHTNESS_PCT,
-    ATTR_ENTITY_ID,
     ATTR_RGB_COLOR,
     DOMAIN,
     SERVICE_TURN_ON,

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -36,6 +36,12 @@ turn_on:
     brightness_pct:
       description: Number between 0..100 indicating percentage of full brightness, where 0 turns the light off, 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
       example: 47
+    brightness_step:
+      description: Change brightness by an amount. Should be between -255..255.
+      example: -25.5
+    brightness_step_pct:
+      description: Change brightness by a percentage. Should be between -100..100.
+      example: -10
     profile:
       description: Name of a light profile to use.
       example: relax

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -19,7 +19,6 @@ import voluptuous as vol
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
-    ATTR_ENTITY_ID,
     ATTR_HS_COLOR,
     PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
@@ -27,7 +26,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR_TEMP,
     Light,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import color, dt

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -298,18 +298,16 @@ async def test_signal_repetitions_cancelling(hass, monkeypatch):
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: DOMAIN + ".test"}
     )
 
-    hass.async_create_task(
-        hass.services.async_call(
-            DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: DOMAIN + ".test"}
-        )
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: DOMAIN + ".test"}, blocking=True
     )
 
-    await hass.async_block_till_done()
-
-    assert protocol.send_command_ack.call_args_list[0][0][1] == "off"
-    assert protocol.send_command_ack.call_args_list[1][0][1] == "on"
-    assert protocol.send_command_ack.call_args_list[2][0][1] == "on"
-    assert protocol.send_command_ack.call_args_list[3][0][1] == "on"
+    assert [call[0][1] for call in protocol.send_command_ack.call_args_list] == [
+        "off",
+        "on",
+        "on",
+        "on",
+    ]
 
 
 async def test_type_toggle(hass, monkeypatch):

--- a/tests/testing_config/custom_components/test/light.py
+++ b/tests/testing_config/custom_components/test/light.py
@@ -3,6 +3,7 @@ Provide a mock light platform.
 
 Call init before using it in your tests to ensure clean test data.
 """
+from homeassistant.components.light import Light
 from homeassistant.const import STATE_OFF, STATE_ON
 
 from tests.common import MockToggleEntity
@@ -18,9 +19,9 @@ def init(empty=False):
         []
         if empty
         else [
-            MockToggleEntity("Ceiling", STATE_ON),
-            MockToggleEntity("Ceiling", STATE_OFF),
-            MockToggleEntity(None, STATE_OFF),
+            MockLight("Ceiling", STATE_ON),
+            MockLight("Ceiling", STATE_OFF),
+            MockLight(None, STATE_OFF),
         ]
     )
 
@@ -30,3 +31,10 @@ async def async_setup_platform(
 ):
     """Return mock entities."""
     async_add_entities_callback(ENTITIES)
+
+
+class MockLight(MockToggleEntity, Light):
+    """Mock light class."""
+
+    brightness = None
+    supported_features = 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
It is no longer allowed to pass both `brightness` and `brightness_pct` to `light.turn_on` service. Previously passing both would have used `brightness_pct`.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Uses the `register_entity_service` infra to register the light turn on service by moving the generic data processing into the voluptuous schema.

Add `brightness_step` (-255..255) and `brightness_step_pct` (-100..100) to gradually change the brightness of a light. Brightness of a light that's off is 0. If brightness hits 0, the turn on call will turn off the light (as per existing logic). This makes it very nice to dim a light 👍 

Example service data:

```yaml
entity_id: light.bowl
brightness_step_pct: 10
```


Drops usage of wrapping turn_on with `Entity.async_request_call`. Added this back into `helpers/service.py` in #31454

Light device action will also be for another PR. 

Test will be fixed when we rebase after #31454 is merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
