### PR TITLE
Add automation options for parallel action runs

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.async_ import run_callback_threadsafe
-import homeassistant.util.dt as date_util
+from homeassistant.util.dt import utcnow
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 
@@ -58,6 +58,18 @@ ACTION_FIRE_EVENT = "event"
 ACTION_CALL_SERVICE = "call_service"
 ACTION_DEVICE_AUTOMATION = "device"
 ACTION_ACTIVATE_SCENE = "scene"
+
+
+SCRIPT_PARALLEL_ALLOW = "allow"
+SCRIPT_PARALLEL_ERROR = "error"
+SCRIPT_PARALLEL_RESTART = "restart"
+SCRIPT_PARALLEL_SKIP = "skip"
+SCRIPT_PARALLEL_CHOICES = [
+    SCRIPT_PARALLEL_ALLOW,
+    SCRIPT_PARALLEL_ERROR,
+    SCRIPT_PARALLEL_RESTART,
+    SCRIPT_PARALLEL_SKIP,
+]
 
 
 def _determine_action(action):
@@ -130,6 +142,7 @@ class Script:
         sequence: Sequence[Dict[str, Any]],
         name: Optional[str] = None,
         change_listener: Optional[Callable[..., Any]] = None,
+        mode: Optional[str] = None,
     ) -> None:
         """Initialize the script."""
         self.hass = hass
@@ -137,32 +150,35 @@ class Script:
         template.attach(hass, self.sequence)
         self.name = name
         self._change_listener = change_listener
-        self._cur = -1
-        self._exception_step: Optional[int] = None
-        self.last_action = None
+        self._runs: List[Script._ScriptRun] = []
         self.last_triggered: Optional[datetime] = None
         self.can_cancel = any(
             CONF_DELAY in action or CONF_WAIT_TEMPLATE in action
             for action in self.sequence
         )
-        self._async_listener: List[CALLBACK_TYPE] = []
         self._config_cache: Dict[Set[Tuple], Callable[..., bool]] = {}
-        self._actions = {
-            ACTION_DELAY: self._async_delay,
-            ACTION_WAIT_TEMPLATE: self._async_wait_template,
-            ACTION_CHECK_CONDITION: self._async_check_condition,
-            ACTION_FIRE_EVENT: self._async_fire_event,
-            ACTION_CALL_SERVICE: self._async_call_service,
-            ACTION_DEVICE_AUTOMATION: self._async_device_automation,
-            ACTION_ACTIVATE_SCENE: self._async_activate_scene,
-        }
+        self._mode = (
+            mode
+            if mode
+            else SCRIPT_PARALLEL_RESTART
+            if self.can_cancel
+            else SCRIPT_PARALLEL_ALLOW
+        )
         self._referenced_entities: Optional[Set[str]] = None
         self._referenced_devices: Optional[Set[str]] = None
 
     @property
+    def last_action(self):
+        """Return last action."""
+        try:
+            return self._runs[0].last_action
+        except IndexError:
+            return None
+
+    @property
     def is_running(self) -> bool:
         """Return true if script is on."""
-        return self._cur != -1
+        return len(self._runs) > 0
 
     @property
     def referenced_devices(self):
@@ -220,53 +236,335 @@ class Script:
         self._referenced_entities = referenced
         return referenced
 
-    def run(self, variables=None, context=None):
+    def run(self, variables=None, context=None, logger=None, message_base=None):
         """Run script."""
         asyncio.run_coroutine_threadsafe(
-            self.async_run(variables, context), self.hass.loop
+            self.async_run(variables, context, logger, message_base), self.hass.loop
         ).result()
 
-    async def async_run(
-        self, variables: Optional[Sequence] = None, context: Optional[Context] = None
-    ) -> None:
-        """Run script.
+    class _ScriptRun:
+        def __init__(
+            self,
+            hass: HomeAssistant,
+            parent: "Script",
+            variables: Optional[Sequence] = None,
+            context: Optional[Context] = None,
+            logger: Optional[logging.Logger] = None,
+            message_base: Optional[str] = None,
+        ) -> None:
+            self.hass = hass
+            self._parent = parent
+            self._variables = variables
+            self._context = context
+            self._logger = logger or _LOGGER
+            self._message_base = message_base or "Error executing script"
+            self._actions = {
+                ACTION_DELAY: self._async_delay,
+                ACTION_WAIT_TEMPLATE: self._async_wait_template,
+                ACTION_CHECK_CONDITION: self._async_check_condition,
+                ACTION_FIRE_EVENT: self._async_fire_event,
+                ACTION_CALL_SERVICE: self._async_call_service,
+                ACTION_DEVICE_AUTOMATION: self._async_device_automation,
+                ACTION_ACTIVATE_SCENE: self._async_activate_scene,
+            }
+            self.task: Optional[asyncio.Task] = None
+            self.last_action = None
+            self._cur = -1
+            self._async_listener: List[CALLBACK_TYPE] = []
 
-        This method is a coroutine.
-        """
-        self.last_triggered = date_util.utcnow()
-        if self._cur == -1:
-            self._log("Running script")
-            self._cur = 0
+        async def async_run(self) -> None:
+            """Run script."""
+            if self._cur == -1:
+                self._log("Running script")
+                self._cur = 0
 
-        # Unregister callback if we were in a delay or wait but turn on is
-        # called again. In that case we just continue execution.
-        self._async_remove_listener()
+            assert not self._async_listener
 
-        for cur, action in islice(enumerate(self.sequence), self._cur, None):
+            for cur, action in islice(
+                enumerate(self._parent.sequence), self._cur, None
+            ):
+                try:
+                    await self._handle_action(action)
+                except _SuspendScript:
+                    # Store next step to take and notify change listeners
+                    self.task = None
+                    self._cur = cur + 1
+                    # pylint: disable=protected-access
+                    if self._parent._change_listener:
+                        self.hass.async_add_job(self._parent._change_listener)
+                    return
+                except _StopScript:
+                    break
+                except Exception as err:
+                    self._async_log_exception(cur, action, err)
+                    self._async_stop()
+                    # Pass exception on.
+                    raise
+
+            self._async_stop()
+            # pylint: disable=protected-access
+            if self._parent._change_listener:
+                self.hass.async_add_job(self._parent._change_listener)
+
+        @callback
+        def _async_stop(self):
+            self._async_remove_listener()
+            self._parent._runs.remove(self)  # pylint: disable=protected-access
+
+        @callback
+        def async_stop(self):
+            """Stop script run."""
+            self._async_stop()
+            with suppress(AttributeError):
+                self.task.cancel()
+
+        @callback
+        def _async_log_exception(self, step, action, exception):
+            action_type = _determine_action(action)
+
+            error = None
+            meth = self._logger.error
+
+            if isinstance(exception, vol.Invalid):
+                error_desc = "Invalid data"
+
+            elif isinstance(exception, exceptions.TemplateError):
+                error_desc = "Error rendering template"
+
+            elif isinstance(exception, exceptions.Unauthorized):
+                error_desc = "Unauthorized"
+
+            elif isinstance(exception, exceptions.ServiceNotFound):
+                error_desc = "Service not found"
+
+            else:
+                # Print the full stack trace, unknown error
+                error_desc = "Unknown error"
+                meth = self._logger.exception
+                error = ""
+
+            if error is None:
+                error = str(exception)
+
+            meth(
+                "%s. %s for %s at pos %s: %s",
+                self._message_base,
+                error_desc,
+                action_type,
+                step + 1,
+                error,
+            )
+
+        async def _handle_action(self, action):
+            """Handle an action."""
+            await self._actions[_determine_action(action)](action)
+
+        async def _async_delay(self, action):
+            """Handle delay."""
+            # Call ourselves in the future to continue work
+            unsub = None
+
+            @callback
+            def async_script_delay(now):
+                """Handle delay."""
+                with suppress(ValueError):
+                    self._async_listener.remove(unsub)
+                self.task = self.hass.async_create_task(self.async_run())
+
+            delay = action[CONF_DELAY]
+
             try:
-                await self._handle_action(action, variables, context)
-            except _SuspendScript:
-                # Store next step to take and notify change listeners
-                self._cur = cur + 1
-                if self._change_listener:
-                    self.hass.async_add_job(self._change_listener)
-                return
-            except _StopScript:
-                break
-            except Exception:
-                # Store the step that had an exception
-                self._exception_step = cur
-                # Set script to not running
-                self._cur = -1
-                self.last_action = None
-                # Pass exception on.
-                raise
+                if isinstance(delay, template.Template):
+                    delay = vol.All(cv.time_period, cv.positive_timedelta)(
+                        delay.async_render(self._variables)
+                    )
+                elif isinstance(delay, dict):
+                    delay_data = {}
+                    delay_data.update(template.render_complex(delay, self._variables))
+                    delay = cv.time_period(delay_data)
+            except (exceptions.TemplateError, vol.Invalid) as ex:
+                _LOGGER.error(
+                    "Error rendering '%s' delay template: %s", self._parent.name, ex
+                )
+                raise _StopScript
 
-        # Set script to not-running.
-        self._cur = -1
-        self.last_action = None
-        if self._change_listener:
-            self.hass.async_add_job(self._change_listener)
+            self.last_action = action.get(CONF_ALIAS, f"delay {delay}")
+            self._log("Executing step %s" % self.last_action)
+
+            unsub = async_track_point_in_utc_time(
+                self.hass, async_script_delay, utcnow() + delay
+            )
+            self._async_listener.append(unsub)
+            raise _SuspendScript
+
+        async def _async_wait_template(self, action):
+            """Handle a wait template."""
+            # Call ourselves in the future to continue work
+            wait_template = action[CONF_WAIT_TEMPLATE]
+            wait_template.hass = self.hass
+
+            self.last_action = action.get(CONF_ALIAS, "wait template")
+            self._log("Executing step %s" % self.last_action)
+
+            # check if condition already okay
+            if condition.async_template(self.hass, wait_template, self._variables):
+                return
+
+            @callback
+            def async_script_wait(entity_id, from_s, to_s):
+                """Handle script after template condition is true."""
+                self._async_remove_listener()
+                self.task = self.hass.async_create_task(self.async_run())
+
+            self._async_listener.append(
+                async_track_template(
+                    self.hass, wait_template, async_script_wait, self._variables
+                )
+            )
+
+            if CONF_TIMEOUT in action:
+                self._async_set_timeout(action)
+
+            raise _SuspendScript
+
+        async def _async_call_service(self, action):
+            """Call the service specified in the action."""
+            self.last_action = action.get(CONF_ALIAS, "call service")
+            self._log("Executing step %s" % self.last_action)
+            await service.async_call_from_config(
+                self.hass,
+                action,
+                blocking=True,
+                variables=self._variables,
+                validate_config=False,
+                context=self._context,
+            )
+
+        async def _async_device_automation(self, action):
+            """Perform the device automation specified in the action."""
+            self.last_action = action.get(CONF_ALIAS, "device automation")
+            self._log("Executing step %s" % self.last_action)
+            platform = await device_automation.async_get_device_automation_platform(
+                self.hass, action[CONF_DOMAIN], "action"
+            )
+            await platform.async_call_action_from_config(
+                self.hass, action, self._variables, self._context
+            )
+
+        async def _async_activate_scene(self, action):
+            """Activate the scene specified in the action."""
+            self.last_action = action.get(CONF_ALIAS, "activate scene")
+            self._log("Executing step %s" % self.last_action)
+            await self.hass.services.async_call(
+                scene.DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: action[CONF_SCENE]},
+                blocking=True,
+                context=self._context,
+            )
+
+        async def _async_fire_event(self, action):
+            """Fire an event."""
+            self.last_action = action.get(CONF_ALIAS, action[CONF_EVENT])
+            self._log("Executing step %s" % self.last_action)
+            event_data = dict(action.get(CONF_EVENT_DATA, {}))
+            if CONF_EVENT_DATA_TEMPLATE in action:
+                try:
+                    event_data.update(
+                        template.render_complex(
+                            action[CONF_EVENT_DATA_TEMPLATE], self._variables
+                        )
+                    )
+                except exceptions.TemplateError as ex:
+                    _LOGGER.error("Error rendering event data template: %s", ex)
+
+            self.hass.bus.async_fire(
+                action[CONF_EVENT], event_data, context=self._context
+            )
+
+        async def _async_check_condition(self, action):
+            """Test if condition is matching."""
+            config_cache_key = frozenset((k, str(v)) for k, v in action.items())
+            # pylint: disable=protected-access
+            config = self._parent._config_cache.get(config_cache_key)
+            if not config:
+                config = await condition.async_from_config(self.hass, action, False)
+                self._parent._config_cache[config_cache_key] = config
+
+            self.last_action = action.get(CONF_ALIAS, action[CONF_CONDITION])
+            check = config(self.hass, self._variables)
+            self._log(f"Test condition {self.last_action}: {check}")
+
+            if not check:
+                raise _StopScript
+
+        def _async_set_timeout(self, action):
+            """Schedule a timeout to abort or continue script."""
+            timeout = action[CONF_TIMEOUT]
+            unsub = None
+
+            @callback
+            def async_script_timeout(now):
+                """Call after timeout is retrieve."""
+                with suppress(ValueError):
+                    self._async_listener.remove(unsub)
+                self._async_remove_listener()
+
+                # Check if we want to continue to execute
+                # the script after the timeout
+                if action.get(CONF_CONTINUE, True):
+                    self.task = self.hass.async_create_task(self.async_run())
+                else:
+                    self._log("Timeout reached, abort script.")
+                    self._async_stop()
+
+            unsub = async_track_point_in_utc_time(
+                self.hass, async_script_timeout, utcnow() + timeout
+            )
+            self._async_listener.append(unsub)
+
+        def _async_remove_listener(self):
+            """Remove listeners, if any."""
+            for unsub in self._async_listener:
+                unsub()
+            self._async_listener.clear()
+
+        def _log(self, msg):
+            """Logger helper."""
+            if self._parent.name is not None:
+                msg = f"Script {self._parent.name}: {msg}"
+
+            _LOGGER.info(msg)
+
+    async def async_run(
+        self,
+        variables: Optional[Sequence] = None,
+        context: Optional[Context] = None,
+        logger: Optional[logging.Logger] = None,
+        message_base: Optional[str] = None,
+    ) -> None:
+        """Run script."""
+        if self.is_running:
+            if self._mode == SCRIPT_PARALLEL_SKIP:
+                self._log("Skipping script")
+                return
+            if self._mode == SCRIPT_PARALLEL_ERROR:
+                if logger:
+                    logger.error("%s. Already running", message_base)
+                raise exceptions.HomeAssistantError(
+                    f"{self.name if self.name else 'Script'} already running"
+                )
+            if self._mode == SCRIPT_PARALLEL_RESTART:
+                self._log("Restarting script")
+                self.async_stop()
+
+        self.last_triggered = utcnow()
+        run = Script._ScriptRun(
+            self.hass, self, variables, context, logger, message_base
+        )
+        self._runs.append(run)
+        run.task = self.hass.async_create_task(run.async_run())
+        await run.task
 
     def stop(self) -> None:
         """Stop running script."""
@@ -275,232 +573,12 @@ class Script:
     @callback
     def async_stop(self) -> None:
         """Stop running script."""
-        if self._cur == -1:
+        if not self.is_running:
             return
-
-        self._cur = -1
-        self._async_remove_listener()
+        for run in self._runs:
+            run.async_stop()
         if self._change_listener:
             self.hass.async_add_job(self._change_listener)
-
-    @callback
-    def async_log_exception(self, logger, message_base, exception):
-        """Log an exception for this script.
-
-        Should only be called on exceptions raised by this scripts async_run.
-        """
-        step = self._exception_step
-        action = self.sequence[step]
-        action_type = _determine_action(action)
-
-        error = None
-        meth = logger.error
-
-        if isinstance(exception, vol.Invalid):
-            error_desc = "Invalid data"
-
-        elif isinstance(exception, exceptions.TemplateError):
-            error_desc = "Error rendering template"
-
-        elif isinstance(exception, exceptions.Unauthorized):
-            error_desc = "Unauthorized"
-
-        elif isinstance(exception, exceptions.ServiceNotFound):
-            error_desc = "Service not found"
-
-        else:
-            # Print the full stack trace, unknown error
-            error_desc = "Unknown error"
-            meth = logger.exception
-            error = ""
-
-        if error is None:
-            error = str(exception)
-
-        meth(
-            "%s. %s for %s at pos %s: %s",
-            message_base,
-            error_desc,
-            action_type,
-            step + 1,
-            error,
-        )
-
-    async def _handle_action(self, action, variables, context):
-        """Handle an action."""
-        await self._actions[_determine_action(action)](action, variables, context)
-
-    async def _async_delay(self, action, variables, context):
-        """Handle delay."""
-        # Call ourselves in the future to continue work
-        unsub = None
-
-        @callback
-        def async_script_delay(now):
-            """Handle delay."""
-            with suppress(ValueError):
-                self._async_listener.remove(unsub)
-
-            self.hass.async_create_task(self.async_run(variables, context))
-
-        delay = action[CONF_DELAY]
-
-        try:
-            if isinstance(delay, template.Template):
-                delay = vol.All(cv.time_period, cv.positive_timedelta)(
-                    delay.async_render(variables)
-                )
-            elif isinstance(delay, dict):
-                delay_data = {}
-                delay_data.update(template.render_complex(delay, variables))
-                delay = cv.time_period(delay_data)
-        except (exceptions.TemplateError, vol.Invalid) as ex:
-            _LOGGER.error("Error rendering '%s' delay template: %s", self.name, ex)
-            raise _StopScript
-
-        self.last_action = action.get(CONF_ALIAS, f"delay {delay}")
-        self._log("Executing step %s" % self.last_action)
-
-        unsub = async_track_point_in_utc_time(
-            self.hass, async_script_delay, date_util.utcnow() + delay
-        )
-        self._async_listener.append(unsub)
-        raise _SuspendScript
-
-    async def _async_wait_template(self, action, variables, context):
-        """Handle a wait template."""
-        # Call ourselves in the future to continue work
-        wait_template = action[CONF_WAIT_TEMPLATE]
-        wait_template.hass = self.hass
-
-        self.last_action = action.get(CONF_ALIAS, "wait template")
-        self._log("Executing step %s" % self.last_action)
-
-        # check if condition already okay
-        if condition.async_template(self.hass, wait_template, variables):
-            return
-
-        @callback
-        def async_script_wait(entity_id, from_s, to_s):
-            """Handle script after template condition is true."""
-            self._async_remove_listener()
-            self.hass.async_create_task(self.async_run(variables, context))
-
-        self._async_listener.append(
-            async_track_template(self.hass, wait_template, async_script_wait, variables)
-        )
-
-        if CONF_TIMEOUT in action:
-            self._async_set_timeout(
-                action, variables, context, action.get(CONF_CONTINUE, True)
-            )
-
-        raise _SuspendScript
-
-    async def _async_call_service(self, action, variables, context):
-        """Call the service specified in the action.
-
-        This method is a coroutine.
-        """
-        self.last_action = action.get(CONF_ALIAS, "call service")
-        self._log("Executing step %s" % self.last_action)
-        await service.async_call_from_config(
-            self.hass,
-            action,
-            blocking=True,
-            variables=variables,
-            validate_config=False,
-            context=context,
-        )
-
-    async def _async_device_automation(self, action, variables, context):
-        """Perform the device automation specified in the action.
-
-        This method is a coroutine.
-        """
-        self.last_action = action.get(CONF_ALIAS, "device automation")
-        self._log("Executing step %s" % self.last_action)
-        platform = await device_automation.async_get_device_automation_platform(
-            self.hass, action[CONF_DOMAIN], "action"
-        )
-        await platform.async_call_action_from_config(
-            self.hass, action, variables, context
-        )
-
-    async def _async_activate_scene(self, action, variables, context):
-        """Activate the scene specified in the action.
-
-        This method is a coroutine.
-        """
-        self.last_action = action.get(CONF_ALIAS, "activate scene")
-        self._log("Executing step %s" % self.last_action)
-        await self.hass.services.async_call(
-            scene.DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: action[CONF_SCENE]},
-            blocking=True,
-            context=context,
-        )
-
-    async def _async_fire_event(self, action, variables, context):
-        """Fire an event."""
-        self.last_action = action.get(CONF_ALIAS, action[CONF_EVENT])
-        self._log("Executing step %s" % self.last_action)
-        event_data = dict(action.get(CONF_EVENT_DATA, {}))
-        if CONF_EVENT_DATA_TEMPLATE in action:
-            try:
-                event_data.update(
-                    template.render_complex(action[CONF_EVENT_DATA_TEMPLATE], variables)
-                )
-            except exceptions.TemplateError as ex:
-                _LOGGER.error("Error rendering event data template: %s", ex)
-
-        self.hass.bus.async_fire(action[CONF_EVENT], event_data, context=context)
-
-    async def _async_check_condition(self, action, variables, context):
-        """Test if condition is matching."""
-        config_cache_key = frozenset((k, str(v)) for k, v in action.items())
-        config = self._config_cache.get(config_cache_key)
-        if not config:
-            config = await condition.async_from_config(self.hass, action, False)
-            self._config_cache[config_cache_key] = config
-
-        self.last_action = action.get(CONF_ALIAS, action[CONF_CONDITION])
-        check = config(self.hass, variables)
-        self._log(f"Test condition {self.last_action}: {check}")
-
-        if not check:
-            raise _StopScript
-
-    def _async_set_timeout(self, action, variables, context, continue_on_timeout):
-        """Schedule a timeout to abort or continue script."""
-        timeout = action[CONF_TIMEOUT]
-        unsub = None
-
-        @callback
-        def async_script_timeout(now):
-            """Call after timeout is retrieve."""
-            with suppress(ValueError):
-                self._async_listener.remove(unsub)
-
-            # Check if we want to continue to execute
-            # the script after the timeout
-            if continue_on_timeout:
-                self.hass.async_create_task(self.async_run(variables, context))
-            else:
-                self._log("Timeout reached, abort script.")
-                self.async_stop()
-
-        unsub = async_track_point_in_utc_time(
-            self.hass, async_script_timeout, date_util.utcnow() + timeout
-        )
-        self._async_listener.append(unsub)
-
-    def _async_remove_listener(self):
-        """Remove point in time listener, if any."""
-        for unsub in self._async_listener:
-            unsub()
-        self._async_listener.clear()
 
     def _log(self, msg):
         """Logger helper."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously if the action section of an automation contained a delay or wait_template step, and a trigger fires while the automation is still in one of these steps from a previous trigger event, the step would be aborted and the action would continue with the next step. This was apparently unintentional behavior and many people have been surprised by it, and have had to work around it.

This change fixes that behavior by allowing the user to specify what should happen when the automation is triggered while it is still running its actions from a previous trigger event. The default behavior in the scenario described above will be to stop the previous run and start the action sequence over from the beginning. Although this is probably what most people would have expected, it can break existing automations that depend on the current odd behavior.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new, optional configuration parameter for automations, namely `parallel_action`, which will control what happens when the automation is triggered while the action sequence is still running from a previous trigger event. There are four options:

- `allow` -- The action sequence will be run in parallel with the previous run. This is the default if the action sequence does _not_ contain a `delay` or `wait_template`.
- `error` -- The trigger will cause an ERROR.
- `restart` -- The previous run will be cancelled before a new run is started. This is the default if the action sequence _does_ contain `delay` or `wait_template`.
- `skip` -- The trigger will be ignored and the previous run will continue unaltered.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
automation:
- trigger:
    platform: state
    entity_id: binary_sensor.motion
    to: 'on'
  action:
  - service: light.turn_on
    entity_id: light.porch
  - delay: "00:05:00"
  - service: light.turn_off
    entity_id: light.porch
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31364
- This PR is related to issue: 
- Link to documentation pull request: 

## Detailed list of changes

- Add optional automation config parameter parallel_action. Options and default are defined in Script helper class.
- Move async_log_exception functionality entirely inside Script class.
- Automation uses Script's last_triggered attribute.
- Enhance Script class to properly support simultaneous parallel runs regardless of whether the script sequence contains delays or wait_templates.
- Four options are available for what happens if script is run while it is already running: allow, error, restart & skip.
- All run context is moved into a new helper class _ScriptRun.
- Only update last_triggered when Script first run (i.e., not when resumed after delay or wait_template.)
- Fix bug where wait_template listener is not canceled when timeout expires.
- Update tests.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
