### PR TITLE
Implement soundtouch select source

### DIFF
--- a/homeassistant/components/soundtouch/manifest.json
+++ b/homeassistant/components/soundtouch/manifest.json
@@ -3,6 +3,5 @@
   "name": "Bose Soundtouch",
   "documentation": "https://www.home-assistant.io/integrations/soundtouch",
   "requirements": ["libsoundtouch==0.8"],
-  "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/soundtouch/manifest.json
+++ b/homeassistant/components/soundtouch/manifest.json
@@ -2,6 +2,7 @@
   "domain": "soundtouch",
   "name": "Bose Soundtouch",
   "documentation": "https://www.home-assistant.io/integrations/soundtouch",
-  "requirements": ["libsoundtouch==0.7.2"],
+  "requirements": ["libsoundtouch==0.8"],
+  "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -12,6 +12,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
@@ -80,6 +81,7 @@ SUPPORT_SOUNDTOUCH = (
     | SUPPORT_TURN_ON
     | SUPPORT_PLAY
     | SUPPORT_PLAY_MEDIA
+    | SUPPORT_SELECT_SOURCE
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -356,6 +358,20 @@ class SoundTouchDevice(MediaPlayerEntity):
                 self._device.select_preset(preset)
             else:
                 _LOGGER.warning("Unable to find preset with id %s", media_id)
+
+    def select_source(self, source):
+        """
+        Select the source to play audio from.
+        :param source:source to select
+        """
+        if source == "AUX":
+            _LOGGER.info("Selecting source AUX")
+            self._device.select_source_aux()
+        elif source == "Bluetooth":
+            _LOGGER.info("Selecting source Bluetooth")
+            self._device.select_source_bluetooth()
+        else:
+            _LOGGER.warning("Source not supported")
 
     def create_zone(self, slaves):
         """

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -3,6 +3,7 @@ import logging
 import re
 
 from libsoundtouch import soundtouch_device
+from libsoundtouch.utils import Source
 import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
@@ -237,6 +238,19 @@ class SoundTouchDevice(MediaPlayerEntity):
         return MAP_STATUS.get(self._status.play_status, STATE_UNAVAILABLE)
 
     @property
+    def source(self):
+        """Name of the current input source."""
+        return self._status.source
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return [
+            Source.AUX,
+            Source.BLUETOOTH,
+        ]
+
+    @property
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._volume.muted
@@ -361,10 +375,10 @@ class SoundTouchDevice(MediaPlayerEntity):
 
     def select_source(self, source):
         """Select input source."""
-        if source == "AUX":
+        if source == Source.AUX:
             _LOGGER.debug("Selecting source AUX")
             self._device.select_source_aux()
-        elif source == "Bluetooth":
+        elif source == Source.BLUETOOTH:
             _LOGGER.debug("Selecting source Bluetooth")
             self._device.select_source_bluetooth()
         else:

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -246,8 +246,8 @@ class SoundTouchDevice(MediaPlayerEntity):
     def source_list(self):
         """List of available input sources."""
         return [
-            Source.AUX,
-            Source.BLUETOOTH,
+            Source.AUX.value,
+            Source.BLUETOOTH.value,
         ]
 
     @property
@@ -375,10 +375,10 @@ class SoundTouchDevice(MediaPlayerEntity):
 
     def select_source(self, source):
         """Select input source."""
-        if source == Source.AUX:
+        if source == Source.AUX.value:
             _LOGGER.debug("Selecting source AUX")
             self._device.select_source_aux()
-        elif source == Source.BLUETOOTH:
+        elif source == Source.BLUETOOTH.value:
             _LOGGER.debug("Selecting source Bluetooth")
             self._device.select_source_bluetooth()
         else:

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -360,19 +360,14 @@ class SoundTouchDevice(MediaPlayerEntity):
                 _LOGGER.warning("Unable to find preset with id %s", media_id)
 
     def select_source(self, source):
-        """
-        Select the source to play audio from.
-
-        :param source:source to select
-        """
         if source == "AUX":
-            _LOGGER.info("Selecting source AUX")
+            _LOGGER.debug("Selecting source AUX")
             self._device.select_source_aux()
         elif source == "Bluetooth":
-            _LOGGER.info("Selecting source Bluetooth")
+            _LOGGER.debug("Selecting source Bluetooth")
             self._device.select_source_bluetooth()
         else:
-            _LOGGER.warning("Source not supported")
+            _LOGGER.warning("Source %s is not supported", source)
 
     def create_zone(self, slaves):
         """

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -362,6 +362,7 @@ class SoundTouchDevice(MediaPlayerEntity):
     def select_source(self, source):
         """
         Select the source to play audio from.
+
         :param source:source to select
         """
         if source == "AUX":

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -360,6 +360,7 @@ class SoundTouchDevice(MediaPlayerEntity):
                 _LOGGER.warning("Unable to find preset with id %s", media_id)
 
     def select_source(self, source):
+        """Select input source."""
         if source == "AUX":
             _LOGGER.debug("Selecting source AUX")
             self._device.select_source_aux()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -837,7 +837,7 @@ libpyvivotek==0.4.0
 librouteros==3.0.0
 
 # homeassistant.components.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.8
 
 # homeassistant.components.life360
 life360==4.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -356,7 +356,7 @@ libpurecool==0.6.1
 librouteros==3.0.0
 
 # homeassistant.components.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.8
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.2

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -255,6 +255,36 @@ class MockStatusPause(Status):
         self._station_name = None
 
 
+class MockStatusPlayingAux(Status):
+    """Mock status AUX."""
+
+    def __init__(self):
+        """Init the class."""
+        self._source = "AUX"
+        self._play_status = "PLAY_STATE"
+        self._image = "image.url"
+        self._artist = None
+        self._track = None
+        self._album = None
+        self._duration = None
+        self._station_name = None
+
+
+class MockStatusPlayingBluetooth(Status):
+    """Mock status Bluetooth."""
+
+    def __init__(self):
+        """Init the class."""
+        self._source = "BLUETOOTH"
+        self._play_status = "PLAY_STATE"
+        self._image = "image.url"
+        self._artist = "artist"
+        self._track = "track"
+        self._album = "album"
+        self._duration = None
+        self._station_name = None
+
+
 async def test_ensure_setup_config(mocked_status, mocked_volume, hass, one_device):
     """Test setup OK with custom config."""
     await setup_soundtouch(
@@ -364,6 +394,37 @@ async def test_playing_radio(mocked_status, mocked_volume, hass, one_device):
     entity_1_state = hass.states.get("media_player.soundtouch_1")
     assert entity_1_state.state == STATE_PLAYING
     assert entity_1_state.attributes["media_title"] == "station"
+
+
+async def test_playing_aux(mocked_status, mocked_volume, hass, one_device):
+    """Test playing AUX info."""
+    mocked_status.side_effect = MockStatusPlayingAux
+    await setup_soundtouch(hass, DEVICE_1_CONFIG)
+
+    assert one_device.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
+
+    entity_1_state = hass.states.get("media_player.soundtouch_1")
+    assert entity_1_state.state == STATE_PLAYING
+    assert entity_1_state.attributes["source"] == "AUX"
+
+
+async def test_playing_bluetooth(mocked_status, mocked_volume, hass, one_device):
+    """Test playing Bluetooth info."""
+    mocked_status.side_effect = MockStatusPlayingBluetooth
+    await setup_soundtouch(hass, DEVICE_1_CONFIG)
+
+    assert one_device.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
+
+    entity_1_state = hass.states.get("media_player.soundtouch_1")
+    assert entity_1_state.state == STATE_PLAYING
+    assert entity_1_state.attributes["source"] == "BLUETOOTH"
+    assert entity_1_state.attributes["media_track"] == "track"
+    assert entity_1_state.attributes["media_artist"] == "artist"
+    assert entity_1_state.attributes["media_album_name"] == "album"
 
 
 async def test_get_volume_level(mocked_status, mocked_volume, hass, one_device):

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -426,7 +426,7 @@ async def test_media_commands(mocked_status, mocked_volume, hass, one_device):
     assert mocked_volume.call_count == 2
 
     entity_1_state = hass.states.get("media_player.soundtouch_1")
-    assert entity_1_state.attributes["supported_features"] == 18365
+    assert entity_1_state.attributes["supported_features"] == 20413
 
 
 @patch("libsoundtouch.device.SoundTouchDevice.power_off")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I use Bose Soundtouch speakers and were missing the ability to select the input source.
I saw that the external package libsoundtouch 0.8 already support this, but Home-assistant not yet.
So I updated the requirements from libsoundtouch 0.7.2 to libsoundtouch 0.8 and implemented the feature in the component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
I doubt that will help since you need the device, but here it is anyway
```yaml
# Example configuration.yaml
media_player:
  - platform: soundtouch
    host: 192.168.1.2
    port: 8090
    name: Soundtouch speaker
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
