### PR TITLE
Significantly reduce the number of API calls that the august integration

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -1,5 +1,5 @@
 """Support for August devices."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from august.api import Api
@@ -42,8 +42,21 @@ DEFAULT_ENTITY_NAMESPACE = "august"
 # avoid hitting rate limits
 MIN_TIME_BETWEEN_LOCK_DETAIL_UPDATES = timedelta(seconds=1800)
 
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=10)
+# Limit locks status check to 900 seconds now that
+# we get the state from the lock and unlock api calls
+# and the lock and unlock activities are now captured
+MIN_TIME_BETWEEN_LOCK_STATUS_UPDATES = timedelta(seconds=900)
+
+# Doorbells need to update more frequently than locks
+# since we get an image from the doorbell api
+MIN_TIME_BETWEEN_DOORBELL_STATUS_UPDATES = timedelta(seconds=20)
+
+# Activity needs to be checked more frequently as the
+# doorbell motion and rings are included here
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=10)
+
 
 LOGIN_METHODS = ["phone", "email"]
 
@@ -192,6 +205,7 @@ class AugustData:
             self._house_ids.add(device.house_id)
 
         self._doorbell_detail_by_id = {}
+        self._lock_last_status_update_by_id = {}
         self._lock_status_by_id = {}
         self._lock_detail_by_id = {}
         self._door_state_by_id = {}
@@ -243,6 +257,7 @@ class AugustData:
                 self._activities_by_id[device_id] = [
                     a for a in activities if a.device_id == device_id
                 ]
+
         _LOGGER.debug("Completed retrieving device activities")
 
     def get_doorbell_detail(self, doorbell_id):
@@ -250,7 +265,7 @@ class AugustData:
         self._update_doorbells()
         return self._doorbell_detail_by_id.get(doorbell_id)
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    @Throttle(MIN_TIME_BETWEEN_DOORBELL_STATUS_UPDATES)
     def _update_doorbells(self):
         detail_by_id = {}
 
@@ -274,6 +289,17 @@ class AugustData:
 
         _LOGGER.debug("Completed retrieving doorbell details")
         self._doorbell_detail_by_id = detail_by_id
+
+    def update_lock_status(self, lock_id, lock_status, update_start_time):
+        """Set the lock status and last status update time.
+
+        This is used when the lock, unlock apis are called
+        or newer activity is detected on the activity feed
+        in order to keep the internal data in sync
+        """
+        self._lock_status_by_id[lock_id] = lock_status
+        self._lock_last_status_update_by_id[lock_id] = update_start_time
+        return True
 
     def get_lock_status(self, lock_id):
         """Return status if the door is locked or unlocked.
@@ -300,13 +326,15 @@ class AugustData:
         self._update_locks_status()
         self._update_locks_detail()
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    @Throttle(MIN_TIME_BETWEEN_LOCK_STATUS_UPDATES)
     def _update_locks_status(self):
         status_by_id = {}
         state_by_id = {}
+        last_status_update_by_id = {}
 
         _LOGGER.debug("Start retrieving lock and door status")
         for lock in self._locks:
+            update_start_time = datetime.now()
             _LOGGER.debug("Updating lock and door status for %s", lock.device_name)
             try:
                 (
@@ -315,6 +343,12 @@ class AugustData:
                 ) = self._api.get_lock_status(
                     self._access_token, lock.device_id, door_status=True
                 )
+                # Since there is a a race condition between calling the
+                # lock and activity apis, we set the last update time
+                # BEFORE making the api call since we will compare this
+                # to activity later we want activity to win over stale lock
+                # state.
+                last_status_update_by_id[lock.device_id] = update_start_time
             except RequestException as ex:
                 _LOGGER.error(
                     "Request error trying to retrieve lock and door status for %s. %s",
@@ -331,6 +365,17 @@ class AugustData:
         _LOGGER.debug("Completed retrieving lock and door status")
         self._lock_status_by_id = status_by_id
         self._door_state_by_id = state_by_id
+        self._lock_last_status_update_by_id = last_status_update_by_id
+
+    def get_last_lock_status_update_time(self, lock_id):
+        """Return the last time that a lock status update was seen from the august API."""
+        # Since the activity api is called more frequently than
+        # the lock api it is possible that the lock has not
+        # been updated yet
+        if lock_id not in self._lock_last_status_update_by_id:
+            return datetime.fromtimestamp(0)
+
+        return self._lock_last_status_update_by_id[lock_id]
 
     @Throttle(MIN_TIME_BETWEEN_LOCK_DETAIL_UPDATES)
     def _update_locks_detail(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a followup to PR #31558 

It seems that the folks at August were not so thrilled with the number of API calls unofficial integrations were making, which likely lead to the implementation of the HTTP 429s. 

The goal is to make home assistant more sustainable for August, and reduce the amount of load on their servers as much as possible. The hope is that there isn’t any need for them to do any more disruptive rate-limiting, and the component stays working for everyone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
