### PR TITLE
Catch unexpected exceptions when validating config

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -697,6 +697,9 @@ async def async_process_component_config(
         except (vol.Invalid, HomeAssistantError) as ex:
             async_log_exception(ex, domain, config, hass, integration.documentation)
             return None
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unknown error calling %s config validator", domain)
+            return None
 
     # No custom config validator, proceed with schema validation
     if hasattr(component, "CONFIG_SCHEMA"):
@@ -704,6 +707,9 @@ async def async_process_component_config(
             return component.CONFIG_SCHEMA(config)  # type: ignore
         except vol.Invalid as ex:
             async_log_exception(ex, domain, config, hass, integration.documentation)
+            return None
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unknown error calling %s CONFIG_SCHEMA", domain)
             return None
 
     component_platform_schema = getattr(
@@ -720,6 +726,13 @@ async def async_process_component_config(
             p_validated = component_platform_schema(p_config)
         except vol.Invalid as ex:
             async_log_exception(ex, domain, p_config, hass, integration.documentation)
+            continue
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Unknown error validating %s platform config with %s component platform schema",
+                p_name,
+                domain,
+            )
             continue
 
         # Not all platform components follow same pattern for platforms
@@ -754,6 +767,13 @@ async def async_process_component_config(
                     p_config,
                     hass,
                     p_integration.documentation,
+                )
+                continue
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(
+                    "Unknown error validating config for %s platform for %s component with PLATFORM_SCHEMA",
+                    p_name,
+                    domain,
                 )
                 continue
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,11 @@ import asyncio
 from collections import OrderedDict
 import copy
 import os
-import unittest.mock as mock
+from unittest import mock
+from unittest.mock import Mock
 
 import asynctest
+from asynctest import CoroutineMock, patch
 import pytest
 from voluptuous import Invalid, MultipleInvalid
 import yaml
@@ -893,3 +895,97 @@ async def test_merge_split_component_definition(hass):
     assert len(config["light one"]) == 1
     assert len(config["light two"]) == 1
     assert len(config["light three"]) == 1
+
+
+async def test_component_config_exceptions(hass, caplog):
+    """Test unexpected exceptions validating component config."""
+    # Config validator
+    assert (
+        await config_util.async_process_component_config(
+            hass,
+            {},
+            integration=Mock(
+                domain="test_domain",
+                get_platform=Mock(
+                    return_value=Mock(
+                        async_validate_config=CoroutineMock(
+                            side_effect=ValueError("broken")
+                        )
+                    )
+                ),
+            ),
+        )
+        is None
+    )
+    assert "ValueError: broken" in caplog.text
+    assert "Unknown error calling test_domain config validator" in caplog.text
+
+    # component.CONFIG_SCHEMA
+    caplog.clear()
+    assert (
+        await config_util.async_process_component_config(
+            hass,
+            {},
+            integration=Mock(
+                domain="test_domain",
+                get_platform=Mock(return_value=None),
+                get_component=Mock(
+                    return_value=Mock(
+                        CONFIG_SCHEMA=Mock(side_effect=ValueError("broken"))
+                    )
+                ),
+            ),
+        )
+        is None
+    )
+    assert "ValueError: broken" in caplog.text
+    assert "Unknown error calling test_domain CONFIG_SCHEMA" in caplog.text
+
+    # component.PLATFORM_SCHEMA
+    caplog.clear()
+    assert await config_util.async_process_component_config(
+        hass,
+        {"test_domain": {"platform": "test_platform"}},
+        integration=Mock(
+            domain="test_domain",
+            get_platform=Mock(return_value=None),
+            get_component=Mock(
+                return_value=Mock(
+                    spec=["PLATFORM_SCHEMA_BASE"],
+                    PLATFORM_SCHEMA_BASE=Mock(side_effect=ValueError("broken")),
+                )
+            ),
+        ),
+    ) == {"test_domain": []}
+    assert "ValueError: broken" in caplog.text
+    assert (
+        "Unknown error validating test_platform platform config with test_domain component platform schema"
+        in caplog.text
+    )
+
+    # platform.PLATFORM_SCHEMA
+    caplog.clear()
+    with patch(
+        "homeassistant.config.async_get_integration_with_requirements",
+        return_value=Mock(  # integration that owns platform
+            get_platform=Mock(
+                return_value=Mock(  # platform
+                    PLATFORM_SCHEMA=Mock(side_effect=ValueError("broken"))
+                )
+            )
+        ),
+    ):
+        assert await config_util.async_process_component_config(
+            hass,
+            {"test_domain": {"platform": "test_platform"}},
+            integration=Mock(
+                domain="test_domain",
+                get_platform=Mock(return_value=None),
+                get_component=Mock(return_value=Mock(spec=["PLATFORM_SCHEMA_BASE"])),
+            ),
+        ) == {"test_domain": []}
+        assert "ValueError: broken" in caplog.text
+        assert (
+            "Unknown error validating config for test_platform platform for test_domain component with PLATFORM_SCHEMA"
+            in caplog.text
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Catch unexpected errors when validating config for a platform/component. This used to propegate up and cancel the `gather` and so cancel set up of unrelated components.

Fixes #31767

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
