### PR TITLE
Add optimistic mode to template switch

### DIFF
--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -134,14 +134,15 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        # restore state after startup
-        await super().async_added_to_hass()
-        state = await self.async_get_last_state()
-        if state:
-            self._state = state.state == STATE_ON
-
-        # no need to listen for events
         if self._template is None:
+
+            # restore state after startup
+            await super().async_added_to_hass()
+            state = await self.async_get_last_state()
+            if state:
+                self._state = state.state == STATE_ON
+
+            # no need to listen for events
             return
 
         # set up event listening
@@ -153,10 +154,9 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
         @callback
         def template_switch_startup(event):
             """Update template on startup."""
-            if self._template is not None:
-                async_track_state_change(
-                    self.hass, self._entities, template_switch_state_listener
-                )
+            async_track_state_change(
+                self.hass, self._entities, template_switch_state_listener
+            )
 
             self.async_schedule_update_ha_state(True)
 

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -142,7 +142,7 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
         @callback
         def template_switch_startup(event):
             """Update template on startup."""
-            if (self._template is not None):
+            if self._template is not None:
                 async_track_state_change(
                     self.hass, self._entities, template_switch_state_listener
                 )
@@ -262,5 +262,5 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
 
     @property
     def assumed_state(self):
-        """State is assumed, if no template given"""
-        return (self._template is None)
+        """State is assumed, if no template given."""
+        return self._template is None

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -23,8 +23,8 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.script import Script
 
 from . import extract_entities, initialise_templates

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -202,7 +202,7 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
         if self._template is None:
             self._state = False
             self.async_schedule_update_ha_state()
-            
+
     async def async_update(self):
         """Update the state from the template."""
         if self._template is None:
@@ -262,5 +262,5 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
 
     @property
     def assumed_state(self):
-       """State is assumed, if no template given"""
-       return (self._template is None)
+        """State is assumed, if no template given"""
+        return (self._template is None)

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -1,7 +1,5 @@
 """The tests for the  Template switch platform."""
 
-import pytest
-
 from homeassistant import setup
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import CoreState, State, callback
@@ -14,26 +12,6 @@ from tests.common import (
     mock_restore_cache,
 )
 from tests.components.switch import common
-
-
-@pytest.fixture
-def storage_setup(hass, hass_storage):
-    """Storage setup."""
-
-    async def _storage(items=None, config=None):
-        if items is None:
-            hass_storage["switch"] = {
-                "key": "switch",
-                "version": 1,
-                "data": {"items": [{"id": "from_storage", "name": "from storage"}]},
-            }
-        else:
-            hass_storage["switch"] = items
-        if config is None:
-            config = {"switch": {}}
-        return await async_setup_component(hass, "switch", config)
-
-    return _storage
 
 
 class TestTemplateSwitch:

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -1,5 +1,7 @@
 """The tests for the  Template switch platform."""
 
+import pytest
+
 from homeassistant import setup
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import CoreState, State, callback
@@ -51,13 +53,13 @@ async def test_template_state_text(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    state = hass.states.set("switch.test_state", STATE_ON)
+    hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")
     assert state.state == STATE_ON
 
-    state = hass.states.set("switch.test_state", STATE_OFF)
+    hass.states.async_set("switch.test_state", STATE_OFF)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")
@@ -165,7 +167,7 @@ async def test_icon_template(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.attributes.get("icon") == ""
 
-    state = hass.states.set("switch.test_state", STATE_ON)
+    hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")
@@ -207,7 +209,7 @@ async def test_entity_picture_template(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.attributes.get("entity_picture") == ""
 
-    state = hass.states.set("switch.test_state", STATE_ON)
+    hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")
@@ -400,7 +402,7 @@ async def test_on_action(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    hass.states.set("switch.test_state", STATE_OFF)
+    hass.states.async_set("switch.test_state", STATE_OFF)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")
@@ -435,7 +437,7 @@ async def test_on_action_optimistic(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    hass.states.set("switch.test_template_switch", STATE_OFF)
+    hass.states.async_set("switch.test_template_switch", STATE_OFF)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")
@@ -474,7 +476,7 @@ async def test_off_action(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    hass.states.set("switch.test_state", STATE_ON)
+    hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")
@@ -509,7 +511,7 @@ async def test_off_action_optimistic(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    hass.states.set("switch.test_template_switch", STATE_ON)
+    hass.states.async_set("switch.test_template_switch", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test_template_switch")

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -21,7 +21,7 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-def test_template_state_text(hass):
+async def test_template_state_text(hass):
     """Test the state text of a template."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -63,7 +63,7 @@ def test_template_state_text(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.state == STATE_OFF
 
-def test_template_state_boolean_on(hass):
+async def test_template_state_boolean_on(hass):
     """Test the setting of the state with boolean on."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -96,7 +96,7 @@ def test_template_state_boolean_on(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.state == STATE_ON
 
-def test_template_state_boolean_off(hass):
+async def test_template_state_boolean_off(hass):
     """Test the setting of the state with off."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -129,7 +129,7 @@ def test_template_state_boolean_off(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.state == STATE_OFF
 
-def test_icon_template(hass):
+async def test_icon_template(hass):
     """Test icon template."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -171,7 +171,7 @@ def test_icon_template(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.attributes["icon"] == "mdi:check"
 
-def test_entity_picture_template(hass):
+async def test_entity_picture_template(hass):
     """Test entity_picture template."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -213,7 +213,7 @@ def test_entity_picture_template(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.attributes["entity_picture"] == "/local/switch.png"
 
-def test_template_syntax_error(hass):
+async def test_template_syntax_error(hass):
     """Test templating syntax error."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -245,7 +245,7 @@ def test_template_syntax_error(hass):
 
     assert hass.states.all() == []
 
-def test_invalid_name_does_not_create(hass):
+async def test_invalid_name_does_not_create(hass):
     """Test invalid name."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -277,7 +277,7 @@ def test_invalid_name_does_not_create(hass):
 
     assert hass.states.all() == []
 
-def test_invalid_switch_does_not_create(hass):
+async def test_invalid_switch_does_not_create(hass):
     """Test invalid switch."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -297,7 +297,7 @@ def test_invalid_switch_does_not_create(hass):
 
     assert hass.states.all() == []
 
-def test_no_switches_does_not_create(hass):
+async def test_no_switches_does_not_create(hass):
     """Test if there are no switches no creation."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -310,7 +310,7 @@ def test_no_switches_does_not_create(hass):
 
     assert hass.states.all() == []
 
-def test_missing_on_does_not_create(hass):
+async def test_missing_on_does_not_create(hass):
     """Test missing on."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -342,7 +342,7 @@ def test_missing_on_does_not_create(hass):
 
     assert hass.states.all() == []
 
-def test_missing_off_does_not_create(hass):
+async def test_missing_off_does_not_create(hass):
     """Test missing off."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -374,7 +374,7 @@ def test_missing_off_does_not_create(hass):
 
     assert hass.states.all() == []
 
-def test_on_action(hass, calls):
+async def test_on_action(hass, calls):
     """Test on action."""
     assert await async_setup_component(
         hass,
@@ -411,7 +411,7 @@ def test_on_action(hass, calls):
 
     assert len(calls) == 1
 
-def test_on_action_optimistic(hass, calls):
+async def test_on_action_optimistic(hass, calls):
     """Test on action in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -448,7 +448,7 @@ def test_on_action_optimistic(hass, calls):
     assert len(calls) == 1
     assert state.state == STATE_ON
 
-def test_off_action(hass, calls):
+async def test_off_action(hass, calls):
     """Test off action."""
     assert await async_setup_component(
         hass,
@@ -485,7 +485,7 @@ def test_off_action(hass, calls):
 
     assert len(calls) == 1
 
-def test_off_action_optimistic(hass, calls):
+async def test_off_action_optimistic(hass, calls):
     """Test off action in optimistic mode."""
     assert await async_setup_component(
         hass,

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -245,7 +245,7 @@ async def test_template_syntax_error(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.all() == []
+    assert hass.states.async_all() == []
 
 async def test_invalid_name_does_not_create(hass):
     """Test invalid name."""
@@ -277,7 +277,7 @@ async def test_invalid_name_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.all() == []
+    assert hass.states.async_all() == []
 
 async def test_invalid_switch_does_not_create(hass):
     """Test invalid switch."""
@@ -297,7 +297,7 @@ async def test_invalid_switch_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.all() == []
+    assert hass.states.async_all() == []
 
 async def test_no_switches_does_not_create(hass):
     """Test if there are no switches no creation."""
@@ -310,7 +310,7 @@ async def test_no_switches_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.all() == []
+    assert hass.states.async_all() == []
 
 async def test_missing_on_does_not_create(hass):
     """Test missing on."""
@@ -342,7 +342,7 @@ async def test_missing_on_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.all() == []
+    assert hass.states.async_all() == []
 
 async def test_missing_off_does_not_create(hass):
     """Test missing off."""
@@ -374,7 +374,7 @@ async def test_missing_off_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.all() == []
+    assert hass.states.async_all() == []
 
 async def test_on_action(hass, calls):
     """Test on action."""

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -4,13 +4,12 @@ import pytest
 
 from homeassistant import setup
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
-from homeassistant.core import CoreState, State, callback
+from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
     assert_setup_component,
     async_mock_service,
-    get_test_home_assistant,
     mock_component,
     mock_restore_cache,
 )
@@ -65,6 +64,7 @@ async def test_template_state_text(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.state == STATE_OFF
 
+
 async def test_template_state_boolean_on(hass):
     """Test the setting of the state with boolean on."""
     with assert_setup_component(1, "switch"):
@@ -98,6 +98,7 @@ async def test_template_state_boolean_on(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.state == STATE_ON
 
+
 async def test_template_state_boolean_off(hass):
     """Test the setting of the state with off."""
     with assert_setup_component(1, "switch"):
@@ -130,6 +131,7 @@ async def test_template_state_boolean_off(hass):
 
     state = hass.states.get("switch.test_template_switch")
     assert state.state == STATE_OFF
+
 
 async def test_icon_template(hass):
     """Test icon template."""
@@ -173,6 +175,7 @@ async def test_icon_template(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.attributes["icon"] == "mdi:check"
 
+
 async def test_entity_picture_template(hass):
     """Test entity_picture template."""
     with assert_setup_component(1, "switch"):
@@ -215,6 +218,7 @@ async def test_entity_picture_template(hass):
     state = hass.states.get("switch.test_template_switch")
     assert state.attributes["entity_picture"] == "/local/switch.png"
 
+
 async def test_template_syntax_error(hass):
     """Test templating syntax error."""
     with assert_setup_component(0, "switch"):
@@ -246,6 +250,7 @@ async def test_template_syntax_error(hass):
     await hass.async_block_till_done()
 
     assert hass.states.async_all() == []
+
 
 async def test_invalid_name_does_not_create(hass):
     """Test invalid name."""
@@ -279,6 +284,7 @@ async def test_invalid_name_does_not_create(hass):
 
     assert hass.states.async_all() == []
 
+
 async def test_invalid_switch_does_not_create(hass):
     """Test invalid switch."""
     with assert_setup_component(0, "switch"):
@@ -299,6 +305,7 @@ async def test_invalid_switch_does_not_create(hass):
 
     assert hass.states.async_all() == []
 
+
 async def test_no_switches_does_not_create(hass):
     """Test if there are no switches no creation."""
     with assert_setup_component(0, "switch"):
@@ -311,6 +318,7 @@ async def test_no_switches_does_not_create(hass):
     await hass.async_block_till_done()
 
     assert hass.states.async_all() == []
+
 
 async def test_missing_on_does_not_create(hass):
     """Test missing on."""
@@ -344,6 +352,7 @@ async def test_missing_on_does_not_create(hass):
 
     assert hass.states.async_all() == []
 
+
 async def test_missing_off_does_not_create(hass):
     """Test missing off."""
     with assert_setup_component(0, "switch"):
@@ -375,6 +384,7 @@ async def test_missing_off_does_not_create(hass):
     await hass.async_block_till_done()
 
     assert hass.states.async_all() == []
+
 
 async def test_on_action(hass, calls):
     """Test on action."""
@@ -413,6 +423,7 @@ async def test_on_action(hass, calls):
 
     assert len(calls) == 1
 
+
 async def test_on_action_optimistic(hass, calls):
     """Test on action in optimistic mode."""
     assert await async_setup_component(
@@ -450,6 +461,7 @@ async def test_on_action_optimistic(hass, calls):
     assert len(calls) == 1
     assert state.state == STATE_ON
 
+
 async def test_off_action(hass, calls):
     """Test off action."""
     assert await async_setup_component(
@@ -486,6 +498,7 @@ async def test_off_action(hass, calls):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
+
 
 async def test_off_action_optimistic(hass, calls):
     """Test off action in optimistic mode."""

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -7,6 +7,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import (
     assert_setup_component,
+    async_mock_service,
     get_test_home_assistant,
     mock_component,
     mock_restore_cache,
@@ -14,460 +15,17 @@ from tests.common import (
 from tests.components.switch import common
 
 
-class TestTemplateSwitch:
-    """Test the Template switch."""
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
 
-    hass = None
-    calls = None
-    # pylint: disable=invalid-name
 
-    def setup_method(self, method):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.calls = []
-
-        @callback
-        def record_call(service):
-            """Track function calls.."""
-            self.calls.append(service)
-
-        self.hass.services.register("test", "automation", record_call)
-
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_template_state_text(self):
-        """Test the state text of a template."""
-        with assert_setup_component(1, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{{ states.switch.test_state.state }}",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.set("switch.test_state", STATE_ON)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_ON
-
-        state = self.hass.states.set("switch.test_state", STATE_OFF)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_OFF
-
-    def test_template_state_boolean_on(self):
-        """Test the setting of the state with boolean on."""
-        with assert_setup_component(1, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{{ 1 == 1 }}",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_ON
-
-    def test_template_state_boolean_off(self):
-        """Test the setting of the state with off."""
-        with assert_setup_component(1, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{{ 1 == 2 }}",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_OFF
-
-    def test_icon_template(self):
-        """Test icon template."""
-        with assert_setup_component(1, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{{ states.switch.test_state.state }}",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "icon_template": "{% if states.switch.test_state.state %}"
-                                "mdi:check"
-                                "{% endif %}",
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.attributes.get("icon") == ""
-
-        state = self.hass.states.set("switch.test_state", STATE_ON)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.attributes["icon"] == "mdi:check"
-
-    def test_entity_picture_template(self):
-        """Test entity_picture template."""
-        with assert_setup_component(1, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{{ states.switch.test_state.state }}",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "entity_picture_template": "{% if states.switch.test_state.state %}"
-                                "/local/switch.png"
-                                "{% endif %}",
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.attributes.get("entity_picture") == ""
-
-        state = self.hass.states.set("switch.test_state", STATE_ON)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.attributes["entity_picture"] == "/local/switch.png"
-
-    def test_template_syntax_error(self):
-        """Test templating syntax error."""
-        with assert_setup_component(0, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{% if rubbish %}",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_invalid_name_does_not_create(self):
-        """Test invalid name."""
-        with assert_setup_component(0, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test INVALID switch": {
-                                "value_template": "{{ rubbish }",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_invalid_switch_does_not_create(self):
-        """Test invalid switch."""
-        with assert_setup_component(0, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {"test_template_switch": "Invalid"},
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_no_switches_does_not_create(self):
-        """Test if there are no switches no creation."""
-        with assert_setup_component(0, "switch"):
-            assert setup.setup_component(
-                self.hass, "switch", {"switch": {"platform": "template"}}
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_missing_on_does_not_create(self):
-        """Test missing on."""
-        with assert_setup_component(0, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{{ states.switch.test_state.state }}",
-                                "not_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "turn_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_missing_off_does_not_create(self):
-        """Test missing off."""
-        with assert_setup_component(0, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "template",
-                        "switches": {
-                            "test_template_switch": {
-                                "value_template": "{{ states.switch.test_state.state }}",
-                                "turn_on": {
-                                    "service": "switch.turn_on",
-                                    "entity_id": "switch.test_state",
-                                },
-                                "not_off": {
-                                    "service": "switch.turn_off",
-                                    "entity_id": "switch.test_state",
-                                },
-                            }
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_on_action(self):
-        """Test on action."""
-        assert setup.setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "template",
-                    "switches": {
-                        "test_template_switch": {
-                            "value_template": "{{ states.switch.test_state.state }}",
-                            "turn_on": {"service": "test.automation"},
-                            "turn_off": {
-                                "service": "switch.turn_off",
-                                "entity_id": "switch.test_state",
-                            },
-                        }
-                    },
-                }
-            },
-        )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        self.hass.states.set("switch.test_state", STATE_OFF)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_OFF
-
-        common.turn_on(self.hass, "switch.test_template_switch")
-        self.hass.block_till_done()
-
-        assert len(self.calls) == 1
-
-    def test_on_action_optimistic(self):
-        """Test on action in optimistic mode."""
-        assert setup.setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "template",
-                    "switches": {
-                        "test_template_switch": {
-                            "turn_on": {"service": "test.automation"},
-                            "turn_off": {
-                                "service": "switch.turn_off",
-                                "entity_id": "switch.test_state",
-                            },
-                        }
-                    },
-                }
-            },
-        )
-
-        self.hass.start()
-        self.hass.block_till_done()
-
-        self.hass.states.set("switch.test_template_switch", STATE_OFF)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_OFF
-
-        common.turn_on(self.hass, "switch.test_template_switch")
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert len(self.calls) == 1
-        assert state.state == STATE_ON
-
-    def test_off_action(self):
-        """Test off action."""
-        assert setup.setup_component(
-            self.hass,
+def test_template_state_text(hass):
+    """Test the state text of a template."""
+    with assert_setup_component(1, "switch"):
+        assert await async_setup_component(
+            hass,
             "switch",
             {
                 "switch": {
@@ -479,41 +37,8 @@ class TestTemplateSwitch:
                                 "service": "switch.turn_on",
                                 "entity_id": "switch.test_state",
                             },
-                            "turn_off": {"service": "test.automation"},
-                        }
-                    },
-                }
-            },
-        )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        self.hass.states.set("switch.test_state", STATE_ON)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_ON
-
-        common.turn_off(self.hass, "switch.test_template_switch")
-        self.hass.block_till_done()
-
-        assert len(self.calls) == 1
-
-    def test_off_action_optimistic(self):
-        """Test off action in optimistic mode."""
-        assert setup.setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "template",
-                    "switches": {
-                        "test_template_switch": {
-                            "turn_off": {"service": "test.automation"},
-                            "turn_on": {
-                                "service": "switch.turn_on",
+                            "turn_off": {
+                                "service": "switch.turn_off",
                                 "entity_id": "switch.test_state",
                             },
                         }
@@ -522,21 +47,480 @@ class TestTemplateSwitch:
             },
         )
 
-        self.hass.start()
-        self.hass.block_till_done()
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
-        self.hass.states.set("switch.test_template_switch", STATE_ON)
-        self.hass.block_till_done()
+    state = hass.states.set("switch.test_state", STATE_ON)
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get("switch.test_template_switch")
-        assert state.state == STATE_ON
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_ON
 
-        common.turn_off(self.hass, "switch.test_template_switch")
-        self.hass.block_till_done()
+    state = hass.states.set("switch.test_state", STATE_OFF)
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get("switch.test_template_switch")
-        assert len(self.calls) == 1
-        assert state.state == STATE_OFF
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_OFF
+
+def test_template_state_boolean_on(hass):
+    """Test the setting of the state with boolean on."""
+    with assert_setup_component(1, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test_template_switch": {
+                            "value_template": "{{ 1 == 1 }}",
+                            "turn_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "turn_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_ON
+
+def test_template_state_boolean_off(hass):
+    """Test the setting of the state with off."""
+    with assert_setup_component(1, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test_template_switch": {
+                            "value_template": "{{ 1 == 2 }}",
+                            "turn_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "turn_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_OFF
+
+def test_icon_template(hass):
+    """Test icon template."""
+    with assert_setup_component(1, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test_template_switch": {
+                            "value_template": "{{ states.switch.test_state.state }}",
+                            "turn_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "turn_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                            "icon_template": "{% if states.switch.test_state.state %}"
+                            "mdi:check"
+                            "{% endif %}",
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.attributes.get("icon") == ""
+
+    state = hass.states.set("switch.test_state", STATE_ON)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.attributes["icon"] == "mdi:check"
+
+def test_entity_picture_template(hass):
+    """Test entity_picture template."""
+    with assert_setup_component(1, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test_template_switch": {
+                            "value_template": "{{ states.switch.test_state.state }}",
+                            "turn_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "turn_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                            "entity_picture_template": "{% if states.switch.test_state.state %}"
+                            "/local/switch.png"
+                            "{% endif %}",
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.attributes.get("entity_picture") == ""
+
+    state = hass.states.set("switch.test_state", STATE_ON)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.attributes["entity_picture"] == "/local/switch.png"
+
+def test_template_syntax_error(hass):
+    """Test templating syntax error."""
+    with assert_setup_component(0, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test_template_switch": {
+                            "value_template": "{% if rubbish %}",
+                            "turn_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "turn_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.all() == []
+
+def test_invalid_name_does_not_create(hass):
+    """Test invalid name."""
+    with assert_setup_component(0, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test INVALID switch": {
+                            "value_template": "{{ rubbish }",
+                            "turn_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "turn_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.all() == []
+
+def test_invalid_switch_does_not_create(hass):
+    """Test invalid switch."""
+    with assert_setup_component(0, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {"test_template_switch": "Invalid"},
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.all() == []
+
+def test_no_switches_does_not_create(hass):
+    """Test if there are no switches no creation."""
+    with assert_setup_component(0, "switch"):
+        assert await async_setup_component(
+            hass, "switch", {"switch": {"platform": "template"}}
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.all() == []
+
+def test_missing_on_does_not_create(hass):
+    """Test missing on."""
+    with assert_setup_component(0, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test_template_switch": {
+                            "value_template": "{{ states.switch.test_state.state }}",
+                            "not_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "turn_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.all() == []
+
+def test_missing_off_does_not_create(hass):
+    """Test missing off."""
+    with assert_setup_component(0, "switch"):
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "template",
+                    "switches": {
+                        "test_template_switch": {
+                            "value_template": "{{ states.switch.test_state.state }}",
+                            "turn_on": {
+                                "service": "switch.turn_on",
+                                "entity_id": "switch.test_state",
+                            },
+                            "not_off": {
+                                "service": "switch.turn_off",
+                                "entity_id": "switch.test_state",
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.all() == []
+
+def test_on_action(hass, calls):
+    """Test on action."""
+    assert await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "template",
+                "switches": {
+                    "test_template_switch": {
+                        "value_template": "{{ states.switch.test_state.state }}",
+                        "turn_on": {"service": "test.automation"},
+                        "turn_off": {
+                            "service": "switch.turn_off",
+                            "entity_id": "switch.test_state",
+                        },
+                    }
+                },
+            }
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    hass.states.set("switch.test_state", STATE_OFF)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_OFF
+
+    await common.async_turn_on(hass, "switch.test_template_switch")
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+
+def test_on_action_optimistic(hass, calls):
+    """Test on action in optimistic mode."""
+    assert await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "template",
+                "switches": {
+                    "test_template_switch": {
+                        "turn_on": {"service": "test.automation"},
+                        "turn_off": {
+                            "service": "switch.turn_off",
+                            "entity_id": "switch.test_state",
+                        },
+                    }
+                },
+            }
+        },
+    )
+
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    hass.states.set("switch.test_template_switch", STATE_OFF)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_OFF
+
+    await common.async_turn_on(hass, "switch.test_template_switch")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert len(calls) == 1
+    assert state.state == STATE_ON
+
+def test_off_action(hass, calls):
+    """Test off action."""
+    assert await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "template",
+                "switches": {
+                    "test_template_switch": {
+                        "value_template": "{{ states.switch.test_state.state }}",
+                        "turn_on": {
+                            "service": "switch.turn_on",
+                            "entity_id": "switch.test_state",
+                        },
+                        "turn_off": {"service": "test.automation"},
+                    }
+                },
+            }
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    hass.states.set("switch.test_state", STATE_ON)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_ON
+
+    await common.async_turn_off(hass, "switch.test_template_switch")
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+
+def test_off_action_optimistic(hass, calls):
+    """Test off action in optimistic mode."""
+    assert await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "template",
+                "switches": {
+                    "test_template_switch": {
+                        "turn_off": {"service": "test.automation"},
+                        "turn_on": {
+                            "service": "switch.turn_on",
+                            "entity_id": "switch.test_state",
+                        },
+                    }
+                },
+            }
+        },
+    )
+
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    hass.states.set("switch.test_template_switch", STATE_ON)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert state.state == STATE_ON
+
+    await common.async_turn_off(hass, "switch.test_template_switch")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_template_switch")
+    assert len(calls) == 1
+    assert state.state == STATE_OFF
 
 
 async def test_restore_state(hass):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py36, py37, py38, lint, pylint, typing, cov
 skip_missing_interpreters = True
+skipsdist = True
 
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = py36, py37, py38, lint, pylint, typing, cov
 skip_missing_interpreters = True
-skipsdist = True
 
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the optimistic mode from template light also to template switch:
- value_template is optional. If None: assume state change was successful.
- restore last known state after restarting hass

This is useful for switches which do not report a state back, but need a script to be switched. For me this is the case with pilight switches having a bad reception. I need to send the switching command multiple times. Template switch sems to be the only integration to suport such scripts. Hence the PR for this component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
switch:
- platform: template
  switches:
    wohnzimmer_sitzecke:
      friendly_name: Wohnzimmer Sitzecke
      turn_on:
      - service: pilight.send
        data:
          protocol: elro_800_switch
          systemcode: !secret pilight_systemcode_wohnzimmer
          unitcode: 2
          'on': 1
      turn_off:
      - service: pilight.send
        data:
          protocol: elro_800_switch
          systemcode: !secret pilight_systemcode_wohnzimmer
          unitcode: 2
          'off': 1
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #31466
- This PR is related to issue: none
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12020

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
