### PR TITLE
Use time.monotonic instead of time.time where appropriate

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -4,7 +4,7 @@ import logging
 import logging.handlers
 import os
 import sys
-from time import time
+from time import monotonic
 from typing import Any, Dict, Optional, Set
 
 import voluptuous as vol
@@ -110,7 +110,7 @@ async def async_from_config_dict(
     Dynamically loads required components and its dependencies.
     This method is a coroutine.
     """
-    start = time()
+    start = monotonic()
 
     core_config = config.get(core.DOMAIN, {})
 
@@ -131,7 +131,7 @@ async def async_from_config_dict(
 
     await _async_set_up_integrations(hass, config)
 
-    stop = time()
+    stop = monotonic()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop - start)
 
     if REQUIRED_NEXT_PYTHON_DATE and sys.version_info[:3] < REQUIRED_NEXT_PYTHON_VER:

--- a/homeassistant/components/bme680/sensor.py
+++ b/homeassistant/components/bme680/sensor.py
@@ -1,7 +1,7 @@
 """Support for BME680 Sensor over SMBus."""
 import logging
 import threading
-from time import sleep, time
+from time import monotonic, sleep
 
 import bme680  # pylint: disable=import-error
 from smbus import SMBus  # pylint: disable=import-error
@@ -240,15 +240,15 @@ class BME680Handler:
         # Pause to allow initial data read for device validation.
         sleep(1)
 
-        start_time = time()
-        curr_time = time()
+        start_time = monotonic()
+        curr_time = monotonic()
         burn_in_data = []
 
         _LOGGER.info(
             "Beginning %d second gas sensor burn in for Air Quality", burn_in_time
         )
         while curr_time - start_time < burn_in_time:
-            curr_time = time()
+            curr_time = monotonic()
             if self._sensor.get_sensor_data() and self._sensor.data.heat_stable:
                 gas_resistance = self._sensor.data.gas_resistance
                 burn_in_data.append(gas_resistance)

--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -285,7 +285,7 @@ class Doods(ImageProcessingEntity):
             )
 
         # Run detection
-        start = time.time()
+        start = time.monotonic()
         response = self._doods.detect(
             image, dconfig=self._dconfig, detector_name=self._detector_name
         )
@@ -293,7 +293,7 @@ class Doods(ImageProcessingEntity):
             "doods detect: %s response: %s duration: %s",
             self._dconfig,
             response,
-            time.time() - start,
+            time.monotonic() - start,
         )
 
         matches = {}

--- a/homeassistant/components/maxcube/__init__.py
+++ b/homeassistant/components/maxcube/__init__.py
@@ -90,14 +90,14 @@ class MaxCubeHandle:
         self.cube = cube
         self.scan_interval = scan_interval
         self.mutex = Lock()
-        self._updatets = time.time()
+        self._updatets = time.monotonic()
 
     def update(self):
         """Pull the latest data from the MAX! Cube."""
         # Acquire mutex to prevent simultaneous update from multiple threads
         with self.mutex:
             # Only update every update_interval
-            if (time.time() - self._updatets) >= self.scan_interval:
+            if (time.monotonic() - self._updatets) >= self.scan_interval:
                 _LOGGER.debug("Updating")
 
                 try:
@@ -106,6 +106,6 @@ class MaxCubeHandle:
                     _LOGGER.error("Max!Cube connection failed")
                     return False
 
-                self._updatets = time.time()
+                self._updatets = time.monotonic()
             else:
                 _LOGGER.debug("Skipping update")

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -1,7 +1,6 @@
 """Support for the Netatmo Weather Service."""
 from datetime import timedelta
 import logging
-from time import time
 
 import pyatmo
 
@@ -519,7 +518,6 @@ class NetatmoData:
         """Initialize the data object."""
         self.data = {}
         self.station_data = station_data
-        self._next_update = time()
         self.auth = auth
 
     def get_module_infos(self):

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -147,12 +147,12 @@ class ProxmoxClient:
             verify_ssl=self._verify_ssl,
         )
 
-        self._connection_start_time = time.time()
+        self._connection_start_time = time.monotonic()
 
     def get_api_client(self):
         """Return the ProxmoxAPI client and rebuild it if necessary."""
 
-        connection_age = time.time() - self._connection_start_time
+        connection_age = time.monotonic() - self._connection_start_time
 
         # Workaround for the Proxmoxer bug where the connection stops working after some time
         if connection_age > 30 * 60:

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -1,6 +1,6 @@
 """Support for Verisure locks."""
 import logging
-from time import sleep, time
+from time import monotonic, sleep
 
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import ATTR_CODE, STATE_LOCKED, STATE_UNLOCKED
@@ -71,7 +71,7 @@ class VerisureDoorlock(LockDevice):
 
     def update(self):
         """Update lock status."""
-        if time() - self._change_timestamp < 10:
+        if monotonic() - self._change_timestamp < 10:
             return
         hub.update_overview()
         status = hub.get_first(
@@ -131,4 +131,4 @@ class VerisureDoorlock(LockDevice):
             transaction = hub.session.get_lock_state_transaction(transaction_id)
         if transaction["result"] == "OK":
             self._state = state
-            self._change_timestamp = time()
+            self._change_timestamp = monotonic()

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -1,6 +1,6 @@
 """Support for Verisure Smartplugs."""
 import logging
-from time import time
+from time import monotonic
 
 from homeassistant.components.switch import SwitchDevice
 
@@ -44,7 +44,7 @@ class VerisureSmartplug(SwitchDevice):
     @property
     def is_on(self):
         """Return true if on."""
-        if time() - self._change_timestamp < 10:
+        if monotonic() - self._change_timestamp < 10:
             return self._state
         self._state = (
             hub.get_first(
@@ -67,13 +67,13 @@ class VerisureSmartplug(SwitchDevice):
         """Set smartplug status on."""
         hub.session.set_smartplug_state(self._device_label, True)
         self._state = True
-        self._change_timestamp = time()
+        self._change_timestamp = monotonic()
 
     def turn_off(self, **kwargs):
         """Set smartplug status off."""
         hub.session.set_smartplug_state(self._device_label, False)
         self._state = False
-        self._change_timestamp = time()
+        self._change_timestamp = monotonic()
 
     # pylint: disable=no-self-use
     def update(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

See time() vs monotonic() docs.

For netatmo, self._next_update appears to be unused, so removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
