### PR TITLE
Improve Plex media_player entity naming

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -3,6 +3,7 @@ from homeassistant.const import __version__
 
 DOMAIN = "plex"
 NAME_FORMAT = "Plex ({})"
+COMMON_PLAYERS = ["Plex Web"]
 
 DEFAULT_PORT = 32400
 DEFAULT_SSL = False

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -51,6 +51,7 @@ class PlexServer:
         self._verify_ssl = server_config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
         self.options = options
         self.server_choice = None
+        self._owner_username = None
 
         # Header conditionally added as it is not available in config entry v1
         if CONF_CLIENT_IDENTIFIER in server_config:
@@ -92,6 +93,14 @@ class PlexServer:
             _connect_with_url()
         else:
             _connect_with_token()
+
+        owner_account = [
+            account.name
+            for account in self._plex_server.systemAccounts()
+            if account.accountID == 1
+        ]
+        if owner_account:
+            self._owner_username = owner_account[0]
 
     def refresh_entity(self, machine_identifier, device, session):
         """Forward refresh dispatch to media_player."""
@@ -181,6 +190,11 @@ class PlexServer:
     def plex_server(self):
         """Return the plexapi PlexServer instance."""
         return self._plex_server
+
+    @property
+    def owner(self):
+        """Return the Plex server owner username."""
+        return self._owner_username
 
     @property
     def friendly_name(self):

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -53,6 +53,15 @@ class MockPlexAccount:
         return self._resources
 
 
+class MockPlexSystemAccount:
+    """Mock a PlexSystemAccount instance."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.name = "Dummy"
+        self.accountID = 1
+
+
 class MockPlexServer:
     """Mock a PlexServer instance."""
 
@@ -68,6 +77,11 @@ class MockPlexServer:
         ]
         prefix = "https" if ssl else "http"
         self._baseurl = f"{prefix}://{host}:{port}"
+        self._systemAccount = MockPlexSystemAccount()
+
+    def systemAccounts(self):
+        """Mock the systemAccounts lookup method."""
+        return [self._systemAccount]
 
     @property
     def url_in_use(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Current naming of Plex `media_player` entities does not provide enough information, making it difficult to identify them and potentially creating many duplicates. This is especially true for users that share their Plex server. 

A user watching through a Plex Web client on Chrome would previously be named `media_player.plex_chrome`. Additional similar clients would be named `media_player.plex_chrome_2`, `media_player.plex_chrome_3`, etc.

This PR:
1. Inserts the username if it is a shared or managed user.
2. Adds more detail on the type of client playing.
3. Conditionally adds more context if a common player is in use (Plex Web for now).

If the above client was playing from a shared account, the new name would now be something like `media_player.plex_myfriend_plex_web_chrome_osx`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
