### PR TITLE
Use entity.async_request_call in service helper

### DIFF
--- a/homeassistant/components/rflink/cover.py
+++ b/homeassistant/components/rflink/cover.py
@@ -23,6 +23,8 @@ from . import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 TYPE_STANDARD = "standard"
 TYPE_INVERTED = "inverted"
 

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -31,6 +31,8 @@ from . import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 TYPE_DIMMABLE = "dimmable"
 TYPE_SWITCHABLE = "switchable"
 TYPE_HYBRID = "hybrid"

--- a/homeassistant/components/rflink/switch.py
+++ b/homeassistant/components/rflink/switch.py
@@ -22,6 +22,8 @@ from . import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -568,7 +568,6 @@ class Entity(ABC):
     # call an requests
     async def async_request_call(self, coro):
         """Process request batched."""
-        print("REQUEST CALL", self.entity_id, self.parallel_updates)
         if self.parallel_updates:
             await self.parallel_updates.acquire()
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -568,7 +568,7 @@ class Entity(ABC):
     # call an requests
     async def async_request_call(self, coro):
         """Process request batched."""
-
+        print("REQUEST CALL", self.entity_id, self.parallel_updates)
         if self.parallel_updates:
             await self.parallel_updates.acquire()
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -62,22 +62,38 @@ class EntityPlatform:
         # Platform is None for the EntityComponent "catch-all" EntityPlatform
         # which powers entity_component.add_entities
         if platform is None:
-            self.parallel_updates = None
-            self.parallel_updates_semaphore: Optional[asyncio.Semaphore] = None
+            self.parallel_updates_created = True
+            self.parallel_updates: Optional[asyncio.Semaphore] = None
             return
 
-        self.parallel_updates = getattr(platform, "PARALLEL_UPDATES", None)
-        # semaphore will be created on demand
-        self.parallel_updates_semaphore = None
+        self.parallel_updates_created = False
+        self.parallel_updates = None
 
-    def _get_parallel_updates_semaphore(self) -> asyncio.Semaphore:
-        """Get or create a semaphore for parallel updates."""
-        if self.parallel_updates_semaphore is None:
-            self.parallel_updates_semaphore = asyncio.Semaphore(
-                self.parallel_updates if self.parallel_updates else 1,
-                loop=self.hass.loop,
-            )
-        return self.parallel_updates_semaphore
+    @callback
+    def _get_parallel_updates_semaphore(
+        self, entity_has_async_update: bool
+    ) -> Optional[asyncio.Semaphore]:
+        """Get or create a semaphore for parallel updates.
+
+        semaphore will be created on demand because we base it off if update method is async or not.
+        """
+        if self.parallel_updates_created:
+            return self.parallel_updates
+
+        self.parallel_updates_created = True
+
+        parallel_updates = getattr(self.platform, "PARALLEL_UPDATES", None)
+
+        if parallel_updates is None and not entity_has_async_update:
+            parallel_updates = 1
+
+        if parallel_updates == 0:
+            parallel_updates = None
+
+        if parallel_updates is not None:
+            self.parallel_updates = asyncio.Semaphore(parallel_updates)
+
+        return self.parallel_updates
 
     async def async_setup(self, platform_config, discovery_info=None):
         """Set up the platform from a config file."""
@@ -282,21 +298,9 @@ class EntityPlatform:
 
         entity.hass = self.hass
         entity.platform = self
-
-        # Async entity
-        # PARALLEL_UPDATES == None: entity.parallel_updates = None
-        # PARALLEL_UPDATES == 0:    entity.parallel_updates = None
-        # PARALLEL_UPDATES > 0:     entity.parallel_updates = Semaphore(p)
-        # Sync entity
-        # PARALLEL_UPDATES == None: entity.parallel_updates = Semaphore(1)
-        # PARALLEL_UPDATES == 0:    entity.parallel_updates = None
-        # PARALLEL_UPDATES > 0:     entity.parallel_updates = Semaphore(p)
-        if hasattr(entity, "async_update") and not self.parallel_updates:
-            entity.parallel_updates = None
-        elif not hasattr(entity, "async_update") and self.parallel_updates == 0:
-            entity.parallel_updates = None
-        else:
-            entity.parallel_updates = self._get_parallel_updates_semaphore()
+        entity.parallel_updates = self._get_parallel_updates_semaphore(
+            hasattr(entity, "async_update")
+        )
 
         # Update properties before we generate the entity_id
         if update_before_add:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -75,7 +75,11 @@ class EntityPlatform:
     ) -> Optional[asyncio.Semaphore]:
         """Get or create a semaphore for parallel updates.
 
-        semaphore will be created on demand because we base it off if update method is async or not.
+        Semaphore will be created on demand because we base it off if update method is async or not.
+
+        If parallel updates is set to 0, we skip the semaphore.
+        If parallel updates is set to a number, we initialize the semaphore to that number.
+        Default for entities with `async_update` method is 1. Otherwise it's 0.
         """
         if self.parallel_updates_created:
             return self.parallel_updates

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -389,12 +389,12 @@ async def entity_service_call(hass, platforms, func, call, required_features=Non
 
 
 async def _handle_service_platform_call(
-    hass, func, data, entities, context, required_features
+    hass, func, data, entity_candidates, context, required_features
 ):
     """Handle a function call."""
-    tasks = []
+    entities = []
 
-    for entity in entities:
+    for entity in entity_candidates:
         if not entity.available:
             continue
 
@@ -404,33 +404,61 @@ async def _handle_service_platform_call(
         ):
             continue
 
-        entity.async_set_context(context)
+        entities.append(entity)
 
-        if isinstance(func, str):
-            result = hass.async_add_job(partial(getattr(entity, func), **data))
-        else:
-            result = hass.async_add_job(func, entity, data)
+    if not entities:
+        return
 
-        # Guard because callback functions do not return a task when passed to async_add_job.
-        if result is not None:
-            result = await result
-
-        if asyncio.iscoroutine(result):
-            _LOGGER.error(
-                "Service %s for %s incorrectly returns a coroutine object. Await result instead in service handler. Report bug to integration author.",
-                func,
-                entity.entity_id,
+    done, pending = await asyncio.wait(
+        [
+            entity.async_request_call(
+                _handle_entity_call(hass, entity, func, data, context)
             )
-            await result
+            for entity in entities
+        ]
+    )
+    assert not pending
+    for future in done:
+        future.result()  # pop exception if have
 
-        if entity.should_poll:
-            tasks.append(entity.async_update_ha_state(True))
+    tasks = []
+
+    for entity in entities:
+        if not entity.should_poll:
+            continue
+
+        # Context expires if the turn on commands took a long time.
+        # Set context again so it's there when we update
+        entity.async_set_context(context)
+        tasks.append(entity.async_update_ha_state(True))
 
     if tasks:
         done, pending = await asyncio.wait(tasks)
         assert not pending
         for future in done:
             future.result()  # pop exception if have
+
+
+async def _handle_entity_call(hass, entity, func, data, context):
+    """Handle calling service method."""
+    entity.async_set_context(context)
+
+    if isinstance(func, str):
+        result = hass.async_add_job(partial(getattr(entity, func), **data))
+    else:
+        result = hass.async_add_job(func, entity, data)
+
+    # Guard because callback functions do not return a task when passed to async_add_job.
+    if result is not None:
+        await result
+
+    if asyncio.iscoroutine(result):
+        _LOGGER.error(
+            "Service %s for %s incorrectly returns a coroutine object. Await result instead in service handler. Report bug to integration author.",
+            func,
+            entity.entity_id,
+        )
+        await result
 
 
 @bind_hass
@@ -474,6 +502,7 @@ def verify_domain_control(hass: HomeAssistantType, domain: str) -> Callable:
                 return await service_handler(call)
 
             user = await hass.auth.async_get_user(call.context.user_id)
+
             if user is None:
                 raise UnknownUser(
                     context=call.context,
@@ -482,14 +511,12 @@ def verify_domain_control(hass: HomeAssistantType, domain: str) -> Callable:
                 )
 
             reg = await hass.helpers.entity_registry.async_get_registry()
-            entities = [
-                entity.entity_id
-                for entity in reg.entities.values()
-                if entity.platform == domain
-            ]
 
-            for entity_id in entities:
-                if user.permissions.check_entity(entity_id, POLICY_CONTROL):
+            for entity in reg.entities.values():
+                if entity.platform != domain:
+                    continue
+
+                if user.permissions.check_entity(entity.entity_id, POLICY_CONTROL):
                     return await service_handler(call)
 
             raise Unauthorized(

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -4,6 +4,8 @@ Test setup of RFLink lights component/platform. State tracking and
 control of RFLink switch devices.
 
 """
+import asyncio
+
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
@@ -297,6 +299,7 @@ async def test_signal_repetitions_cancelling(hass, monkeypatch):
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: DOMAIN + ".test"}
     )
+    await asyncio.sleep(0)
 
     hass.async_create_task(
         hass.services.async_call(

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -4,8 +4,6 @@ Test setup of RFLink lights component/platform. State tracking and
 control of RFLink switch devices.
 
 """
-import asyncio
-
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
@@ -299,7 +297,6 @@ async def test_signal_repetitions_cancelling(hass, monkeypatch):
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: DOMAIN + ".test"}
     )
-    await asyncio.sleep(0)
 
     hass.async_create_task(
         hass.services.async_call(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -270,8 +270,6 @@ async def test_parallel_updates_async_platform_with_constant(hass):
 
     handle = list(component._platforms.values())[-1]
 
-    assert handle.parallel_updates == 2
-
     class AsyncEntity(MockEntity):
         """Mock entity that has async_update."""
 
@@ -296,7 +294,6 @@ async def test_parallel_updates_sync_platform(hass):
     await component.async_setup({DOMAIN: {"platform": "platform"}})
 
     handle = list(component._platforms.values())[-1]
-    assert handle.parallel_updates is None
 
     class SyncEntity(MockEntity):
         """Mock entity that has update."""
@@ -323,7 +320,6 @@ async def test_parallel_updates_sync_platform_with_constant(hass):
     await component.async_setup({DOMAIN: {"platform": "platform"}})
 
     handle = list(component._platforms.values())[-1]
-    assert handle.parallel_updates == 2
 
     class SyncEntity(MockEntity):
         """Mock entity that has update."""

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -39,10 +39,10 @@ from tests.common import (
 
 
 @pytest.fixture
-def mock_service_platform_call():
+def mock_handle_entity_call():
     """Mock service platform call."""
     with patch(
-        "homeassistant.helpers.service._handle_service_platform_call",
+        "homeassistant.helpers.service._handle_entity_call",
         side_effect=lambda *args: mock_coro(),
     ) as mock_call:
         yield mock_call
@@ -372,7 +372,7 @@ async def test_call_context_user_not_exist(hass):
     assert err.value.context.user_id == "non-existing"
 
 
-async def test_call_context_target_all(hass, mock_service_platform_call, mock_entities):
+async def test_call_context_target_all(hass, mock_handle_entity_call, mock_entities):
     """Check we only target allowed entities if targeting all."""
     with patch(
         "homeassistant.auth.AuthManager.async_get_user",
@@ -396,13 +396,12 @@ async def test_call_context_target_all(hass, mock_service_platform_call, mock_en
             ),
         )
 
-    assert len(mock_service_platform_call.mock_calls) == 1
-    entities = mock_service_platform_call.mock_calls[0][1][3]
-    assert entities == [mock_entities["light.kitchen"]]
+    assert len(mock_handle_entity_call.mock_calls) == 1
+    assert mock_handle_entity_call.mock_calls[0][1][1].entity_id == "light.kitchen"
 
 
 async def test_call_context_target_specific(
-    hass, mock_service_platform_call, mock_entities
+    hass, mock_handle_entity_call, mock_entities
 ):
     """Check targeting specific entities."""
     with patch(
@@ -427,13 +426,12 @@ async def test_call_context_target_specific(
             ),
         )
 
-    assert len(mock_service_platform_call.mock_calls) == 1
-    entities = mock_service_platform_call.mock_calls[0][1][3]
-    assert entities == [mock_entities["light.kitchen"]]
+    assert len(mock_handle_entity_call.mock_calls) == 1
+    assert mock_handle_entity_call.mock_calls[0][1][1].entity_id == "light.kitchen"
 
 
 async def test_call_context_target_specific_no_auth(
-    hass, mock_service_platform_call, mock_entities
+    hass, mock_handle_entity_call, mock_entities
 ):
     """Check targeting specific entities without auth."""
     with pytest.raises(exceptions.Unauthorized) as err:
@@ -457,9 +455,7 @@ async def test_call_context_target_specific_no_auth(
     assert err.value.entity_id == "light.kitchen"
 
 
-async def test_call_no_context_target_all(
-    hass, mock_service_platform_call, mock_entities
-):
+async def test_call_no_context_target_all(hass, mock_handle_entity_call, mock_entities):
     """Check we target all if no user context given."""
     await service.entity_service_call(
         hass,
@@ -470,13 +466,14 @@ async def test_call_no_context_target_all(
         ),
     )
 
-    assert len(mock_service_platform_call.mock_calls) == 1
-    entities = mock_service_platform_call.mock_calls[0][1][3]
-    assert entities == list(mock_entities.values())
+    assert len(mock_handle_entity_call.mock_calls) == 2
+    assert [call[1][1] for call in mock_handle_entity_call.mock_calls] == list(
+        mock_entities.values()
+    )
 
 
 async def test_call_no_context_target_specific(
-    hass, mock_service_platform_call, mock_entities
+    hass, mock_handle_entity_call, mock_entities
 ):
     """Check we can target specified entities."""
     await service.entity_service_call(
@@ -490,13 +487,12 @@ async def test_call_no_context_target_specific(
         ),
     )
 
-    assert len(mock_service_platform_call.mock_calls) == 1
-    entities = mock_service_platform_call.mock_calls[0][1][3]
-    assert entities == [mock_entities["light.kitchen"]]
+    assert len(mock_handle_entity_call.mock_calls) == 1
+    assert mock_handle_entity_call.mock_calls[0][1][1].entity_id == "light.kitchen"
 
 
 async def test_call_with_match_all(
-    hass, mock_service_platform_call, mock_entities, caplog
+    hass, mock_handle_entity_call, mock_entities, caplog
 ):
     """Check we only target allowed entities if targeting all."""
     await service.entity_service_call(
@@ -506,20 +502,13 @@ async def test_call_with_match_all(
         ha.ServiceCall("test_domain", "test_service", {"entity_id": "all"}),
     )
 
-    assert len(mock_service_platform_call.mock_calls) == 1
-    entities = mock_service_platform_call.mock_calls[0][1][3]
-    assert entities == [
-        mock_entities["light.kitchen"],
-        mock_entities["light.living_room"],
-    ]
-    assert (
-        "Not passing an entity ID to a service to target all entities is deprecated"
-    ) not in caplog.text
+    assert len(mock_handle_entity_call.mock_calls) == 2
+    assert [call[1][1] for call in mock_handle_entity_call.mock_calls] == list(
+        mock_entities.values()
+    )
 
 
-async def test_call_with_omit_entity_id(
-    hass, mock_service_platform_call, mock_entities
-):
+async def test_call_with_omit_entity_id(hass, mock_handle_entity_call, mock_entities):
     """Check service call if we do not pass an entity ID."""
     await service.entity_service_call(
         hass,
@@ -528,9 +517,7 @@ async def test_call_with_omit_entity_id(
         ha.ServiceCall("test_domain", "test_service"),
     )
 
-    assert len(mock_service_platform_call.mock_calls) == 1
-    entities = mock_service_platform_call.mock_calls[0][1][3]
-    assert entities == []
+    assert len(mock_handle_entity_call.mock_calls) == 0
 
 
 async def test_register_admin_service(hass, hass_read_only_user, hass_admin_user):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The entity base class has an `async_request_call` helper that will limit the number of simultaneous requests that we make to a platform based on the `PARALLEL_UPDATES` value. This migrates the entity service helper to use this method. This means that for platforms that support it, we now run as many requests in parallel as we can.

Previously this was only implemented in light.turn_on. 

I also noticed that the verify domain control tests were passing Entity objects instead of EntityRegistryEntry objects. Cleaned up those tests once I started using MockEntity to be able to access `async_request_call`.

Docs; https://github.com/home-assistant/developers.home-assistant/pull/402

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
