### PR TITLE
Add POD support, sleep fitness sensor to EightSleep

### DIFF
--- a/homeassistant/components/eight_sleep/__init__.py
+++ b/homeassistant/components/eight_sleep/__init__.py
@@ -59,8 +59,14 @@ NAME_MAP = {
     "room_temp": "Room Temperature",
 }
 
-SENSORS = ["current_sleep", "current_sleep_fitness", "last_sleep",
-           "bed_state", "bed_temp", "sleep_stage"]
+SENSORS = [
+    "current_sleep",
+    "current_sleep_fitness",
+    "last_sleep",
+    "bed_state",
+    "bed_temp",
+    "sleep_stage",
+]
 
 SERVICE_HEAT_SET = "heat_set"
 

--- a/homeassistant/components/eight_sleep/__init__.py
+++ b/homeassistant/components/eight_sleep/__init__.py
@@ -43,12 +43,14 @@ SIGNAL_UPDATE_USER = "eight_user_update"
 
 NAME_MAP = {
     "left_current_sleep": "Left Sleep Session",
+    "left_current_sleep_fitness": "Left Sleep Fitness",
     "left_last_sleep": "Left Previous Sleep Session",
     "left_bed_state": "Left Bed State",
     "left_presence": "Left Bed Presence",
     "left_bed_temp": "Left Bed Temperature",
     "left_sleep_stage": "Left Sleep Stage",
     "right_current_sleep": "Right Sleep Session",
+    "right_current_sleep_fitness": "Right Sleep Fitness",
     "right_last_sleep": "Right Previous Sleep Session",
     "right_bed_state": "Right Bed State",
     "right_presence": "Right Bed Presence",
@@ -57,14 +59,15 @@ NAME_MAP = {
     "room_temp": "Room Temperature",
 }
 
-SENSORS = ["current_sleep", "last_sleep", "bed_state", "bed_temp", "sleep_stage"]
+SENSORS = ["current_sleep", "current_sleep_fitness", "last_sleep",
+           "bed_state", "bed_temp", "sleep_stage"]
 
 SERVICE_HEAT_SET = "heat_set"
 
 ATTR_TARGET_HEAT = "target"
 ATTR_HEAT_DURATION = "duration"
 
-VALID_TARGET_HEAT = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=100))
+VALID_TARGET_HEAT = vol.All(vol.Coerce(int), vol.Clamp(min=-100, max=100))
 VALID_DURATION = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=28800))
 
 SERVICE_EIGHT_SCHEMA = vol.Schema(
@@ -101,7 +104,7 @@ async def async_setup(hass, config):
         _LOGGER.error("Timezone is not set in Home Assistant.")
         return False
 
-    timezone = hass.config.time_zone
+    timezone = str(hass.config.time_zone)
 
     eight = EightSleep(user, password, timezone, partner, None, hass.loop)
 

--- a/homeassistant/components/eight_sleep/manifest.json
+++ b/homeassistant/components/eight_sleep/manifest.json
@@ -2,7 +2,7 @@
   "domain": "eight_sleep",
   "name": "Eight Sleep",
   "documentation": "https://www.home-assistant.io/integrations/eight_sleep",
-  "requirements": ["pyeight==0.1.2"],
+  "requirements": ["pyeight==0.1.3"],
   "dependencies": [],
   "codeowners": ["@mezz64"]
 }

--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -28,6 +28,11 @@ ATTR_ACTIVE_HEAT = "Heating Active"
 ATTR_DURATION_HEAT = "Heating Time Remaining"
 ATTR_PROCESSING = "Processing"
 ATTR_SESSION_START = "Session Start"
+ATTR_FIT_DATE = "Fitness Date"
+ATTR_FIT_DURATION_SCORE = "Fitness Duration Score"
+ATTR_FIT_ASLEEP_SCORE = "Fitness Asleep Score"
+ATTR_FIT_OUT_SCORE = "Fitness Out-of-Bed Score"
+ATTR_FIT_WAKEUP_SCORE = "Fitness Wakeup Score"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -151,7 +156,11 @@ class EightUserSensor(EightSleepUserEntity):
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        if "current_sleep" in self._sensor or "last_sleep" in self._sensor:
+        if (
+            "current_sleep" in self._sensor
+            or "last_sleep" in self._sensor
+            or "current_sleep_fitness" in self._sensor
+        ):
             return "Score"
         if "bed_temp" in self._sensor:
             if self._units == "si":
@@ -169,8 +178,12 @@ class EightUserSensor(EightSleepUserEntity):
         """Retrieve latest state."""
         _LOGGER.debug("Updating User sensor: %s", self._sensor)
         if "current" in self._sensor:
-            self._state = self._usrobj.current_sleep_score
-            self._attr = self._usrobj.current_values
+            if "fitness" in self._sensor:
+                self._state = self._usrobj.current_sleep_fitness_score
+                self._attr = self._usrobj.current_fitness_values
+            else:
+                self._state = self._usrobj.current_sleep_score
+                self._attr = self._usrobj.current_values
         elif "last" in self._sensor:
             self._state = self._usrobj.last_sleep_score
             self._attr = self._usrobj.last_values
@@ -192,6 +205,14 @@ class EightUserSensor(EightSleepUserEntity):
         if self._attr is None:
             # Skip attributes if sensor type doesn't support
             return None
+
+        if "fitness" in self._sensor_root:
+            state_attr = {ATTR_FIT_DATE: self._attr["date"]}
+            state_attr[ATTR_FIT_DURATION_SCORE] = self._attr["duration"]
+            state_attr[ATTR_FIT_ASLEEP_SCORE] = self._attr["asleep"]
+            state_attr[ATTR_FIT_OUT_SCORE] = self._attr["out"]
+            state_attr[ATTR_FIT_WAKEUP_SCORE] = self._attr["wakeup"]
+            return state_attr
 
         state_attr = {ATTR_SESSION_START: self._attr["date"]}
         state_attr[ATTR_TNT] = self._attr["tnt"]

--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -207,11 +207,13 @@ class EightUserSensor(EightSleepUserEntity):
             return None
 
         if "fitness" in self._sensor_root:
-            state_attr = {ATTR_FIT_DATE: self._attr["date"]}
-            state_attr[ATTR_FIT_DURATION_SCORE] = self._attr["duration"]
-            state_attr[ATTR_FIT_ASLEEP_SCORE] = self._attr["asleep"]
-            state_attr[ATTR_FIT_OUT_SCORE] = self._attr["out"]
-            state_attr[ATTR_FIT_WAKEUP_SCORE] = self._attr["wakeup"]
+            state_attr = {
+                ATTR_FIT_DATE: self._attr["date"],
+                ATTR_FIT_DURATION_SCORE: self._attr["duration"],
+                ATTR_FIT_ASLEEP_SCORE: self._attr["asleep"],
+                ATTR_FIT_OUT_SCORE: self._attr["out"],
+                ATTR_FIT_WAKEUP_SCORE: self._attr["wakeup"],
+            }
             return state_attr
 
         state_attr = {ATTR_SESSION_START: self._attr["date"]}

--- a/homeassistant/components/eight_sleep/services.yaml
+++ b/homeassistant/components/eight_sleep/services.yaml
@@ -1,6 +1,6 @@
 heat_set:
-  description: Set heating level for eight sleep.
+  description: Set heating/cooling level for eight sleep.
   fields:
-    duration: {description: Duration to heat at the target level in seconds., example: 3600}
+    duration: {description: Duration to heat/cool at the target level in seconds., example: 3600}
     entity_id: {description: Entity id of the bed state to adjust., example: sensor.eight_left_bed_state}
-    target: {description: Target heating level from 0-100., example: 35}
+    target: {description: Target cooling/heating level from -100 to 100., example: 35}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1225,7 +1225,7 @@ pyeconet==0.0.11
 pyedimax==0.2.1
 
 # homeassistant.components.eight_sleep
-pyeight==0.1.2
+pyeight==0.1.3
 
 # homeassistant.components.emby
 pyemby==1.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Update eight sleep component to support cooling on the POD mattress and add a new sensor to show new sleep fitness scores.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
eight_sleep:
  username: "user@email.com"
  password: "password"
  partner: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/12105

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
