### PR TITLE
Add device name to sensor name for mobile_app

### DIFF
--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
 from .const import (
+    ATTR_DEVICE_NAME,
     ATTR_SENSOR_ATTRIBUTES,
     ATTR_SENSOR_DEVICE_CLASS,
     ATTR_SENSOR_ICON,
@@ -38,6 +39,7 @@ class MobileAppEntity(Entity):
         )
         self._entity_type = config[ATTR_SENSOR_TYPE]
         self.unsub_dispatcher = None
+        self._name = f"{entry.data[ATTR_DEVICE_NAME]} {config[ATTR_SENSOR_NAME]}"
 
     async def async_added_to_hass(self):
         """Register callbacks."""
@@ -58,7 +60,7 @@ class MobileAppEntity(Entity):
     @property
     def name(self):
         """Return the name of the mobile app sensor."""
-        return self._config[ATTR_SENSOR_NAME]
+        return self._name
 
     @property
     def device_class(self):

--- a/tests/components/mobile_app/test_entity.py
+++ b/tests/components/mobile_app/test_entity.py
@@ -35,7 +35,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert json == {"success": True}
     await hass.async_block_till_done()
 
-    entity = hass.states.get("sensor.battery_state")
+    entity = hass.states.get("sensor.test_1_battery_state")
     assert entity is not None
 
     assert entity.attributes["device_class"] == "battery"
@@ -43,7 +43,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert entity.attributes["unit_of_measurement"] == "%"
     assert entity.attributes["foo"] == "bar"
     assert entity.domain == "sensor"
-    assert entity.name == "Battery State"
+    assert entity.name == "Test 1 Battery State"
     assert entity.state == "100"
 
     update_resp = await webhook_client.post(
@@ -63,7 +63,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
 
     assert update_resp.status == 200
 
-    updated_entity = hass.states.get("sensor.battery_state")
+    updated_entity = hass.states.get("sensor.test_1_battery_state")
     assert updated_entity.state == "123"
 
     dev_reg = await device_registry.async_get_registry(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change because once the entity is registered and rename this won't impact it.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the device name to the sensor name so they are easy to distinguish.  Especially useful when you are logging into more than 1 device at a time because the sensor names will be like `sensor.battery_level` and `sensor.battery_level_2`.  We will still hit the same issue if the device name is the same but it should help clear up some confusion about what device it is.

Fixes home-assistant/home-assistant-iOS#478
Fixes home-assistant/home-assistant-android#381

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
mobile_app:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/home-assistant-android/issues/381 and home-assistant/home-assistant-iOS#478 and maybe others too that I have not found
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
