### PR TITLE
Google Assistant: Remove speaker type and earlier filter out devices from being locally exposed

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -145,3 +145,5 @@ STORE_AGENT_USER_IDS = "agent_user_ids"
 
 SOURCE_CLOUD = "cloud"
 SOURCE_LOCAL = "local"
+
+NOT_EXPOSE_LOCAL = {TYPE_ALARM, TYPE_LOCK}

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -133,7 +133,6 @@ DEVICE_CLASS_TO_GOOGLE_TYPES = {
     (binary_sensor.DOMAIN, binary_sensor.DEVICE_CLASS_OPENING): TYPE_SENSOR,
     (binary_sensor.DOMAIN, binary_sensor.DEVICE_CLASS_WINDOW): TYPE_SENSOR,
     (media_player.DOMAIN, media_player.DEVICE_CLASS_TV): TYPE_TV,
-    (media_player.DOMAIN, media_player.DEVICE_CLASS_SPEAKER): TYPE_SPEAKER,
     (sensor.DOMAIN, sensor.DEVICE_CLASS_TEMPERATURE): TYPE_SENSOR,
     (sensor.DOMAIN, sensor.DEVICE_CLASS_HUMIDITY): TYPE_SENSOR,
 }

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -243,9 +243,7 @@ async def async_devices_reachable(hass, data: RequestData, payload):
         "devices": [
             entity.reachable_device_serialize()
             for entity in async_get_entities(hass, data.config)
-            if entity.entity_id in google_ids
-            and entity.should_expose()
-            and not entity.might_2fa()
+            if entity.entity_id in google_ids and entity.should_expose_local()
         ]
     }
 

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.google_assistant import helpers
 from homeassistant.components.google_assistant.const import (  # noqa: F401
     EVENT_COMMAND_RECEIVED,
+    NOT_EXPOSE_LOCAL,
 )
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
@@ -45,6 +46,15 @@ async def test_google_entity_sync_serialize_with_local_sdk(hass):
         "proxyDeviceId": None,
         "webhookId": "mock-webhook-id",
     }
+
+    for device_type in NOT_EXPOSE_LOCAL:
+        with patch(
+            "homeassistant.components.google_assistant.helpers.get_google_type",
+            return_value=device_type,
+        ):
+            serialized = await entity.sync_serialize(None)
+            assert "otherDeviceIds" not in serialized
+            assert "customData" not in serialized
 
 
 async def test_config_local_sdk(hass, hass_client):

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -682,7 +682,6 @@ async def test_device_class_cover(hass, device_class, google_type):
     "device_class,google_type",
     [
         ("non_existing_class", "action.devices.types.SWITCH"),
-        ("speaker", "action.devices.types.SPEAKER"),
         ("tv", "action.devices.types.TV"),
     ],
 )


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some fixes for certification:

- Filter out devices that might 2FA for local SDK in SYNC response instead of REACHABLE_DEVICES response
- Filter out locks and alarm panels for local exposure based on type
- Remove speaker type because it's only for built-in speakers


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
