### PR TITLE
Add recorder vars db_max_retries and db_retry_wait

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -141,13 +141,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     conf = config[DOMAIN]
     keep_days = conf.get(CONF_PURGE_KEEP_DAYS)
     purge_interval = conf.get(CONF_PURGE_INTERVAL)
+    db_max_retries = conf[CONF_DB_MAX_RETRIES]
+    db_retry_wait = conf[CONF_DB_RETRY_WAIT]
 
     db_url = conf.get(CONF_DB_URL, None)
     if not db_url:
         db_url = DEFAULT_URL.format(hass_config_path=hass.config.path(DEFAULT_DB_FILE))
 
-    db_max_retries = conf.get(CONF_DB_MAX_RETRIES)
-    db_retry_wait = conf.get(CONF_DB_RETRY_WAIT)
+
 
     include = conf.get(CONF_INCLUDE, {})
     exclude = conf.get(CONF_EXCLUDE, {})

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -98,8 +98,8 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Coerce(int), vol.Range(min=0)
                 ),
                 vol.Optional(CONF_DB_URL): cv.string,
-                vol.Optional(CONF_DB_MAX_RETRIES): cv.positive_int,
-                vol.Optional(CONF_DB_RETRY_WAIT): cv.positive_int,
+                vol.Optional(CONF_DB_MAX_RETRIES, default=DEFAULT_DB_MAX_RETRIES): cv.positive_int,
+                vol.Optional(CONF_DB_RETRY_WAIT, default=DEFAULT_DB_RETRY_WAIT): cv.positive_int,
             }
         )
     },
@@ -142,13 +142,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if not db_url:
         db_url = DEFAULT_URL.format(hass_config_path=hass.config.path(DEFAULT_DB_FILE))
 
-    db_max_retries = conf.get(CONF_DB_MAX_RETRIES, None)
-    if not db_max_retries:
-        db_max_retries = DEFAULT_DB_MAX_RETRIES
-
-    db_retry_wait = conf.get(CONF_DB_RETRY_WAIT, None)
-    if not db_retry_wait:
-        db_retry_wait = DEFAULT_DB_RETRY_WAIT
+    db_max_retries = conf.get(CONF_DB_MAX_RETRIES)
+    db_retry_wait = conf.get(CONF_DB_RETRY_WAIT)
 
     include = conf.get(CONF_INCLUDE, {})
     exclude = conf.get(CONF_EXCLUDE, {})

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -148,8 +148,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if not db_url:
         db_url = DEFAULT_URL.format(hass_config_path=hass.config.path(DEFAULT_DB_FILE))
 
-
-
     include = conf.get(CONF_INCLUDE, {})
     exclude = conf.get(CONF_EXCLUDE, {})
     instance = hass.data[DATA_INSTANCE] = Recorder(

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -59,13 +59,15 @@ SERVICE_PURGE_SCHEMA = vol.Schema(
 
 DEFAULT_URL = "sqlite:///{hass_config_path}"
 DEFAULT_DB_FILE = "home-assistant_v2.db"
+DEFAULT_DB_MAX_RETRIES = 10
+DEFAULT_DB_RETRY_WAIT = 3
 
 CONF_DB_URL = "db_url"
+CONF_DB_MAX_RETRIES = "db_max_retries"
+CONF_DB_RETRY_WAIT = "db_retry_wait"
 CONF_PURGE_KEEP_DAYS = "purge_keep_days"
 CONF_PURGE_INTERVAL = "purge_interval"
 CONF_EVENT_TYPES = "event_types"
-
-CONNECT_RETRY_WAIT = 3
 
 FILTER_SCHEMA = vol.Schema(
     {
@@ -96,6 +98,8 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Coerce(int), vol.Range(min=0)
                 ),
                 vol.Optional(CONF_DB_URL): cv.string,
+                vol.Optional(CONF_DB_MAX_RETRIES): cv.positive_int,
+                vol.Optional(CONF_DB_RETRY_WAIT): cv.positive_int,
             }
         )
     },
@@ -138,6 +142,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if not db_url:
         db_url = DEFAULT_URL.format(hass_config_path=hass.config.path(DEFAULT_DB_FILE))
 
+    db_max_retries = conf.get(CONF_DB_MAX_RETRIES, None)
+    if not db_max_retries:
+        db_max_retries = DEFAULT_DB_MAX_RETRIES
+
+    db_retry_wait = conf.get(CONF_DB_RETRY_WAIT, None)
+    if not db_retry_wait:
+        db_retry_wait = DEFAULT_DB_RETRY_WAIT
+
     include = conf.get(CONF_INCLUDE, {})
     exclude = conf.get(CONF_EXCLUDE, {})
     instance = hass.data[DATA_INSTANCE] = Recorder(
@@ -145,6 +157,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         keep_days=keep_days,
         purge_interval=purge_interval,
         uri=db_url,
+        db_max_retries=db_max_retries,
+        db_retry_wait=db_retry_wait,
         include=include,
         exclude=exclude,
     )
@@ -174,6 +188,8 @@ class Recorder(threading.Thread):
         keep_days: int,
         purge_interval: int,
         uri: str,
+        db_max_retries: int,
+        db_retry_wait: int,
         include: Dict,
         exclude: Dict,
     ) -> None:
@@ -186,6 +202,8 @@ class Recorder(threading.Thread):
         self.queue: Any = queue.Queue()
         self.recording_start = dt_util.utcnow()
         self.db_url = uri
+        self.db_max_retries = db_max_retries
+        self.db_retry_wait = db_retry_wait
         self.async_db_ready = asyncio.Future()
         self.engine: Any = None
         self.run_info: Any = None
@@ -217,9 +235,9 @@ class Recorder(threading.Thread):
         tries = 1
         connected = False
 
-        while not connected and tries <= 10:
+        while not connected and tries <= self.db_max_retries:
             if tries != 1:
-                time.sleep(CONNECT_RETRY_WAIT)
+                time.sleep(self.db_retry_wait)
             try:
                 self._setup_connection()
                 migration.migrate_schema(self)
@@ -230,7 +248,7 @@ class Recorder(threading.Thread):
                 _LOGGER.error(
                     "Error during connection setup: %s (retrying in %s seconds)",
                     err,
-                    CONNECT_RETRY_WAIT,
+                    self.db_retry_wait,
                 )
                 tries += 1
 
@@ -337,9 +355,9 @@ class Recorder(threading.Thread):
 
             tries = 1
             updated = False
-            while not updated and tries <= 10:
+            while not updated and tries <= self.db_max_retries:
                 if tries != 1:
-                    time.sleep(CONNECT_RETRY_WAIT)
+                    time.sleep(self.db_retry_wait)
                 try:
                     with session_scope(session=self.get_session()) as session:
                         try:
@@ -367,7 +385,7 @@ class Recorder(threading.Thread):
                         "Error in database connectivity: %s. "
                         "(retrying in %s seconds)",
                         err,
-                        CONNECT_RETRY_WAIT,
+                        self.db_retry_wait,
                     )
                     tries += 1
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -98,8 +98,12 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Coerce(int), vol.Range(min=0)
                 ),
                 vol.Optional(CONF_DB_URL): cv.string,
-                vol.Optional(CONF_DB_MAX_RETRIES, default=DEFAULT_DB_MAX_RETRIES): cv.positive_int,
-                vol.Optional(CONF_DB_RETRY_WAIT, default=DEFAULT_DB_RETRY_WAIT): cv.positive_int,
+                vol.Optional(
+                    CONF_DB_MAX_RETRIES, default=DEFAULT_DB_MAX_RETRIES
+                ): cv.positive_int,
+                vol.Optional(
+                    CONF_DB_RETRY_WAIT, default=DEFAULT_DB_RETRY_WAIT
+                ): cv.positive_int,
             }
         )
     },

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -205,7 +205,7 @@ def test_recorder_setup_failure():
             db_max_retries=10,
             db_retry_wait=3,
             include={},
-            exclude={}
+            exclude={},
         )
         rec.start()
         rec.join()

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -198,7 +198,14 @@ def test_recorder_setup_failure():
     ):
         setup.side_effect = ImportError("driver not found")
         rec = Recorder(
-            hass, keep_days=7, purge_interval=2, uri="sqlite://", db_max_retries=10, db_retry_wait=3, include={}, exclude={}
+            hass,
+            keep_days=7,
+            purge_interval=2,
+            uri="sqlite://",
+            db_max_retries=10,
+            db_retry_wait=3,
+            include={},
+            exclude={}
         )
         rec.start()
         rec.join()

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -198,7 +198,7 @@ def test_recorder_setup_failure():
     ):
         setup.side_effect = ImportError("driver not found")
         rec = Recorder(
-            hass, keep_days=7, purge_interval=2, uri="sqlite://", db_max_retries=10, db_retry_wait=3 include={}, exclude={}
+            hass, keep_days=7, purge_interval=2, uri="sqlite://", db_max_retries=10, db_retry_wait=3, include={}, exclude={}
         )
         rec.start()
         rec.join()

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -198,7 +198,7 @@ def test_recorder_setup_failure():
     ):
         setup.side_effect = ImportError("driver not found")
         rec = Recorder(
-            hass, keep_days=7, purge_interval=2, uri="sqlite://", include={}, exclude={}
+            hass, keep_days=7, purge_interval=2, uri="sqlite://", db_max_retries=10, db_retry_wait=3 include={}, exclude={}
         )
         rec.start()
         rec.join()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Essentially, i'm proposing to add:
* db_retry_wait: <int>
* db_max_retries: <int>

to the recorder component. These are necessary because currently the retry count and sleep time is fixed to 10 retries, and 3 seconds sleep. I want to change that, so that its a variable.

The need came from an issue i had where my mariadb were consistently so slow to start, that my Home assistant container made its 10 retries and moved on. Testing shows that a completely new mariadb is about 2 mins to start up, so i was trying to figure out a way to force HA to check a bit more.
Proposed fixed were scripting the deploy, wrapping Home Assistant in a wait-for-it or dockerize container and using that to wait, but this seems like the best solution that benefits most people.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

default_config:

group: !include groups.yaml
automation: !include automations.yaml
script: !include scripts.yaml
scene: !include scenes.yaml

recorder:
  db_url: mysql://hass:hass@db:3306/hass?charset=utf8
  db_retry_wait: 10 # Wait 10 seconds between tries.
  db_max_retries: 20 # Try to connect 20 times.

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I have not submitted an issue for this however we did have a lengthy dicussion about this on discord Installation>Core around 12:27 AM the 6th of february. Here we discussed possible other solutions and came to the conclusion that this was probably the best solution.

Also, disclaimer. This is my first run with python. I'm a capable developer otherwise, but this is the first time i've ever done anything with python. Please let me know if you got any comments or anything im missing.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
