### PR TITLE
Update vizio host check to handle entries that don't have port

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -53,6 +53,16 @@ def _get_config_flow_schema(input_dict: Dict[str, Any] = None) -> vol.Schema:
     )
 
 
+def _host_is_same(host1: str, host2: str) -> bool:
+    """Check if host1 and host2 are the same."""
+    return host1.split(":")[0] == host2.split(":")[0]
+
+
+def _name_is_same(name1: str, name2: str) -> bool:
+    """Check if name1 and name2 are the same."""
+    return name1 == name2
+
+
 class VizioOptionsConfigFlow(config_entries.OptionsFlow):
     """Handle Transmission client options."""
 
@@ -108,11 +118,11 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Check if new config entry matches any existing config entries
             for entry in self.hass.config_entries.async_entries(DOMAIN):
-                if entry.data[CONF_HOST] == user_input[CONF_HOST]:
+                if _host_is_same(entry.data[CONF_HOST], user_input[CONF_HOST]):
                     errors[CONF_HOST] = "host_exists"
                     break
 
-                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                if _name_is_same(entry.data[CONF_NAME], user_input[CONF_NAME]):
                     errors[CONF_NAME] = "name_exists"
                     break
 
@@ -165,9 +175,11 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a config entry from configuration.yaml."""
         # Check if new config entry matches any existing config entries
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data[CONF_HOST] == import_config[CONF_HOST] and entry.data[
-                CONF_NAME
-            ] == import_config.get(CONF_NAME):
+            if _host_is_same(
+                entry.data[CONF_HOST], import_config[CONF_HOST]
+            ) and _name_is_same(
+                entry.data[CONF_NAME], import_config.get(CONF_NAME, DEFAULT_NAME)
+            ):
                 updated_options = {}
 
                 if entry.data[CONF_VOLUME_STEP] != import_config[CONF_VOLUME_STEP]:
@@ -199,7 +211,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Check if new config entry matches any existing config entries and abort if so
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data[CONF_HOST] == discovery_info[CONF_HOST]:
+            if _host_is_same(entry.data[CONF_HOST], discovery_info[CONF_HOST]):
                 return self.async_abort(reason="already_setup")
 
         # Set default name to discovered device name by stripping zeroconf service

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -21,7 +21,7 @@
         "abort": {
             "already_setup": "This entry has already been setup.",
             "already_setup_with_diff_host_and_name": "This entry appears to have already been setup with a different host and name based on its serial number. Please remove any old entries from your configuration.yaml and from the Integrations menu before reattempting to add this device.",
-            "updated_entrry": "This entry has already been setup but the name and/or options defined in the config do not match the previously imported config so the config entry has been updated accordingly."
+            "updated_entry": "This entry has already been setup but the name and/or options defined in the config do not match the previously imported config so the config entry has been updated accordingly."
         }
     },
     "options": {

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -21,7 +21,7 @@
         "abort": {
             "already_setup": "This entry has already been setup.",
             "already_setup_with_diff_host_and_name": "This entry appears to have already been setup with a different host and name based on its serial number. Please remove any old entries from your configuration.yaml and from the Integrations menu before reattempting to add this device.",
-            "updated_options": "This entry has already been setup but the options defined in the config do not match the previously imported options values so the config entry has been updated accordingly."
+            "updated_entrry": "This entry has already been setup but the name and/or options defined in the config do not match the previously imported config so the config entry has been updated accordingly."
         }
     },
     "options": {

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -130,6 +130,29 @@ async def test_user_host_already_configured(
     assert result["errors"] == {CONF_HOST: "host_exists"}
 
 
+async def test_user_host_already_configured_no_port(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
+) -> None:
+    """Test host is already configured during user setup when existing entry has no port."""
+    no_port_entry = MOCK_SPEAKER_CONFIG.copy()
+    no_port_entry[CONF_HOST] = no_port_entry[CONF_HOST].split(":")[0]
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=no_port_entry, options={CONF_VOLUME_STEP: VOLUME_STEP}
+    )
+    entry.add_to_hass(hass)
+    fail_entry = MOCK_SPEAKER_CONFIG.copy()
+    fail_entry[CONF_NAME] = "newtestname"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "host_exists"}
+
+
 async def test_user_name_already_configured(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -317,11 +317,41 @@ async def test_import_flow_update_options(
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "updated_options"
+    assert result["reason"] == "updated_entry"
     assert (
         hass.config_entries.async_get_entry(entry_id).options[CONF_VOLUME_STEP]
         == VOLUME_STEP + 1
     )
+
+
+async def test_import_flow_update_name(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_update: pytest.fixture,
+) -> None:
+    """Test import config flow with updated name."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
+    )
+    await hass.async_block_till_done()
+
+    assert result["result"].data[CONF_NAME] == NAME
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    entry_id = result["result"].entry_id
+
+    updated_config = MOCK_IMPORT_VALID_TV_CONFIG.copy()
+    updated_config[CONF_NAME] = NAME2
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=vol.Schema(VIZIO_SCHEMA)(updated_config),
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "updated_entry"
+    assert hass.config_entries.async_get_entry(entry_id).data[CONF_NAME] == NAME2
 
 
 async def test_zeroconf_flow(

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -136,6 +136,7 @@ async def test_user_host_already_configured_no_port(
     vizio_bypass_setup: pytest.fixture,
 ) -> None:
     """Test host is already configured during user setup when existing entry has no port."""
+    # Mock entry without port so we can test that the same entry WITH a port will fail
     no_port_entry = MOCK_SPEAKER_CONFIG.copy()
     no_port_entry[CONF_HOST] = no_port_entry[CONF_HOST].split(":")[0]
     entry = MockConfigEntry(


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While testing the 0.105 beta, a user pointed out that they were still getting new entries from the discovery workflow for a host they already had imported via config. This is because the user had a host in their config with no port, and when a port isn't provided, `pyvizio` defaults to one. Since discovery always adds a port to the `host` property, the same host check wasn't catching that an entry was already configured. I updated the logic for checking a host to always strip the port when checking and added a test for this use case.

This should be cherry picked into the 0.105 release (please add the appropriate milestone label to the PR)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: issue was reported on Discord

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
