### PR TITLE
UniFi - Change handling of updated options

### DIFF
--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -164,7 +164,7 @@ class UniFiController:
                     WIRELESS_GUEST_CONNECTED,
                 ):
                     self.update_wireless_clients()
-            else:
+            elif data.get("clients") or data.get("devices"):
                 async_dispatcher_send(self.hass, self.signal_update)
 
     @property
@@ -238,13 +238,13 @@ class UniFiController:
 
         self.api.start_websocket()
 
-        self.config_entry.add_update_listener(self.async_options_updated)
+        self.config_entry.add_update_listener(self.async_config_entry_updated)
 
         return True
 
     @staticmethod
-    async def async_options_updated(hass, entry):
-        """Triggered by config entry options updates."""
+    async def async_config_entry_updated(hass, entry) -> None:
+        """Handle signals of config entry being updated."""
         controller_id = CONTROLLER_ID.format(
             host=entry.data[CONF_CONTROLLER][CONF_HOST],
             site=entry.data[CONF_CONTROLLER][CONF_SITE_ID],

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -3,9 +3,7 @@ import logging
 
 from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
 from homeassistant.core import callback
-from homeassistant.helpers import entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_registry import DISABLED_CONFIG_ENTRY
 
 from .unifi_client import UniFiClient
 
@@ -24,11 +22,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     controller = get_controller_from_config_entry(hass, config_entry)
     sensors = {}
 
-    registry = await entity_registry.async_get_registry(hass)
+    option_allow_bandwidth_sensors = controller.option_allow_bandwidth_sensors
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
     @callback
     def update_controller():
         """Update the values of the controller."""
+        nonlocal option_allow_bandwidth_sensors
+
+        if not option_allow_bandwidth_sensors:
+            return
+
         add_entities(controller, async_add_entities, sensors)
 
     controller.listeners.append(
@@ -36,24 +41,29 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
     @callback
-    def update_disable_on_entities():
+    def options_updated():
         """Update the values of the controller."""
-        for entity in sensors.values():
+        nonlocal option_allow_bandwidth_sensors
 
-            if entity.entity_registry_enabled_default == entity.enabled:
-                continue
+        if option_allow_bandwidth_sensors != controller.option_allow_bandwidth_sensors:
+            option_allow_bandwidth_sensors = controller.option_allow_bandwidth_sensors
 
-            disabled_by = None
-            if not entity.entity_registry_enabled_default and entity.enabled:
-                disabled_by = DISABLED_CONFIG_ENTRY
+            if option_allow_bandwidth_sensors:
+                update_controller()
 
-            registry.async_update_entity(
-                entity.registry_entry.entity_id, disabled_by=disabled_by
-            )
+            else:
+                for sensor in sensors.values():
+
+                    if entity_registry.async_is_registered(sensor.entity_id):
+                        entity_registry.async_remove(sensor.entity_id)
+
+                    hass.async_create_task(sensor.async_remove())
+
+                sensors.clear()
 
     controller.listeners.append(
         async_dispatcher_connect(
-            hass, controller.signal_options_update, update_disable_on_entities
+            hass, controller.signal_options_update, options_updated
         )
     )
 
@@ -86,13 +96,6 @@ def add_entities(controller, async_add_entities, sensors):
 
 class UniFiRxBandwidthSensor(UniFiClient):
     """Receiving bandwidth sensor."""
-
-    @property
-    def entity_registry_enabled_default(self):
-        """Return if the entity should be enabled when first added to the entity registry."""
-        if self.controller.option_allow_bandwidth_sensors:
-            return True
-        return False
 
     @property
     def state(self):

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -11,6 +11,7 @@ from homeassistant.components import unifi
 import homeassistant.components.device_tracker as device_tracker
 from homeassistant.components.unifi.const import (
     CONF_SSID_FILTER,
+    CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
     CONF_TRACK_WIRED_CLIENTS,
 )
@@ -114,7 +115,7 @@ async def test_tracked_devices(hass):
         devices_response=[DEVICE_1, DEVICE_2],
         known_wireless_clients=(CLIENT_4["mac"],),
     )
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -125,7 +126,8 @@ async def test_tracked_devices(hass):
     assert client_2.state == "not_home"
 
     client_3 = hass.states.get("device_tracker.client_3")
-    assert client_3 is None
+    assert client_3 is not None
+    assert client_3.state == "not_home"
 
     # Wireless client with wired bug, if bug active on restart mark device away
     client_4 = hass.states.get("device_tracker.client_4")
@@ -136,6 +138,7 @@ async def test_tracked_devices(hass):
     assert device_1 is not None
     assert device_1.state == "not_home"
 
+    # State change signalling works
     client_1_copy = copy(CLIENT_1)
     client_1_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
     event = {"meta": {"message": "sta:sync"}, "data": [client_1_copy]}
@@ -144,28 +147,6 @@ async def test_tracked_devices(hass):
     device_1_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
     event = {"meta": {"message": "device:sync"}, "data": [device_1_copy]}
     controller.api.message_handler(event)
-    await hass.async_block_till_done()
-
-    client_1 = hass.states.get("device_tracker.client_1")
-    assert client_1.state == "home"
-
-    device_1 = hass.states.get("device_tracker.device_1")
-    assert device_1.state == "home"
-
-    # Controller unavailable
-    controller.async_unifi_signalling_callback(
-        SIGNAL_CONNECTION_STATE, STATE_DISCONNECTED
-    )
-    await hass.async_block_till_done()
-
-    client_1 = hass.states.get("device_tracker.client_1")
-    assert client_1.state == STATE_UNAVAILABLE
-
-    device_1 = hass.states.get("device_tracker.device_1")
-    assert device_1.state == STATE_UNAVAILABLE
-
-    # Controller available
-    controller.async_unifi_signalling_callback(SIGNAL_CONNECTION_STATE, STATE_RUNNING)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -184,23 +165,204 @@ async def test_tracked_devices(hass):
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1.state == STATE_UNAVAILABLE
 
-    # Don't track wired clients nor devices
-    controller.config_entry.add_update_listener(controller.async_options_updated)
-    hass.config_entries.async_update_entry(
-        controller.config_entry,
-        options={
-            CONF_SSID_FILTER: [],
-            CONF_TRACK_WIRED_CLIENTS: False,
-            CONF_TRACK_DEVICES: False,
-        },
+
+async def test_controller_state_change(hass):
+    """Verify entities state reflect on controller becoming unavailable."""
+    controller = await setup_unifi_integration(
+        hass, clients_response=[CLIENT_1], devices_response=[DEVICE_1],
+    )
+    assert len(hass.states.async_all()) == 3
+
+    # Controller unavailable
+    controller.async_unifi_signalling_callback(
+        SIGNAL_CONNECTION_STATE, STATE_DISCONNECTED
     )
     await hass.async_block_till_done()
+
     client_1 = hass.states.get("device_tracker.client_1")
-    assert client_1
+    assert client_1.state == STATE_UNAVAILABLE
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1.state == STATE_UNAVAILABLE
+
+    # Controller available
+    controller.async_unifi_signalling_callback(SIGNAL_CONNECTION_STATE, STATE_RUNNING)
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1.state == "not_home"
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1.state == "not_home"
+
+
+async def test_option_track_clients(hass):
+    """Test the tracking of clients can be turned off."""
+    controller = await setup_unifi_integration(
+        hass, clients_response=[CLIENT_1, CLIENT_2], devices_response=[DEVICE_1],
+    )
+    assert len(hass.states.async_all()) == 4
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is not None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry, options={CONF_TRACK_CLIENTS: False},
+    )
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is None
+
     client_2 = hass.states.get("device_tracker.wired_client")
     assert client_2 is None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry, options={CONF_TRACK_CLIENTS: True},
+    )
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is not None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+
+async def test_option_track_wired_clients(hass):
+    """Test the tracking of wired clients can be turned off."""
+    controller = await setup_unifi_integration(
+        hass, clients_response=[CLIENT_1, CLIENT_2], devices_response=[DEVICE_1],
+    )
+    assert len(hass.states.async_all()) == 4
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is not None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry, options={CONF_TRACK_WIRED_CLIENTS: False},
+    )
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry, options={CONF_TRACK_WIRED_CLIENTS: True},
+    )
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is not None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+
+async def test_option_track_devices(hass):
+    """Test the tracking of devices can be turned off."""
+    controller = await setup_unifi_integration(
+        hass, clients_response=[CLIENT_1, CLIENT_2], devices_response=[DEVICE_1],
+    )
+    assert len(hass.states.async_all()) == 4
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is not None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry, options={CONF_TRACK_DEVICES: False},
+    )
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is not None
+
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1 is None
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry, options={CONF_TRACK_DEVICES: True},
+    )
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+
+    client_2 = hass.states.get("device_tracker.wired_client")
+    assert client_2 is not None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+
+
+async def test_option_ssid_filter(hass):
+    """Test the SSID filter works."""
+    controller = await setup_unifi_integration(
+        hass, options={CONF_SSID_FILTER: ["ssid"]}, clients_response=[CLIENT_3],
+    )
+    assert len(hass.states.async_all()) == 2
+
+    # SSID filter active
+    client_3 = hass.states.get("device_tracker.client_3")
+    assert client_3.state == "not_home"
+
+    client_3_copy = copy(CLIENT_3)
+    client_3_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
+    event = {"meta": {"message": "sta:sync"}, "data": [client_3_copy]}
+    controller.api.message_handler(event)
+    await hass.async_block_till_done()
+
+    # SSID filter active even though time stamp should mark as home
+    client_3 = hass.states.get("device_tracker.client_3")
+    assert client_3.state == "not_home"
+
+    # Remove SSID filter
+    hass.config_entries.async_update_entry(
+        controller.config_entry, options={CONF_SSID_FILTER: []},
+    )
+    event = {"meta": {"message": "sta:sync"}, "data": [client_3_copy]}
+    controller.api.message_handler(event)
+    await hass.async_block_till_done()
+
+    # SSID no longer filtered
+    client_3 = hass.states.get("device_tracker.client_3")
+    assert client_3.state == "home"
 
 
 async def test_wireless_client_go_wired_issue(hass):

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -99,3 +99,27 @@ async def test_sensors(hass):
 
     wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
     assert wireless_client_tx.state == "6789.0"
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry,
+        options={unifi.const.CONF_ALLOW_BANDWIDTH_SENSORS: False},
+    )
+    await hass.async_block_till_done()
+
+    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
+    assert wireless_client_rx is None
+
+    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
+    assert wireless_client_tx is None
+
+    hass.config_entries.async_update_entry(
+        controller.config_entry,
+        options={unifi.const.CONF_ALLOW_BANDWIDTH_SENSORS: True},
+    )
+    await hass.async_block_till_done()
+
+    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
+    assert wireless_client_rx.state == "2345.0"
+
+    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
+    assert wireless_client_tx.state == "6789.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Changing tracking settings will no longer disable entities but will remove them completely from the state machine and entity registry.
SSID filter will now mark all wireless clients as not_home if they are connected to SSIDs that are not a part of the filter. This is based on changes done to the [developer documentation](https://github.com/home-assistant/developers.home-assistant/pull/396).


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow the new guidelines of [Update disabled_by recommendation](https://github.com/home-assistant/developers.home-assistant/pull/396).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27243
- This PR is related to issue: https://github.com/home-assistant/developers.home-assistant/pull/396
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
