### PR TITLE
Fix iCloud device battery level can be None

### DIFF
--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -331,14 +331,13 @@ class IcloudDevice:
         device_status = DEVICE_STATUS_CODES.get(self._status[DEVICE_STATUS], "error")
         self._attrs[ATTR_DEVICE_STATUS] = device_status
 
-        if self._status[DEVICE_BATTERY_STATUS] != "Unknown":
-            self._battery_level = int(self._status.get(DEVICE_BATTERY_LEVEL, 0) * 100)
-            self._battery_status = self._status[DEVICE_BATTERY_STATUS]
-            low_power_mode = self._status[DEVICE_LOW_POWER_MODE]
-
+        self._battery_status = self._status[DEVICE_BATTERY_STATUS]
+        self._attrs[ATTR_BATTERY_STATUS] = self._battery_status
+        device_battery_level = self._status.get(DEVICE_BATTERY_LEVEL, 0)
+        if self._battery_status != "Unknown" and device_battery_level is not None:
+            self._battery_level = int(device_battery_level * 100)
             self._attrs[ATTR_BATTERY] = self._battery_level
-            self._attrs[ATTR_BATTERY_STATUS] = self._battery_status
-            self._attrs[ATTR_LOW_POWER_MODE] = low_power_mode
+            self._attrs[ATTR_LOW_POWER_MODE] = self._status[DEVICE_LOW_POWER_MODE]
 
             if (
                 self._status[DEVICE_LOCATION]


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix this error : 

```shell
   File "/usr/src/homeassistant/homeassistant/components/icloud/__init__.py", line 514, in update
     self._battery_level = int(self._status.get(DEVICE_BATTERY_LEVEL, 0) * 100)
 TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

It appears that a retrieved device can have a battery status not "Unknown" with a battery level to None on the API side, maybe the Apple Watch (which I can't test on).

So just checking the None value before setting a battery level.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31152
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
