### PR TITLE
Fix librouteros response error handling

### DIFF
--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -126,7 +126,7 @@ class MikrotikData:
     def get_info(self, param):
         """Return device model name."""
         cmd = IDENTITY if param == NAME else INFO
-        data = list(self.command(MIKROTIK_SERVICES[cmd]))
+        data = self.command(MIKROTIK_SERVICES[cmd])
         return data[0].get(param) if data else None
 
     def get_hub_details(self):
@@ -148,7 +148,7 @@ class MikrotikData:
 
     def get_list_from_interface(self, interface):
         """Get devices from interface."""
-        result = list(self.command(MIKROTIK_SERVICES[interface]))
+        result = self.command(MIKROTIK_SERVICES[interface])
         return self.load_mac(result) if result else {}
 
     def restore_device(self, mac):
@@ -224,7 +224,7 @@ class MikrotikData:
             "address": ip_address,
         }
         cmd = "/ping"
-        data = list(self.command(cmd, params))
+        data = self.command(cmd, params)
         if data is not None:
             status = 0
             for result in data:
@@ -242,9 +242,9 @@ class MikrotikData:
         try:
             _LOGGER.info("Running command %s", cmd)
             if params:
-                response = self.api(cmd=cmd, **params)
+                response = list(self.api(cmd=cmd, **params))
             else:
-                response = self.api(cmd=cmd)
+                response = list(self.api(cmd=cmd))
         except (
             librouteros.exceptions.ConnectionClosed,
             socket.error,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Better handle `ProtocolError` from librouteros by applying `list` to the response.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
