### PR TITLE
bump velbus version + load velbus module names into device info

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -140,11 +140,11 @@ class VelbusEntity(Entity):
             "identifiers": {
                 (DOMAIN, self._module.get_module_address(), self._module.serial)
             },
-            "name": "{} {}".format(
-                self._module.get_module_address(), self._module.get_module_name()
+            "name": "{} ({})".format(
+                self._module.get_module_name(), self._module.get_module_address()
             ),
             "manufacturer": "Velleman",
-            "model": self._module.get_module_name(),
+            "model": self._module.get_module_type_name(),
             "sw_version": "{}.{}-{}".format(
                 self._module.memory_map_version,
                 self._module.build_year,

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["python-velbus==2.0.36"],
+  "requirements": ["python-velbus==2.0.40"],
   "config_flow": true,
   "dependencies": [],
   "codeowners": ["@Cereal2nd", "@brefra"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1636,7 +1636,7 @@ python-telnet-vlc==1.0.4
 python-twitch-client==0.6.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.36
+python-velbus==2.0.40
 
 # homeassistant.components.vlc
 python-vlc==1.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -562,7 +562,7 @@ python-miio==0.4.8
 python-nest==4.1.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.36
+python-velbus==2.0.40
 
 # homeassistant.components.awair
 python_awair==0.0.4


### PR DESCRIPTION
## Proposed change
This upgrades to python-velbus 2.0.40
- Adds support for module names
- Adds support for memotext
- Adds support for some newer modules
the 2nd change in the PR is to load the module names into the device_info in hass

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
