### PR TITLE
VSCode Remote Dev container, using our Alpine base & Home Assistant Wheels

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
   "name": "Home Assistant Dev",
   "context": "..",
   "dockerFile": "../Dockerfile.dev",
-  "postCreateCommand": "mkdir -p config && pip3 install -e .",
+  "postCreateCommand": "mkdir -p config && pip3 install --find-links \"${WHEELS_LINKS}\" -e .",
   "appPort": 8123,
-  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
+  "runArgs": ["-e", "GIT_EDITOR=\"code --wait\""],
   "extensions": [
     "ms-python.python",
     "visualstudioexptteam.vscodeintellicode",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,9 +19,7 @@
       "label": "Pytest",
       "type": "shell",
       "command": "pytest --timeout=10 tests",
-      "dependsOn": [
-        "Install all Test Requirements"
-      ],
+      "dependsOn": ["Install all Test Requirements"],
       "group": {
         "kind": "test",
         "isDefault": true
@@ -50,9 +48,7 @@
       "label": "Pylint",
       "type": "shell",
       "command": "pylint homeassistant",
-      "dependsOn": [
-        "Install all Requirements"
-      ],
+      "dependsOn": ["Install all Requirements"],
       "group": {
         "kind": "test",
         "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,9 @@
       "label": "Pytest",
       "type": "shell",
       "command": "pytest --timeout=10 tests",
-      "dependsOn": ["Install all Test Requirements"],
+      "dependsOn": [
+        "Install all Test Requirements"
+      ],
       "group": {
         "kind": "test",
         "isDefault": true
@@ -48,7 +50,9 @@
       "label": "Pylint",
       "type": "shell",
       "command": "pylint homeassistant",
-      "dependsOn": ["Install all Requirements"],
+      "dependsOn": [
+        "Install all Requirements"
+      ],
       "group": {
         "kind": "test",
         "isDefault": true
@@ -76,7 +80,7 @@
     {
       "label": "Install all Requirements",
       "type": "shell",
-      "command": "pip3 install -r requirements_all.txt -c homeassistant/package_constraints.txt",
+      "command": "pip3 install --find-links \"${WHEELS_LINKS}\" -r requirements_all.txt -c homeassistant/package_constraints.txt",
       "group": {
         "kind": "build",
         "isDefault": true
@@ -90,7 +94,7 @@
     {
       "label": "Install all Test Requirements",
       "type": "shell",
-      "command": "pip3 install -r requirements_test_all.txt -c homeassistant/package_constraints.txt",
+      "command": "pip3 install --find-links \"${WHEELS_LINKS}\"  -r requirements_test_all.txt -c homeassistant/package_constraints.txt",
       "group": {
         "kind": "build",
         "isDefault": true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,32 +1,24 @@
-FROM python:3.7
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libudev-dev \
-        libavformat-dev \
-        libavcodec-dev \
-        libavdevice-dev \
-        libavutil-dev \
-        libswscale-dev \
-        libswresample-dev \
-        libavfilter-dev \
-        git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+FROM homeassistant/amd64-homeassistant-base:4.1
 
 WORKDIR /usr/src
+
+# Install build tools
+RUN apk add --no-cache build-base
 
 # Setup hass-release
 RUN git clone --depth 1 https://github.com/home-assistant/hass-release \
     && cd hass-release \
-    && pip3 install -e .
+    && pip3 install --find-links "${WHEELS_LINKS}" -e .
 
 WORKDIR /workspaces
 
 # Install Python dependencies from requirements
-COPY requirements_test.txt requirements_test_pre_commit.txt homeassistant/package_constraints.txt ./
-RUN pip3 install -r requirements_test.txt -c package_constraints.txt \
-    && rm -f requirements_test.txt package_constraints.txt requirements_test_pre_commit.txt
+COPY requirements_test.txt homeassistant/package_constraints.txt ./
+RUN pip3 install \
+        --find-links "${WHEELS_LINKS}" \
+        -r requirements_test.txt \
+        -c package_constraints.txt \
+    && rm -f requirements_test.txt package_constraints.txt
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM homeassistant/amd64-homeassistant-base:4.1
+FROM homeassistant/amd64-homeassistant-base:5.4
 
 WORKDIR /usr/src
 
@@ -13,12 +13,16 @@ RUN git clone --depth 1 https://github.com/home-assistant/hass-release \
 WORKDIR /workspaces
 
 # Install Python dependencies from requirements
-COPY requirements_test.txt homeassistant/package_constraints.txt ./
-RUN pip3 install \
+COPY requirements_test.txt requirements_test_pre_commit.txt homeassistant/package_constraints.txt ./
+RUN \
+    pip3 install \
         --find-links "${WHEELS_LINKS}" \
         -r requirements_test.txt \
         -c package_constraints.txt \
-    && rm -f requirements_test.txt package_constraints.txt
+    && rm -f \
+        package_constraints.txt \
+        requirements_test_pre_commit.txt \
+        requirements_test.txt
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR changes our VSCode dev container to use Alpine, based on our own base images.

It also leverages our pre-build Python Wheels, to make the general installation and setup fly 🚀 

All VSCode tasks are adjusted to have those same benefits.

⚠️ **Warning!**

I've originally created this branch in October 2019, however I never published it because I found it unstable.

During my testing, I've noticed issues with the Python Language server crashing.

I've now rebased this branch and updated it to match our current codebase. However, on my end, it did still crash using the latest language servers and vscode. At this point, I'm doubting my set up.

Output from the Python Language Server at some point:
```txt
[Error - 9:10:40 AM] Starting client failed
Launching server using command /root/.vscode-server/extensions/ms-python.python-2020.1.58038/languageServer.0.5.30/Microsoft.Python.LanguageServer failed.
```

VSCode showing:

![image](https://user-images.githubusercontent.com/195327/74223580-4fd05180-4cb7-11ea-96c3-8192fafdb636.png)


So some testing from others is required for this to be mergeable!

Supersedes: #31715

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
