### PR TITLE
Implement PlatformNotReady to Linky + fix TypeError

### DIFF
--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     ENERGY_KILO_WATT_HOUR,
 )
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
@@ -73,6 +74,7 @@ class LinkyAccount:
             _LOGGER.debug(json.dumps(self._data, indent=2))
         except PyLinkyException as exp:
             _LOGGER.error(exp)
+            raise PlatformNotReady
         finally:
             client.close_session()
 
@@ -146,6 +148,9 @@ class LinkySensor(Entity):
 
     async def async_update(self) -> None:
         """Retrieve the new data for the sensor."""
+        if self._account.data is None:
+            return
+
         data = self._account.data[self._scale][self._when]
         self._consumption = data[CONSUMPTION]
         self._time = data[TIME]


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implement PlatformNotReady to Linky (when HA start)
+
fix TypeError in case of website in maintenance, every day between 10PM and 3AM (when HA already started) : 

```shell
2020-02-12 21:40:56 ERROR (MainThread) [homeassistant.components.sensor] linky: Error on device update!
Traceback (most recent call last):
  File "/Users/pollet/dev/home-assistant/homeassistant/helpers/entity_platform.py", line 312, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/Users/pollet/dev/home-assistant/homeassistant/helpers/entity.py", line 471, in async_device_update
    await self.async_update()
  File "/Users/pollet/dev/home-assistant/homeassistant/components/linky/sensor.py", line 152, in async_update
    data = self._account.data[self._scale][self._when]
TypeError: 'NoneType' object is not subscriptable
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
