### PR TITLE
Add Home Assistant Companion to manifest.json so we can suggest the app to the user

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -62,6 +62,10 @@ MANIFEST_JSON = {
     "short_name": "Assistant",
     "start_url": "/?homescreen=1",
     "theme_color": DEFAULT_THEME_COLOR,
+    "prefer_related_applications": True,
+    "related_applications": [
+        {"platform": "play", "id": "io.homeassistant.companion.android"}
+    ],
 }
 
 DATA_PANELS = "frontend_panels"


### PR DESCRIPTION
First half of the work required to enable prompting Android users to install HAC. [As per instructions found here](https://developers.google.com/web/fundamentals/app-install-banners/native).

Related: https://github.com/home-assistant/home-assistant-polymer/issues/4312