### PR TITLE
Hue Group features based on the bulbs in it

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -6,7 +6,6 @@ import logging
 import random
 
 import aiohue
-from aiohue.groups import Groups
 import async_timeout
 
 from homeassistant.components.light import (
@@ -73,6 +72,21 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
+def create_light(item_class, coordinator, bridge, is_group, api, item_id):
+    """Create the light."""
+    if is_group:
+        supported_features = 0
+        for light_id in api[item_id].lights:
+            if light_id not in bridge.api.lights:
+                continue
+            light = bridge.api.lights[light_id]
+            supported_features |= SUPPORT_HUE.get(light.type, SUPPORT_HUE_EXTENDED)
+        supported_features = supported_features or SUPPORT_HUE_EXTENDED
+    else:
+        supported_features = SUPPORT_HUE.get(api[item_id].type, SUPPORT_HUE_EXTENDED)
+    return item_class(coordinator, bridge, is_group, api[item_id], supported_features)
+
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Hue lights from a config entry."""
     bridge = hass.data[HUE_DOMAIN][config_entry.entry_id]
@@ -101,7 +115,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         bridge.api.lights,
         {},
         async_add_entities,
-        partial(HueLight, light_coordinator, bridge, False),
+        partial(create_light, HueLight, light_coordinator, bridge, False),
     )
 
     # We add a listener after fetching the data, so manually trigger listener
@@ -139,7 +153,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         bridge.api.groups,
         {},
         async_add_entities,
-        partial(HueLight, group_coordinator, bridge, True),
+        partial(create_light, HueLight, group_coordinator, bridge, True),
     )
 
     group_coordinator.async_add_listener(update_groups)
@@ -171,19 +185,7 @@ def async_update_items(bridge, api, current, async_add_entities, create_item):
         if item_id in current:
             continue
 
-        if isinstance(api, Groups):
-            supported_features = 0
-            for light_id in api[item_id].lights:
-                if light_id not in bridge.api.lights:
-                    continue
-                light = bridge.api.lights[light_id]
-                supported_features |= SUPPORT_HUE.get(light.type, SUPPORT_HUE_EXTENDED)
-            supported_features = supported_features or SUPPORT_HUE_EXTENDED
-        else:
-            supported_features = SUPPORT_HUE.get(
-                api[item_id].type, SUPPORT_HUE_EXTENDED
-            )
-        current[item_id] = create_item(api[item_id], supported_features)
+        current[item_id] = create_item(api, item_id)
         new_items.append(current[item_id])
 
     bridge.hass.async_create_task(remove_devices(bridge, api, current))
@@ -195,14 +197,7 @@ def async_update_items(bridge, api, current, async_add_entities, create_item):
 class HueLight(Light):
     """Representation of a Hue light."""
 
-    def __init__(
-        self,
-        coordinator,
-        bridge,
-        is_group,
-        light,
-        supported_features=SUPPORT_HUE_EXTENDED,
-    ):
+    def __init__(self, coordinator, bridge, is_group, light, supported_features):
         """Initialize the light."""
         self.light = light
         self.coordinator = coordinator

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -788,3 +788,185 @@ def test_hs_color():
     )
 
     assert light.hs_color == color.color_xy_to_hs(0.4, 0.5, LIGHT_GAMUT)
+
+
+async def test_group_features(hass, mock_bridge):
+    """Test group features."""
+
+    color_temp_type = "Color temperature light"
+    extended_color_type = "Extended color light"
+
+    group_response = {
+        "1": {
+            "name": "Group 1",
+            "lights": ["1", "2"],
+            "type": "Room",
+            "action": {
+                "on": True,
+                "bri": 254,
+                "hue": 10000,
+                "sat": 254,
+                "effect": "none",
+                "xy": [0.5, 0.5],
+                "ct": 250,
+                "alert": "select",
+                "colormode": "ct",
+            },
+            "state": {"any_on": True, "all_on": False},
+        },
+        "2": {
+            "name": "Group 2",
+            "lights": ["3", "4"],
+            "type": "Room",
+            "action": {
+                "on": True,
+                "bri": 153,
+                "hue": 4345,
+                "sat": 254,
+                "effect": "none",
+                "xy": [0.5, 0.5],
+                "ct": 250,
+                "alert": "select",
+                "colormode": "ct",
+            },
+            "state": {"any_on": True, "all_on": False},
+        },
+        "3": {
+            "name": "Group 3",
+            "lights": ["1", "3"],
+            "type": "Room",
+            "action": {
+                "on": True,
+                "bri": 153,
+                "hue": 4345,
+                "sat": 254,
+                "effect": "none",
+                "xy": [0.5, 0.5],
+                "ct": 250,
+                "alert": "select",
+                "colormode": "ct",
+            },
+            "state": {"any_on": True, "all_on": False},
+        },
+    }
+
+    light_1 = {
+        "state": {
+            "on": True,
+            "bri": 144,
+            "ct": 467,
+            "alert": "none",
+            "effect": "none",
+            "reachable": True,
+        },
+        "capabilities": {
+            "control": {
+                "colorgamuttype": "A",
+                "colorgamut": [[0.704, 0.296], [0.2151, 0.7106], [0.138, 0.08]],
+            }
+        },
+        "type": color_temp_type,
+        "name": "Hue Lamp 1",
+        "modelid": "LCT001",
+        "swversion": "66009461",
+        "manufacturername": "Philips",
+        "uniqueid": "456",
+    }
+    light_2 = {
+        "state": {
+            "on": False,
+            "bri": 0,
+            "ct": 0,
+            "alert": "none",
+            "effect": "none",
+            "colormode": "xy",
+            "reachable": True,
+        },
+        "capabilities": {
+            "control": {
+                "colorgamuttype": "A",
+                "colorgamut": [[0.704, 0.296], [0.2151, 0.7106], [0.138, 0.08]],
+            }
+        },
+        "type": color_temp_type,
+        "name": "Hue Lamp 2",
+        "modelid": "LCT001",
+        "swversion": "66009461",
+        "manufacturername": "Philips",
+        "uniqueid": "456",
+    }
+    light_3 = {
+        "state": {
+            "on": False,
+            "bri": 0,
+            "hue": 0,
+            "sat": 0,
+            "xy": [0, 0],
+            "ct": 0,
+            "alert": "none",
+            "effect": "none",
+            "colormode": "hs",
+            "reachable": True,
+        },
+        "capabilities": {
+            "control": {
+                "colorgamuttype": "A",
+                "colorgamut": [[0.704, 0.296], [0.2151, 0.7106], [0.138, 0.08]],
+            }
+        },
+        "type": extended_color_type,
+        "name": "Hue Lamp 3",
+        "modelid": "LCT001",
+        "swversion": "66009461",
+        "manufacturername": "Philips",
+        "uniqueid": "123",
+    }
+    light_4 = {
+        "state": {
+            "on": True,
+            "bri": 100,
+            "hue": 13088,
+            "sat": 210,
+            "xy": [0.5, 0.4],
+            "ct": 420,
+            "alert": "none",
+            "effect": "none",
+            "colormode": "hs",
+            "reachable": True,
+        },
+        "capabilities": {
+            "control": {
+                "colorgamuttype": "A",
+                "colorgamut": [[0.704, 0.296], [0.2151, 0.7106], [0.138, 0.08]],
+            }
+        },
+        "type": extended_color_type,
+        "name": "Hue Lamp 4",
+        "modelid": "LCT001",
+        "swversion": "66009461",
+        "manufacturername": "Philips",
+        "uniqueid": "123",
+    }
+    light_response = {
+        "1": light_1,
+        "2": light_2,
+        "3": light_3,
+        "4": light_4,
+    }
+
+    mock_bridge.allow_groups = True
+    mock_bridge.mock_light_responses.append(light_response)
+    mock_bridge.mock_group_responses.append(group_response)
+    await setup_bridge(hass, mock_bridge)
+
+    color_temp_feature = hue_light.SUPPORT_HUE["Color temperature light"]
+    extended_color_feature = hue_light.SUPPORT_HUE["Extended color light"]
+
+    group_1 = hass.states.get("light.group_1")
+    assert group_1.attributes["supported_features"] == color_temp_feature
+
+    group_2 = hass.states.get("light.group_2")
+    assert group_2.attributes["supported_features"] == extended_color_feature
+
+    group_3 = hass.states.get("light.group_3")
+    assert group_3.attributes["supported_features"] == extended_color_feature

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -706,6 +706,7 @@ def test_available():
         coordinator=Mock(last_update_success=True),
         bridge=Mock(allow_unreachable=False),
         is_group=False,
+        supported_features=hue_light.SUPPORT_HUE_EXTENDED,
     )
 
     assert light.available is False
@@ -720,6 +721,7 @@ def test_available():
         coordinator=Mock(last_update_success=True),
         bridge=Mock(allow_unreachable=True),
         is_group=False,
+        supported_features=hue_light.SUPPORT_HUE_EXTENDED,
     )
 
     assert light.available is True
@@ -734,6 +736,7 @@ def test_available():
         coordinator=Mock(last_update_success=True),
         bridge=Mock(allow_unreachable=False),
         is_group=True,
+        supported_features=hue_light.SUPPORT_HUE_EXTENDED,
     )
 
     assert light.available is True
@@ -751,6 +754,7 @@ def test_hs_color():
         coordinator=Mock(last_update_success=True),
         bridge=Mock(),
         is_group=False,
+        supported_features=hue_light.SUPPORT_HUE_EXTENDED,
     )
 
     assert light.hs_color is None
@@ -765,6 +769,7 @@ def test_hs_color():
         coordinator=Mock(last_update_success=True),
         bridge=Mock(),
         is_group=False,
+        supported_features=hue_light.SUPPORT_HUE_EXTENDED,
     )
 
     assert light.hs_color is None
@@ -779,6 +784,7 @@ def test_hs_color():
         coordinator=Mock(last_update_success=True),
         bridge=Mock(),
         is_group=False,
+        supported_features=hue_light.SUPPORT_HUE_EXTENDED,
     )
 
     assert light.hs_color == color.color_xy_to_hs(0.4, 0.5, LIGHT_GAMUT)


### PR DESCRIPTION
Computes the features of a hue group as the union of the features of the bulbs in the group.

Home assistant threats groups of bulbs create on the hue app as if all the bulbs in it had all possible features (brightness, color temperature and color, etc...), even if the group is only composed by simpler bulbs.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
May break scripts that relay on information of bulb groups that might no longer exist. For instance, information about color of a group that does not have any bulb that supports color. This informations must be removed from the script.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the way the feature of a group is computed, by calculating the feature of a group as the union of the features of the bulbs in the group. As such, a group composed by bulbs that only have brightness and color temperature control (as the hue ambiance bulbs) will only display these options in the user interface. Simplifying the interface by remove unsupported features.

This change is specially important for the homekit integration. In the Home App, a group of bulbs containing only hue ambiance bulbs would had shown the color option as well, since the ambiance bulbs have no color option, it would ignore the color changes made through the Home App, making it not possible to change even the color temperature of the light (a feature that the hue ambiance bulbs do support).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This might be related to issue #31784.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
