### PR TITLE
Fix for wrong City Data

### DIFF
--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -215,8 +215,8 @@ class ZamgData:
 def _get_zamg_stations():
     """Return {CONF_STATION: (lat, lon)} for all stations, for auto-config."""
     capital_stations = {r["Station"] for r in ZamgData.current_observations()}
-    capital_stations.add('11231')  # correct number for Klagenfurt
-    capital_stations.add('11120')  # correct number for Innsbruck
+    capital_stations.add("11231")  # correct number for Klagenfurt
+    capital_stations.add("11120")  # correct number for Innsbruck
     req = requests.get(
         "https://www.zamg.ac.at/cms/en/documents/climate/"
         "doc_metnetwork/zamg-observation-points",

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -226,8 +226,10 @@ def _get_zamg_stations():
     for row in csv.DictReader(req.text.splitlines(), delimiter=";", quotechar='"'):
         if row.get("synnr") in capital_stations:
             try:
-                if row["synnr"] == "11231": row["synnr"] = "11331"  # Override for Klagenfurt
-                if row["synnr"] == "11120": row["synnr"] = "11121"  # Override for Innsbruck
+                if row["synnr"] == "11231":  # Override for Klagenfurt
+                    row["synnr"] = "11331"
+                if row["synnr"] == "11120":  # Override for Innsbruck
+                    row["synnr"] = "11121"
                 stations[row["synnr"]] = tuple(
                     float(row[coord].replace(",", "."))
                     for coord in ["breite_dezi", "länge_dezi"]

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -215,6 +215,8 @@ class ZamgData:
 def _get_zamg_stations():
     """Return {CONF_STATION: (lat, lon)} for all stations, for auto-config."""
     capital_stations = {r["Station"] for r in ZamgData.current_observations()}
+    capital_stations.add('11231')  # correct number for Klagenfurt
+    capital_stations.add('11120')  # correct number for Innsbruck
     req = requests.get(
         "https://www.zamg.ac.at/cms/en/documents/climate/"
         "doc_metnetwork/zamg-observation-points",
@@ -224,6 +226,8 @@ def _get_zamg_stations():
     for row in csv.DictReader(req.text.splitlines(), delimiter=";", quotechar='"'):
         if row.get("synnr") in capital_stations:
             try:
+                if row["synnr"] == "11231": row["synnr"] = "11331"  # Override for Klagenfurt
+                if row["synnr"] == "11120": row["synnr"] = "11121"  # Override for Innsbruck
                 stations[row["synnr"]] = tuple(
                     float(row[coord].replace(",", "."))
                     for coord in ["breite_dezi", "länge_dezi"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

the Zamg data for the city Klagenfurt and Innsbruck do not match between the list of measurement points and the realtime data.

This fix adds the numbers used in the realtime data to the list of measurement points.

Realtime data: http://www.zamg.ac.at/ogd/

Measurement point list: https://www.zamg.ac.at/cms/en/documents/climate/doc_metnetwork/zamg-observation-points

Like this the auto search for the nearest location works and also all citys can be used.

The way this works may not be the best, maybe somebody should even highlight this mismatch to Zamg?

(im from Innsbruck and was wondering why i could not use the City and the auto search found something quite far away, where i knew that Zamg has a location just next to me)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: zamg
  - latitude: 47.26
  - longitude: 11.4

```
This is located in Innsbruck, it should NOT give "Patscherkofel" as nearest station, with this Bugfix it returns "Innsbruck"

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
