### PR TITLE
Handle missing next train from NS

### DIFF
--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -191,7 +191,9 @@ class NSDepartureSensor(Entity):
             attributes["arrival_delay"] = True
 
         # Next attributes
-        if self._trips[1].departure_time_actual is not None:
+        if len(self._trips) < 2:
+            attributes["next"] = "-"
+        elif self._trips[1].departure_time_actual is not None:
             attributes["next"] = self._trips[1].departure_time_actual.strftime("%H:%M")
         elif self._trips[1].departure_time_planned is not None:
             attributes["next"] = self._trips[1].departure_time_planned.strftime("%H:%M")

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -191,12 +191,15 @@ class NSDepartureSensor(Entity):
             attributes["arrival_delay"] = True
 
         # Next attributes
-        if len(self._trips) < 2:
-            attributes["next"] = "-"
-        elif self._trips[1].departure_time_actual is not None:
-            attributes["next"] = self._trips[1].departure_time_actual.strftime("%H:%M")
-        elif self._trips[1].departure_time_planned is not None:
-            attributes["next"] = self._trips[1].departure_time_planned.strftime("%H:%M")
+        if len(self._trips) > 1:
+            if self._trips[1].departure_time_actual is not None:
+                attributes["next"] = self._trips[1].departure_time_actual.strftime(
+                    "%H:%M"
+                )
+            elif self._trips[1].departure_time_planned is not None:
+                attributes["next"] = self._trips[1].departure_time_planned.strftime(
+                    "%H:%M"
+                )
 
         return attributes
 
@@ -225,7 +228,7 @@ class NSDepartureSensor(Entity):
 
         try:
             self._trips = self._nsapi.get_trips(
-                trip_time, self._departure, self._via, self._heading, True, 0, 2,
+                trip_time, self._departure, self._via, self._heading, True, 0, 2
             )
             if self._trips:
                 if self._trips[0].departure_time_actual is None:


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The NS integration crashes when there is no train found after the next one. This PR checks if this case and handles it gracefully.

The code works as it is now. However, due to the fact this bug only occurs in very specific circumstances, the fix proposed in this PR is based on the error message and has not (yet) been tested directly in the circumstances that caused the bug initially.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31606
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
