### PR TITLE
Fix person device_trackers null

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -88,7 +88,11 @@ _UNDEF = object()
 async def async_create_person(hass, name, *, user_id=None, device_trackers=None):
     """Create a new person."""
     await hass.data[DOMAIN][1].async_create_item(
-        {ATTR_NAME: name, ATTR_USER_ID: user_id, "device_trackers": device_trackers}
+        {
+            ATTR_NAME: name,
+            ATTR_USER_ID: user_id,
+            CONF_DEVICE_TRACKERS: device_trackers or [],
+        }
     )
 
 
@@ -103,14 +107,14 @@ async def async_add_user_device_tracker(
         if person.get(ATTR_USER_ID) != user_id:
             continue
 
-        device_trackers = person["device_trackers"]
+        device_trackers = person[CONF_DEVICE_TRACKERS]
 
         if device_tracker_entity_id in device_trackers:
             return
 
         await coll.async_update_item(
             person[collection.CONF_ID],
-            {"device_trackers": device_trackers + [device_tracker_entity_id]},
+            {CONF_DEVICE_TRACKERS: device_trackers + [device_tracker_entity_id]},
         )
         break
 
@@ -161,6 +165,23 @@ class PersonStorageCollection(collection.StorageCollection):
         super().__init__(store, logger, id_manager)
         self.yaml_collection = yaml_collection
 
+    async def _async_load_data(self) -> Optional[dict]:
+        """Load the data.
+
+        A past bug caused onboarding to create invalid person objects.
+        This patches it up.
+        """
+        data = await super()._async_load_data()
+
+        if data is None:
+            return data
+
+        for person in data["items"]:
+            if person[CONF_DEVICE_TRACKERS] is None:
+                person[CONF_DEVICE_TRACKERS] = []
+
+        return data
+
     async def async_load(self) -> None:
         """Load the Storage collection."""
         await super().async_load()
@@ -179,14 +200,16 @@ class PersonStorageCollection(collection.StorageCollection):
             return
 
         for person in list(self.data.values()):
-            if entity_id not in person["device_trackers"]:
+            if entity_id not in person[CONF_DEVICE_TRACKERS]:
                 continue
 
             await self.async_update_item(
                 person[collection.CONF_ID],
                 {
-                    "device_trackers": [
-                        devt for devt in person["device_trackers"] if devt != entity_id
+                    CONF_DEVICE_TRACKERS: [
+                        devt
+                        for devt in person[CONF_DEVICE_TRACKERS]
+                        if devt != entity_id
                     ]
                 },
             )
@@ -408,7 +431,7 @@ class Person(RestoreEntity):
             self._unsub_track_device()
             self._unsub_track_device = None
 
-        trackers = self._config.get(CONF_DEVICE_TRACKERS)
+        trackers = self._config[CONF_DEVICE_TRACKERS]
 
         if trackers:
             _LOGGER.debug("Subscribe to device trackers for %s", self.entity_id)
@@ -428,7 +451,7 @@ class Person(RestoreEntity):
     def _update_state(self):
         """Update the state."""
         latest_non_gps_home = latest_not_home = latest_gps = latest = None
-        for entity_id in self._config.get(CONF_DEVICE_TRACKERS, []):
+        for entity_id in self._config[CONF_DEVICE_TRACKERS]:
             state = self.hass.states.get(entity_id)
 
             if not state or state.state in IGNORE_STATES:

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -158,9 +158,13 @@ class StorageCollection(ObservableCollection):
         """Home Assistant object."""
         return self.store.hass
 
+    async def _async_load_data(self) -> Optional[dict]:
+        """Load the data."""
+        return cast(Optional[dict], await self.store.async_load())
+
     async def async_load(self) -> None:
         """Load the storage Manager."""
-        raw_storage = cast(Optional[dict], await self.store.async_load())
+        raw_storage = await self._async_load_data()
 
         if raw_storage is None:
             raw_storage = {"items": []}

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,7 +1,7 @@
 """The tests for the person component."""
 import logging
-from unittest.mock import patch
 
+from asynctest import patch
 import pytest
 
 from homeassistant.components import person
@@ -773,3 +773,15 @@ async def test_reload(hass, hass_admin_user):
     assert state_2 is None
     assert state_3 is not None
     assert state_3.name == "Person 3"
+
+
+async def test_person_storage_fixing_device_trackers(storage_collection):
+    """Test None device trackers become lists."""
+    with patch.object(
+        storage_collection.store,
+        "async_load",
+        return_value={"items": [{"id": "bla", "name": "bla", "device_trackers": None}]},
+    ):
+        await storage_collection.async_load()
+
+    assert storage_collection.data["bla"]["device_trackers"] == []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a person has onboarded before we migrated person integration to the new collection helper, we accidentally had written device_trackers as `None`. It should always be a list. Some people fixed this for themselves by mutating person via the config UI, for the rest, this will fix it.

This should fix errors people experience with registering a mobile app.

Fixes #31816

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
