### PR TITLE
Add support of multiple Tado accounts

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.util import Throttle
 
-from .const import CONF_FALLBACK
+from .const import CONF_FALLBACK, DATA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,12 +27,15 @@ SCAN_INTERVAL = timedelta(seconds=15)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_FALLBACK, default=True): cv.boolean,
-            }
+        DOMAIN: vol.All(
+            cv.ensure_list,
+            [
+                {
+                    vol.Required(CONF_USERNAME): cv.string,
+                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Optional(CONF_FALLBACK, default=True): cv.boolean,
+                }
+            ],
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -41,32 +44,36 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up of the Tado component."""
-    username = config[DOMAIN][CONF_USERNAME]
-    password = config[DOMAIN][CONF_PASSWORD]
+    acc_list = config[DOMAIN]
 
-    tadoconnector = TadoConnector(hass, username, password)
-    if not tadoconnector.setup():
-        return False
+    api_data_list = []
 
-    hass.data[DOMAIN] = tadoconnector
+    for acc in acc_list:
+        username = acc[CONF_USERNAME]
+        password = acc[CONF_PASSWORD]
+        fallback = acc[CONF_FALLBACK]
 
-    # Do first update
-    tadoconnector.update()
+        tadoconnector = TadoConnector(hass, username, password, fallback)
+        if not tadoconnector.setup():
+            continue
+
+        # Do first update
+        tadoconnector.update()
+
+        api_data_list.append(tadoconnector)
+        # Poll for updates in the background
+        hass.helpers.event.track_time_interval(
+            lambda now: tadoconnector.update(), SCAN_INTERVAL
+        )
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][DATA] = api_data_list
 
     # Load components
     for component in TADO_COMPONENTS:
         load_platform(
-            hass,
-            component,
-            DOMAIN,
-            {CONF_FALLBACK: config[DOMAIN][CONF_FALLBACK]},
-            config,
+            hass, component, DOMAIN, {}, config,
         )
-
-    # Poll for updates in the background
-    hass.helpers.event.track_time_interval(
-        lambda now: tadoconnector.update(), SCAN_INTERVAL
-    )
 
     return True
 
@@ -74,12 +81,14 @@ def setup(hass, config):
 class TadoConnector:
     """An object to store the Tado data."""
 
-    def __init__(self, hass, username, password):
+    def __init__(self, hass, username, password, fallback):
         """Initialize Tado Connector."""
         self.hass = hass
         self._username = username
         self._password = password
+        self._fallback = fallback
 
+        self.device_id = None
         self.tado = None
         self.zones = None
         self.devices = None
@@ -87,6 +96,11 @@ class TadoConnector:
             "zone": {},
             "device": {},
         }
+
+    @property
+    def fallback(self):
+        """Return fallback flag to Smart Schedule."""
+        return self._fallback
 
     def setup(self):
         """Connect to Tado and fetch the zones."""
@@ -101,7 +115,7 @@ class TadoConnector:
         # Load zones and devices
         self.zones = self.tado.getZones()
         self.devices = self.tado.getMe()["homes"]
-
+        self.device_id = self.devices[0]["id"]
         return True
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -63,7 +63,10 @@ def setup(hass, config):
         api_data_list.append(tadoconnector)
         # Poll for updates in the background
         hass.helpers.event.track_time_interval(
-            lambda now, tc=tadoconnector: tc.update(), SCAN_INTERVAL
+            # we're using here tadoconnector as a parameter of lambda
+            # to capture actual value instead of closuring of latest value
+            lambda now, tc=tadoconnector: tc.update(),
+            SCAN_INTERVAL,
         )
 
     hass.data[DOMAIN] = {}

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -63,7 +63,7 @@ def setup(hass, config):
         api_data_list.append(tadoconnector)
         # Poll for updates in the background
         hass.helpers.event.track_time_interval(
-            lambda now: tadoconnector.update(), SCAN_INTERVAL
+            lambda now, tc=tadoconnector: tc.update(), SCAN_INTERVAL
         )
 
     hass.data[DOMAIN] = {}

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -25,7 +25,7 @@ from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, TEMP_CELSIUS
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import CONF_FALLBACK, DOMAIN, SIGNAL_TADO_UPDATE_RECEIVED
+from . import DATA, DOMAIN, SIGNAL_TADO_UPDATE_RECEIVED
 from .const import (
     CONST_MODE_OFF,
     CONST_MODE_SMART_SCHEDULE,
@@ -70,21 +70,22 @@ SUPPORT_PRESET = [PRESET_AWAY, PRESET_HOME]
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tado climate platform."""
-    tado = hass.data[DOMAIN]
-
+    #    if discovery_info is None:
+    #      return
+    api_list = hass.data[DOMAIN][DATA]
     entities = []
-    for zone in tado.zones:
-        entity = create_climate_entity(
-            tado, zone["name"], zone["id"], discovery_info[CONF_FALLBACK]
-        )
-        if entity:
-            entities.append(entity)
+
+    for tado in api_list:
+        for zone in tado.zones:
+            entity = create_climate_entity(tado, zone["name"], zone["id"])
+            if entity:
+                entities.append(entity)
 
     if entities:
         add_entities(entities, True)
 
 
-def create_climate_entity(tado, name: str, zone_id: int, fallback: bool):
+def create_climate_entity(tado, name: str, zone_id: int):
     """Create a Tado climate entity."""
     capabilities = tado.get_capabilities(zone_id)
     _LOGGER.debug("Capabilities for zone %s: %s", zone_id, capabilities)
@@ -112,15 +113,7 @@ def create_climate_entity(tado, name: str, zone_id: int, fallback: bool):
     step = temperatures["celsius"].get("step", PRECISION_TENTHS)
 
     entity = TadoClimate(
-        tado,
-        name,
-        zone_id,
-        zone_type,
-        min_temp,
-        max_temp,
-        step,
-        ac_support_heat,
-        fallback,
+        tado, name, zone_id, zone_type, min_temp, max_temp, step, ac_support_heat,
     )
     return entity
 
@@ -138,7 +131,6 @@ class TadoClimate(ClimateDevice):
         max_temp,
         step,
         ac_support_heat,
-        fallback,
     ):
         """Initialize of Tado climate entity."""
         self._tado = tado
@@ -162,7 +154,7 @@ class TadoClimate(ClimateDevice):
         self._step = step
         self._target_temp = None
 
-        if fallback:
+        if tado.fallback:
             _LOGGER.debug("Default overlay is set to TADO MODE")
             # Fallback to Smart Schedule at next Schedule switch
             self._default_overlay = CONST_OVERLAY_TADO_MODE

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -138,6 +138,7 @@ class TadoClimate(ClimateDevice):
         self.zone_name = zone_name
         self.zone_id = zone_id
         self.zone_type = zone_type
+        self._unique_id = f"{zone_type} {zone_id} {tado.device_id}"
 
         self._ac_device = zone_type == TYPE_AIR_CONDITIONING
         self._ac_support_heat = ac_support_heat
@@ -190,6 +191,11 @@ class TadoClimate(ClimateDevice):
     def name(self):
         """Return the name of the entity."""
         return self.zone_name
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -70,8 +70,6 @@ SUPPORT_PRESET = [PRESET_AWAY, PRESET_HOME]
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tado climate platform."""
-    #    if discovery_info is None:
-    #      return
     api_list = hass.data[DOMAIN][DATA]
     entities = []
 

--- a/homeassistant/components/tado/const.py
+++ b/homeassistant/components/tado/const.py
@@ -2,6 +2,7 @@
 
 # Configuration
 CONF_FALLBACK = "fallback"
+DATA = "data"
 
 # Types
 TYPE_AIR_CONDITIONING = "AIR_CONDITIONING"

--- a/homeassistant/components/tado/sensor.py
+++ b/homeassistant/components/tado/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from . import DOMAIN, SIGNAL_TADO_UPDATE_RECEIVED
+from . import DATA, DOMAIN, SIGNAL_TADO_UPDATE_RECEIVED
 from .const import TYPE_AIR_CONDITIONING, TYPE_HEATING, TYPE_HOT_WATER
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,26 +40,29 @@ DEVICE_SENSORS = ["tado bridge status"]
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
-    tado = hass.data[DOMAIN]
+    api_list = hass.data[DOMAIN][DATA]
 
-    # Create zone sensors
     entities = []
-    for zone in tado.zones:
-        entities.extend(
-            [
-                create_zone_sensor(tado, zone["name"], zone["id"], variable)
-                for variable in ZONE_SENSORS.get(zone["type"])
-            ]
-        )
 
-    # Create device sensors
-    for home in tado.devices:
-        entities.extend(
-            [
-                create_device_sensor(tado, home["name"], home["id"], variable)
-                for variable in DEVICE_SENSORS
-            ]
-        )
+    for tado in api_list:
+        # Create zone sensors
+
+        for zone in tado.zones:
+            entities.extend(
+                [
+                    create_zone_sensor(tado, zone["name"], zone["id"], variable)
+                    for variable in ZONE_SENSORS.get(zone["type"])
+                ]
+            )
+
+        # Create device sensors
+        for home in tado.devices:
+            entities.extend(
+                [
+                    create_device_sensor(tado, home["name"], home["id"], variable)
+                    for variable in DEVICE_SENSORS
+                ]
+            )
 
     add_entities(entities, True)
 
@@ -86,7 +89,7 @@ class TadoSensor(Entity):
         self.zone_variable = zone_variable
         self.sensor_type = sensor_type
 
-        self._unique_id = f"{zone_variable} {zone_id}"
+        self._unique_id = f"{zone_variable} {zone_id} {tado.device_id}"
 
         self._state = None
         self._state_attributes = None

--- a/homeassistant/components/tado/sensor.py
+++ b/homeassistant/components/tado/sensor.py
@@ -230,23 +230,16 @@ class TadoSensor(Entity):
                 self._state = data["tadoMode"]
 
         elif self.zone_variable == "overlay":
-            if "overlay" in data and data["overlay"] is not None:
-                self._state = True
-                self._state_attributes = {
-                    "termination": data["overlay"]["termination"]["type"]
-                }
-            else:
-                self._state = False
-                self._state_attributes = {}
+            self._state = "overlay" in data and data["overlay"] is not None
+            self._state_attributes = (
+                {"termination": data["overlay"]["termination"]["type"]}
+                if self._state
+                else {}
+            )
 
         elif self.zone_variable == "early start":
-            if "preparation" in data and data["preparation"] is not None:
-                self._state = True
-            else:
-                self._state = False
+            self._state = "preparation" in data and data["preparation"] is not None
 
         elif self.zone_variable == "open window":
-            if "openWindowDetected" in data:
-                self._state = data["openWindowDetected"]
-            else:
-                self._state = False
+            self._state = "openWindow" in data and data["openWindow"] is not None
+            self._state_attributes = data["openWindow"] if self._state else {}


### PR DESCRIPTION
Added support of multiple Tado accounts
Changed generation of sensor unique id.
FIxed error detecting opened window.
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Changed generation of unique id of sensor and climate - now it includes id of home.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
RIght now Tado has no native support of multiple bridges in one account. This change allows to add multiple Tado accounts to HASS.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
tado:
  - username: user1@example.com
    password: !secret tado_pwd1
  - username: user2@example.com
    password: !secret tado_pwd2
```
In case of only one account this configuration will also work:
```yaml
# Example configuration.yaml
tado:
    username: user@example.com
    password: !secret tado_pwd
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
**Important**: chrism0dwk/PyTado#10 must be merged into PyTado to this change to work correctly.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
