### PR TITLE
Provide user consumable errors when lock operations fail

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -506,6 +506,6 @@ def _call_api_operation_that_requires_bridge(
     try:
         ret = func(*args, **kwargs)
     except AugustApiHTTPError as err:
-        raise HomeAssistantError(device_name + ": " + str(err)) from AugustApiHTTPError
+        raise HomeAssistantError(device_name + ": " + str(err))
 
     return ret

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -477,23 +477,9 @@ class AugustData:
         _LOGGER.debug("Completed retrieving locks detail")
         self._lock_detail_by_id = detail_by_id
 
-    def _call_api_operation_that_requires_bridge(
-        self, device_name, operation_name, func, *args, **kwargs
-    ):
-        """Call an API that requires the bridge to be online."""
-        ret = None
-        try:
-            ret = func(*args, **kwargs)
-        except AugustApiHTTPError as err:
-            raise HomeAssistantError(
-                device_name + ": " + str(err)
-            ) from AugustApiHTTPError
-
-        return ret
-
     def lock(self, device_id):
         """Lock the device."""
-        return self._call_api_operation_that_requires_bridge(
+        return _call_api_operation_that_requires_bridge(
             self.get_lock_name(device_id),
             "lock",
             self._api.lock,
@@ -503,10 +489,23 @@ class AugustData:
 
     def unlock(self, device_id):
         """Unlock the device."""
-        return self._call_api_operation_that_requires_bridge(
+        return _call_api_operation_that_requires_bridge(
             self.get_lock_name(device_id),
             "unlock",
             self._api.unlock,
             self._access_token,
             device_id,
         )
+
+
+def _call_api_operation_that_requires_bridge(
+    device_name, operation_name, func, *args, **kwargs
+):
+    """Call an API that requires the bridge to be online."""
+    ret = None
+    try:
+        ret = func(*args, **kwargs)
+    except AugustApiHTTPError as err:
+        raise HomeAssistantError(device_name + ": " + str(err)) from AugustApiHTTPError
+
+    return ret

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from functools import partial
 import logging
 
-from august.api import Api
+from august.api import Api, AugustApiHTTPError
 from august.authenticator import AuthenticationState, Authenticator, ValidationResult
 from requests import RequestException, Session
 import voluptuous as vol
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, dt
@@ -364,6 +365,12 @@ class AugustData:
         await self._async_update_locks()
         return self._lock_detail_by_id.get(lock_id)
 
+    def get_lock_name(self, device_id):
+        """Return lock name as August has it stored."""
+        for lock in self._locks:
+            if lock.device_id == device_id:
+                return lock.device_name
+
     async def async_get_door_state(self, lock_id):
         """Return status if the door is open or closed.
 
@@ -470,10 +477,34 @@ class AugustData:
         _LOGGER.debug("Completed retrieving locks detail")
         self._lock_detail_by_id = detail_by_id
 
+    def _call_api_operation_that_requires_bridge(
+        self, device_name, operation_name, func, *args, **kwargs
+    ):
+        """Call an API that requires the bridge to be online."""
+        ret = None
+        try:
+            ret = func(*args, **kwargs)
+        except AugustApiHTTPError as err:
+            raise HomeAssistantError(device_name + ": " + str(err))
+
+        return ret
+
     def lock(self, device_id):
         """Lock the device."""
-        return self._api.lock(self._access_token, device_id)
+        return self._call_api_operation_that_requires_bridge(
+            self.get_lock_name(device_id),
+            "lock",
+            self._api.lock,
+            self._access_token,
+            device_id,
+        )
 
     def unlock(self, device_id):
         """Unlock the device."""
-        return self._api.unlock(self._access_token, device_id)
+        return self._call_api_operation_that_requires_bridge(
+            self.get_lock_name(device_id),
+            "unlock",
+            self._api.unlock,
+            self._access_token,
+            device_id,
+        )

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -485,7 +485,9 @@ class AugustData:
         try:
             ret = func(*args, **kwargs)
         except AugustApiHTTPError as err:
-            raise HomeAssistantError(device_name + ": " + str(err))
+            raise HomeAssistantError(
+                device_name + ": " + str(err)
+            ) from AugustApiHTTPError
 
         return ret
 

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -56,7 +56,7 @@ async def _async_activity_time_based_state(data, doorbell, activity_types):
     return None
 
 
-# Sensor types: Name, device_class, async_state_provider
+# sensor_type: [name, device_class, async_state_provider]
 SENSOR_TYPES_DOOR = {"door_open": ["Open", "door", _async_retrieve_door_state]}
 
 SENSOR_TYPES_DOORBELL = {

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["py-august==0.12.0"],
+  "requirements": ["py-august==0.14.0"],
   "dependencies": ["configurator"],
   "codeowners": ["@bdraco"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1075,7 +1075,7 @@ pushover_complete==1.1.1
 pwmled==1.4.1
 
 # homeassistant.components.august
-py-august==0.12.0
+py-august==0.14.0
 
 # homeassistant.components.canary
 py-canary==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -391,7 +391,7 @@ pure-python-adb==0.2.2.dev0
 pushbullet.py==0.11.0
 
 # homeassistant.components.august
-py-august==0.12.0
+py-august==0.14.0
 
 # homeassistant.components.canary
 py-canary==0.5.0

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -3,9 +3,28 @@ import datetime
 from unittest.mock import MagicMock, PropertyMock
 
 from august.activity import Activity
+from august.api import Api
+from august.exceptions import AugustApiHTTPError
 
 from homeassistant.components.august import AugustData
+from homeassistant.components.august.lock import AugustLock
 from homeassistant.util import dt
+
+
+class MockAugustApi(Api):
+    """A mock for py-august Api class."""
+
+    def _call_api(self, *args, **kwargs):
+        """Mock the time activity started."""
+        raise AugustApiHTTPError("This should bubble up as its user consumable")
+
+
+class MockAugustApiFailing(MockAugustApi):
+    """A mock for py-august Api class that always has an AugustApiHTTPError."""
+
+    def _call_api(self, *args, **kwargs):
+        """Mock the time activity started."""
+        raise AugustApiHTTPError("This should bubble up as its user consumable")
 
 
 class MockActivity(Activity):
@@ -35,6 +54,37 @@ class MockActivity(Activity):
         return self._action
 
 
+class MockAugustLock(AugustLock):
+    """A mock for august component AugustLock class."""
+
+    def __init__(self, august_data=None):
+        """Init the mock for august component AugustLock class."""
+        self._data = august_data
+        self._lock = _mock_august_lock()
+
+    @property
+    def device_id(self):
+        """Mock device_id."""
+        return "mockdeviceid1"
+
+    @property
+    def device_name(self):
+        """Mock device_name."""
+        return "Mocked Lock 1"
+
+    def _update_lock_status(self, lock_status, activity_start_time_utc):
+        """Mock updating the lock status."""
+        self._data.set_last_lock_status_update_time_utc(
+            self._lock.device_id, activity_start_time_utc
+        )
+        self.last_update_lock_status = {}
+        self.last_update_lock_status["lock_status"] = lock_status
+        self.last_update_lock_status[
+            "activity_start_time_utc"
+        ] = activity_start_time_utc
+        return MagicMock()
+
+
 class MockAugustData(AugustData):
     """A wrapper to mock AugustData."""
 
@@ -42,7 +92,11 @@ class MockAugustData(AugustData):
     # mocking we currently only mock one lockid
 
     def __init__(
-        self, last_lock_status_update_timestamp=1, last_door_state_update_timestamp=1
+        self,
+        last_lock_status_update_timestamp=1,
+        last_door_state_update_timestamp=1,
+        api=MockAugustApi(),
+        access_token="mocked_access_token",
     ):
         """Mock AugustData."""
         self._last_lock_status_update_time_utc = dt.as_utc(
@@ -51,6 +105,9 @@ class MockAugustData(AugustData):
         self._last_door_state_update_time_utc = dt.as_utc(
             datetime.datetime.fromtimestamp(last_lock_status_update_timestamp)
         )
+        self._api = api
+        self._access_token = access_token
+        self._locks = [MockAugustLock()]
 
     def get_last_lock_status_update_time_utc(self, device_id):
         """Mock to get last lock status update time."""

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -7,21 +7,26 @@ from homeassistant.exceptions import HomeAssistantError
 
 from tests.components.august.mocks import (
     MockAugustApiFailing,
-    MockAugustData,
+    MockAugustComponentData,
     _mock_august_authentication,
     _mock_august_authenticator,
+    _mock_august_lock,
 )
 
 
 def test_get_lock_name():
     """Get the lock name from August data."""
-    data = MockAugustData(last_lock_status_update_timestamp=1)
+    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
+    lock = _mock_august_lock()
+    data.set_mocked_locks([lock])
     assert data.get_lock_name("mockdeviceid1") == "Mocked Lock 1"
 
 
 def test_unlock_throws_august_api_http_error():
     """Test unlock."""
-    data = MockAugustData(api=MockAugustApiFailing())
+    data = MockAugustComponentData(api=MockAugustApiFailing())
+    lock = _mock_august_lock()
+    data.set_mocked_locks([lock])
     last_err = None
     try:
         data.unlock("mockdeviceid1")
@@ -34,7 +39,9 @@ def test_unlock_throws_august_api_http_error():
 
 def test_lock_throws_august_api_http_error():
     """Test lock."""
-    data = MockAugustData(api=MockAugustApiFailing())
+    data = MockAugustComponentData(api=MockAugustApiFailing())
+    lock = _mock_august_lock()
+    data.set_mocked_locks([lock])
     last_err = None
     try:
         data.unlock("mockdeviceid1")
@@ -45,7 +52,7 @@ def test_lock_throws_august_api_http_error():
     )
 
 
-def test__refresh_access_token():
+async def test__refresh_access_token(hass):
     """Test refresh of the access token."""
     authentication = _mock_august_authentication("original_token", 1234)
     authenticator = _mock_august_authenticator()

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -3,15 +3,50 @@ import asyncio
 from unittest.mock import MagicMock
 
 from homeassistant.components import august
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.components.august.mocks import (
+    MockAugustApiFailing,
+    MockAugustData,
     _mock_august_authentication,
     _mock_august_authenticator,
 )
 
 
-async def test__refresh_access_token(hass):
-    """Set up things to be run when tests are started."""
+def test_get_lock_name():
+    """Get the lock name from August data."""
+    data = MockAugustData(last_lock_status_update_timestamp=1)
+    assert data.get_lock_name("mockdeviceid1") == "Mocked Lock 1"
+
+
+def test_unlock_throws_august_api_http_error():
+    """Test unlock."""
+    data = MockAugustData(api=MockAugustApiFailing())
+    last_err = None
+    try:
+        data.unlock("mockdeviceid1")
+    except HomeAssistantError as err:
+        last_err = err
+    assert (
+        str(last_err) == "Mocked Lock 1: This should bubble up as its user consumable"
+    )
+
+
+def test_lock_throws_august_api_http_error():
+    """Test lock."""
+    data = MockAugustData(api=MockAugustApiFailing())
+    last_err = None
+    try:
+        data.unlock("mockdeviceid1")
+    except HomeAssistantError as err:
+        last_err = err
+    assert (
+        str(last_err) == "Mocked Lock 1: This should bubble up as its user consumable"
+    )
+
+
+def test__refresh_access_token():
+    """Test refresh of the access token."""
     authentication = _mock_august_authentication("original_token", 1234)
     authenticator = _mock_august_authenticator()
     token_refresh_lock = asyncio.Lock()

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -1,7 +1,6 @@
 """The lock tests for the august platform."""
 
 import datetime
-from unittest.mock import MagicMock
 
 from august.activity import (
     ACTION_LOCK_LOCK,
@@ -10,40 +9,9 @@ from august.activity import (
 )
 from august.lock import LockStatus
 
-from homeassistant.components.august.lock import AugustLock
 from homeassistant.util import dt
 
-from tests.components.august.mocks import (
-    MockActivity,
-    MockAugustData,
-    _mock_august_lock,
-)
-
-
-class MockAugustLock(AugustLock):
-    """A mock for august component AugustLock class."""
-
-    def __init__(self, august_data=None):
-        """Init the mock for august component AugustLock class."""
-        self._data = august_data
-        self._lock = _mock_august_lock()
-
-    @property
-    def device_id(self):
-        """Mock device_id."""
-        return "mockdeviceid1"
-
-    def _update_lock_status(self, lock_status, activity_start_time_utc):
-        """Mock updating the lock status."""
-        self._data.set_last_lock_status_update_time_utc(
-            self._lock.device_id, activity_start_time_utc
-        )
-        self.last_update_lock_status = {}
-        self.last_update_lock_status["lock_status"] = lock_status
-        self.last_update_lock_status[
-            "activity_start_time_utc"
-        ] = activity_start_time_utc
-        return MagicMock()
+from tests.components.august.mocks import MockActivity, MockAugustData, MockAugustLock
 
 
 def test__sync_lock_activity_locked_via_onetouchlock():

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -11,13 +11,20 @@ from august.lock import LockStatus
 
 from homeassistant.util import dt
 
-from tests.components.august.mocks import MockActivity, MockAugustData, MockAugustLock
+from tests.components.august.mocks import (
+    MockActivity,
+    MockAugustComponentData,
+    MockAugustComponentLock,
+    _mock_august_lock,
+)
 
 
 def test__sync_lock_activity_locked_via_onetouchlock():
     """Test _sync_lock_activity locking."""
-    data = MockAugustData(last_lock_status_update_timestamp=1)
-    lock = MockAugustLock(august_data=data)
+    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
+    august_lock = _mock_august_lock()
+    data.set_mocked_locks([august_lock])
+    lock = MockAugustComponentLock(data, august_lock)
     lock_activity_start_timestamp = 1234
     lock_activity = MockActivity(
         action=ACTION_LOCK_ONETOUCHLOCK,
@@ -33,8 +40,10 @@ def test__sync_lock_activity_locked_via_onetouchlock():
 
 def test__sync_lock_activity_locked_via_lock():
     """Test _sync_lock_activity locking."""
-    data = MockAugustData(last_lock_status_update_timestamp=1)
-    lock = MockAugustLock(august_data=data)
+    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
+    august_lock = _mock_august_lock()
+    data.set_mocked_locks([august_lock])
+    lock = MockAugustComponentLock(data, august_lock)
     lock_activity_start_timestamp = 1234
     lock_activity = MockActivity(
         action=ACTION_LOCK_LOCK,
@@ -50,8 +59,10 @@ def test__sync_lock_activity_locked_via_lock():
 
 def test__sync_lock_activity_unlocked():
     """Test _sync_lock_activity unlocking."""
-    data = MockAugustData(last_lock_status_update_timestamp=1)
-    lock = MockAugustLock(august_data=data)
+    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
+    august_lock = _mock_august_lock()
+    data.set_mocked_locks([august_lock])
+    lock = MockAugustComponentLock(data, august_lock)
     lock_activity_timestamp = 1234
     lock_activity = MockActivity(
         action=ACTION_LOCK_UNLOCK,
@@ -67,8 +78,10 @@ def test__sync_lock_activity_unlocked():
 
 def test__sync_lock_activity_ignores_old_data():
     """Test _sync_lock_activity unlocking."""
-    data = MockAugustData(last_lock_status_update_timestamp=1)
-    lock = MockAugustLock(august_data=data)
+    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
+    august_lock = _mock_august_lock()
+    data.set_mocked_locks([august_lock])
+    lock = MockAugustComponentLock(data, august_lock)
     first_lock_activity_timestamp = 1234
     lock_activity = MockActivity(
         action=ACTION_LOCK_UNLOCK,
@@ -84,7 +97,7 @@ def test__sync_lock_activity_ignores_old_data():
     # Now we do the update with an older start time to
     # make sure it ignored
     data.set_last_lock_status_update_time_utc(
-        lock.device_id, dt.as_utc(datetime.datetime.fromtimestamp(1000))
+        august_lock.device_id, dt.as_utc(datetime.datetime.fromtimestamp(1000))
     )
     lock_activity_timestamp = 2
     lock_activity = MockActivity(


### PR DESCRIPTION
This fixes #26672

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Provide user consumable errors when lock operations fail

Example: "Failed to call service lock/lock. Door: The operation failed because the bridge (connect) is offline."

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26672
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
