### PR TITLE
Fix lg soundbar

### DIFF
--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -26,15 +26,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the LG platform."""
     if discovery_info is not None:
         async_add_entities([LGDevice(discovery_info)], True)
+    if config.get("host") and config.get("port"):
+        async_add_entities([LGDevice(config)], True)
         
 
 class LGDevice(MediaPlayerDevice):
     """Representation of an LG soundbar device."""
 
-    def __init__(self, discovery_info):
+    def __init__(self, config):
         """Initialize the LG speakers."""
-        host = discovery_info.get("host")
-        port = discovery_info.get("port")
+        host = config.get("host")
+        port = config.get("port")
 
         self._name = ""
         self._volume = 0

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -22,11 +22,11 @@ SUPPORT_LG = (
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the LG platform."""
     if discovery_info is not None:
-        add_entities([LGDevice(discovery_info)], True)
-
+        async_add_entities([LGDevice(discovery_info)], True)
+        
 
 class LGDevice(MediaPlayerDevice):
     """Representation of an LG soundbar device."""
@@ -55,7 +55,7 @@ class LGDevice(MediaPlayerDevice):
         self._treble = 0
 
         self._device = temescal.temescal(host, port=port, callback=self.handle_event)
-        self.update()
+        self.async_update()
 
     def handle_event(self, response):
         """Handle responses from the speakers."""
@@ -106,7 +106,7 @@ class LGDevice(MediaPlayerDevice):
                 self._name = data["s_user_name"]
         self.schedule_update_ha_state()
 
-    def update(self):
+    async def async_update(self):
         """Trigger updates from the device."""
         self._device.get_eq()
         self._device.get_info()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Converts lg_soundbar component to async per `https://developers.home-assistant.io/docs/en/asyncio_working_with_async.html` documentation.
Adds ability to manually configure lg_soundbar host and port (accessing from different network for example). Fixes #23752.

Reason for async change:
I ran into issues using lg_soundbar on my main home assistant instance, it would crash retrieving data from the soundbar. Interestingly I was not able to replicate the issue with an empty HA docker instance. Converting to async component resolved this issue for me.
```
2804-Exception in thread Thread-2:
22834-Traceback (most recent call last):
22869-  File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
22947-    self.run()
22962-  File "/usr/local/lib/python3.7/threading.py", line 870, in run
23027-    self._target(*self._args, **self._kwargs)
23073-  File "/usr/local/lib/python3.7/site-packages/temescal/__init__.py", line 99, in listen
23162-    self.callback(json.loads(response))
23202:  File "/config/custom_components/lg_soundbar/media_player.py", line 107, in handle_event
23292-    self.schedule_update_ha_state()
23328-  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 418, in schedule_update_ha_state
23431-    self.hass.add_job(self.async_update_ha_state(force_refresh))
23496-AttributeError: 'NoneType' object has no attribute 'add_job'
```

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```
media_player:
  - platform: lg_soundbar
    host: <IP address of soundbar>
    port: 9741```

```

## Additional information

- This PR fixes or closes issue: fixes #23752
- This PR is related to issue: closes #28876
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
