### PR TITLE
Limit OAuth scopes for Netatmo and Home Assistant Cloud

### DIFF
--- a/homeassistant/components/netatmo/config_flow.py
+++ b/homeassistant/components/netatmo/config_flow.py
@@ -25,24 +25,21 @@ class NetatmoFlowHandler(
     @property
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
-        return {
-            "scope": (
-                " ".join(
-                    [
-                        "read_station",
-                        "read_camera",
-                        "access_camera",
-                        "write_camera",
-                        "read_presence",
-                        "access_presence",
-                        "read_homecoach",
-                        "read_smokedetector",
-                        "read_thermostat",
-                        "write_thermostat",
-                    ]
-                )
-            )
-        }
+        scopes = [
+            "read_station",
+            "read_camera",
+            "write_camera",
+            "read_presence",
+            "read_homecoach",
+            "read_smokedetector",
+            "read_thermostat",
+            "write_thermostat",
+        ]
+
+        if self.flow_impl.name != "Home Assistant Cloud":
+            scopes.extend(["access_camera", "access_presence"])
+
+        return {"scope": " ".join(scopes)}
 
     async def async_step_user(self, user_input=None):
         """Handle a flow start."""

--- a/homeassistant/components/netatmo/config_flow.py
+++ b/homeassistant/components/netatmo/config_flow.py
@@ -26,18 +26,19 @@ class NetatmoFlowHandler(
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
         scopes = [
-            "read_station",
             "read_camera",
-            "write_camera",
-            "read_presence",
             "read_homecoach",
+            "read_presence",
             "read_smokedetector",
+            "read_station",
             "read_thermostat",
+            "write_camera",
             "write_thermostat",
         ]
 
         if self.flow_impl.name != "Home Assistant Cloud":
             scopes.extend(["access_camera", "access_presence"])
+            scopes.sort()
 
         return {"scope": " ".join(scopes)}
 

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -54,15 +54,15 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock):
 
     scope = "+".join(
         [
-            "read_station",
-            "read_camera",
             "access_camera",
-            "write_camera",
-            "read_presence",
             "access_presence",
+            "read_camera",
             "read_homecoach",
+            "read_presence",
             "read_smokedetector",
+            "read_station",
             "read_thermostat",
+            "write_camera",
             "write_thermostat",
         ]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds a temporary hotfix for Netatmo when using Home Assistant Cloud.

The PR limits the scopes used until the Home Assistant Cloud Partner account gets access to these scopes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
