### PR TITLE
Only normalise Garmin connect data to minutes if the value is not None

### DIFF
--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -165,9 +165,9 @@ class GarminConnectSensor(Entity):
             return
 
         data = self._data.data
-        if "Duration" in self._type:
+        if "Duration" in self._type and data[self._type]:
             self._state = data[self._type] // 60
-        elif "Seconds" in self._type:
+        elif "Seconds" in self._type and data[self._type]:
             self._state = data[self._type] // 60
         else:
             self._state = data[self._type]


### PR DESCRIPTION
Otherwise this causes additional TypeError messages to be logged for
division of None.

## Proposed change
 Minor improvement to reduce errors logged by Garmin connect.

This should fix these two errors:
- https://sentry.io/share/issue/4cdba06ab24c4c6d8ada5044d8cb84d8/
- https://sentry.io/share/issue/42860e340540420bb27f417725bcf0b1/

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.