### PR TITLE
Disable Hue groups for new setups

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -11,21 +11,21 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .bridge import HueBridge
-from .const import DOMAIN
+from .const import (
+    CONF_ALLOW_HUE_GROUPS,
+    CONF_ALLOW_UNREACHABLE,
+    DEFAULT_ALLOW_HUE_GROUPS,
+    DEFAULT_ALLOW_UNREACHABLE,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_BRIDGES = "bridges"
 
-CONF_ALLOW_UNREACHABLE = "allow_unreachable"
-DEFAULT_ALLOW_UNREACHABLE = False
-
 DATA_CONFIGS = "hue_configs"
 
 PHUE_CONFIG_FILE = "phue.conf"
-
-CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
-DEFAULT_ALLOW_HUE_GROUPS = True
 
 BRIDGE_CONFIG_SCHEMA = vol.Schema(
     {
@@ -112,8 +112,10 @@ async def async_setup_entry(
     config = hass.data[DATA_CONFIGS].get(host)
 
     if config is None:
-        allow_unreachable = DEFAULT_ALLOW_UNREACHABLE
-        allow_groups = DEFAULT_ALLOW_HUE_GROUPS
+        allow_unreachable = entry.data.get(
+            CONF_ALLOW_UNREACHABLE, DEFAULT_ALLOW_UNREACHABLE
+        )
+        allow_groups = entry.data.get(CONF_ALLOW_HUE_GROUPS, DEFAULT_ALLOW_HUE_GROUPS)
     else:
         allow_unreachable = config[CONF_ALLOW_UNREACHABLE]
         allow_groups = config[CONF_ALLOW_HUE_GROUPS]

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -14,7 +14,11 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import aiohttp_client
 
 from .bridge import authenticate_bridge
-from .const import DOMAIN, LOGGER  # pylint: disable=unused-import
+from .const import (  # pylint: disable=unused-import
+    CONF_ALLOW_HUE_GROUPS,
+    DOMAIN,
+    LOGGER,
+)
 from .errors import AuthenticationRequired, CannotConnect
 
 HUE_MANUFACTURERURL = "http://www.philips.com"
@@ -125,7 +129,11 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             return self.async_create_entry(
                 title=bridge.config.name,
-                data={"host": bridge.host, "username": bridge.username},
+                data={
+                    "host": bridge.host,
+                    "username": bridge.username,
+                    CONF_ALLOW_HUE_GROUPS: False,
+                },
             )
         except AuthenticationRequired:
             errors["base"] = "register_failed"

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -7,3 +7,9 @@ DOMAIN = "hue"
 # How long to wait to actually do the refresh after requesting it.
 # We wait some time so if we control multiple lights, we batch requests.
 REQUEST_REFRESH_DELAY = 0.3
+
+CONF_ALLOW_UNREACHABLE = "allow_unreachable"
+DEFAULT_ALLOW_UNREACHABLE = False
+
+CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
+DEFAULT_ALLOW_HUE_GROUPS = True

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -79,6 +79,7 @@ async def test_flow_works(hass):
     assert result["data"] == {
         "host": "1.2.3.4",
         "username": "home-assistant#test-home",
+        "allow_hue_groups": False,
     }
 
     assert len(mock_bridge.initialize.mock_calls) == 1
@@ -440,6 +441,7 @@ async def test_creating_entry_removes_entries_for_same_host_or_bridge(hass):
     assert result["data"] == {
         "host": "2.2.2.2",
         "username": "username-abc",
+        "allow_hue_groups": False,
     }
     entries = hass.config_entries.async_entries("hue")
     assert len(entries) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hue groups don't have unique IDs (#31002), hence they cannot be put in the entity registry or device registry. They are also _kinda_ useless as Hue can be controlled via groups in Home Assistant.

So moving forward, all new set ups of Hue will disable Hue groups. They can always be enabled again via configuration.yaml. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
