### PR TITLE
Simplify missing Garmin Connect data handling, mark entities un/available

### DIFF
--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -160,21 +160,21 @@ class GarminConnectSensor(Entity):
             return
 
         await self._data.async_update()
-        if not self._data.data:
+        data = self._data.data
+        if not data:
             _LOGGER.error("Didn't receive data from Garmin Connect")
             return
-
-        data = self._data.data
-        try:
-            if "Duration" in self._type and data[self._type]:
-                self._state = data[self._type] // 60
-            elif "Seconds" in self._type and data[self._type]:
-                self._state = data[self._type] // 60
-            else:
-                self._state = data[self._type]
-        except KeyError:
-            _LOGGER.debug("Entity type %s not found in fetched data", self._type)
+        if data.get(self._type) is None:
+            _LOGGER.debug("Entity type %s not set in fetched data", self._type)
+            self._available = False
             return
+        else:
+            self._available = True
+
+        if "Duration" in self._type or "Seconds" in self._type:
+            self._state = data[self._type] // 60
+        else:
+            self._state = data[self._type]
 
         _LOGGER.debug(
             "Entity %s set to state %s %s", self._type, self._state, self._unit

--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -168,8 +168,7 @@ class GarminConnectSensor(Entity):
             _LOGGER.debug("Entity type %s not set in fetched data", self._type)
             self._available = False
             return
-        else:
-            self._available = True
+        self._available = True
 
         if "Duration" in self._type or "Seconds" in self._type:
             self._state = data[self._type] // 60


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This cleans up missing Garmin Connect data handling as mentioned in #31670:
- test for data availability and `None`ness and return gracefully early when appropriate instead of testing repeatedly later and handling exceptions
- mark entities for which no data is available as unavailable
- combine duplicate Duration and Seconds code blocks to one

Caveat: I haven't actually tested this at all, will do later if you want.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31670
- This PR is related to issue: #31608
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
