### PR TITLE
Add Lightwave TRV

### DIFF
--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -77,8 +77,8 @@ async def async_setup(hass, config):
         )
 
     trv = config[DOMAIN][CONF_TRV]
-    trvs = trv[CONF_TRVS]
     if trv:
+        trvs = trv[CONF_TRVS]
         proxy_ip = trv[CONF_PROXY_IP]
         proxy_port = trv[CONF_PROXY_PORT]
         lwlink.set_trv_proxy(proxy_ip, proxy_port)

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -87,6 +87,8 @@ async def async_setup(hass, config):
 
         platforms = [CLIMATE_DOMAIN, SENSOR_DOMAIN]
         for platform in platforms:
-            hass.async_create_task(async_load_platform(hass, platform, DOMAIN, trvs, config))
+            hass.async_create_task(
+                async_load_platform(hass, platform, DOMAIN, trvs, config)
+            )
 
     return True

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -6,11 +6,11 @@ from homeassistant.const import CONF_HOST, CONF_LIGHTS, CONF_NAME, CONF_SWITCHES
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-CONF_DEFAULT_PORT = 7878
-CONF_DEFAULT_IP = "127.0.0.1"
 CONF_SERIAL = "serial"
 CONF_TRV = "trv"
 CONF_TRVS = "trvs"
+DEFAULT_PORT = 7878
+DEFAULT_IP = "127.0.0.1"
 DOMAIN = "lightwave"
 LIGHTWAVE_LINK = "lightwave_link"
 LIGHTWAVE_TRV_PROXY = "lightwave_proxy"
@@ -33,8 +33,8 @@ CONFIG_SCHEMA = vol.Schema(
                         cv.string: vol.Schema({vol.Required(CONF_NAME): cv.string})
                     },
                     vol.Optional(CONF_TRV, default={}): {
-                        vol.Optional(PROXY_PORT, default=CONF_DEFAULT_PORT): cv.port,
-                        vol.Optional(PROXY_IP, default=CONF_DEFAULT_IP): cv.string,
+                        vol.Optional(PROXY_PORT, default=DEFAULT_PORT): cv.port,
+                        vol.Optional(PROXY_IP, default=DEFAULT_IP): cv.string,
                         vol.Required(CONF_TRVS, default={}): {
                             cv.string: vol.Schema(
                                 {
@@ -70,14 +70,15 @@ async def async_setup(hass, config):
         )
 
     trv = config[DOMAIN][CONF_TRV]
+    trvs = trv[CONF_TRVS]
     if trv:
         hass.data[LIGHTWAVE_TRV_PROXY] = trv[PROXY_IP]
         hass.data[LIGHTWAVE_TRV_PROXY_PORT] = trv[PROXY_PORT]
         hass.async_create_task(
-            async_load_platform(hass, "climate", DOMAIN, trv[CONF_TRVS], config)
+            async_load_platform(hass, "climate", DOMAIN, trvs, config)
         )
         hass.async_create_task(
-            async_load_platform(hass, "sensor", DOMAIN, trv[CONF_TRVS], config)
+            async_load_platform(hass, "sensor", DOMAIN, trvs, config)
         )
 
     return True

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -85,7 +85,7 @@ async def async_setup(hass, config):
         hass.data[LIGHTWAVE_TRV_PROXY_PORT] = proxy_port
         lwlink.set_trv_proxy(proxy_ip, proxy_port)
 
-        entities = [CLIMATE_DOMAIN, SENSOR_DOMAIN]
+        platforms = [CLIMATE_DOMAIN, SENSOR_DOMAIN]
         for ent in entities:
             hass.async_create_task(async_load_platform(hass, ent, DOMAIN, trvs, config))
 

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -87,6 +87,6 @@ async def async_setup(hass, config):
 
         platforms = [CLIMATE_DOMAIN, SENSOR_DOMAIN]
         for ent in entities:
-            hass.async_create_task(async_load_platform(hass, ent, DOMAIN, trvs, config))
+            hass.async_create_task(async_load_platform(hass, platform, DOMAIN, trvs, config))
 
     return True

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -86,7 +86,7 @@ async def async_setup(hass, config):
         lwlink.set_trv_proxy(proxy_ip, proxy_port)
 
         platforms = [CLIMATE_DOMAIN, SENSOR_DOMAIN]
-        for ent in entities:
+        for platform in platforms:
             hass.async_create_task(async_load_platform(hass, platform, DOMAIN, trvs, config))
 
     return True

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -81,8 +81,6 @@ async def async_setup(hass, config):
     if trv:
         proxy_ip = trv[CONF_PROXY_IP]
         proxy_port = trv[CONF_PROXY_PORT]
-        hass.data[LIGHTWAVE_TRV_PROXY] = proxy_ip
-        hass.data[LIGHTWAVE_TRV_PROXY_PORT] = proxy_port
         lwlink.set_trv_proxy(proxy_ip, proxy_port)
 
         platforms = [CLIMATE_DOMAIN, SENSOR_DOMAIN]

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -6,23 +6,37 @@ from homeassistant.const import CONF_HOST, CONF_LIGHTS, CONF_NAME, CONF_SWITCHES
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-LIGHTWAVE_LINK = "lightwave_link"
-
 DOMAIN = "lightwave"
+LIGHTWAVE_LINK = "lightwave_link"
+LIGHTWAVE_TRV_PROXY = "lightwave_proxy"
+LIGHTWAVE_TRV_PROXY_PORT = "lightwave_proxy_port"
+PROXY_IP = "trv_proxy_ip"
+PROXY_PORT = "trv_proxy_port"
 
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             vol.All(
-                cv.has_at_least_one_key(CONF_LIGHTS, CONF_SWITCHES),
+                cv.has_at_least_one_key(CONF_LIGHTS, CONF_SWITCHES, "trv"),
                 {
+                    vol.Required(CONF_HOST): cv.string,
+                    vol.Optional(PROXY_IP): cv.string,
+                    vol.Optional(PROXY_PORT): cv.string,
                     vol.Required(CONF_HOST): cv.string,
                     vol.Optional(CONF_LIGHTS, default={}): {
                         cv.string: vol.Schema({vol.Required(CONF_NAME): cv.string})
                     },
                     vol.Optional(CONF_SWITCHES, default={}): {
                         cv.string: vol.Schema({vol.Required(CONF_NAME): cv.string})
+                    },
+                    vol.Optional("trv", default={}): {
+                        cv.string: vol.Schema(
+                            {
+                                vol.Required(CONF_NAME): cv.string,
+                                vol.Required("serial"): cv.string,
+                            }
+                        )
                     },
                 },
             )
@@ -34,9 +48,18 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Try to start embedded Lightwave broker."""
-
     host = config[DOMAIN][CONF_HOST]
     hass.data[LIGHTWAVE_LINK] = LWLink(host)
+
+    trv_proxy_ip = "127.0.0.1"
+    if PROXY_IP in config[DOMAIN].keys():
+        trv_proxy_ip = config[DOMAIN][PROXY_IP]
+    trv_proxy_port = 7878
+    if PROXY_PORT in config[DOMAIN].keys():
+        trv_proxy_port = int(config[DOMAIN][PROXY_PORT])
+
+    hass.data[LIGHTWAVE_TRV_PROXY] = trv_proxy_ip
+    hass.data[LIGHTWAVE_TRV_PROXY_PORT] = trv_proxy_port
 
     lights = config[DOMAIN][CONF_LIGHTS]
     if lights:
@@ -48,6 +71,15 @@ async def async_setup(hass, config):
     if switches:
         hass.async_create_task(
             async_load_platform(hass, "switch", DOMAIN, switches, config)
+        )
+
+    trvs = config[DOMAIN]["trv"]
+    if trvs:
+        hass.async_create_task(
+            async_load_platform(hass, "climate", DOMAIN, trvs, config)
+        )
+        hass.async_create_task(
+            async_load_platform(hass, "sensor", DOMAIN, trvs, config)
         )
 
     return True

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -55,7 +55,8 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass, config):
     """Try to start embedded Lightwave broker."""
     host = config[DOMAIN][CONF_HOST]
-    hass.data[LIGHTWAVE_LINK] = LWLink(host)
+    lwlink = LWLink(host)
+    hass.data[LIGHTWAVE_LINK] = lwlink
 
     lights = config[DOMAIN][CONF_LIGHTS]
     if lights:
@@ -72,8 +73,11 @@ async def async_setup(hass, config):
     trv = config[DOMAIN][CONF_TRV]
     trvs = trv[CONF_TRVS]
     if trv:
-        hass.data[LIGHTWAVE_TRV_PROXY] = trv[PROXY_IP]
-        hass.data[LIGHTWAVE_TRV_PROXY_PORT] = trv[PROXY_PORT]
+        proxy_ip = trv[PROXY_IP]
+        proxy_port = trv[PROXY_PORT]
+        hass.data[LIGHTWAVE_TRV_PROXY] = proxy_ip
+        hass.data[LIGHTWAVE_TRV_PROXY_PORT] = proxy_port
+        lwlink.set_trv_proxy(proxy_ip, proxy_port)
         hass.async_create_task(
             async_load_platform(hass, "climate", DOMAIN, trvs, config)
         )

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -1,0 +1,198 @@
+"""Support for LightwaveRF TRVs."""
+import json
+import logging
+import socket
+
+from homeassistant.components.climate import (
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_TARGET_TEMPERATURE,
+    ClimateDevice,
+)
+from homeassistant.components.climate.const import CURRENT_HVAC_HEAT, CURRENT_HVAC_OFF
+from homeassistant.const import ATTR_TEMPERATURE, CONF_NAME, TEMP_CELSIUS
+
+from . import LIGHTWAVE_LINK, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Find and return LightWave lights."""
+    if not discovery_info:
+        return
+
+    trv = []
+    lwlink = hass.data[LIGHTWAVE_LINK]
+    trv_proxy_ip = hass.data[LIGHTWAVE_TRV_PROXY]
+    trv_proxy_port = hass.data[LIGHTWAVE_TRV_PROXY_PORT]
+
+    for device_id, device_config in discovery_info.items():
+        name = device_config[CONF_NAME]
+        serial = device_config["serial"]
+        trv.append(
+            LightwaveTrv(name, device_id, lwlink, serial, trv_proxy_ip, trv_proxy_port)
+        )
+
+    async_add_entities(trv)
+
+
+class LightwaveTrv(ClimateDevice):
+    """Representation of a LightWaveRF TRV."""
+
+    def __init__(self, name, device_id, lwlink, serial, trv_proxy_ip, trv_proxy_port):
+        """Initialize LightwaveTrv entity."""
+        self._name = name
+        self._device_id = device_id
+        self._state = None
+        self._max_temp = DEFAULT_MAX_TEMP
+        self._min_temp = DEFAULT_MIN_TEMP
+        self._current_temperature = None
+        self._target_temperature = None
+        self._temperature_unit = TEMP_CELSIUS
+        self._target_temperature_step = 0.5
+        self._hvac_mode = HVAC_MODE_HEAT
+        self._hvac_action = None
+        self._lwlink = lwlink
+        self._battery = None
+        self._serial = serial
+        self._proxy_ip = trv_proxy_ip
+        self._proxy_port = trv_proxy_port
+        self._inhibit = 0
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_TARGET_TEMPERATURE
+
+    @property
+    def should_poll(self):
+        """Poll the Proxy."""
+        return True
+
+    def update_ctarg(self, j):
+        """Update target temp logic."""
+        if self._inhibit == 0:
+            self._target_temperature = j["cTarg"]
+            if j["cTarg"] == 0:
+                # TRV off
+                self._target_temperature = None
+            if j["cTarg"] >= 40:
+                # Call for heat mode, or TRV in a fixed position
+                self._target_temperature = None
+                self._target_temperature = j["cTarg"]
+        else:
+            # Done the job - use proxy next iteration
+            self._inhibit = 0
+
+    def update(self):
+        """Communicate with a Lightwave RTF Proxy to get state."""
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.settimeout(2.0)
+                msg = self._serial.encode("UTF-8")
+                sock.sendto(msg, (self._proxy_ip, self._proxy_port))
+                response, dummy = sock.recvfrom(1024)
+                msg = response.decode()
+                j = json.loads(msg)
+                if "cTemp" in j.keys():
+                    self._current_temperature = j["cTemp"]
+                if "cTarg" in j.keys():
+                    self.update_ctarg(j)
+                if "batt" in j.keys():
+                    # convert the voltage to a rough percentage
+                    self._battery = int((j["batt"] - 2.22) * 110)
+                if "output" in j.keys():
+                    if int(j["output"]) > 0:
+                        self._hvac_action = CURRENT_HVAC_HEAT
+                    else:
+                        self._hvac_action = CURRENT_HVAC_OFF
+                if "error" in j.keys():
+                    _LOGGER.warning("TRV proxy error: %s", j["error"])
+
+        except socket.timeout:
+            _LOGGER.warning("TRV proxy not responing")
+
+        except socket.error as ex:
+            _LOGGER.warning("TRV proxy error %s", ex)
+
+        except json.JSONDecodeError:
+            _LOGGER.warning("TRV proxy JSON error")
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {
+            "Battery Level": self._battery,
+            "Device Type": "LightwaveRF TRV",
+        }
+
+    @property
+    def name(self):
+        """Lightwave trv name."""
+        return self._name
+
+    @property
+    def current_temperature(self):
+        """Property giving the current room temperature."""
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Target room temperature."""
+        if self._inhibit > 0:
+            # if we get an update before the new temp has
+            # propagated, the GUI target temp is set back to the
+            # old target, showing a false reading temporarily
+            self._target_temperature = self._inhibit
+        return self._target_temperature
+
+    @property
+    def hvac_modes(self):
+        """HVAC modes."""
+        return [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+
+    @property
+    def hvac_mode(self):
+        """HVAC mode."""
+        return self._hvac_mode
+
+    @property
+    def hvac_action(self):
+        """HVAC action."""
+        return self._hvac_action
+
+    @property
+    def min_temp(self):
+        """Min Temp."""
+        return self._min_temp
+
+    @property
+    def max_temp(self):
+        """Max Temp."""
+        return self._max_temp
+
+    @property
+    def temperature_unit(self):
+        """Set temperature unit."""
+        return self._temperature_unit
+
+    @property
+    def target_temperature_step(self):
+        """Set temperature step."""
+        return self._target_temperature_step
+
+    def set_temperature(self, **kwargs):
+        """Set TRV target temperature."""
+        if ATTR_TEMPERATURE in kwargs:
+            self._target_temperature = kwargs[ATTR_TEMPERATURE]
+            self._inhibit = self._target_temperature
+        self._lwlink.set_temperature(
+            self._device_id, self._target_temperature, self._name
+        )
+        self.async_schedule_update_ha_state()
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Set HVAC Mode for TRV."""

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -88,7 +88,7 @@ class LightwaveTrv(ClimateDevice):
             else:
                 # Done the job - use proxy next iteration
                 self._inhibit = 0
-        if battery is not None:
+        if battery:
             self._battery = battery
         if trv_output is not None:
             if trv_output > 0:

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Find and return LightWave lights."""
-    if not discovery_info:
+    if discovery_info is None:
         return
 
     trv = []

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -64,7 +64,7 @@ class LightwaveTrv(ClimateDevice):
     def update(self):
         """Communicate with a Lightwave RTF Proxy to get state."""
         targ = temp = battery = trv_output = None
-        (temp, targ, battery, trv_output) = self._lwlink.read_trv_status(self._serial)
+        (temp, targ, _, trv_output) = self._lwlink.read_trv_status(self._serial)
         if temp is not None:
             self._current_temperature = temp
         if targ is not None:

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -52,7 +52,6 @@ class LightwaveTrv(ClimateDevice):
         self._hvac_mode = HVAC_MODE_HEAT
         self._hvac_action = None
         self._lwlink = lwlink
-        self._battery = None
         self._serial = serial
         # inhibit is used to prevent race condition on update.  If non zero, skip next update cycle.
         self._inhibit = 0

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -69,9 +69,9 @@ class LightwaveTrv(ClimateDevice):
         """Communicate with a Lightwave RTF Proxy to get state."""
         targ = temp = battery = trv_output = None
         (temp, targ, battery, trv_output) = self._lwlink.read_trv_status(self._serial)
-        if temp:
+        if temp is not None:
             self._current_temperature = temp
-        if targ:
+        if targ is not None:
             if self._inhibit == 0:
                 self._target_temperature = targ
                 if targ == 0:
@@ -83,9 +83,9 @@ class LightwaveTrv(ClimateDevice):
             else:
                 # Done the job - use proxy next iteration
                 self._inhibit = 0
-        if battery:
+        if battery is not None:
             self._battery = battery
-        if trv_output:
+        if trv_output is not None:
             if trv_output > 0:
                 self._hvac_action = CURRENT_HVAC_HEAT
             else:

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 
-from . import CONF_SERIAL, LIGHTWAVE_LINK, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
+from . import CONF_SERIAL, LIGHTWAVE_LINK
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,15 +29,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     trv = []
     lwlink = hass.data[LIGHTWAVE_LINK]
-    trv_proxy_ip = hass.data[LIGHTWAVE_TRV_PROXY]
-    trv_proxy_port = hass.data[LIGHTWAVE_TRV_PROXY_PORT]
 
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
         serial = device_config[CONF_SERIAL]
-        trv.append(
-            LightwaveTrv(name, device_id, lwlink, serial, trv_proxy_ip, trv_proxy_port)
-        )
+        trv.append(LightwaveTrv(name, device_id, lwlink, serial))
 
     async_add_entities(trv)
 
@@ -45,7 +41,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class LightwaveTrv(ClimateDevice):
     """Representation of a LightWaveRF TRV."""
 
-    def __init__(self, name, device_id, lwlink, serial, trv_proxy_ip, trv_proxy_port):
+    def __init__(self, name, device_id, lwlink, serial):
         """Initialize LightwaveTrv entity."""
         self._name = name
         self._device_id = device_id
@@ -61,8 +57,6 @@ class LightwaveTrv(ClimateDevice):
         self._lwlink = lwlink
         self._battery = None
         self._serial = serial
-        self._proxy_ip = trv_proxy_ip
-        self._proxy_port = trv_proxy_port
         self._inhibit = 0
 
     @property

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -82,7 +82,6 @@ class LightwaveTrv(ClimateDevice):
             if j["cTarg"] >= 40:
                 # Call for heat mode, or TRV in a fixed position
                 self._target_temperature = None
-                self._target_temperature = j["cTarg"]
         else:
             # Done the job - use proxy next iteration
             self._inhibit = 0

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -57,6 +57,7 @@ class LightwaveTrv(ClimateDevice):
         self._lwlink = lwlink
         self._battery = None
         self._serial = serial
+        # inhibit used to prevent race condition on update.  If non zero, skip next update cycle.
         self._inhibit = 0
 
     @property

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -46,11 +46,8 @@ class LightwaveTrv(ClimateDevice):
         self._name = name
         self._device_id = device_id
         self._state = None
-        self._max_temp = DEFAULT_MAX_TEMP
-        self._min_temp = DEFAULT_MIN_TEMP
         self._current_temperature = None
         self._target_temperature = None
-        self._temperature_unit = TEMP_CELSIUS
         self._target_temperature_step = 0.5
         self._hvac_mode = HVAC_MODE_HEAT
         self._hvac_action = None
@@ -136,17 +133,17 @@ class LightwaveTrv(ClimateDevice):
     @property
     def min_temp(self):
         """Min Temp."""
-        return self._min_temp
+        return DEFAULT_MIN_TEMP
 
     @property
     def max_temp(self):
         """Max Temp."""
-        return self._max_temp
+        return DEFAULT_MAX_TEMP
 
     @property
     def temperature_unit(self):
         """Set temperature unit."""
-        return self._temperature_unit
+        return TEMP_CELSIUS
 
     @property
     def target_temperature_step(self):

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -27,7 +27,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if discovery_info is None:
         return
 
-    trv = []
+    entities = []
     lwlink = hass.data[LIGHTWAVE_LINK]
 
     for device_id, device_config in discovery_info.items():

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -74,7 +74,7 @@ class LightwaveTrv(ClimateDevice):
         """Communicate with a Lightwave RTF Proxy to get state."""
         targ = temp = battery = trv_output = None
         (temp, targ, battery, trv_output) = self._lwlink.read_trv_status(self._serial)
-        if temp is not None:
+        if temp:
             self._current_temperature = temp
         if targ is not None:
             if self._inhibit == 0:

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -101,7 +101,7 @@ class LightwaveTrv(ClimateDevice):
         """Return the device state attributes."""
         return {
             ATTR_BATTERY_LEVEL: self._battery,
-            "Device Type": "LightwaveRF TRV",
+            "device_type": "LightwaveRF TRV",
         }
 
     @property

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -145,7 +145,6 @@ class LightwaveTrv(ClimateDevice):
         self._lwlink.set_temperature(
             self._device_id, self._target_temperature, self._name
         )
-        self.async_schedule_update_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set HVAC Mode for TRV."""

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -89,13 +89,6 @@ class LightwaveTrv(ClimateDevice):
                 self._hvac_action = CURRENT_HVAC_OFF
 
     @property
-    def device_state_attributes(self):
-        """Return the device state attributes."""
-        return {
-            ATTR_BATTERY_LEVEL: self._battery,
-        }
-
-    @property
     def name(self):
         """Lightwave trv name."""
         return self._name

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -14,7 +14,7 @@ from homeassistant.components.climate import (
 from homeassistant.components.climate.const import CURRENT_HVAC_HEAT, CURRENT_HVAC_OFF
 from homeassistant.const import ATTR_TEMPERATURE, CONF_NAME, TEMP_CELSIUS
 
-from . import LIGHTWAVE_LINK, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
+from . import CONF_SERIAL, LIGHTWAVE_LINK, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
-        serial = device_config["serial"]
+        serial = device_config[CONF_SERIAL]
         trv.append(
             LightwaveTrv(name, device_id, lwlink, serial, trv_proxy_ip, trv_proxy_port)
         )

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -17,8 +17,6 @@ from homeassistant.const import (
 
 from . import CONF_SERIAL, LIGHTWAVE_LINK
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Find and return LightWave lights."""

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -1,6 +1,4 @@
 """Support for LightwaveRF TRVs."""
-import logging
-
 from homeassistant.components.climate import (
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -33,7 +33,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
         serial = device_config[CONF_SERIAL]
-        trv.append(LightwaveTrv(name, device_id, lwlink, serial))
+        entities.append(LightwaveTrv(name, device_id, lwlink, serial))
 
     async_add_entities(trv)
 

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -101,7 +101,6 @@ class LightwaveTrv(ClimateDevice):
         """Return the device state attributes."""
         return {
             ATTR_BATTERY_LEVEL: self._battery,
-            "device_type": "LightwaveRF TRV",
         }
 
     @property

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -35,7 +35,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         serial = device_config[CONF_SERIAL]
         entities.append(LightwaveTrv(name, device_id, lwlink, serial))
 
-    async_add_entities(trv)
+    async_add_entities(entities)
 
 
 class LightwaveTrv(ClimateDevice):

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -8,12 +8,7 @@ from homeassistant.components.climate import (
     ClimateDevice,
 )
 from homeassistant.components.climate.const import CURRENT_HVAC_HEAT, CURRENT_HVAC_OFF
-from homeassistant.const import (
-    ATTR_BATTERY_LEVEL,
-    ATTR_TEMPERATURE,
-    CONF_NAME,
-    TEMP_CELSIUS,
-)
+from homeassistant.const import ATTR_TEMPERATURE, CONF_NAME, TEMP_CELSIUS
 
 from . import CONF_SERIAL, LIGHTWAVE_LINK
 
@@ -45,7 +40,6 @@ class LightwaveTrv(ClimateDevice):
         self._current_temperature = None
         self._target_temperature = None
         self._target_temperature_step = 0.5
-        self._hvac_mode = HVAC_MODE_HEAT
         self._hvac_action = None
         self._lwlink = lwlink
         self._serial = serial
@@ -94,9 +88,10 @@ class LightwaveTrv(ClimateDevice):
     def target_temperature(self):
         """Target room temperature."""
         if self._inhibit > 0:
-            # if we get an update before the new temp has
-            # propagated, the GUI target temp is set back to the
-            # old target, showing a false reading temporarily
+            # If we get an update before the new temp has
+            # propagated, the target temp is set back to the
+            # old target on the next poll, showing a false
+            # reading temporarily.
             self._target_temperature = self._inhibit
         return self._target_temperature
 
@@ -108,7 +103,7 @@ class LightwaveTrv(ClimateDevice):
     @property
     def hvac_mode(self):
         """HVAC mode."""
-        return self._hvac_mode
+        return HVAC_MODE_HEAT
 
     @property
     def hvac_action(self):

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -90,7 +90,7 @@ class LightwaveTrv(ClimateDevice):
                 self._inhibit = 0
         if battery:
             self._battery = battery
-        if trv_output is not None:
+        if trv_output:
             if trv_output > 0:
                 self._hvac_action = CURRENT_HVAC_HEAT
             else:

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -39,7 +39,6 @@ class LightwaveTrv(ClimateDevice):
         self._state = None
         self._current_temperature = None
         self._target_temperature = None
-        self._target_temperature_step = 0.5
         self._hvac_action = None
         self._lwlink = lwlink
         self._serial = serial
@@ -128,7 +127,7 @@ class LightwaveTrv(ClimateDevice):
     @property
     def target_temperature_step(self):
         """Set temperature step."""
-        return self._target_temperature_step
+        return 0.5
 
     def set_temperature(self, **kwargs):
         """Set TRV target temperature."""

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -57,7 +57,7 @@ class LightwaveTrv(ClimateDevice):
         self._lwlink = lwlink
         self._battery = None
         self._serial = serial
-        # inhibit used to prevent race condition on update.  If non zero, skip next update cycle.
+        # inhibit is used to prevent race condition on update.  If non zero, skip next update cycle.
         self._inhibit = 0
 
     @property

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -61,7 +61,6 @@ class LightwaveTrv(ClimateDevice):
 
     def update(self):
         """Communicate with a Lightwave RTF Proxy to get state."""
-        targ = temp = battery = trv_output = None
         (temp, targ, _, trv_output) = self._lwlink.read_trv_status(self._serial)
         if temp is not None:
             self._current_temperature = temp

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -12,7 +12,12 @@ from homeassistant.components.climate import (
     ClimateDevice,
 )
 from homeassistant.components.climate.const import CURRENT_HVAC_HEAT, CURRENT_HVAC_OFF
-from homeassistant.const import ATTR_TEMPERATURE, CONF_NAME, TEMP_CELSIUS
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL,
+    ATTR_TEMPERATURE,
+    CONF_NAME,
+    TEMP_CELSIUS,
+)
 
 from . import CONF_SERIAL, LIGHTWAVE_LINK, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
 
@@ -67,11 +72,6 @@ class LightwaveTrv(ClimateDevice):
         """Flag supported features."""
         return SUPPORT_TARGET_TEMPERATURE
 
-    @property
-    def should_poll(self):
-        """Poll the Proxy."""
-        return True
-
     def update_ctarg(self, j):
         """Update target temp logic."""
         if self._inhibit == 0:
@@ -124,7 +124,7 @@ class LightwaveTrv(ClimateDevice):
     def device_state_attributes(self):
         """Return the device state attributes."""
         return {
-            "Battery Level": self._battery,
+            ATTR_BATTERY_LEVEL: self._battery,
             "Device Type": "LightwaveRF TRV",
         }
 

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -80,8 +80,6 @@ class LightwaveTrv(ClimateDevice):
             else:
                 # Done the job - use proxy next iteration
                 self._inhibit = 0
-        if battery is not None:
-            self._battery = battery
         if trv_output is not None:
             if trv_output > 0:
                 self._hvac_action = CURRENT_HVAC_HEAT

--- a/homeassistant/components/lightwave/climate.py
+++ b/homeassistant/components/lightwave/climate.py
@@ -76,7 +76,7 @@ class LightwaveTrv(ClimateDevice):
         (temp, targ, battery, trv_output) = self._lwlink.read_trv_status(self._serial)
         if temp:
             self._current_temperature = temp
-        if targ is not None:
+        if targ:
             if self._inhibit == 0:
                 self._target_temperature = targ
                 if targ == 0:

--- a/homeassistant/components/lightwave/manifest.json
+++ b/homeassistant/components/lightwave/manifest.json
@@ -2,6 +2,6 @@
   "domain": "lightwave",
   "name": "Lightwave",
   "documentation": "https://www.home-assistant.io/integrations/lightwave",
-  "requirements": ["lightwave==0.17"],
+  "requirements": ["lightwave==0.18"],
   "codeowners": []
 }

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -71,7 +71,7 @@ class LightwaveBattery(Entity):
     def device_state_attributes(self):
         """Return the device state attributes."""
         return {
-            "Device Type": "LightwaveRF TRV",
+            "device_type": "LightwaveRF TRV",
         }
 
     def update(self):

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -6,8 +6,6 @@ from homeassistant.helpers.entity import Entity
 
 from . import CONF_SERIAL, LIGHTWAVE_LINK
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Find and return battery."""

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -1,7 +1,7 @@
 """Support for LightwaveRF TRV - Associated Battery."""
 import logging
 
-from homeassistant.const import CONF_NAME, DEVICE_CLASS_BATTERY
+from homeassistant.const import CONF_NAME, DEVICE_CLASS_BATTERY, UNIT_PERCENTAGE
 from homeassistant.helpers.entity import Entity
 
 from . import CONF_SERIAL, LIGHTWAVE_LINK
@@ -14,16 +14,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if not discovery_info:
         return
 
-    batt = []
+    batteries = []
 
     lwlink = hass.data[LIGHTWAVE_LINK]
 
-    for dummy, device_config in discovery_info.items():
+    for _, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
         serial = device_config[CONF_SERIAL]
-        batt.append(LightwaveBattery(name, lwlink, serial))
+        batteries.append(LightwaveBattery(name, lwlink, serial))
 
-    async_add_entities(batt)
+    async_add_entities(batteries)
 
 
 class LightwaveBattery(Entity):
@@ -35,13 +35,11 @@ class LightwaveBattery(Entity):
         self._state = None
         self._lwlink = lwlink
         self._serial = serial
-        self._device_class = DEVICE_CLASS_BATTERY
-        self._unit_of_measurement = "%"
 
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        return self._device_class
+        return DEVICE_CLASS_BATTERY
 
     @property
     def name(self):
@@ -56,7 +54,7 @@ class LightwaveBattery(Entity):
     @property
     def unit_of_measurement(self):
         """Return the state of the sensor."""
-        return self._unit_of_measurement
+        return UNIT_PERCENTAGE
 
     def update(self):
         """Communicate with a Lightwave RTF Proxy to get state."""

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.const import CONF_NAME, DEVICE_CLASS_BATTERY
 from homeassistant.helpers.entity import Entity
 
-from . import CONF_SERIAL, LIGHTWAVE_LINK, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
+from . import CONF_SERIAL, LIGHTWAVE_LINK
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,17 +17,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     batt = []
 
     lwlink = hass.data[LIGHTWAVE_LINK]
-    trv_proxy_ip = hass.data[LIGHTWAVE_TRV_PROXY]
-    trv_proxy_port = hass.data[LIGHTWAVE_TRV_PROXY_PORT]
 
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
         serial = device_config[CONF_SERIAL]
-        batt.append(
-            LightwaveBattery(
-                name, device_id, lwlink, serial, trv_proxy_ip, trv_proxy_port
-            )
-        )
+        batt.append(LightwaveBattery(name, device_id, lwlink, serial))
 
     async_add_entities(batt)
 
@@ -35,7 +29,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class LightwaveBattery(Entity):
     """Lightwave TRV Battery."""
 
-    def __init__(self, name, device_id, lwlink, serial, trv_proxy_ip, trv_proxy_port):
+    def __init__(self, name, device_id, lwlink, serial):
         """Initialize the Lightwave Trv battery sensor."""
         self._name = name
         self._device_id = device_id
@@ -44,8 +38,6 @@ class LightwaveBattery(Entity):
         self._serial = serial
         self._device_class = DEVICE_CLASS_BATTERY
         self._unit_of_measurement = "%"
-        self._proxy_ip = trv_proxy_ip
-        self._proxy_port = trv_proxy_port
 
     @property
     def device_class(self):

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -21,7 +21,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
         serial = device_config[CONF_SERIAL]
-        batt.append(LightwaveBattery(name, device_id, lwlink, serial))
+        batt.append(LightwaveBattery(name, lwlink, serial))
 
     async_add_entities(batt)
 
@@ -29,10 +29,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class LightwaveBattery(Entity):
     """Lightwave TRV Battery."""
 
-    def __init__(self, name, device_id, lwlink, serial):
+    def __init__(self, name, lwlink, serial):
         """Initialize the Lightwave Trv battery sensor."""
         self._name = name
-        self._device_id = device_id
         self._state = None
         self._lwlink = lwlink
         self._serial = serial

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -18,7 +18,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     lwlink = hass.data[LIGHTWAVE_LINK]
 
-    for _, device_config in discovery_info.items():
+    for device_config in discovery_info.values():
         name = device_config[CONF_NAME]
         serial = device_config[CONF_SERIAL]
         batteries.append(LightwaveBattery(name, lwlink, serial))

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -1,0 +1,103 @@
+"""Support for LightwaveRF TRV - Associated Battery."""
+import json
+import logging
+import socket
+
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.entity import Entity
+
+from . import LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Find and return battery."""
+    if not discovery_info:
+        return
+
+    batt = []
+
+    trv_proxy_ip = hass.data[LIGHTWAVE_TRV_PROXY]
+    trv_proxy_port = hass.data[LIGHTWAVE_TRV_PROXY_PORT]
+
+    for device_id, device_config in discovery_info.items():
+        name = device_config[CONF_NAME]
+        serial = device_config["serial"]
+        batt.append(
+            LightwaveBattery(name, device_id, serial, trv_proxy_ip, trv_proxy_port)
+        )
+
+    async_add_entities(batt)
+
+
+class LightwaveBattery(Entity):
+    """Lightwave TRV Battery."""
+
+    def __init__(self, name, device_id, serial, trv_proxy_ip, trv_proxy_port):
+        """Initialize the Lightwave Trv battery sensor."""
+        self._name = name
+        self._device_id = device_id
+        self._state = None
+        self._serial = serial
+        self._device_class = "battery"
+        self._unit_of_measurement = "%"
+        self._proxy_ip = trv_proxy_ip
+        self._proxy_port = trv_proxy_port
+
+    @property
+    def should_poll(self):
+        """Connect to the TRV proxy."""
+        return True
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the state of the sensor."""
+        return self._unit_of_measurement
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {
+            "Device Type": "LightwaveRF TRV",
+        }
+
+    def update(self):
+        """Communicate with a Lightwave RTF Proxy to get state."""
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.settimeout(2.0)
+                msg = self._serial.encode("UTF-8")
+                sock.sendto(msg, (self._proxy_ip, self._proxy_port))
+                response, dummy = sock.recvfrom(1024)
+                msg = response.decode()
+                j = json.loads(msg)
+                if "batt" in j.keys():
+                    # convert the voltage to a rough percentage
+                    self._state = int((j["batt"] - 2.22) * 110)
+                if "error" in j.keys():
+                    _LOGGER.warning("TRV proxy error: %s", j["error"])
+
+        except socket.timeout:
+            _LOGGER.warning("TRV proxy not responing")
+
+        except socket.error as ex:
+            _LOGGER.warning("TRV proxy error %s", ex)
+
+        except json.JSONDecodeError:
+            _LOGGER.warning("TRV proxy JSON error")

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -1,7 +1,7 @@
 """Support for LightwaveRF TRV - Associated Battery."""
 import logging
 
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, DEVICE_CLASS_BATTERY
 from homeassistant.helpers.entity import Entity
 
 from . import CONF_SERIAL, LIGHTWAVE_LINK, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
@@ -42,7 +42,7 @@ class LightwaveBattery(Entity):
         self._state = None
         self._lwlink = lwlink
         self._serial = serial
-        self._device_class = "battery"
+        self._device_class = DEVICE_CLASS_BATTERY
         self._unit_of_measurement = "%"
         self._proxy_ip = trv_proxy_ip
         self._proxy_port = trv_proxy_port
@@ -80,5 +80,4 @@ class LightwaveBattery(Entity):
         (dummy_temp, dummy_targ, battery, dummy_output) = self._lwlink.read_trv_status(
             self._serial
         )
-        if battery is not None:
-            self._state = battery
+        self._state = battery

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Find and return battery."""
-    if not discovery_info:
+    if discovery_info is None:
         return
 
     batteries = []

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -67,13 +67,6 @@ class LightwaveBattery(Entity):
         """Return the state of the sensor."""
         return self._unit_of_measurement
 
-    @property
-    def device_state_attributes(self):
-        """Return the device state attributes."""
-        return {
-            "device_type": "LightwaveRF TRV",
-        }
-
     def update(self):
         """Communicate with a Lightwave RTF Proxy to get state."""
         battery = None

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -1,6 +1,4 @@
 """Support for LightwaveRF TRV - Associated Battery."""
-import logging
-
 from homeassistant.const import CONF_NAME, DEVICE_CLASS_BATTERY, UNIT_PERCENTAGE
 from homeassistant.helpers.entity import Entity
 

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -58,7 +58,6 @@ class LightwaveBattery(Entity):
 
     def update(self):
         """Communicate with a Lightwave RTF Proxy to get state."""
-        battery = None
         (dummy_temp, dummy_targ, battery, dummy_output) = self._lwlink.read_trv_status(
             self._serial
         )

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -18,7 +18,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     lwlink = hass.data[LIGHTWAVE_LINK]
 
-    for device_id, device_config in discovery_info.items():
+    for dummy, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
         serial = device_config[CONF_SERIAL]
         batt.append(LightwaveBattery(name, lwlink, serial))

--- a/homeassistant/components/lightwave/sensor.py
+++ b/homeassistant/components/lightwave/sensor.py
@@ -6,7 +6,7 @@ import socket
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 
-from . import LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
+from . import CONF_SERIAL, LIGHTWAVE_TRV_PROXY, LIGHTWAVE_TRV_PROXY_PORT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     for device_id, device_config in discovery_info.items():
         name = device_config[CONF_NAME]
-        serial = device_config["serial"]
+        serial = device_config[CONF_SERIAL]
         batt.append(
             LightwaveBattery(name, device_id, serial, trv_proxy_ip, trv_proxy_port)
         )
@@ -44,11 +44,6 @@ class LightwaveBattery(Entity):
         self._unit_of_measurement = "%"
         self._proxy_ip = trv_proxy_ip
         self._proxy_port = trv_proxy_port
-
-    @property
-    def should_poll(self):
-        """Connect to the TRV proxy."""
-        return True
 
     @property
     def device_class(self):

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -24,11 +24,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         devices = hass.data[DOMAIN][DEVICES]
 
-        if CONF_SHADOW in hass.data[DOMAIN].keys():
-            shadow = hass.data[DOMAIN][CONF_SHADOW]
-        else:
-            shadow = False
-
         return [
             SomfyCover(
                 cover, hass.data[DOMAIN][API], hass.data[DOMAIN][CONF_OPTIMISTIC]

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -8,7 +8,7 @@ from homeassistant.components.cover import (
     CoverDevice,
 )
 
-from . import API, DEVICES, DOMAIN, SomfyEntity
+from . import API, CONF_OPTIMISTIC, DEVICES, DOMAIN, SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -24,6 +24,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         devices = hass.data[DOMAIN][DEVICES]
 
+        if CONF_SHADOW in hass.data[DOMAIN].keys():
+            shadow = hass.data[DOMAIN][CONF_SHADOW]
+        else:
+            shadow = False
+
         return [
             SomfyCover(
                 cover, hass.data[DOMAIN][API], hass.data[DOMAIN][CONF_OPTIMISTIC]

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -8,7 +8,7 @@ from homeassistant.components.cover import (
     CoverDevice,
 )
 
-from . import API, CONF_SHADOW, DEVICES, DOMAIN, SomfyEntity
+from . import API, DEVICES, DOMAIN, SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -23,11 +23,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         }
 
         devices = hass.data[DOMAIN][DEVICES]
-
-        if CONF_SHADOW in hass.data[DOMAIN].keys():
-            shadow = hass.data[DOMAIN][CONF_SHADOW]
-        else:
-            shadow = False
 
         return [
             SomfyCover(

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -8,7 +8,7 @@ from homeassistant.components.cover import (
     CoverDevice,
 )
 
-from . import API, CONF_OPTIMISTIC, DEVICES, DOMAIN, SomfyEntity
+from . import API, CONF_SHADOW, DEVICES, DOMAIN, SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -23,6 +23,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         }
 
         devices = hass.data[DOMAIN][DEVICES]
+
+        if CONF_SHADOW in hass.data[DOMAIN].keys():
+            shadow = hass.data[DOMAIN][CONF_SHADOW]
+        else:
+            shadow = False
 
         return [
             SomfyCover(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -818,7 +818,7 @@ liffylights==0.9.4
 lightify==1.0.7.2
 
 # homeassistant.components.lightwave
-lightwave==0.17
+lightwave==0.18
 
 # homeassistant.components.limitlessled
 limitlessled==1.1.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added support for Lightwave TRVs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] New feature (which adds functionality to an existing integration)

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
lightwave:
  host: 192.168.10.10
  trv:
    trv_proxy_ip: 127.0.0.1
    trv_proxy_port: 7878
    trvs:
        R1Dh:
            name: Bedroom TRV
            serial: E84902
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: [Pull 12027](https://github.com/home-assistant/home-assistant.io/pull/12027)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
(possibly Silver depending on how the requirements are interpreted!)
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
