### PR TITLE
Fix exceptions when using newer Samsung TVs

### DIFF
--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -32,11 +32,11 @@ RESULT_SUCCESS = "success"
 RESULT_NOT_SUCCESSFUL = "not_successful"
 RESULT_NOT_SUPPORTED = "not_supported"
 
-SUPPORTED_METHOS = [
+SUPPORTED_METHOS = (
     {"method": "websocket", "timeout": 1},
     # We need this high timeout because waiting for auth popup is just an open socket
     {"method": "legacy", "timeout": 31},
-]
+)
 
 
 def _get_ip(host):

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from samsungctl import Remote
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 import voluptuous as vol
+from websocket import WebSocketException
 
 from homeassistant import config_entries
 from homeassistant.components.ssdp import (
@@ -100,7 +101,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except AccessDenied:
                 LOGGER.debug("Working but denied config: %s", config)
                 return RESULT_AUTH_MISSING
-            except UnhandledResponse:
+            except (UnhandledResponse, WebSocketException):
                 LOGGER.debug("Working but unsupported config: %s", config)
                 return RESULT_NOT_SUPPORTED
             except OSError as err:

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 )
 
 # pylint:disable=unused-import
-from .const import CONF_MANUFACTURER, CONF_MODEL, DOMAIN, LOGGER, METHODS
+from .const import CONF_MANUFACTURER, CONF_MODEL, DOMAIN, LOGGER
 
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str, vol.Required(CONF_NAME): str})
 
@@ -31,6 +31,12 @@ RESULT_AUTH_MISSING = "auth_missing"
 RESULT_SUCCESS = "success"
 RESULT_NOT_SUCCESSFUL = "not_successful"
 RESULT_NOT_SUPPORTED = "not_supported"
+
+SUPPORTED_METHOS = [
+    {"method": "websocket", "timeout": 1},
+    # We need this high timeout because waiting for auth popup is just an open socket
+    {"method": "legacy", "timeout": 31},
+]
 
 
 def _get_ip(host):
@@ -76,22 +82,20 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _try_connect(self):
         """Try to connect and check auth."""
-        for method in METHODS:
+        for cfg in SUPPORTED_METHOS:
             config = {
                 "name": "HomeAssistant",
                 "description": "HomeAssistant",
                 "id": "ha.component.samsung",
                 "host": self._host,
-                "method": method,
                 "port": self._port,
-                # We need this high timeout because waiting for auth popup is just an open socket
-                "timeout": 31,
             }
+            config.update(cfg)
             try:
                 LOGGER.debug("Try config: %s", config)
                 with Remote(config.copy()):
                     LOGGER.debug("Working config: %s", config)
-                    self._method = method
+                    self._method = cfg["method"]
                     return RESULT_SUCCESS
             except AccessDenied:
                 LOGGER.debug("Working but denied config: %s", config)

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -33,7 +33,7 @@ RESULT_SUCCESS = "success"
 RESULT_NOT_SUCCESSFUL = "not_successful"
 RESULT_NOT_SUPPORTED = "not_supported"
 
-SUPPORTED_METHOS = (
+SUPPORTED_METHODS = (
     {"method": "websocket", "timeout": 1},
     # We need this high timeout because waiting for auth popup is just an open socket
     {"method": "legacy", "timeout": 31},
@@ -83,7 +83,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _try_connect(self):
         """Try to connect and check auth."""
-        for cfg in SUPPORTED_METHOS:
+        for cfg in SUPPORTED_METHODS:
             config = {
                 "name": "HomeAssistant",
                 "description": "HomeAssistant",

--- a/homeassistant/components/samsungtv/const.py
+++ b/homeassistant/components/samsungtv/const.py
@@ -9,5 +9,3 @@ DEFAULT_NAME = "Samsung TV"
 CONF_MANUFACTURER = "manufacturer"
 CONF_MODEL = "model"
 CONF_ON_ACTION = "turn_on_action"
-
-METHODS = ("websocket", "legacy")

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -42,7 +42,7 @@ AUTODETECT_WEBSOCKET = {
     "method": "websocket",
     "port": None,
     "host": "fake_host",
-    "timeout": 31,
+    "timeout": 1,
 }
 AUTODETECT_LEGACY = {
     "name": "HomeAssistant",

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import call, patch
 from asynctest import mock
 import pytest
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
+from websocket import WebSocketProtocolException
 
 from homeassistant.components.samsungtv.const import (
     CONF_MANUFACTURER,
@@ -228,6 +229,28 @@ async def test_ssdp_not_supported(hass):
     with patch(
         "homeassistant.components.samsungtv.config_flow.Remote",
         side_effect=UnhandledResponse("Boom"),
+    ), patch("homeassistant.components.samsungtv.config_flow.socket"):
+
+        # confirm to add the entry
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "confirm"
+
+        # device not supported
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input="whatever"
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == "not_supported"
+
+
+async def test_ssdp_not_supported_2(hass):
+    """Test starting a flow from discovery for not supported device."""
+    with patch(
+        "homeassistant.components.samsungtv.config_flow.Remote",
+        side_effect=WebSocketProtocolException("Boom"),
     ), patch("homeassistant.components.samsungtv.config_flow.socket"):
 
         # confirm to add the entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Catch exceptions from newer websocket TVs and show not supported message. This is a step back compared to pre-0.105 because we now do not add the newer TVs. Previously they were added but showed at least on/off state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This does not solve the issue #31504 but catches the exceptions.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [<] The code has been formatted using Black (`black --fast homeassistant tests`)
- [<] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
