### PR TITLE
Make emulated_hue less open

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -42,6 +42,8 @@ CONF_LISTEN_PORT = "listen_port"
 CONF_OFF_MAPS_TO_ON_DOMAINS = "off_maps_to_on_domains"
 CONF_TYPE = "type"
 CONF_UPNP_BIND_MULTICAST = "upnp_bind_multicast"
+CONF_LINK_BUTTON_ENTITY = "link_button_entity"
+CONF_CLIENT_USERNAME = "client_username"
 
 TYPE_ALEXA = "alexa"
 TYPE_GOOGLE = "google_home"
@@ -59,6 +61,7 @@ DEFAULT_EXPOSED_DOMAINS = [
     "fan",
 ]
 DEFAULT_TYPE = TYPE_GOOGLE
+DEFAULT_HUE_API_USERNAME = "12345678901234567890"
 
 CONFIG_ENTITY_SCHEMA = vol.Schema(
     {
@@ -85,6 +88,8 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_ENTITIES): vol.Schema(
                     {cv.entity_id: CONFIG_ENTITY_SCHEMA}
                 ),
+                vol.Optional(CONF_LINK_BUTTON_ENTITY): cv.string,
+                vol.Optional(CONF_CLIENT_USERNAME): cv.string,
             }
         )
     },
@@ -114,7 +119,7 @@ async def async_setup(hass, yaml_config):
     site = None
 
     DescriptionXmlView(config).register(app, app.router)
-    HueUsernameView().register(app, app.router)
+    HueUsernameView(config).register(app, app.router)
     HueUnauthorizedUser().register(app, app.router)
     HueAllLightsStateView(config).register(app, app.router)
     HueOneLightStateView(config).register(app, app.router)
@@ -228,6 +233,12 @@ class Config:
         self.advertise_port = conf.get(CONF_ADVERTISE_PORT) or self.listen_port
 
         self.entities = conf.get(CONF_ENTITIES, {})
+
+        self.link_button_entity_id = conf.get(CONF_LINK_BUTTON_ENTITY, None)
+
+        self.client_username = (
+            conf.get(CONF_CLIENT_USERNAME) or DEFAULT_HUE_API_USERNAME
+        )
 
     def entity_id_to_number(self, entity_id):
         """Get a unique number for the entity id."""

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,7 +1,12 @@
 """Test the Emulated Hue component."""
 from unittest.mock import MagicMock, Mock, patch
 
-from homeassistant.components.emulated_hue import Config
+from homeassistant.components.emulated_hue import (
+    CONF_CLIENT_USERNAME,
+    CONF_LINK_BUTTON_ENTITY,
+    DEFAULT_HUE_API_USERNAME,
+    Config,
+)
 
 
 def test_config_google_home_entity_id_to_number():
@@ -115,3 +120,21 @@ def test_config_alexa_entity_id_to_number():
 
     entity_id = conf.number_to_entity_id("light.test")
     assert entity_id == "light.test"
+
+
+def test_config_client_username_has_default():
+    """Test config adheres to the type."""
+    conf = Config(None, {})
+    assert conf.client_username == DEFAULT_HUE_API_USERNAME
+
+
+def test_config_client_username():
+    """Test config adheres to the type."""
+    conf = Config(None, {CONF_CLIENT_USERNAME: "test_value"})
+    assert conf.client_username == "test_value"
+
+
+def test_config_link_button_entity():
+    """Test config adheres to the type."""
+    conf = Config(None, {CONF_LINK_BUTTON_ENTITY: "input_boolean.some_button"})
+    assert conf.link_button_entity_id == "input_boolean.some_button"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As of right now, `emulated_hue` is open for any device that tries to connect it - anytime client device initiates paring procedure it receives `username` right away as if the hue bridge "link button" was already pressed. Not only that, this `username` is always the same, for every device, hardcoded into the code, and thus well known. The fact that `emulated_hue` responds with the `username` right away may even confuse some devices (Harmony Remote @ Mobile App) and result in endless pairing.
This PR adds two new configuration options for `emulated_hue` to improve this behavior: 

* *link_button_entity* - accepts any on/off entity (like `input_boolean`). If set, this entity controls virtual "link button". When the entity is `ON`, `emulated_hue` accepts any paring request. If it's `OFF`, `emulated_hue` rejects any paring request in the same way as Hue Bridge does. If this option is omitted, `emulated_hue` behaves as before (button always *ON*) for backwards compatibility.
* *client_username* - overrides default hardcoded `username` send to paired device. This is to prevent malicious apps from bypassing paring process due to default `username` being public.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
emulated_hue:
  listen_port: 80

  link_button_entity: input_boolean.hue_link_button
  client_username: "30197ed87b6fb3d7c2a8c1fcdcdb3291"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: -
- This PR is related to issue: -
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12007

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
