### PR TITLE
Use latest version of python-pushover (forked) to fix issue with diff…

### DIFF
--- a/homeassistant/components/pushover/manifest.json
+++ b/homeassistant/components/pushover/manifest.json
@@ -2,7 +2,7 @@
   "domain": "pushover",
   "name": "Pushover",
   "documentation": "https://www.home-assistant.io/integrations/pushover",
-  "requirements": ["python-pushover==0.4"],
+  "requirements": ["softxperience-pushover==1.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/pushover/manifest.json
+++ b/homeassistant/components/pushover/manifest.json
@@ -2,7 +2,7 @@
   "domain": "pushover",
   "name": "Pushover",
   "documentation": "https://www.home-assistant.io/integrations/pushover",
-  "requirements": ["softxperience-pushover==1.0"],
+  "requirements": ["pushover_complete==1.1.1"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -71,7 +71,7 @@ class PushoverNotificationService(BaseNotificationService):
         image = data.get(ATTR_ATTACHMENT, None)
         # Check for attachment
         if image is not None:
-            # Not a URL, check valid path first
+            # Only allow attachments from whitelisted paths, check valid path
             if self._hass.config.is_allowed_path(data[ATTR_ATTACHMENT]):
                 # try to open it as a normal file.
                 try:

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -1,7 +1,7 @@
 """Pushover platform for notify component."""
 import logging
 
-from pushover import Pushover, RequestError
+from pushover_complete import PushoverAPI
 import requests
 import voluptuous as vol
 
@@ -19,6 +19,15 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ATTACHMENT = "attachment"
+ATTR_URL = "url"
+ATTR_URL_TITLE = "url_title"
+ATTR_PRIORITY = "priority"
+ATTR_RETRY = "retry"
+ATTR_SOUND = "sound"
+ATTR_HTML = "html"
+ATTR_CALLBACK_URL = "callback_url"
+ATTR_EXPIRE = "expire"
+ATTR_TIMESTAMP = "timestamp"
 
 CONF_USER_KEY = "user_key"
 
@@ -42,26 +51,36 @@ class PushoverNotificationService(BaseNotificationService):
         self._hass = hass
         self._user_key = user_key
         self._api_token = api_token
-        self.pushover = Pushover(self._api_token)
+        self.pushover = PushoverAPI(self._api_token)
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        # Make a copy and use empty dict if necessary
+
+        # Extract params from data dict
+        title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = dict(kwargs.get(ATTR_DATA) or {})
+        url = data.get(ATTR_URL, None)
+        url_title = data.get(ATTR_URL_TITLE, None)
+        priority = data.get(ATTR_PRIORITY, None)
+        retry = data.get(ATTR_PRIORITY, None)
+        expire = data.get(ATTR_EXPIRE, None)
+        callback_url = data.get(ATTR_CALLBACK_URL, None)
+        timestamp = data.get(ATTR_TIMESTAMP, None)
+        sound = data.get(ATTR_SOUND, None)
+        html = 1 if data.get(ATTR_HTML, False) else 0
 
-        data["title"] = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-
-        # Check for attachment.
-        if ATTR_ATTACHMENT in data:
+        image = data.get(ATTR_ATTACHMENT, None)
+        # Check for attachment
+        if image is not None:
             # If attachment is a URL, use requests to open it as a stream.
-            if data[ATTR_ATTACHMENT].startswith("http"):
+            if image.startswith("http"):
                 try:
                     response = requests.get(
                         data[ATTR_ATTACHMENT], stream=True, timeout=5
                     )
                     if response.status_code == 200:
                         # Replace the attachment identifier with file object.
-                        data[ATTR_ATTACHMENT] = response.content
+                        image = response.content
                     else:
                         _LOGGER.error(
                             "Failed to download image %s, response code: %d",
@@ -69,11 +88,11 @@ class PushoverNotificationService(BaseNotificationService):
                             response.status_code,
                         )
                         # Remove attachment key to send without attachment.
-                        del data[ATTR_ATTACHMENT]
+                        image = None
                 except requests.exceptions.RequestException as ex_val:
                     _LOGGER.error(ex_val)
-                    # Remove attachment key to try sending without attachment
-                    del data[ATTR_ATTACHMENT]
+                    # Remove attachment key to send without attachment.
+                    image = None
             else:
                 # Not a URL, check valid path first
                 if self._hass.config.is_allowed_path(data[ATTR_ATTACHMENT]):
@@ -81,15 +100,15 @@ class PushoverNotificationService(BaseNotificationService):
                     try:
                         file_handle = open(data[ATTR_ATTACHMENT], "rb")
                         # Replace the attachment identifier with file object.
-                        data[ATTR_ATTACHMENT] = file_handle
+                        image = file_handle
                     except OSError as ex_val:
                         _LOGGER.error(ex_val)
                         # Remove attachment key to send without attachment.
-                        del data[ATTR_ATTACHMENT]
+                        image = None
                 else:
                     _LOGGER.error("Path is not whitelisted")
                     # Remove attachment key to send without attachment.
-                    del data[ATTR_ATTACHMENT]
+                    image = None
 
         targets = kwargs.get(ATTR_TARGET)
 
@@ -97,12 +116,22 @@ class PushoverNotificationService(BaseNotificationService):
             targets = [targets]
 
         for target in targets:
-            if target is not None:
-                data["device"] = target
-
             try:
-                self.pushover.message(self._user_key, message, **data)
+                self.pushover.send_message(
+                    self._user_key,
+                    message,
+                    target,
+                    title,
+                    url,
+                    url_title,
+                    image,
+                    priority,
+                    retry,
+                    expire,
+                    callback_url,
+                    timestamp,
+                    sound,
+                    html,
+                )
             except ValueError as val_err:
                 _LOGGER.error(val_err)
-            except RequestError:
-                _LOGGER.exception("Could not send pushover notification")

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -1,7 +1,7 @@
 """Pushover platform for notify component."""
 import logging
 
-from pushover import Client, InitError, RequestError
+from pushover import Pushover, RequestError
 import requests
 import voluptuous as vol
 
@@ -29,13 +29,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_service(hass, config, discovery_info=None):
     """Get the Pushover notification service."""
-    try:
-        return PushoverNotificationService(
-            hass, config[CONF_USER_KEY], config[CONF_API_KEY]
-        )
-    except InitError:
-        _LOGGER.error("Wrong API key supplied")
-        return None
+    return PushoverNotificationService(
+        hass, config[CONF_USER_KEY], config[CONF_API_KEY]
+    )
 
 
 class PushoverNotificationService(BaseNotificationService):
@@ -46,7 +42,7 @@ class PushoverNotificationService(BaseNotificationService):
         self._hass = hass
         self._user_key = user_key
         self._api_token = api_token
-        self.pushover = Client(self._user_key, api_token=self._api_token)
+        self.pushover = Pushover(self._api_token)
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
@@ -105,7 +101,7 @@ class PushoverNotificationService(BaseNotificationService):
                 data["device"] = target
 
             try:
-                self.pushover.send_message(message, **data)
+                self.pushover.message(self._user_key, message, **data)
             except ValueError as val_err:
                 _LOGGER.error(val_err)
             except RequestError:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1605,9 +1605,6 @@ python-nest==4.1.0
 # homeassistant.components.nmap_tracker
 python-nmap==0.6.1
 
-# homeassistant.components.pushover
-python-pushover==0.4
-
 # homeassistant.components.qbittorrent
 python-qbittorrent==0.4.1
 
@@ -1862,6 +1859,9 @@ snapcast==2.0.10
 
 # homeassistant.components.socialblade
 socialbladeclient==0.2
+
+# homeassistant.components.pushover
+softxperience-pushover==1.0
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1064,6 +1064,9 @@ pushbullet.py==0.11.0
 # homeassistant.components.pushetta
 pushetta==1.0.15
 
+# homeassistant.components.pushover
+pushover_complete==1.1.1
+
 # homeassistant.components.rpi_gpio_pwm
 pwmled==1.4.1
 
@@ -1859,9 +1862,6 @@ snapcast==2.0.10
 
 # homeassistant.components.socialblade
 socialbladeclient==0.2
-
-# homeassistant.components.pushover
-softxperience-pushover==1.0
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.0


### PR DESCRIPTION
…erent API tokens. (https://community.home-assistant.io/t/different-applications-in-pushover/6985)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There is a problem in the pushover integration. The underlying python lib stored the API token globally, so all notifies used one same API token, instead of possibly different tokens configured.
The code owner of the underlying lib already fixed it in the code, but did not provide a new release eiter in github nor in pypi, so I couldn't use that.
That's why I forked that repo and published the latest version on pypi.
There were also some small changes in the integration needed to reflect the new version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #11641
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
