### PR TITLE
Fix iCloud determine_interval: add default interval to max_interval

### DIFF
--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -26,6 +26,7 @@ from .const import (
     DEVICE_DISPLAY_NAME,
     DEVICE_ID,
     DEVICE_LOCATION,
+    DEVICE_LOCATION_HORIZONTAL_ACCURACY,
     DEVICE_LOCATION_LATITUDE,
     DEVICE_LOCATION_LONGITUDE,
     DEVICE_LOST_MODE_CAPABLE,
@@ -175,8 +176,9 @@ class IcloudAccount:
 
     def _determine_interval(self) -> int:
         """Calculate new interval between two API fetch (in minutes)."""
-        intervals = {}
+        intervals = {"default": self._max_interval}
         for device in self._devices.values():
+            # Max interval if no location
             if device.location is None:
                 continue
 
@@ -186,10 +188,11 @@ class IcloudAccount:
                 self.hass,
                 device.location[DEVICE_LOCATION_LATITUDE],
                 device.location[DEVICE_LOCATION_LONGITUDE],
+                device.location[DEVICE_LOCATION_HORIZONTAL_ACCURACY],
             ).result()
 
+            # Max interval if in zone
             if current_zone is not None:
-                intervals[device.name] = self._max_interval
                 continue
 
             zones = (
@@ -209,6 +212,7 @@ class IcloudAccount:
                 )
                 distances.append(round(zone_distance / 1000, 1))
 
+            # Max interval if no zone
             if not distances:
                 continue
             mindistance = min(distances)


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a default interval to default to take care of non location/in zone/no zone use case.

Will also avoid this log : 
```shell
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 215, in async_setup
    hass, self
  File "/usr/src/homeassistant/homeassistant/components/icloud/__init__.py", line 158, in async_setup_entry
    await hass.async_add_executor_job(account.setup)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/icloud/__init__.py", line 307, in setup
    self.update_devices()
  File "/usr/src/homeassistant/homeassistant/components/icloud/__init__.py", line 341, in update_devices
    self._fetch_interval = self._determine_interval()
  File "/usr/src/homeassistant/homeassistant/components/icloud/__init__.py", line 411, in _determine_interval
    int(min(intervals.items(), key=operator.itemgetter(1))[1]),
ValueError: min() arg is an empty sequence
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31374 and fixes #31535
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
