### PR TITLE
Speed up tests of HomematicIP Cloud

### DIFF
--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -1,5 +1,5 @@
 """Initializer helpers for HomematicIP fake server."""
-from asynctest import CoroutineMock, MagicMock, Mock, patch
+from asynctest import CoroutineMock, MagicMock, Mock
 from homematicip.aio.auth import AsyncAuth
 from homematicip.aio.connection import AsyncConnection
 from homematicip.aio.home import AsyncHome
@@ -19,9 +19,8 @@ from homeassistant.components.homematicip_cloud.const import (
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-from homeassistant.setup import async_setup_component
 
-from .helper import AUTH_TOKEN, HAPID, HAPPIN, HomeTemplate
+from .helper import AUTH_TOKEN, HAPID, HAPPIN, HomeFactory
 
 from tests.common import MockConfigEntry
 
@@ -66,46 +65,12 @@ def hmip_config_entry_fixture() -> config_entries.ConfigEntry:
     return config_entry
 
 
-@pytest.fixture(name="default_mock_home")
-def default_mock_home_fixture(mock_connection) -> AsyncHome:
-    """Create a fake homematic async home."""
-    return HomeTemplate(connection=mock_connection).init_home().get_async_home_mock()
-
-
-@pytest.fixture(name="default_mock_hap")
-async def default_mock_hap_fixture(
+@pytest.fixture(name="default_mock_hap_factory")
+async def default_mock_hap_factory_fixture(
     hass: HomeAssistantType, mock_connection, hmip_config_entry
 ) -> HomematicipHAP:
     """Create a mocked homematic access point."""
-    return await get_mock_hap(hass, mock_connection, hmip_config_entry)
-
-
-async def get_mock_hap(
-    hass: HomeAssistantType,
-    mock_connection,
-    hmip_config_entry: config_entries.ConfigEntry,
-) -> HomematicipHAP:
-    """Create a mocked homematic access point."""
-    home_name = hmip_config_entry.data["name"]
-    mock_home = (
-        HomeTemplate(connection=mock_connection, home_name=home_name)
-        .init_home()
-        .get_async_home_mock()
-    )
-
-    hmip_config_entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.homematicip_cloud.hap.HomematicipHAP.get_hap",
-        return_value=mock_home,
-    ):
-        assert await async_setup_component(hass, HMIPC_DOMAIN, {}) is True
-
-    await hass.async_block_till_done()
-
-    hap = hass.data[HMIPC_DOMAIN][HAPID]
-    mock_home.on_update(hap.async_update)
-    mock_home.on_create(hap.async_create_entity)
-    return hap
+    return HomeFactory(hass, mock_connection, hmip_config_entry)
 
 
 @pytest.fixture(name="hmip_config")
@@ -130,13 +95,14 @@ def dummy_config_fixture() -> ConfigType:
 
 @pytest.fixture(name="mock_hap_with_service")
 async def mock_hap_with_service_fixture(
-    hass: HomeAssistantType, default_mock_hap, dummy_config
+    hass: HomeAssistantType, default_mock_hap_factory, dummy_config
 ) -> HomematicipHAP:
     """Create a fake homematic access point with hass services."""
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap()
     await hmip_async_setup(hass, dummy_config)
     await hass.async_block_till_done()
-    hass.data[HMIPC_DOMAIN] = {HAPID: default_mock_hap}
-    return default_mock_hap
+    hass.data[HMIPC_DOMAIN] = {HAPID: mock_hap}
+    return mock_hap
 
 
 @pytest.fixture(name="simple_mock_home")

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -1,7 +1,7 @@
 """Helper for HomematicIP Cloud Tests."""
 import json
 
-from asynctest import Mock
+from asynctest import Mock, patch
 from homematicip.aio.class_maps import (
     TYPE_CLASS_MAP,
     TYPE_GROUP_MAP,
@@ -12,10 +12,15 @@ from homematicip.aio.group import AsyncGroup
 from homematicip.aio.home import AsyncHome
 from homematicip.home import Home
 
+from homeassistant import config_entries
+from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.components.homematicip_cloud.device import (
     ATTR_IS_GROUP,
     ATTR_MODEL_TYPE,
 )
+from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
 
@@ -25,9 +30,7 @@ AUTH_TOKEN = "1234"
 HOME_JSON = "homematicip_cloud.json"
 
 
-def get_and_check_entity_basics(
-    hass, default_mock_hap, entity_id, entity_name, device_model
-):
+def get_and_check_entity_basics(hass, mock_hap, entity_id, entity_name, device_model):
     """Get and test basic device."""
     ha_state = hass.states.get(entity_id)
     assert ha_state is not None
@@ -35,7 +38,7 @@ def get_and_check_entity_basics(
         assert ha_state.attributes[ATTR_MODEL_TYPE] == device_model
     assert ha_state.name == entity_name
 
-    hmip_device = default_mock_hap.hmip_device_by_entity_id.get(entity_id)
+    hmip_device = mock_hap.hmip_device_by_entity_id.get(entity_id)
 
     if hmip_device:
         if isinstance(hmip_device, AsyncDevice):
@@ -67,6 +70,51 @@ async def async_manipulate_test_data(
     await hass.async_block_till_done()
 
 
+class HomeFactory:
+    """Factory to create a HomematicIP Cloud Home."""
+
+    def __init__(
+        self,
+        hass: HomeAssistantType,
+        mock_connection,
+        hmip_config_entry: config_entries.ConfigEntry,
+    ):
+        """Initialize the Factory."""
+        self.hass = hass
+        self.mock_connection = mock_connection
+        self.hmip_config_entry = hmip_config_entry
+
+    async def async_get_mock_hap(
+        self, test_devices=[], test_groups=[]
+    ) -> HomematicipHAP:
+        """Create a mocked homematic access point."""
+        home_name = self.hmip_config_entry.data["name"]
+        mock_home = (
+            HomeTemplate(
+                connection=self.mock_connection,
+                home_name=home_name,
+                test_devices=test_devices,
+                test_groups=test_groups,
+            )
+            .init_home()
+            .get_async_home_mock()
+        )
+
+        self.hmip_config_entry.add_to_hass(self.hass)
+        with patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipHAP.get_hap",
+            return_value=mock_home,
+        ):
+            assert await async_setup_component(self.hass, HMIPC_DOMAIN, {}) is True
+
+        await self.hass.async_block_till_done()
+
+        hap = self.hass.data[HMIPC_DOMAIN][HAPID]
+        mock_home.on_update(hap.async_update)
+        mock_home.on_create(hap.async_create_entity)
+        return hap
+
+
 class HomeTemplate(Home):
     """
     Home template as builder for home mock.
@@ -84,17 +132,36 @@ class HomeTemplate(Home):
     _typeGroupMap = TYPE_GROUP_MAP
     _typeSecurityEventMap = TYPE_SECURITY_EVENT_MAP
 
-    def __init__(self, connection=None, home_name=""):
+    def __init__(self, connection=None, home_name="", test_devices=[], test_groups=[]):
         """Init template with connection."""
         super().__init__(connection=connection)
         self.label = "Access Point"
         self.name = home_name
         self.model_type = "HmIP-HAP"
         self.init_json_state = None
+        self.test_devices = test_devices
+        self.test_groups = test_groups
+
+    def _cleanup_json(self, json):
+        if self.test_devices is not None:
+            new_devices = {}
+            for json_device in json["devices"].items():
+                if json_device[1]["label"] in self.test_devices:
+                    new_devices.update([json_device])
+            json["devices"] = new_devices
+
+        if self.test_groups is not None:
+            new_groups = {}
+            for json_group in json["groups"].items():
+                if json_group[1]["label"] in self.test_groups:
+                    new_groups.update([json_group])
+            json["groups"] = new_groups
+
+        return json
 
     def init_home(self, json_path=HOME_JSON):
         """Init template with json."""
-        self.init_json_state = json.loads(load_fixture(HOME_JSON))
+        self.init_json_state = self._cleanup_json(json.loads(load_fixture(HOME_JSON)))
         self.update_home(json_state=self.init_json_state, clearConfig=True)
         return self
 

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -28,6 +28,7 @@ HAPID = "3014F7110000000000000001"
 HAPPIN = "5678"
 AUTH_TOKEN = "1234"
 HOME_JSON = "homematicip_cloud.json"
+FIXTURE_DATA = load_fixture(HOME_JSON)
 
 
 def get_and_check_entity_basics(hass, mock_hap, entity_id, entity_name, device_model):
@@ -159,9 +160,9 @@ class HomeTemplate(Home):
 
         return json
 
-    def init_home(self, json_path=HOME_JSON):
+    def init_home(self):
         """Init template with json."""
-        self.init_json_state = self._cleanup_json(json.loads(load_fixture(HOME_JSON)))
+        self.init_json_state = self._cleanup_json(json.loads(FIXTURE_DATA))
         self.update_home(json_state=self.init_json_state, clearConfig=True)
         return self
 

--- a/tests/components/homematicip_cloud/test_alarm_control_panel.py
+++ b/tests/components/homematicip_cloud/test_alarm_control_panel.py
@@ -48,20 +48,23 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_alarm_control_panel(hass, default_mock_hap):
+async def test_hmip_alarm_control_panel(hass, default_mock_hap_factory):
     """Test HomematicipAlarmControlPanel."""
     entity_id = "alarm_control_panel.hmip_alarm_control_panel"
     entity_name = "HmIP Alarm Control Panel"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_groups=["EXTERNAL", "INTERNAL"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "disarmed"
     assert not hmip_device
 
-    home = default_mock_hap.home
+    home = mock_hap.home
 
     await hass.services.async_call(
         "alarm_control_panel", "alarm_arm_away", {"entity_id": entity_id}, blocking=True

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -41,14 +41,17 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_acceleration_sensor(hass, default_mock_hap):
+async def test_hmip_acceleration_sensor(hass, default_mock_hap_factory):
     """Test HomematicipAccelerationSensor."""
     entity_id = "binary_sensor.garagentor"
     entity_name = "Garagentor"
     device_model = "HmIP-SAM"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -75,14 +78,17 @@ async def test_hmip_acceleration_sensor(hass, default_mock_hap):
     assert len(hmip_device.mock_calls) == service_call_counter + 2
 
 
-async def test_hmip_contact_interface(hass, default_mock_hap):
+async def test_hmip_contact_interface(hass, default_mock_hap_factory):
     """Test HomematicipContactInterface."""
     entity_id = "binary_sensor.kontakt_schnittstelle_unterputz_1_fach"
     entity_name = "Kontakt-Schnittstelle Unterputz – 1-fach"
     device_model = "HmIP-FCI1"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -95,14 +101,17 @@ async def test_hmip_contact_interface(hass, default_mock_hap):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_shutter_contact(hass, default_mock_hap):
+async def test_hmip_shutter_contact(hass, default_mock_hap_factory):
     """Test HomematicipShutterContact."""
     entity_id = "binary_sensor.fenstergriffsensor"
     entity_name = "Fenstergriffsensor"
     device_model = "HmIP-SRH"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -124,14 +133,17 @@ async def test_hmip_shutter_contact(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_SABOTAGE]
 
 
-async def test_hmip_motion_detector(hass, default_mock_hap):
+async def test_hmip_motion_detector(hass, default_mock_hap_factory):
     """Test HomematicipMotionDetector."""
     entity_id = "binary_sensor.bewegungsmelder_fur_55er_rahmen_innen"
     entity_name = "Bewegungsmelder für 55er Rahmen – innen"
     device_model = "HmIP-SMI55"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -140,14 +152,17 @@ async def test_hmip_motion_detector(hass, default_mock_hap):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_presence_detector(hass, default_mock_hap):
+async def test_hmip_presence_detector(hass, default_mock_hap_factory):
     """Test HomematicipPresenceDetector."""
     entity_id = "binary_sensor.spi_1"
     entity_name = "SPI_1"
     device_model = "HmIP-SPI"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -161,14 +176,19 @@ async def test_hmip_presence_detector(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_EVENT_DELAY]
 
 
-async def test_hmip_pluggable_mains_failure_surveillance_sensor(hass, default_mock_hap):
+async def test_hmip_pluggable_mains_failure_surveillance_sensor(
+    hass, default_mock_hap_factory
+):
     """Test HomematicipPresenceDetector."""
     entity_id = "binary_sensor.netzausfall"
     entity_name = "Netzausfall"
     device_model = "HmIP-PMFS"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -177,14 +197,17 @@ async def test_hmip_pluggable_mains_failure_surveillance_sensor(hass, default_mo
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_smoke_detector(hass, default_mock_hap):
+async def test_hmip_smoke_detector(hass, default_mock_hap_factory):
     """Test HomematicipSmokeDetector."""
     entity_id = "binary_sensor.rauchwarnmelder"
     entity_name = "Rauchwarnmelder"
     device_model = "HmIP-SWSD"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -198,14 +221,17 @@ async def test_hmip_smoke_detector(hass, default_mock_hap):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_water_detector(hass, default_mock_hap):
+async def test_hmip_water_detector(hass, default_mock_hap_factory):
     """Test HomematicipWaterDetector."""
     entity_id = "binary_sensor.wassersensor"
     entity_name = "Wassersensor"
     device_model = "HmIP-SWD"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -230,14 +256,17 @@ async def test_hmip_water_detector(hass, default_mock_hap):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_storm_sensor(hass, default_mock_hap):
+async def test_hmip_storm_sensor(hass, default_mock_hap_factory):
     """Test HomematicipStormSensor."""
     entity_id = "binary_sensor.weather_sensor_plus_storm"
     entity_name = "Weather Sensor – plus Storm"
     device_model = "HmIP-SWO-PL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Weather Sensor – plus"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -246,14 +275,17 @@ async def test_hmip_storm_sensor(hass, default_mock_hap):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_rain_sensor(hass, default_mock_hap):
+async def test_hmip_rain_sensor(hass, default_mock_hap_factory):
     """Test HomematicipRainSensor."""
     entity_id = "binary_sensor.wettersensor_pro_raining"
     entity_name = "Wettersensor - pro Raining"
     device_model = "HmIP-SWO-PR"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Wettersensor - pro"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -262,14 +294,17 @@ async def test_hmip_rain_sensor(hass, default_mock_hap):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_sunshine_sensor(hass, default_mock_hap):
+async def test_hmip_sunshine_sensor(hass, default_mock_hap_factory):
     """Test HomematicipSunshineSensor."""
     entity_id = "binary_sensor.wettersensor_pro_sunshine"
     entity_name = "Wettersensor - pro Sunshine"
     device_model = "HmIP-SWO-PR"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Wettersensor - pro"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -279,14 +314,17 @@ async def test_hmip_sunshine_sensor(hass, default_mock_hap):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_battery_sensor(hass, default_mock_hap):
+async def test_hmip_battery_sensor(hass, default_mock_hap_factory):
     """Test HomematicipSunshineSensor."""
     entity_id = "binary_sensor.wohnungsture_battery"
     entity_name = "Wohnungstüre Battery"
     device_model = "HMIP-SWDO"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Wohnungstüre"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -295,14 +333,17 @@ async def test_hmip_battery_sensor(hass, default_mock_hap):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_security_zone_sensor_group(hass, default_mock_hap):
+async def test_hmip_security_zone_sensor_group(hass, default_mock_hap_factory):
     """Test HomematicipSecurityZoneSensorGroup."""
     entity_id = "binary_sensor.internal_securityzone"
     entity_name = "INTERNAL SecurityZone"
     device_model = "HmIP-SecurityZone"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_groups=["INTERNAL"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -327,14 +368,15 @@ async def test_hmip_security_zone_sensor_group(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_WINDOW_STATE] == WindowState.OPEN
 
 
-async def test_hmip_security_sensor_group(hass, default_mock_hap):
+async def test_hmip_security_sensor_group(hass, default_mock_hap_factory):
     """Test HomematicipSecuritySensorGroup."""
     entity_id = "binary_sensor.buro_sensors"
     entity_name = "Büro Sensors"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(test_groups=["Büro"])
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     await async_manipulate_test_data(

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -41,14 +41,18 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_heating_group_heat(hass, default_mock_hap):
+async def test_hmip_heating_group_heat(hass, default_mock_hap_factory):
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.badezimmer"
     entity_name = "Badezimmer"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Wandthermostat", "Heizkörperthermostat"],
+        test_groups=[entity_name],
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == HVAC_MODE_AUTO
@@ -142,7 +146,7 @@ async def test_hmip_heating_group_heat(hass, default_mock_hap):
     await async_manipulate_test_data(hass, hmip_device, "controlMode", "ECO")
     await async_manipulate_test_data(
         hass,
-        default_mock_hap.home.get_functionalHome(IndoorClimateHome),
+        mock_hap.home.get_functionalHome(IndoorClimateHome),
         "absenceType",
         AbsenceType.VACATION,
         fire_device=hmip_device,
@@ -153,7 +157,7 @@ async def test_hmip_heating_group_heat(hass, default_mock_hap):
     await async_manipulate_test_data(hass, hmip_device, "controlMode", "ECO")
     await async_manipulate_test_data(
         hass,
-        default_mock_hap.home.get_functionalHome(IndoorClimateHome),
+        mock_hap.home.get_functionalHome(IndoorClimateHome),
         "absenceType",
         AbsenceType.PERIOD,
         fire_device=hmip_device,
@@ -172,7 +176,7 @@ async def test_hmip_heating_group_heat(hass, default_mock_hap):
     assert hmip_device.mock_calls[-1][0] == "set_active_profile"
     assert hmip_device.mock_calls[-1][1] == (1,)
 
-    default_mock_hap.home.get_functionalHome(
+    mock_hap.home.get_functionalHome(
         IndoorClimateHome
     ).absenceType = AbsenceType.PERMANENT
     await async_manipulate_test_data(hass, hmip_device, "controlMode", "ECO")
@@ -230,14 +234,17 @@ async def test_hmip_heating_group_heat(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
 
 
-async def test_hmip_heating_group_cool(hass, default_mock_hap):
+async def test_hmip_heating_group_cool(hass, default_mock_hap_factory):
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.badezimmer"
     entity_name = "Badezimmer"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_groups=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     hmip_device.activeProfile = hmip_device.profiles[3]
@@ -347,14 +354,17 @@ async def test_hmip_heating_group_cool(hass, default_mock_hap):
     assert hmip_device.mock_calls[-1][1] == (4,)
 
 
-async def test_hmip_heating_group_heat_with_switch(hass, default_mock_hap):
+async def test_hmip_heating_group_heat_with_switch(hass, default_mock_hap_factory):
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.schlafzimmer"
     entity_name = "Schlafzimmer"
     device_model = None
-
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Wandthermostat", "Heizkörperthermostat", "Pc"],
+        test_groups=[entity_name],
+    )
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert hmip_device
@@ -480,14 +490,17 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     assert len(home._connection.mock_calls) == 10  # pylint: disable=protected-access
 
 
-async def test_hmip_heating_group_services(hass, mock_hap_with_service):
+async def test_hmip_heating_group_services(hass, default_mock_hap_factory):
     """Test HomematicipHeatingGroup services."""
     entity_id = "climate.badezimmer"
     entity_name = "Badezimmer"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_groups=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, mock_hap_with_service, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
     assert ha_state
 
@@ -512,6 +525,5 @@ async def test_hmip_heating_group_services(hass, mock_hap_with_service):
     assert hmip_device.mock_calls[-1][0] == "set_active_profile"
     assert hmip_device.mock_calls[-1][1] == (1,)
     assert (
-        len(hmip_device._connection.mock_calls)  # pylint: disable=protected-access
-        == 12
+        len(hmip_device._connection.mock_calls) == 4  # pylint: disable=protected-access
     )

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -24,14 +24,17 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_cover_shutter(hass, default_mock_hap):
+async def test_hmip_cover_shutter(hass, default_mock_hap_factory):
     """Test HomematicipCoverShutte."""
     entity_id = "cover.sofa_links"
     entity_name = "Sofa links"
     device_model = "HmIP-FBL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "closed"
@@ -90,14 +93,17 @@ async def test_hmip_cover_shutter(hass, default_mock_hap):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_cover_slats(hass, default_mock_hap):
+async def test_hmip_cover_slats(hass, default_mock_hap_factory):
     """Test HomematicipCoverSlats."""
     entity_id = "cover.sofa_links"
     entity_name = "Sofa links"
     device_model = "HmIP-FBL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_CLOSED
@@ -157,14 +163,17 @@ async def test_hmip_cover_slats(hass, default_mock_hap):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_garage_door_tormatic(hass, default_mock_hap):
+async def test_hmip_garage_door_tormatic(hass, default_mock_hap_factory):
     """Test HomematicipCoverShutte."""
     entity_id = "cover.garage_door_module"
     entity_name = "Garage Door Module"
     device_model = "HmIP-MOD-TM"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "closed"

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -7,18 +7,25 @@ from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .conftest import get_mock_hap
-from .helper import HAPID, async_manipulate_test_data, get_and_check_entity_basics
+from .helper import (
+    HAPID,
+    HomeFactory,
+    async_manipulate_test_data,
+    get_and_check_entity_basics,
+)
 
 
-async def test_hmip_remove_device(hass, default_mock_hap):
+async def test_hmip_remove_device(hass, default_mock_hap_factory):
     """Test Remove of hmip device."""
     entity_id = "light.treppe"
     entity_name = "Treppe"
     device_model = "HmIP-BSL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -29,7 +36,7 @@ async def test_hmip_remove_device(hass, default_mock_hap):
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
-    pre_mapping_count = len(default_mock_hap.hmip_device_by_entity_id)
+    pre_mapping_count = len(mock_hap.hmip_device_by_entity_id)
 
     hmip_device.fire_remove_event()
 
@@ -37,17 +44,20 @@ async def test_hmip_remove_device(hass, default_mock_hap):
 
     assert len(device_registry.devices) == pre_device_count - 1
     assert len(entity_registry.entities) == pre_entity_count - 3
-    assert len(default_mock_hap.hmip_device_by_entity_id) == pre_mapping_count - 3
+    assert len(mock_hap.hmip_device_by_entity_id) == pre_mapping_count - 3
 
 
-async def test_hmip_add_device(hass, default_mock_hap, hmip_config_entry):
+async def test_hmip_add_device(hass, default_mock_hap_factory, hmip_config_entry):
     """Test Remove of hmip device."""
     entity_id = "light.treppe"
     entity_name = "Treppe"
     device_model = "HmIP-BSL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -58,25 +68,25 @@ async def test_hmip_add_device(hass, default_mock_hap, hmip_config_entry):
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
-    pre_mapping_count = len(default_mock_hap.hmip_device_by_entity_id)
+    pre_mapping_count = len(mock_hap.hmip_device_by_entity_id)
 
     hmip_device.fire_remove_event()
     await hass.async_block_till_done()
 
     assert len(device_registry.devices) == pre_device_count - 1
     assert len(entity_registry.entities) == pre_entity_count - 3
-    assert len(default_mock_hap.hmip_device_by_entity_id) == pre_mapping_count - 3
+    assert len(mock_hap.hmip_device_by_entity_id) == pre_mapping_count - 3
 
     reloaded_hap = HomematicipHAP(hass, hmip_config_entry)
     with patch(
         "homeassistant.components.homematicip_cloud.HomematicipHAP",
         return_value=reloaded_hap,
     ), patch.object(reloaded_hap, "async_connect"), patch.object(
-        reloaded_hap, "get_hap", return_value=default_mock_hap.home
+        reloaded_hap, "get_hap", return_value=mock_hap.home
     ), patch(
         "homeassistant.components.homematicip_cloud.hap.asyncio.sleep"
     ):
-        default_mock_hap.home.fire_create_event(event_type=EventType.DEVICE_ADDED)
+        mock_hap.home.fire_create_event(event_type=EventType.DEVICE_ADDED)
         await hass.async_block_till_done()
 
     assert len(device_registry.devices) == pre_device_count
@@ -85,14 +95,15 @@ async def test_hmip_add_device(hass, default_mock_hap, hmip_config_entry):
     assert len(new_hap.hmip_device_by_entity_id) == pre_mapping_count
 
 
-async def test_hmip_remove_group(hass, default_mock_hap):
+async def test_hmip_remove_group(hass, default_mock_hap_factory):
     """Test Remove of hmip group."""
     entity_id = "switch.strom_group"
     entity_name = "Strom Group"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(test_groups=["Strom"])
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -103,59 +114,67 @@ async def test_hmip_remove_group(hass, default_mock_hap):
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
-    pre_mapping_count = len(default_mock_hap.hmip_device_by_entity_id)
+    pre_mapping_count = len(mock_hap.hmip_device_by_entity_id)
 
     hmip_device.fire_remove_event()
     await hass.async_block_till_done()
 
     assert len(device_registry.devices) == pre_device_count
     assert len(entity_registry.entities) == pre_entity_count - 1
-    assert len(default_mock_hap.hmip_device_by_entity_id) == pre_mapping_count - 1
+    assert len(mock_hap.hmip_device_by_entity_id) == pre_mapping_count - 1
 
 
-async def test_all_devices_unavailable_when_hap_not_connected(hass, default_mock_hap):
+async def test_all_devices_unavailable_when_hap_not_connected(
+    hass, default_mock_hap_factory
+):
     """Test make all devices unavaulable when hap is not connected."""
     entity_id = "light.treppe"
     entity_name = "Treppe"
     device_model = "HmIP-BSL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
     assert hmip_device
 
-    assert default_mock_hap.home.connected
+    assert mock_hap.home.connected
 
-    await async_manipulate_test_data(hass, default_mock_hap.home, "connected", False)
+    await async_manipulate_test_data(hass, mock_hap.home, "connected", False)
 
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_UNAVAILABLE
 
 
-async def test_hap_reconnected(hass, default_mock_hap):
+async def test_hap_reconnected(hass, default_mock_hap_factory):
     """Test reconnect hap."""
     entity_id = "light.treppe"
     entity_name = "Treppe"
     device_model = "HmIP-BSL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
     assert hmip_device
 
-    assert default_mock_hap.home.connected
+    assert mock_hap.home.connected
 
-    await async_manipulate_test_data(hass, default_mock_hap.home, "connected", False)
+    await async_manipulate_test_data(hass, mock_hap.home, "connected", False)
 
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_UNAVAILABLE
 
-    default_mock_hap._accesspoint_connected = False  # pylint: disable=protected-access
-    await async_manipulate_test_data(hass, default_mock_hap.home, "connected", True)
+    mock_hap._accesspoint_connected = False  # pylint: disable=protected-access
+    await async_manipulate_test_data(hass, mock_hap.home, "connected", True)
     await hass.async_block_till_done()
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_ON
@@ -169,7 +188,9 @@ async def test_hap_with_name(hass, mock_connection, hmip_config_entry):
     device_model = "HmIP-BSL"
 
     hmip_config_entry.data["name"] = home_name
-    mock_hap = await get_mock_hap(hass, mock_connection, hmip_config_entry)
+    mock_hap = await HomeFactory(
+        hass, mock_connection, hmip_config_entry
+    ).async_get_mock_hap(test_devices=["Treppe"])
     assert mock_hap
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -181,14 +202,17 @@ async def test_hap_with_name(hass, mock_connection, hmip_config_entry):
     assert ha_state.attributes["friendly_name"] == entity_name
 
 
-async def test_hmip_reset_energy_counter_services(hass, mock_hap_with_service):
+async def test_hmip_reset_energy_counter_services(hass, default_mock_hap_factory):
     """Test reset_energy_counter service."""
     entity_id = "switch.pc"
     entity_name = "Pc"
     device_model = "HMIP-PSM"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, mock_hap_with_service, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
     assert ha_state
 
@@ -205,4 +229,4 @@ async def test_hmip_reset_energy_counter_services(hass, mock_hap_with_service):
         "homematicip_cloud", "reset_energy_counter", {"entity_id": "all"}, blocking=True
     )
     assert hmip_device.mock_calls[-1][0] == "reset_energy_counter"
-    assert len(hmip_device._connection.mock_calls) == 12  # pylint: disable=W0212
+    assert len(hmip_device._connection.mock_calls) == 4  # pylint: disable=W0212

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -107,9 +107,10 @@ async def test_hap_setup_connection_error():
     assert not hass.config_entries.flow.async_init.mock_calls
 
 
-async def test_hap_reset_unloads_entry_if_setup(hass, default_mock_hap):
+async def test_hap_reset_unloads_entry_if_setup(hass, default_mock_hap_factory):
     """Test calling reset while the entry has been setup."""
-    assert hass.data[HMIPC_DOMAIN][HAPID] == default_mock_hap
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap()
+    assert hass.data[HMIPC_DOMAIN][HAPID] == mock_hap
     config_entries = hass.config_entries.async_entries(HMIPC_DOMAIN)
     assert len(config_entries) == 1
     # hap_reset is called during unload

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -28,14 +28,17 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_light(hass, default_mock_hap):
+async def test_hmip_light(hass, default_mock_hap_factory):
     """Test HomematicipLight."""
     entity_id = "light.treppe"
     entity_name = "Treppe"
     device_model = "HmIP-BSL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -64,14 +67,17 @@ async def test_hmip_light(hass, default_mock_hap):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_notification_light(hass, default_mock_hap):
+async def test_hmip_notification_light(hass, default_mock_hap_factory):
     """Test HomematicipNotificationLight."""
     entity_id = "light.treppe_top_notification"
     entity_name = "Treppe Top Notification"
     device_model = "HmIP-BSL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Treppe"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -152,14 +158,17 @@ async def test_hmip_notification_light(hass, default_mock_hap):
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_dimmer(hass, default_mock_hap):
+async def test_hmip_dimmer(hass, default_mock_hap_factory):
     """Test HomematicipDimmer."""
     entity_id = "light.schlafzimmerlicht"
     entity_name = "Schlafzimmerlicht"
     device_model = "HmIP-BDT"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF
@@ -201,14 +210,17 @@ async def test_hmip_dimmer(hass, default_mock_hap):
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_light_measuring(hass, default_mock_hap):
+async def test_hmip_light_measuring(hass, default_mock_hap_factory):
     """Test HomematicipLightMeasuring."""
     entity_id = "light.flur_oben"
     entity_name = "Flur oben"
     device_model = "HmIP-BSM"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -39,14 +39,17 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_accesspoint_status(hass, default_mock_hap):
+async def test_hmip_accesspoint_status(hass, default_mock_hap_factory):
     """Test HomematicipSwitch."""
     entity_id = "sensor.access_point"
     entity_name = "Access Point"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
     assert hmip_device
     assert ha_state.state == "8.0"
@@ -58,14 +61,17 @@ async def test_hmip_accesspoint_status(hass, default_mock_hap):
     assert ha_state.state == "17.3"
 
 
-async def test_hmip_heating_thermostat(hass, default_mock_hap):
+async def test_hmip_heating_thermostat(hass, default_mock_hap_factory):
     """Test HomematicipHeatingThermostat."""
     entity_id = "sensor.heizkorperthermostat_heating"
     entity_name = "Heizkörperthermostat Heating"
     device_model = "HMIP-eTRV"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Heizkörperthermostat"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "0"
@@ -89,14 +95,17 @@ async def test_hmip_heating_thermostat(hass, default_mock_hap):
     assert ha_state.attributes["icon"] == "mdi:battery-outline"
 
 
-async def test_hmip_humidity_sensor(hass, default_mock_hap):
+async def test_hmip_humidity_sensor(hass, default_mock_hap_factory):
     """Test HomematicipHumiditySensor."""
     entity_id = "sensor.bwth_1_humidity"
     entity_name = "BWTH 1 Humidity"
     device_model = "HmIP-BWTH"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["BWTH 1"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "40"
@@ -109,14 +118,17 @@ async def test_hmip_humidity_sensor(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_RSSI_PEER] == -77
 
 
-async def test_hmip_temperature_sensor1(hass, default_mock_hap):
+async def test_hmip_temperature_sensor1(hass, default_mock_hap_factory):
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.bwth_1_temperature"
     entity_name = "BWTH 1 Temperature"
     device_model = "HmIP-BWTH"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["BWTH 1"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "21.0"
@@ -131,14 +143,17 @@ async def test_hmip_temperature_sensor1(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_TEMPERATURE_OFFSET] == 10
 
 
-async def test_hmip_temperature_sensor2(hass, default_mock_hap):
+async def test_hmip_temperature_sensor2(hass, default_mock_hap_factory):
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.heizkorperthermostat_temperature"
     entity_name = "Heizkörperthermostat Temperature"
     device_model = "HMIP-eTRV"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Heizkörperthermostat"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "20.0"
@@ -153,14 +168,17 @@ async def test_hmip_temperature_sensor2(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_TEMPERATURE_OFFSET] == 10
 
 
-async def test_hmip_power_sensor(hass, default_mock_hap):
+async def test_hmip_power_sensor(hass, default_mock_hap_factory):
     """Test HomematicipPowerSensor."""
     entity_id = "sensor.flur_oben_power"
     entity_name = "Flur oben Power"
     device_model = "HmIP-BSM"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Flur oben"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "0.0"
@@ -187,14 +205,17 @@ async def test_hmip_power_sensor(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_CONFIG_PENDING]
 
 
-async def test_hmip_illuminance_sensor1(hass, default_mock_hap):
+async def test_hmip_illuminance_sensor1(hass, default_mock_hap_factory):
     """Test HomematicipIlluminanceSensor."""
     entity_id = "sensor.wettersensor_illuminance"
     entity_name = "Wettersensor Illuminance"
     device_model = "HmIP-SWO-B"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Wettersensor"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "4890.0"
@@ -204,14 +225,17 @@ async def test_hmip_illuminance_sensor1(hass, default_mock_hap):
     assert ha_state.state == "231"
 
 
-async def test_hmip_illuminance_sensor2(hass, default_mock_hap):
+async def test_hmip_illuminance_sensor2(hass, default_mock_hap_factory):
     """Test HomematicipIlluminanceSensor."""
     entity_id = "sensor.lichtsensor_nord_illuminance"
     entity_name = "Lichtsensor Nord Illuminance"
     device_model = "HmIP-SLO"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Lichtsensor Nord"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "807.3"
@@ -224,14 +248,17 @@ async def test_hmip_illuminance_sensor2(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_LOWEST_ILLUMINATION] == 785.2
 
 
-async def test_hmip_windspeed_sensor(hass, default_mock_hap):
+async def test_hmip_windspeed_sensor(hass, default_mock_hap_factory):
     """Test HomematicipWindspeedSensor."""
     entity_id = "sensor.wettersensor_pro_windspeed"
     entity_name = "Wettersensor - pro Windspeed"
     device_model = "HmIP-SWO-PR"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Wettersensor - pro"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "2.6"
@@ -268,14 +295,17 @@ async def test_hmip_windspeed_sensor(hass, default_mock_hap):
         assert ha_state.attributes[ATTR_WIND_DIRECTION] == txt
 
 
-async def test_hmip_today_rain_sensor(hass, default_mock_hap):
+async def test_hmip_today_rain_sensor(hass, default_mock_hap_factory):
     """Test HomematicipTodayRainSensor."""
     entity_id = "sensor.weather_sensor_plus_today_rain"
     entity_name = "Weather Sensor – plus Today Rain"
     device_model = "HmIP-SWO-PL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Weather Sensor – plus"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "3.9"
@@ -285,14 +315,17 @@ async def test_hmip_today_rain_sensor(hass, default_mock_hap):
     assert ha_state.state == "14.2"
 
 
-async def test_hmip_passage_detector_delta_counter(hass, default_mock_hap):
+async def test_hmip_passage_detector_delta_counter(hass, default_mock_hap_factory):
     """Test HomematicipPassageDetectorDeltaCounter."""
     entity_id = "sensor.spdr_1"
     entity_name = "SPDR_1"
     device_model = "HmIP-SPDR"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "164"

--- a/tests/components/homematicip_cloud/test_switch.py
+++ b/tests/components/homematicip_cloud/test_switch.py
@@ -25,14 +25,17 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_switch(hass, default_mock_hap):
+async def test_hmip_switch(hass, default_mock_hap_factory):
     """Test HomematicipSwitch."""
     entity_id = "switch.schrank"
     entity_name = "Schrank"
     device_model = "HMIP-PS"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -59,14 +62,17 @@ async def test_hmip_switch(hass, default_mock_hap):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_switch_measuring(hass, default_mock_hap):
+async def test_hmip_switch_measuring(hass, default_mock_hap_factory):
     """Test HomematicipSwitchMeasuring."""
     entity_id = "switch.pc"
     entity_name = "Pc"
     device_model = "HMIP-PSM"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -100,14 +106,15 @@ async def test_hmip_switch_measuring(hass, default_mock_hap):
     assert not ha_state.attributes.get(ATTR_TODAY_ENERGY_KWH)
 
 
-async def test_hmip_group_switch(hass, default_mock_hap):
+async def test_hmip_group_switch(hass, default_mock_hap_factory):
     """Test HomematicipGroupSwitch."""
     entity_id = "switch.strom_group"
     entity_name = "Strom Group"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(test_groups=["Strom"])
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_ON
@@ -139,14 +146,17 @@ async def test_hmip_group_switch(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_GROUP_MEMBER_UNREACHABLE]
 
 
-async def test_hmip_multi_switch(hass, default_mock_hap):
+async def test_hmip_multi_switch(hass, default_mock_hap_factory):
     """Test HomematicipMultiSwitch."""
     entity_id = "switch.jalousien_1_kizi_2_schlazi_channel1"
     entity_name = "Jalousien - 1 KiZi, 2 SchlaZi Channel1"
     device_model = "HmIP-PCBS2"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Jalousien - 1 KiZi, 2 SchlaZi"]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == STATE_OFF

--- a/tests/components/homematicip_cloud/test_weather.py
+++ b/tests/components/homematicip_cloud/test_weather.py
@@ -24,14 +24,17 @@ async def test_manually_configured_platform(hass):
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_weather_sensor(hass, default_mock_hap):
+async def test_hmip_weather_sensor(hass, default_mock_hap_factory):
     """Test HomematicipWeatherSensor."""
     entity_id = "weather.weather_sensor_plus"
     entity_name = "Weather Sensor – plus"
     device_model = "HmIP-SWO-PL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == ""
@@ -45,14 +48,17 @@ async def test_hmip_weather_sensor(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_WEATHER_TEMPERATURE] == 12.1
 
 
-async def test_hmip_weather_sensor_pro(hass, default_mock_hap):
+async def test_hmip_weather_sensor_pro(hass, default_mock_hap_factory):
     """Test HomematicipWeatherSensorPro."""
     entity_id = "weather.wettersensor_pro"
     entity_name = "Wettersensor - pro"
     device_model = "HmIP-SWO-PR"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=[entity_name]
+    )
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
 
     assert ha_state.state == "sunny"
@@ -67,14 +73,15 @@ async def test_hmip_weather_sensor_pro(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_WEATHER_TEMPERATURE] == 12.1
 
 
-async def test_hmip_home_weather(hass, default_mock_hap):
+async def test_hmip_home_weather(hass, default_mock_hap_factory):
     """Test HomematicipHomeWeather."""
     entity_id = "weather.weather_1010_wien_osterreich"
     entity_name = "Weather 1010  Wien, Österreich"
     device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap()
 
     ha_state, hmip_device = get_and_check_entity_basics(
-        hass, default_mock_hap, entity_id, entity_name, device_model
+        hass, mock_hap, entity_id, entity_name, device_model
     )
     assert hmip_device
     assert ha_state.state == "partlycloudy"
@@ -85,11 +92,7 @@ async def test_hmip_home_weather(hass, default_mock_hap):
     assert ha_state.attributes[ATTR_WEATHER_ATTRIBUTION] == "Powered by Homematic IP"
 
     await async_manipulate_test_data(
-        hass,
-        default_mock_hap.home.weather,
-        "temperature",
-        28.3,
-        fire_device=default_mock_hap.home,
+        hass, mock_hap.home.weather, "temperature", 28.3, fire_device=mock_hap.home
     )
 
     ha_state = hass.states.get(entity_id)


### PR DESCRIPTION
## Proposed change
This PR speeds up the execution of the HomematicIP Cloud tests by filtering out not required devices or groups from origin test data json.

Besides some required renaming this PR adds a factory to create a HomematicIP Access Point.
This Factory expects a list of device/group names to just create these and not all available devices.

As a result the tests are executed in 11 seconds instead of 60 seconds before. (on my machine)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31794
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
