### PR TITLE
Add pigpio remote functionality

### DIFF
--- a/homeassistant/components/rpi_gpio_pwm/light.py
+++ b/homeassistant/components/rpi_gpio_pwm/light.py
@@ -19,7 +19,7 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     Light,
 )
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE, STATE_ON
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_TYPE, STATE_ON
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.util.color as color_util
@@ -58,6 +58,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Required(CONF_TYPE): vol.In(CONF_LED_TYPES),
                     vol.Optional(CONF_FREQUENCY): cv.positive_int,
                     vol.Optional(CONF_ADDRESS): cv.byte,
+                    vol.Optional(CONF_HOST): cv.string,
                 }
             ],
         )
@@ -76,6 +77,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if CONF_FREQUENCY in led_conf:
             opt_args["freq"] = led_conf[CONF_FREQUENCY]
         if driver_type == CONF_DRIVER_GPIO:
+            if CONF_HOST in led_conf:
+                opt_args["host"] = led_conf[CONF_HOST]
             driver = GpioDriver(pins, **opt_args)
         elif driver_type == CONF_DRIVER_PCA9685:
             if CONF_ADDRESS in led_conf:

--- a/homeassistant/components/rpi_gpio_pwm/manifest.json
+++ b/homeassistant/components/rpi_gpio_pwm/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rpi_gpio_pwm",
   "name": "pigpio Daemon PWM LED",
   "documentation": "https://www.home-assistant.io/integrations/rpi_gpio_pwm",
-  "requirements": ["pwmled==1.4.1"],
+  "requirements": ["pwmled==1.5.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1065,7 +1065,7 @@ pushbullet.py==0.11.0
 pushetta==1.0.15
 
 # homeassistant.components.rpi_gpio_pwm
-pwmled==1.4.1
+pwmled==1.5.0
 
 # homeassistant.components.august
 py-august==0.8.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a `host` option to specify the host of the running pigpio daemon. This allows home-assistant to control also gpio pins on remote raspberry pi's.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
light:
  - platform: rpi_gpio_pwm
    leds:
      - name: Lightstrip Cupboard
        driver: gpio
        host: 127.0.0.1
        pins: [17]
        type: simple
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12028

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
