### PR TITLE
deCONZ - Directly reflect changes to config entry options

### DIFF
--- a/homeassistant/components/deconz/.translations/en.json
+++ b/homeassistant/components/deconz/.translations/en.json
@@ -108,7 +108,8 @@
                     "allow_clip_sensor": "Allow deCONZ CLIP sensors",
                     "allow_deconz_groups": "Allow deCONZ light groups"
                 },
-                "description": "Configure visibility of deCONZ device types"
+                "description": "Configure visibility of deCONZ device types",
+                "title": "deCONZ options"
             }
         }
     }

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -37,6 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")
                 )
+                and sensor.deconz_id not in gateway.deconz_ids.values()
             ):
                 entities.append(DeconzBinarySensor(sensor, gateway))
 

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -44,6 +44,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")
                 )
+                and sensor.deconz_id not in gateway.deconz_ids.values()
             ):
                 entities.append(DeconzThermostat(sensor, gateway))
 

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -85,7 +85,6 @@ class DeconzDevice(DeconzBase, Entity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect device object when removed."""
-        print("REMOVE")
         self._device.remove_callback(self.async_update_callback)
         del self.gateway.deconz_ids[self.entity_id]
         for unsub_dispatcher in self.listeners:

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -77,13 +77,28 @@ class DeconzDevice(DeconzBase, Entity):
                 self.hass, self.gateway.signal_reachable, self.async_update_callback
             )
         )
+        self.listeners.append(
+            async_dispatcher_connect(
+                self.hass, self.gateway.signal_remove_entity, self.async_remove_self
+            )
+        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect device object when removed."""
+        print("REMOVE")
         self._device.remove_callback(self.async_update_callback)
         del self.gateway.deconz_ids[self.entity_id]
         for unsub_dispatcher in self.listeners:
             unsub_dispatcher()
+
+    async def async_remove_self(self, deconz_ids: list) -> None:
+        """Schedule removal of this entity.
+
+        Called by signal_remove_entity scheduled by async_added_to_hass.
+        """
+        if self._device.deconz_id not in deconz_ids:
+            return
+        await self.async_remove()
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -149,12 +149,12 @@ class DeconzGateway:
             if self.option_allow_clip_sensor:
                 self.async_add_device_callback(NEW_SENSOR, sensors)
             else:
-                deconz_ids += [sensor.deconz_id for sensor in self.api.sensors.values()]
+                deconz_ids += [sensor.deconz_id for sensor in sensors]
 
         if self._current_option_allow_deconz_groups != self.option_allow_deconz_groups:
             self._current_option_allow_deconz_groups = self.option_allow_deconz_groups
 
-            groups = [group for group in self.api.groups.values()]
+            groups = list(self.api.groups.values())
 
             if self.option_allow_deconz_groups:
                 self.async_add_device_callback(NEW_GROUP, groups)

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -20,6 +20,8 @@ from .const import (
     DOMAIN,
     LOGGER,
     NEW_DEVICE,
+    NEW_GROUP,
+    NEW_SENSOR,
     SUPPORTED_PLATFORMS,
 )
 from .errors import AuthenticationRequired, CannotConnect
@@ -44,6 +46,9 @@ class DeconzGateway:
         self.deconz_ids = {}
         self.events = []
         self.listeners = []
+
+        self._current_option_allow_clip_sensor = self.option_allow_clip_sensor
+        self._current_option_allow_deconz_groups = self.option_allow_deconz_groups
 
     @property
     def bridgeid(self) -> str:
@@ -108,22 +113,64 @@ class DeconzGateway:
 
         self.api.start()
 
-        self.config_entry.add_update_listener(self.async_new_address)
+        self.config_entry.add_update_listener(self.async_config_entry_updated)
 
         return True
 
     @staticmethod
-    async def async_new_address(hass, entry) -> None:
-        """Handle signals of gateway getting new address.
+    async def async_config_entry_updated(hass, entry) -> None:
+        """Handle signals of config entry being updated.
 
-        This is a static method because a class method (bound method),
-        can not be used with weak references.
+        This is a static method because a class method (bound method), can not be used with weak references.
+        Causes for this is either discovery updating host address or config entry options changing.
         """
         gateway = get_gateway_from_config_entry(hass, entry)
         if gateway.api.host != entry.data[CONF_HOST]:
             gateway.api.close()
             gateway.api.host = entry.data[CONF_HOST]
             gateway.api.start()
+            return
+
+        await gateway.options_updated()
+
+    async def options_updated(self):
+        """Manage entities affected by config entry options."""
+        deconz_ids = []
+
+        if self._current_option_allow_clip_sensor != self.option_allow_clip_sensor:
+            self._current_option_allow_clip_sensor = self.option_allow_clip_sensor
+
+            sensors = [
+                sensor
+                for sensor in self.api.sensors.values()
+                if sensor.type.startswith("CLIP")
+            ]
+
+            if self.option_allow_clip_sensor:
+                self.async_add_device_callback(NEW_SENSOR, sensors)
+            else:
+                deconz_ids += [sensor.deconz_id for sensor in self.api.sensors.values()]
+
+        if self._current_option_allow_deconz_groups != self.option_allow_deconz_groups:
+            self._current_option_allow_deconz_groups = self.option_allow_deconz_groups
+
+            groups = [group for group in self.api.groups.values()]
+
+            if self.option_allow_deconz_groups:
+                self.async_add_device_callback(NEW_GROUP, groups)
+            else:
+                deconz_ids += [group.deconz_id for group in groups]
+
+        if deconz_ids:
+            async_dispatcher_send(self.hass, self.signal_remove_entity, deconz_ids)
+
+        entity_registry = await self.hass.helpers.entity_registry.async_get_registry()
+
+        for entity_id, deconz_id in self.deconz_ids.items():
+            if deconz_id in deconz_ids and entity_registry.async_is_registered(
+                entity_id
+            ):
+                entity_registry.async_remove(entity_id)
 
     @property
     def signal_reachable(self) -> str:
@@ -140,6 +187,11 @@ class DeconzGateway:
     def async_signal_new_device(self, device_type) -> str:
         """Gateway specific event to signal new device."""
         return NEW_DEVICE[device_type].format(self.bridgeid)
+
+    @property
+    def signal_remove_entity(self) -> str:
+        """Gateway specific event to signal removal of entity."""
+        return f"deconz-remove-{self.bridgeid}"
 
     @callback
     def async_add_device_callback(self, device_type, device) -> None:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -67,7 +67,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
 
         for group in groups:
-            if group.lights:
+            if group.lights and group.deconz_id not in gateway.deconz_ids.values():
                 entities.append(DeconzGroup(group, gateway))
 
         async_add_entities(entities, True)

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -68,6 +68,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")
                 )
+                and sensor.deconz_id not in gateway.deconz_ids.values()
             ):
                 entities.append(DeconzSensor(sensor, gateway))
 

--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -14,20 +14,9 @@
         "title": "Link with deCONZ",
         "description": "Unlock your deCONZ gateway to register with Home Assistant.\n\n1. Go to deCONZ Settings -> Gateway -> Advanced\n2. Press \"Authenticate app\" button"
       },
-      "options": {
-        "title": "Extra configuration options for deCONZ",
-        "data": {
-          "allow_clip_sensor": "Allow importing virtual sensors",
-          "allow_deconz_groups": "Allow importing deCONZ groups"
-        }
-      },
       "hassio_confirm": {
         "title": "deCONZ Zigbee gateway via Hass.io add-on",
-        "description": "Do you want to configure Home Assistant to connect to the deCONZ gateway provided by the Hass.io add-on {addon}?",
-        "data": {
-          "allow_clip_sensor": "Allow importing virtual sensors",
-          "allow_deconz_groups": "Allow importing deCONZ groups"
-        }
+        "description": "Do you want to configure Home Assistant to connect to the deCONZ gateway provided by the Hass.io add-on {addon}?"
       }
     },
     "error": {
@@ -45,11 +34,12 @@
   "options": {
     "step": {
       "deconz_devices": {
-        "description": "Configure visibility of deCONZ device types",
         "data": {
           "allow_clip_sensor": "Allow deCONZ CLIP sensors",
           "allow_deconz_groups": "Allow deCONZ light groups"
-        }
+        },
+        "description": "Configure visibility of deCONZ device types",
+        "title": "deCONZ options"
       }
     }
   },

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -134,6 +134,28 @@ async def test_allow_clip_sensor(hass):
     vibration_sensor = hass.states.get("binary_sensor.vibration_sensor")
     assert vibration_sensor.state == "on"
 
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: False}
+    )
+    await hass.async_block_till_done()
+
+    assert "binary_sensor.presence_sensor" in gateway.deconz_ids
+    assert "binary_sensor.temperature_sensor" not in gateway.deconz_ids
+    assert "binary_sensor.clip_presence_sensor" not in gateway.deconz_ids
+    assert "binary_sensor.vibration_sensor" in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 3
+
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: True}
+    )
+    await hass.async_block_till_done()
+
+    assert "binary_sensor.presence_sensor" in gateway.deconz_ids
+    assert "binary_sensor.temperature_sensor" not in gateway.deconz_ids
+    assert "binary_sensor.clip_presence_sensor" in gateway.deconz_ids
+    assert "binary_sensor.vibration_sensor" in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 4
+
 
 async def test_add_new_binary_sensor(hass):
     """Test that adding a new binary sensor works."""

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -214,6 +214,30 @@ async def test_clip_climate_device(hass):
     clip_thermostat = hass.states.get("climate.clip_thermostat")
     assert clip_thermostat.state == "heat"
 
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: False}
+    )
+    await hass.async_block_till_done()
+
+    assert "climate.thermostat" in gateway.deconz_ids
+    assert "sensor.thermostat" not in gateway.deconz_ids
+    assert "sensor.thermostat_battery_level" in gateway.deconz_ids
+    assert "climate.presence_sensor" not in gateway.deconz_ids
+    assert "climate.clip_thermostat" not in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 3
+
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: True}
+    )
+    await hass.async_block_till_done()
+
+    assert "climate.thermostat" in gateway.deconz_ids
+    assert "sensor.thermostat" not in gateway.deconz_ids
+    assert "sensor.thermostat_battery_level" in gateway.deconz_ids
+    assert "climate.presence_sensor" not in gateway.deconz_ids
+    assert "climate.clip_thermostat" in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 4
+
 
 async def test_verify_state_update(hass):
     """Test that state update properly."""

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -245,3 +245,29 @@ async def test_disable_light_groups(hass):
 
     empty_group = hass.states.get("light.empty_group")
     assert empty_group is None
+
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_DECONZ_GROUPS: True}
+    )
+    await hass.async_block_till_done()
+
+    assert "light.rgb_light" in gateway.deconz_ids
+    assert "light.tunable_white_light" in gateway.deconz_ids
+    assert "light.light_group" in gateway.deconz_ids
+    assert "light.empty_group" not in gateway.deconz_ids
+    assert "light.on_off_switch" not in gateway.deconz_ids
+    # 3 entities
+    assert len(hass.states.async_all()) == 5
+
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_DECONZ_GROUPS: False}
+    )
+    await hass.async_block_till_done()
+
+    assert "light.rgb_light" in gateway.deconz_ids
+    assert "light.tunable_white_light" in gateway.deconz_ids
+    assert "light.light_group" not in gateway.deconz_ids
+    assert "light.empty_group" not in gateway.deconz_ids
+    assert "light.on_off_switch" not in gateway.deconz_ids
+    # 3 entities
+    assert len(hass.states.async_all()) == 4

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -218,6 +218,40 @@ async def test_allow_clip_sensors(hass):
     clip_light_level_sensor = hass.states.get("sensor.clip_light_level_sensor")
     assert clip_light_level_sensor.state == "999.8"
 
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: False}
+    )
+    await hass.async_block_till_done()
+
+    assert "sensor.light_level_sensor" in gateway.deconz_ids
+    assert "sensor.presence_sensor" not in gateway.deconz_ids
+    assert "sensor.switch_1" not in gateway.deconz_ids
+    assert "sensor.switch_1_battery_level" not in gateway.deconz_ids
+    assert "sensor.switch_2" not in gateway.deconz_ids
+    assert "sensor.switch_2_battery_level" in gateway.deconz_ids
+    assert "sensor.daylight_sensor" not in gateway.deconz_ids
+    assert "sensor.power_sensor" in gateway.deconz_ids
+    assert "sensor.consumption_sensor" in gateway.deconz_ids
+    assert "sensor.clip_light_level_sensor" not in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 5
+
+    hass.config_entries.async_update_entry(
+        gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: True}
+    )
+    await hass.async_block_till_done()
+
+    assert "sensor.light_level_sensor" in gateway.deconz_ids
+    assert "sensor.presence_sensor" not in gateway.deconz_ids
+    assert "sensor.switch_1" not in gateway.deconz_ids
+    assert "sensor.switch_1_battery_level" not in gateway.deconz_ids
+    assert "sensor.switch_2" not in gateway.deconz_ids
+    assert "sensor.switch_2_battery_level" in gateway.deconz_ids
+    assert "sensor.daylight_sensor" not in gateway.deconz_ids
+    assert "sensor.power_sensor" in gateway.deconz_ids
+    assert "sensor.consumption_sensor" in gateway.deconz_ids
+    assert "sensor.clip_light_level_sensor" in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 6
+
 
 async def test_add_new_sensor(hass):
     """Test that adding a new sensor works."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
deCONZ will no longer change entity to being disabled when using the config options but rather remove them completely from the state machine. Enabling the option will load all relevant entities again. This is based on changes done to the [developer documentation](https://github.com/home-assistant/developers.home-assistant/pull/396).


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/developers.home-assistant/pull/396
- This PR is related to issue: second part to #31446
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
