### PR TITLE
Make heos and transmission config flow tests more robust

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -28,6 +28,7 @@ good-names=id,i,j,k,ex,Run,_,fp
 # too-many-ancestors - it's too strict.
 # wrong-import-order - isort guards this
 disable=
+  import-error,
   format,
   abstract-class-little-used,
   abstract-method,

--- a/pylintrc
+++ b/pylintrc
@@ -28,7 +28,6 @@ good-names=id,i,j,k,ex,Run,_,fp
 # too-many-ancestors - it's too strict.
 # wrong-import-order - isort guards this
 disable=
-  import-error,
   format,
   abstract-class-little-used,
   abstract-method,

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -55,7 +55,7 @@ async def test_create_entry_when_host_valid(hass, controller):
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
     assert controller.connect.call_count == 2
-    assert controller.disconnect.call_count == 2
+    assert controller.disconnect.call_count == 1
 
 
 async def test_create_entry_when_friendly_name_valid(hass, controller):

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -54,8 +54,8 @@ async def test_create_entry_when_host_valid(hass, controller):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
-    assert controller.connect.call_count == 1
-    assert controller.disconnect.call_count == 1
+    assert controller.connect.call_count == 2
+    assert controller.disconnect.call_count == 2
 
 
 async def test_create_entry_when_friendly_name_valid(hass, controller):

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -10,8 +10,6 @@ from homeassistant.components.heos.config_flow import HeosFlowHandler
 from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS
 from homeassistant.const import CONF_HOST
 
-from tests.common import mock_coro
-
 
 async def test_flow_aborts_already_setup(hass, config_entry):
     """Test flow aborts when entry already setup."""
@@ -52,7 +50,7 @@ async def test_create_entry_when_host_valid(hass, controller):
     """Test result type is create entry when host is valid."""
     data = {CONF_HOST: "127.0.0.1"}
     with patch(
-        "homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)
+        "homeassistant.components.hue.async_setup_entry", return_value=True
     ):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data
@@ -69,7 +67,7 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
     data = {CONF_HOST: "Office (127.0.0.1)"}
     with patch(
-        "homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)
+        "homeassistant.components.hue.async_setup_entry", return_value=True
     ):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -49,9 +49,7 @@ async def test_cannot_connect_shows_error_form(hass, controller):
 async def test_create_entry_when_host_valid(hass, controller):
     """Test result type is create entry when host is valid."""
     data = {CONF_HOST: "127.0.0.1"}
-    with patch(
-        "homeassistant.components.hue.async_setup_entry", return_value=True
-    ):
+    with patch("homeassistant.components.hue.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data
         )
@@ -66,9 +64,7 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     """Test result type is create entry when friendly name is valid."""
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
     data = {CONF_HOST: "Office (127.0.0.1)"}
-    with patch(
-        "homeassistant.components.hue.async_setup_entry", return_value=True
-    ):
+    with patch("homeassistant.components.hue.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data
         )

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -6,7 +6,8 @@ from pyheos import HeosError
 from homeassistant import data_entry_flow
 from homeassistant.components import ssdp
 from homeassistant.components.heos.config_flow import HeosFlowHandler
-from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS, DOMAIN
+from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS
+from homeassistant.components import heos
 from homeassistant.const import CONF_HOST
 
 
@@ -32,11 +33,12 @@ async def test_no_host_shows_form(hass):
 
 async def test_cannot_connect_shows_error_form(hass, controller):
     """Test form is shown with error when cannot connect."""
-    flow = HeosFlowHandler()
-    flow.hass = hass
     controller.connect.side_effect = HeosError()
+    result = await hass.config_entries.flow.async_init(
+        heos.DOMAIN, context={"source": "user"}
+    )
     result = await hass.config_entries.flow.async_configure(
-         result["flow_id"], user_input={CONF_HOST: "127.0.0.1"} )
+        result["flow_id"], user_input={CONF_HOST: "127.0.0.1"})
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"][CONF_HOST] == "connection_failure"
@@ -48,11 +50,12 @@ async def test_cannot_connect_shows_error_form(hass, controller):
 
 async def test_create_entry_when_host_valid(hass, controller):
     """Test result type is create entry when host is valid."""
-    flow = HeosFlowHandler()
-    flow.hass = hass
     data = {CONF_HOST: "127.0.0.1"}
+    result = await hass.config_entries.flow.async_init(
+        heos.DOMAIN, context={"source": "user"}
+    )
     result = await hass.config_entries.flow.async_configure(
-         result["flow_id"], user_input=data )
+        result["flow_id"], user_input=data)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
@@ -63,11 +66,12 @@ async def test_create_entry_when_host_valid(hass, controller):
 async def test_create_entry_when_friendly_name_valid(hass, controller):
     """Test result type is create entry when friendly name is valid."""
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
-    flow = HeosFlowHandler()
-    flow.hass = hass
     data = {CONF_HOST: "Office (127.0.0.1)"}
+    result = await hass.config_entries.flow.async_init(
+        heos.DOMAIN, context={"source": "user"}
+    )
     result = await hass.config_entries.flow.async_configure(
-         result["flow_id"], user_input=data )
+        result["flow_id"], user_input=data)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == {CONF_HOST: "127.0.0.1"}
@@ -79,7 +83,7 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
 async def test_discovery_shows_create_form(hass, controller, discovery_data):
     """Test discovery shows form to confirm setup and subsequent abort."""
     await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=discovery_data
+        heos.DOMAIN, context={"source": "ssdp"}, data=discovery_data
     )
     await hass.async_block_till_done()
     assert len(hass.config_entries.flow.async_progress()) == 1
@@ -89,7 +93,7 @@ async def test_discovery_shows_create_form(hass, controller, discovery_data):
     discovery_data[ssdp.ATTR_SSDP_LOCATION] = f"http://127.0.0.2:{port}/"
     discovery_data[ssdp.ATTR_UPNP_FRIENDLY_NAME] = "Bedroom"
     await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=discovery_data
+        heos.DOMAIN, context={"source": "ssdp"}, data=discovery_data
     )
     await hass.async_block_till_done()
     assert len(hass.config_entries.flow.async_progress()) == 1

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -36,14 +36,11 @@ async def test_cannot_connect_shows_error_form(hass, controller):
     result = await hass.config_entries.flow.async_init(
         heos.DOMAIN, context={"source": "user"}, data={CONF_HOST: "127.0.0.1"}
     )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_HOST: "127.0.0.1"}
-    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"][CONF_HOST] == "connection_failure"
-    assert controller.connect.call_count == 2
-    assert controller.disconnect.call_count == 2
+    assert controller.connect.call_count == 1
+    assert controller.disconnect.call_count == 1
     controller.connect.reset_mock()
     controller.disconnect.reset_mock()
 
@@ -52,15 +49,12 @@ async def test_create_entry_when_host_valid(hass, controller):
     """Test result type is create entry when host is valid."""
     data = {CONF_HOST: "127.0.0.1"}
     result = await hass.config_entries.flow.async_init(
-        heos.DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=data
+        heos.DOMAIN, context={"source": "user"}, data=data
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
-    assert controller.connect.call_count == 2
+    assert controller.connect.call_count == 1
     assert controller.disconnect.call_count == 1
 
 
@@ -69,10 +63,7 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
     data = {CONF_HOST: "Office (127.0.0.1)"}
     result = await hass.config_entries.flow.async_init(
-        heos.DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=data
+        heos.DOMAIN, context={"source": "user"}, data=data
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -42,8 +42,8 @@ async def test_cannot_connect_shows_error_form(hass, controller):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"][CONF_HOST] == "connection_failure"
-    assert controller.connect.call_count == 1
-    assert controller.disconnect.call_count == 1
+    assert controller.connect.call_count == 2
+    assert controller.disconnect.call_count == 2
     controller.connect.reset_mock()
     controller.disconnect.reset_mock()
 
@@ -60,8 +60,8 @@ async def test_create_entry_when_host_valid(hass, controller):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
-    assert controller.connect.call_count == 1
-    assert controller.disconnect.call_count == 1
+    assert controller.connect.call_count == 2
+    assert controller.disconnect.call_count == 2
 
 
 async def test_create_entry_when_friendly_name_valid(hass, controller):
@@ -77,8 +77,8 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == {CONF_HOST: "127.0.0.1"}
-    assert controller.connect.call_count == 1
-    assert controller.disconnect.call_count == 1
+    assert controller.connect.call_count == 2
+    assert controller.disconnect.call_count == 2
     assert DATA_DISCOVERED_HOSTS not in hass.data
 
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -49,7 +49,7 @@ async def test_cannot_connect_shows_error_form(hass, controller):
 async def test_create_entry_when_host_valid(hass, controller):
     """Test result type is create entry when host is valid."""
     data = {CONF_HOST: "127.0.0.1"}
-    with patch("homeassistant.components.hue.async_setup_entry", return_value=True):
+    with patch("homeassistant.components.heos.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data
         )
@@ -64,7 +64,7 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     """Test result type is create entry when friendly name is valid."""
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
     data = {CONF_HOST: "Office (127.0.0.1)"}
-    with patch("homeassistant.components.hue.async_setup_entry", return_value=True):
+    with patch("homeassistant.components.heos.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data
         )

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -4,10 +4,9 @@ from urllib.parse import urlparse
 from pyheos import HeosError
 
 from homeassistant import data_entry_flow
-from homeassistant.components import ssdp
+from homeassistant.components import heos, ssdp
 from homeassistant.components.heos.config_flow import HeosFlowHandler
 from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS
-from homeassistant.components import heos
 from homeassistant.const import CONF_HOST
 
 
@@ -38,7 +37,8 @@ async def test_cannot_connect_shows_error_form(hass, controller):
         heos.DOMAIN, context={"source": "user"}, data={CONF_HOST: "127.0.0.1"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_HOST: "127.0.0.1"})
+        result["flow_id"], user_input={CONF_HOST: "127.0.0.1"}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"][CONF_HOST] == "connection_failure"
@@ -55,7 +55,8 @@ async def test_create_entry_when_host_valid(hass, controller):
         heos.DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=data)
+        result["flow_id"], user_input=data
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
@@ -71,7 +72,8 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
         heos.DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=data)
+        result["flow_id"], user_input=data
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == {CONF_HOST: "127.0.0.1"}
@@ -104,7 +106,7 @@ async def test_discovery_shows_create_form(hass, controller, discovery_data):
 
 
 async def test_disovery_flow_aborts_already_setup(
-        hass, controller, discovery_data, config_entry
+    hass, controller, discovery_data, config_entry
 ):
     """Test discovery flow aborts when entry already setup."""
     config_entry.add_to_hass(hass)

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -54,7 +54,8 @@ async def test_create_entry_when_host_valid(hass, controller):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
-    assert controller.connect.call_count == 2
+    await heos.async_setup_entry(hass, result)
+    assert controller.connect.call_count == 1
     assert controller.disconnect.call_count == 1
 
 
@@ -68,7 +69,8 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == {CONF_HOST: "127.0.0.1"}
-    assert controller.connect.call_count == 2
+    await heos.async_setup_entry(hass, result)
+    assert controller.connect.call_count == 1
     assert controller.disconnect.call_count == 1
     assert DATA_DISCOVERED_HOSTS not in hass.data
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_cannot_connect_shows_error_form(hass, controller):
     """Test form is shown with error when cannot connect."""
     controller.connect.side_effect = HeosError()
     result = await hass.config_entries.flow.async_init(
-        heos.DOMAIN, context={"source": "user"}
+        heos.DOMAIN, context={"source": "user"}, data={CONF_HOST: "127.0.0.1"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.1"})
@@ -104,7 +104,7 @@ async def test_discovery_shows_create_form(hass, controller, discovery_data):
 
 
 async def test_disovery_flow_aborts_already_setup(
-    hass, controller, discovery_data, config_entry
+        hass, controller, discovery_data, config_entry
 ):
     """Test discovery flow aborts when entry already setup."""
     config_entry.add_to_hass(hass)

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for the Heos config flow module."""
 from urllib.parse import urlparse
 
+from asynctest import patch
 from pyheos import HeosError
 
 from homeassistant import data_entry_flow
@@ -55,8 +56,9 @@ async def test_create_entry_when_host_valid(hass, controller):
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
     await heos.async_setup_entry(hass, result)
-    assert controller.connect.call_count == 1
-    assert controller.disconnect.call_count == 1
+    with patch("homeassistant.components.hue.async_setup_entry"):
+        assert controller.connect.call_count == 1
+        assert controller.disconnect.call_count == 1
 
 
 async def test_create_entry_when_friendly_name_valid(hass, controller):
@@ -69,9 +71,9 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == {CONF_HOST: "127.0.0.1"}
-    await heos.async_setup_entry(hass, result)
-    assert controller.connect.call_count == 1
-    assert controller.disconnect.call_count == 1
+    with patch("homeassistant.components.hue.async_setup_entry"):
+        assert controller.connect.call_count == 1
+        assert controller.disconnect.call_count == 1
     assert DATA_DISCOVERED_HOSTS not in hass.data
 
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -61,7 +61,7 @@ async def test_create_entry_when_host_valid(hass, controller):
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
     assert controller.connect.call_count == 2
-    assert controller.disconnect.call_count == 2
+    assert controller.disconnect.call_count == 1
 
 
 async def test_create_entry_when_friendly_name_valid(hass, controller):
@@ -78,7 +78,7 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == {CONF_HOST: "127.0.0.1"}
     assert controller.connect.call_count == 2
-    assert controller.disconnect.call_count == 2
+    assert controller.disconnect.call_count == 1
     assert DATA_DISCOVERED_HOSTS not in hass.data
 
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.components.heos.config_flow import HeosFlowHandler
 from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS
 from homeassistant.const import CONF_HOST
 
+from tests.common import mock_coro
+
 
 async def test_flow_aborts_already_setup(hass, config_entry):
     """Test flow aborts when entry already setup."""
@@ -49,14 +51,13 @@ async def test_cannot_connect_shows_error_form(hass, controller):
 async def test_create_entry_when_host_valid(hass, controller):
     """Test result type is create entry when host is valid."""
     data = {CONF_HOST: "127.0.0.1"}
-    result = await hass.config_entries.flow.async_init(
-        heos.DOMAIN, context={"source": "user"}, data=data
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "Controller (127.0.0.1)"
-    assert result["data"] == data
-    await heos.async_setup_entry(hass, result)
-    with patch("homeassistant.components.hue.async_setup_entry"):
+    with patch("homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)):
+        result = await hass.config_entries.flow.async_init(
+            heos.DOMAIN, context={"source": "user"}, data=data
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "Controller (127.0.0.1)"
+        assert result["data"] == data
         assert controller.connect.call_count == 1
         assert controller.disconnect.call_count == 1
 
@@ -65,16 +66,16 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     """Test result type is create entry when friendly name is valid."""
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
     data = {CONF_HOST: "Office (127.0.0.1)"}
-    result = await hass.config_entries.flow.async_init(
-        heos.DOMAIN, context={"source": "user"}, data=data
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "Controller (127.0.0.1)"
-    assert result["data"] == {CONF_HOST: "127.0.0.1"}
-    with patch("homeassistant.components.hue.async_setup_entry"):
+    with patch("homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)):
+        result = await hass.config_entries.flow.async_init(
+            heos.DOMAIN, context={"source": "user"}, data=data
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "Controller (127.0.0.1)"
+        assert result["data"] == {CONF_HOST: "127.0.0.1"}
         assert controller.connect.call_count == 1
         assert controller.disconnect.call_count == 1
-    assert DATA_DISCOVERED_HOSTS not in hass.data
+        assert DATA_DISCOVERED_HOSTS not in hass.data
 
 
 async def test_discovery_shows_create_form(hass, controller, discovery_data):

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -51,7 +51,9 @@ async def test_cannot_connect_shows_error_form(hass, controller):
 async def test_create_entry_when_host_valid(hass, controller):
     """Test result type is create entry when host is valid."""
     data = {CONF_HOST: "127.0.0.1"}
-    with patch("homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)):
+    with patch(
+        "homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)
+    ):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data
         )
@@ -66,7 +68,9 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     """Test result type is create entry when friendly name is valid."""
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
     data = {CONF_HOST: "Office (127.0.0.1)"}
-    with patch("homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)):
+    with patch(
+        "homeassistant.components.hue.async_setup_entry", return_value=mock_coro(True)
+    ):
         result = await hass.config_entries.flow.async_init(
             heos.DOMAIN, context={"source": "user"}, data=data
         )

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -35,7 +35,8 @@ async def test_cannot_connect_shows_error_form(hass, controller):
     flow = HeosFlowHandler()
     flow.hass = hass
     controller.connect.side_effect = HeosError()
-    result = await flow.async_step_user({CONF_HOST: "127.0.0.1"})
+    result = await hass.config_entries.flow.async_configure(
+         result["flow_id"], user_input={CONF_HOST: "127.0.0.1"} )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"][CONF_HOST] == "connection_failure"
@@ -50,7 +51,8 @@ async def test_create_entry_when_host_valid(hass, controller):
     flow = HeosFlowHandler()
     flow.hass = hass
     data = {CONF_HOST: "127.0.0.1"}
-    result = await flow.async_step_user(data)
+    result = await hass.config_entries.flow.async_configure(
+         result["flow_id"], user_input=data )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == data
@@ -64,7 +66,8 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
     flow = HeosFlowHandler()
     flow.hass = hass
     data = {CONF_HOST: "Office (127.0.0.1)"}
-    result = await flow.async_step_user(data)
+    result = await hass.config_entries.flow.async_configure(
+         result["flow_id"], user_input=data )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Controller (127.0.0.1)"
     assert result["data"] == {CONF_HOST: "127.0.0.1"}

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -148,7 +148,7 @@ async def test_import_with_minimum_fields(hass, api):
             CONF_HOST: HOST,
             CONF_PORT: DEFAULT_PORT,
             CONF_SCAN_INTERVAL: timedelta(seconds=DEFAULT_SCAN_INTERVAL),
-        }
+        },
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
@@ -170,7 +170,7 @@ async def test_import_with_all(hass, api):
             CONF_PASSWORD: PASSWORD,
             CONF_PORT: PORT,
             CONF_SCAN_INTERVAL: timedelta(seconds=SCAN_INTERVAL),
-        }
+        },
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == NAME

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -51,7 +51,7 @@ def mock_transmission_api():
 def mock_api_authentication_error():
     """Mock an api."""
     with patch(
-            "transmissionrpc.Client", side_effect=TransmissionError("401: Unauthorized")
+        "transmissionrpc.Client", side_effect=TransmissionError("401: Unauthorized")
     ):
         yield
 
@@ -60,8 +60,8 @@ def mock_api_authentication_error():
 def mock_api_connection_error():
     """Mock an api."""
     with patch(
-            "transmissionrpc.Client",
-            side_effect=TransmissionError("111: Connection refused"),
+        "transmissionrpc.Client",
+        side_effect=TransmissionError("111: Connection refused"),
     ):
         yield
 
@@ -103,7 +103,8 @@ async def test_flow_works(hass, api):
 
     # test with all provided
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_ENTRY)
+        result["flow_id"], user_input=MOCK_ENTRY
+    )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == NAME
@@ -207,7 +208,8 @@ async def test_name_already_configured(hass, api):
         DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=mock_entry)
+        result["flow_id"], user_input=mock_entry
+    )
 
     assert result["type"] == "form"
     assert result["errors"] == {CONF_NAME: "name_exists"}

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -187,7 +187,8 @@ async def test_host_already_configured(hass, api):
         DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_ENTRY)
+        result["flow_id"], user_input=MOCK_ENTRY
+    )
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -100,7 +100,8 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_PORT] == PORT
 
     # test with all provided
-    result = await flow.async_step_user(MOCK_ENTRY)
+    result = await hass.config_entries.flow.async_configure(
+         result["flow_id"], user_input=MOCK_ENTRY )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == NAME
@@ -180,7 +181,8 @@ async def test_host_already_configured(hass, api):
     )
     entry.add_to_hass(hass)
     flow = init_config_flow(hass)
-    result = await flow.async_step_user(MOCK_ENTRY)
+    result = await hass.config_entries.flow.async_configure(
+         result["flow_id"], user_input=MOCK_ENTRY )
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
@@ -198,7 +200,8 @@ async def test_name_already_configured(hass, api):
     mock_entry = MOCK_ENTRY.copy()
     mock_entry[CONF_HOST] = "0.0.0.0"
     flow = init_config_flow(hass)
-    result = await flow.async_step_user(mock_entry)
+    result = await hass.config_entries.flow.async_configure(
+         result["flow_id"], user_input=mock_entry )
 
     assert result["type"] == "form"
     assert result["errors"] == {CONF_NAME: "name_exists"}

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -84,7 +84,9 @@ async def test_flow_works(hass, api):
     """Test user config."""
     flow = init_config_flow(hass)
 
-    result = await flow.async_step_user()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
@@ -101,7 +103,7 @@ async def test_flow_works(hass, api):
 
     # test with all provided
     result = await hass.config_entries.flow.async_configure(
-         result["flow_id"], user_input=MOCK_ENTRY )
+        result["flow_id"], user_input=MOCK_ENTRY)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == NAME
@@ -180,9 +182,11 @@ async def test_host_already_configured(hass, api):
         options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
     )
     entry.add_to_hass(hass)
-    flow = init_config_flow(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
     result = await hass.config_entries.flow.async_configure(
-         result["flow_id"], user_input=MOCK_ENTRY )
+        result["flow_id"], user_input=MOCK_ENTRY)
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
@@ -199,9 +203,11 @@ async def test_name_already_configured(hass, api):
 
     mock_entry = MOCK_ENTRY.copy()
     mock_entry[CONF_HOST] = "0.0.0.0"
-    flow = init_config_flow(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
     result = await hass.config_entries.flow.async_configure(
-         result["flow_id"], user_input=mock_entry )
+        result["flow_id"], user_input=mock_entry)
 
     assert result["type"] == "form"
     assert result["errors"] == {CONF_NAME: "name_exists"}

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -90,7 +90,7 @@ async def test_flow_user_config(hass, api):
 
 
 async def test_flow_required_fields(hass, api):
-    """ Test with required fields only."""
+    """Test with required fields only."""
     result = await hass.config_entries.flow.async_init(
         transmission.DOMAIN,
         context={"source": "user"},
@@ -105,7 +105,7 @@ async def test_flow_required_fields(hass, api):
 
 
 async def test_flow_all_provided(hass, api):
-    """ Test with all provided."""
+    """Test with all provided."""
     result = await hass.config_entries.flow.async_init(
         transmission.DOMAIN, context={"source": "user"}, data=MOCK_ENTRY
     )

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -51,7 +51,7 @@ def mock_transmission_api():
 def mock_api_authentication_error():
     """Mock an api."""
     with patch(
-        "transmissionrpc.Client", side_effect=TransmissionError("401: Unauthorized")
+            "transmissionrpc.Client", side_effect=TransmissionError("401: Unauthorized")
     ):
         yield
 
@@ -60,8 +60,8 @@ def mock_api_authentication_error():
 def mock_api_connection_error():
     """Mock an api."""
     with patch(
-        "transmissionrpc.Client",
-        side_effect=TransmissionError("111: Connection refused"),
+            "transmissionrpc.Client",
+            side_effect=TransmissionError("111: Connection refused"),
     ):
         yield
 

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -102,11 +102,11 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_PORT] == PORT
 
     # test with all provided
-    result = await hass.config_entries.flow.async_init(
-        transmission.DOMAIN, context={"source": "user"}, data=MOCK_ENTRY
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_ENTRY
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -103,10 +103,7 @@ async def test_flow_works(hass, api):
 
     # test with all provided
     result = await hass.config_entries.flow.async_init(
-        transmission.DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_ENTRY
+        transmission.DOMAIN, context={"source": "user"}, data=MOCK_ENTRY
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -73,6 +73,13 @@ def mock_api_unknown_error():
         yield
 
 
+@pytest.fixture(name="transmission_setup", autouse=True)
+def transmission_setup_fixture():
+    """Mock transmission entry setup."""
+    with patch("homeassistant.components.transmission.async_setup_entry", return_value=True):
+        yield
+
+
 def init_config_flow(hass):
     """Init a configuration flow."""
     flow = config_flow.TransmissionFlowHandler()

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -102,12 +102,14 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_PORT] == PORT
 
     # test with all provided
+    result = await hass.config_entries.flow.async_init(
+        transmission.DOMAIN, context={"source": "user"}
+    )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_ENTRY
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == NAME
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_USERNAME] == USERNAME

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -106,7 +106,7 @@ async def test_flow_works(hass, api):
         transmission.DOMAIN, context={"source": "user"}, data=MOCK_ENTRY
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["title"] == NAME
     assert result["data"][CONF_NAME] == NAME
     assert result["data"][CONF_HOST] == HOST

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -107,11 +107,7 @@ async def test_flow_works(hass, api):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["data"][CONF_NAME] == NAME
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_USERNAME] == USERNAME
-    assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_PORT] == PORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_options(hass):
@@ -183,10 +179,7 @@ async def test_host_already_configured(hass, api):
     )
     entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
-        transmission.DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_ENTRY
+        transmission.DOMAIN, context={"source": "user"}, data=MOCK_ENTRY
     )
 
     assert result["type"] == "abort"
@@ -205,10 +198,7 @@ async def test_name_already_configured(hass, api):
     mock_entry = MOCK_ENTRY.copy()
     mock_entry[CONF_HOST] = "0.0.0.0"
     result = await hass.config_entries.flow.async_init(
-        transmission.DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=mock_entry
+        transmission.DOMAIN, context={"source": "user"}, data=mock_entry
     )
 
     assert result["type"] == "form"

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -138,17 +138,18 @@ async def test_options(hass):
     assert result["data"][CONF_SCAN_INTERVAL] == 10
 
 
-async def test_import_with_minimum_fields(hass, api):
-    """Test import with minimum fields only."""
-    result = await hass.config_entries.flow.async_init(
-        transmission.DOMAIN,
-        context={"source": "user"},
-        data={
+async def test_import(hass, api):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with minimum fields only
+    result = await flow.async_step_import(
+        {
             CONF_NAME: DEFAULT_NAME,
             CONF_HOST: HOST,
             CONF_PORT: DEFAULT_PORT,
             CONF_SCAN_INTERVAL: timedelta(seconds=DEFAULT_SCAN_INTERVAL),
-        },
+        }
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
@@ -157,20 +158,16 @@ async def test_import_with_minimum_fields(hass, api):
     assert result["data"][CONF_PORT] == DEFAULT_PORT
     assert result["data"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
 
-
-async def test_import_with_all(hass, api):
-    """Test import with all."""
-    result = await hass.config_entries.flow.async_init(
-        transmission.DOMAIN,
-        context={"source": "user"},
-        data={
+    # import with all
+    result = await flow.async_step_import(
+        {
             CONF_NAME: NAME,
             CONF_HOST: HOST,
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
             CONF_PORT: PORT,
             CONF_SCAN_INTERVAL: timedelta(seconds=SCAN_INTERVAL),
-        },
+        }
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == NAME

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -6,12 +6,12 @@ import pytest
 from transmissionrpc.error import TransmissionError
 
 from homeassistant import data_entry_flow
+from homeassistant.components import transmission
 from homeassistant.components.transmission import config_flow
 from homeassistant.components.transmission.const import (
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -85,7 +85,7 @@ async def test_flow_works(hass, api):
     flow = init_config_flow(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
+        transmission.DOMAIN, context={"source": "user"}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
@@ -118,7 +118,7 @@ async def test_flow_works(hass, api):
 async def test_options(hass):
     """Test updating options."""
     entry = MockConfigEntry(
-        domain=DOMAIN,
+        domain=transmission.DOMAIN,
         title=CONF_NAME,
         data=MOCK_ENTRY,
         options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
@@ -178,13 +178,13 @@ async def test_import(hass, api):
 async def test_host_already_configured(hass, api):
     """Test host is already configured."""
     entry = MockConfigEntry(
-        domain=DOMAIN,
+        domain=transmission.DOMAIN,
         data=MOCK_ENTRY,
         options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
     )
     entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
+        transmission.DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_ENTRY
@@ -197,7 +197,7 @@ async def test_host_already_configured(hass, api):
 async def test_name_already_configured(hass, api):
     """Test name is already configured."""
     entry = MockConfigEntry(
-        domain=DOMAIN,
+        domain=transmission.DOMAIN,
         data=MOCK_ENTRY,
         options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
     )
@@ -206,7 +206,7 @@ async def test_name_already_configured(hass, api):
     mock_entry = MOCK_ENTRY.copy()
     mock_entry[CONF_HOST] = "0.0.0.0"
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
+        transmission.DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=mock_entry

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -138,13 +138,12 @@ async def test_options(hass):
     assert result["data"][CONF_SCAN_INTERVAL] == 10
 
 
-async def test_import(hass, api):
-    """Test import step."""
-    flow = init_config_flow(hass)
-
-    # import with minimum fields only
-    result = await flow.async_step_import(
-        {
+async def test_import_with_minimum_fields(hass, api):
+    """Test import with minimum fields only."""
+    result = await hass.config_entries.flow.async_init(
+        transmission.DOMAIN,
+        context={"source": "user"},
+        data={
             CONF_NAME: DEFAULT_NAME,
             CONF_HOST: HOST,
             CONF_PORT: DEFAULT_PORT,
@@ -158,9 +157,13 @@ async def test_import(hass, api):
     assert result["data"][CONF_PORT] == DEFAULT_PORT
     assert result["data"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
 
-    # import with all
-    result = await flow.async_step_import(
-        {
+
+async def test_import_with_all(hass, api):
+    """Test import with all."""
+    result = await hass.config_entries.flow.async_init(
+        transmission.DOMAIN,
+        context={"source": "user"},
+        data={
             CONF_NAME: NAME,
             CONF_HOST: HOST,
             CONF_USERNAME: USERNAME,

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -82,8 +82,6 @@ def init_config_flow(hass):
 
 async def test_flow_works(hass, api):
     """Test user config."""
-    flow = init_config_flow(hass)
-
     result = await hass.config_entries.flow.async_init(
         transmission.DOMAIN, context={"source": "user"}
     )
@@ -91,8 +89,8 @@ async def test_flow_works(hass, api):
     assert result["step_id"] == "user"
 
     # test with required fields only
-    result = await flow.async_step_user(
-        {CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT}
+    result = await hass.config_entries.flow.async_init(
+        transmission.DOMAIN, context={"source": "user"}, data={CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -102,8 +100,8 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_PORT] == PORT
 
     # test with all provided
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_ENTRY
+    result = await hass.config_entries.flow.async_init(
+        transmission.DOMAIN, context={"source": "user"}, data=MOCK_ENTRY
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -90,7 +90,9 @@ async def test_flow_works(hass, api):
 
     # test with required fields only
     result = await hass.config_entries.flow.async_init(
-        transmission.DOMAIN, context={"source": "user"}, data={CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT}
+        transmission.DOMAIN,
+        context={"source": "user"},
+        data={CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -76,7 +76,9 @@ def mock_api_unknown_error():
 @pytest.fixture(name="transmission_setup", autouse=True)
 def transmission_setup_fixture():
     """Mock transmission entry setup."""
-    with patch("homeassistant.components.transmission.async_setup_entry", return_value=True):
+    with patch(
+        "homeassistant.components.transmission.async_setup_entry", return_value=True
+    ):
         yield
 
 

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -80,7 +80,7 @@ def init_config_flow(hass):
     return flow
 
 
-async def test_flow_works(hass, api):
+async def test_flow_user_config(hass, api):
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         transmission.DOMAIN, context={"source": "user"}
@@ -88,7 +88,9 @@ async def test_flow_works(hass, api):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    # test with required fields only
+
+async def test_flow_required_fields(hass, api):
+    """ Test with required fields only."""
     result = await hass.config_entries.flow.async_init(
         transmission.DOMAIN,
         context={"source": "user"},
@@ -101,13 +103,20 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
 
-    # test with all provided
+
+async def test_flow_all_provided(hass, api):
+    """ Test with all provided."""
     result = await hass.config_entries.flow.async_init(
         transmission.DOMAIN, context={"source": "user"}, data=MOCK_ENTRY
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_PORT] == PORT
 
 
 async def test_options(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This PR just repeat c66106e (in #28639) for the project consistency.
Original PR is made by @engrbm87, and reviewed by @balloob and @fabaff
That PR said,
> Glances sensors are now dynamically added. Especially sensors for mounted disks and temperature sensor

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`flow.async_step_user` will be `hass.config_entries.flow.async_configure`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
