### PR TITLE
Support XML conversion for RESTful sensors

### DIFF
--- a/homeassistant/components/rest/manifest.json
+++ b/homeassistant/components/rest/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rest",
   "name": "RESTful",
   "documentation": "https://www.home-assistant.io/integrations/rest",
-  "requirements": ["xmltodict==0.12.0"],
+  "requirements": ["jsonpath==0.82", "xmltodict==0.12.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/rest/manifest.json
+++ b/homeassistant/components/rest/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rest",
   "name": "RESTful",
   "documentation": "https://www.home-assistant.io/integrations/rest",
-  "requirements": [],
+  "requirements": ["xmltodict==0.12.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -219,6 +219,9 @@ class RestSensor(Entity):
                     json_dict = json.loads(value)
                     if self._json_attrs_path is not None:
                         json_dict = jsonpath(json_dict, self._json_attrs_path)
+                    # jsonpath will always store the result in json_dict[0]
+                    # so the next line happens to work exactly as needed to
+                    # find the result
                     if isinstance(json_dict, list):
                         json_dict = json_dict[0]
                     if isinstance(json_dict, dict):

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -219,7 +219,7 @@ class RestSensor(Entity):
                     json_dict = json.loads(value)
                     if self._json_attrs_path is not None:
                         json_dict = jsonpath(json_dict, self._json_attrs_path)
-                    elif isinstance(json_dict, list):
+                    if isinstance(json_dict, list):
                         json_dict = json_dict[0]
                     if isinstance(json_dict, dict):
                         attrs = {

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -219,7 +219,7 @@ class RestSensor(Entity):
                     json_dict = json.loads(value)
                     if self._json_attrs_path is not None:
                         json_dict = jsonpath(json_dict, self._json_attrs_path)
-                    if isinstance(json_dict, list):
+                    elif isinstance(json_dict, list):
                         json_dict = json_dict[0]
                     if isinstance(json_dict, dict):
                         attrs = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -742,6 +742,7 @@ iperf3==0.1.11
 # homeassistant.components.route53
 ipify==1.0.0
 
+# homeassistant.components.rest
 # homeassistant.components.verisure
 jsonpath==0.82
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2094,6 +2094,7 @@ xfinity-gateway==0.0.4
 xknx==0.11.2
 
 # homeassistant.components.bluesound
+# homeassistant.components.rest
 # homeassistant.components.startca
 # homeassistant.components.ted5000
 # homeassistant.components.yr

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -278,6 +278,7 @@ iaqualink==0.3.1
 # homeassistant.components.influxdb
 influxdb==5.2.3
 
+# homeassistant.components.rest
 # homeassistant.components.verisure
 jsonpath==0.82
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -711,6 +711,7 @@ withings-api==2.1.3
 wled==0.2.1
 
 # homeassistant.components.bluesound
+# homeassistant.components.rest
 # homeassistant.components.startca
 # homeassistant.components.ted5000
 # homeassistant.components.yr


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many devices continue to use XML for RESTful
APIs.  Interfacing with these APIs requires custom
integrations or command line fork()/exec() overhead
which many of these devices can work with as if
they were JSON using xmltojson via this spec:
https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html

This change implements converting XML output to
JSON via xmltojson so it can work with the existing
rest sensor component.  As the attributes that
usually need to be scraped are deeper in the document
support for passing in a template to find the
JSON attributes that have been added.  JSON APIs that
do not have their attributes at the top level
can also benefit from this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: rest
    resource: http://192.168.1.20/status.xml
    authentication: basic
    username: username
    password: password
    json_attributes:
      - "htstatus"
      - "poolsp"
      - "spasp"
      - "pooltemp"
      - "spatemp"
      - "airtemp"
    json_attributes_path: "$.response.temp"
    value_template: '{{ value_json.response.temp.poolsp }}'
  - platform: rest
    resource: http://192.168.1.5/status.xml
    json_attributes:
      - "led0"
      - "led1"
      - "user0"
      - "temp0"
      - "btn0"
    json_attributes_path: "$.response"
    value_template: "OK"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
https://community.home-assistant.io/t/use-xml-result-from-rest-api/6195
https://community.home-assistant.io/t/sensor-to-read-from-url/30031/3
https://community.home-assistant.io/t/parse-xml-output-from-rest-api/27707
https://community.home-assistant.io/t/reading-xml-data-and-display-specific-element-value/39610/2

- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12084

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
