### PR TITLE
Bump adafruit-blinka and adafruit-circuitpython-mcp230xx

### DIFF
--- a/homeassistant/components/mcp23017/binary_sensor.py
+++ b/homeassistant/components/mcp23017/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for binary sensor using I2C MCP23017 chip."""
 import logging
 
-import adafruit_mcp230xx  # pylint: disable=import-error
+from adafruit_mcp230xx.mcp23017 import MCP23017  # pylint: disable=import-error
 import board  # pylint: disable=import-error
 import busio  # pylint: disable=import-error
 import digitalio  # pylint: disable=import-error
@@ -46,7 +46,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     i2c_address = config[CONF_I2C_ADDRESS]
 
     i2c = busio.I2C(board.SCL, board.SDA)
-    mcp = adafruit_mcp230xx.MCP23017(i2c, address=i2c_address)
+    mcp = MCP23017(i2c, address=i2c_address)
 
     binary_sensors = []
     pins = config[CONF_PINS]

--- a/homeassistant/components/mcp23017/manifest.json
+++ b/homeassistant/components/mcp23017/manifest.json
@@ -4,8 +4,8 @@
   "documentation": "https://www.home-assistant.io/integrations/mcp23017",
   "requirements": [
     "RPi.GPIO==0.7.0",
-    "adafruit-blinka==1.2.1",
-    "adafruit-circuitpython-mcp230xx==1.1.2"
+    "adafruit-blinka==3.9.0",
+    "adafruit-circuitpython-mcp230xx==2.2.2"
   ],
   "dependencies": [],
   "codeowners": ["@jardiamj"]

--- a/homeassistant/components/mcp23017/switch.py
+++ b/homeassistant/components/mcp23017/switch.py
@@ -1,7 +1,7 @@
 """Support for switch sensor using I2C MCP23017 chip."""
 import logging
 
-import adafruit_mcp230xx  # pylint: disable=import-error
+from adafruit_mcp230xx.mcp23017 import MCP23017  # pylint: disable=import-error
 import board  # pylint: disable=import-error
 import busio  # pylint: disable=import-error
 import digitalio  # pylint: disable=import-error
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     i2c_address = config.get(CONF_I2C_ADDRESS)
 
     i2c = busio.I2C(board.SCL, board.SDA)
-    mcp = adafruit_mcp230xx.MCP23017(i2c, address=i2c_address)
+    mcp = MCP23017(i2c, address=i2c_address)
 
     switches = []
     pins = config.get(CONF_PINS)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,10 +108,10 @@ YesssSMS==0.4.1
 abodepy==0.17.0
 
 # homeassistant.components.mcp23017
-adafruit-blinka==1.2.1
+adafruit-blinka==3.9.0
 
 # homeassistant.components.mcp23017
-adafruit-circuitpython-mcp230xx==1.1.2
+adafruit-circuitpython-mcp230xx==2.2.2
 
 # homeassistant.components.androidtv
 adb-shell==0.1.1


### PR DESCRIPTION
…Adafruit_CircuitPython_MCP230xx v-2.2.2

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the mcp23017 integration to use the latest adafruit-blinka (v-3.9.0) and Adafruit_CircuitPython_MCP230xx (v-2.2.2) libraries.
It fixes issues caused by the code refactoring of the Adafruit_Python_PlatformDetect library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31719
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
