### PR TITLE
Change github sensor state to short commit sha

### DIFF
--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -132,18 +132,20 @@ class GitHubSensor(Entity):
         self._github_data.update()
 
         self._name = self._github_data.name
-        self._state = self._github_data.latest_release_url.split("tag/")[1]
         self._repository_path = self._github_data.repository_path
         self._available = self._github_data.available
         self._latest_commit_message = self._github_data.latest_commit_message
         self._latest_commit_sha = self._github_data.latest_commit_sha
         self._latest_release_url = self._github_data.latest_release_url
+        if self._latest_release_url is not None:
+            self._state = self._latest_release_url.split("tag/")[1]
+        else:
+            self._state = None
         self._open_issue_count = self._github_data.open_issue_count
         self._latest_open_issue_url = self._github_data.latest_open_issue_url
         self._pull_request_count = self._github_data.pull_request_count
         self._latest_open_pr_url = self._github_data.latest_open_pr_url
         self._stargazers = self._github_data.stargazers
-
 
 class GitHubData:
     """GitHub Data object."""

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -132,7 +132,7 @@ class GitHubSensor(Entity):
         self._github_data.update()
 
         self._name = self._github_data.name
-        self._state = self._github_data.latest_commit_sha
+        self._state = self._github_data.latest_release_url
         self._repository_path = self._github_data.repository_path
         self._available = self._github_data.available
         self._latest_commit_message = self._github_data.latest_commit_message

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -147,7 +147,7 @@ class GitHubSensor(Entity):
         self._latest_open_pr_url = self._github_data.latest_open_pr_url
         self._stargazers = self._github_data.stargazers
 
-        
+
 class GitHubData:
     """GitHub Data object."""
 

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -132,7 +132,7 @@ class GitHubSensor(Entity):
         self._github_data.update()
 
         self._name = self._github_data.name
-        self._state = self._github_data.latest_release_url
+        self._state = self._github_data.latest_release_url.split("tag/")[1]
         self._repository_path = self._github_data.repository_path
         self._available = self._github_data.available
         self._latest_commit_message = self._github_data.latest_commit_message

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -140,7 +140,7 @@ class GitHubSensor(Entity):
         if self._latest_release_url is not None:
             self._state = self._latest_release_url.split("tag/")[1]
         else:
-            self._state = self._github_data.latest_commit_sha[0:7]
+            self._state = self._github_data.latest_commit_sha[0:8]
         self._open_issue_count = self._github_data.open_issue_count
         self._latest_open_issue_url = self._github_data.latest_open_issue_url
         self._pull_request_count = self._github_data.pull_request_count

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -147,6 +147,7 @@ class GitHubSensor(Entity):
         self._latest_open_pr_url = self._github_data.latest_open_pr_url
         self._stargazers = self._github_data.stargazers
 
+        
 class GitHubData:
     """GitHub Data object."""
 

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -137,10 +137,7 @@ class GitHubSensor(Entity):
         self._latest_commit_message = self._github_data.latest_commit_message
         self._latest_commit_sha = self._github_data.latest_commit_sha
         self._latest_release_url = self._github_data.latest_release_url
-        if self._latest_release_url is not None:
-            self._state = self._latest_release_url.split("tag/")[1]
-        else:
-            self._state = self._github_data.latest_commit_sha[0:8]
+        self._state = self._github_data.latest_commit_sha[0:8]
         self._open_issue_count = self._github_data.open_issue_count
         self._latest_open_issue_url = self._github_data.latest_open_issue_url
         self._pull_request_count = self._github_data.pull_request_count

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -140,7 +140,7 @@ class GitHubSensor(Entity):
         if self._latest_release_url is not None:
             self._state = self._latest_release_url.split("tag/")[1]
         else:
-            self._state = None
+            self._state = self._github_data.latest_commit_sha[0:7]
         self._open_issue_count = self._github_data.open_issue_count
         self._latest_open_issue_url = self._github_data.latest_open_issue_url
         self._pull_request_count = self._github_data.pull_request_count


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The entity state has been changed to return the 'short SHA' commit hash, so automations based on `latest_commit_sha` should be adapted to that.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

to have a meaningful frontend representation.
self._github_data.latest_commit_sha is still available in the attributes, so no info is lost

would be very nice if we could see this, using native HA sensor (now created with a custom-card)
(screenshot only referring to the state, not yet the secondary-info)

<img width="432" alt="Schermafbeelding 2020-02-05 om 12 58 49" src="https://user-images.githubusercontent.com/33354141/74020116-2652b580-4999-11ea-9651-d06dcf66f6b9.png">

opposed to current display with sha as state:

<img width="370" alt="Schermafbeelding 2020-02-07 om 11 04 13" src="https://user-images.githubusercontent.com/33354141/74020375-b55fcd80-4999-11ea-8d85-9e6f91d5e442.png">

To have a more meaningful and useful representation in the frontend

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
