### PR TITLE
Get pending iCloud devices when available + request again when needs an update

### DIFF
--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -123,10 +123,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         hass, username, password, icloud_dir, max_interval, gps_accuracy_threshold,
     )
     await hass.async_add_executor_job(account.setup)
-    if not account.devices:
-        return False
 
-    hass.data[DOMAIN][username] = account
+    hass.data[DOMAIN][entry.unique_id] = account
 
     for platform in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/icloud/const.py
+++ b/homeassistant/components/icloud/const.py
@@ -1,7 +1,6 @@
 """iCloud component constants."""
 
 DOMAIN = "icloud"
-SERVICE_UPDATE = f"{DOMAIN}_update"
 
 CONF_MAX_INTERVAL = "max_interval"
 CONF_GPS_ACCURACY_THRESHOLD = "gps_accuracy_threshold"

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -5,17 +5,16 @@ from typing import Dict
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .account import IcloudDevice
+from .account import IcloudAccount, IcloudDevice
 from .const import (
     DEVICE_LOCATION_HORIZONTAL_ACCURACY,
     DEVICE_LOCATION_LATITUDE,
     DEVICE_LOCATION_LONGITUDE,
     DOMAIN,
-    SERVICE_UPDATE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,25 +29,45 @@ async def async_setup_scanner(
 
 async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
-):
-    """Configure a dispatcher connection based on a config entry."""
-    username = entry.data[CONF_USERNAME]
+) -> None:
+    """Set up device tracker for iCloud component."""
+    account = hass.data[DOMAIN][entry.unique_id]
+    tracked = set()
 
-    for device in hass.data[DOMAIN][username].devices.values():
-        if device.location is None:
-            _LOGGER.debug("No position found for %s", device.name)
+    @callback
+    def update_account():
+        """Update the values of the account."""
+        add_entities(account, async_add_entities, tracked)
+
+    account.listeners.append(
+        async_dispatcher_connect(hass, account.signal_device_new, update_account)
+    )
+
+    update_account()
+
+
+@callback
+def add_entities(account, async_add_entities, tracked):
+    """Add new tracker entities from the account."""
+    new_tracked = []
+
+    for dev_id, device in account.devices.items():
+        if dev_id in tracked or device.location is None:
             continue
 
-        _LOGGER.debug("Adding device_tracker for %s", device.name)
+        new_tracked.append(IcloudTrackerEntity(account, device))
+        tracked.add(dev_id)
 
-        async_add_entities([IcloudTrackerEntity(device)])
+    if new_tracked:
+        async_add_entities(new_tracked, True)
 
 
 class IcloudTrackerEntity(TrackerEntity):
     """Represent a tracked device."""
 
-    def __init__(self, device: IcloudDevice):
+    def __init__(self, account: IcloudAccount, device: IcloudDevice):
         """Set up the iCloud tracker entity."""
+        self._account = account
         self._device = device
         self._unsub_dispatcher = None
 
@@ -115,7 +134,7 @@ class IcloudTrackerEntity(TrackerEntity):
     async def async_added_to_hass(self):
         """Register state update callback."""
         self._unsub_dispatcher = async_dispatcher_connect(
-            self.hass, SERVICE_UPDATE, self.async_write_ha_state
+            self.hass, self._account.signal_device_update, self.async_write_ha_state
         )
 
     async def async_will_remove_from_hass(self):

--- a/homeassistant/components/icloud/sensor.py
+++ b/homeassistant/components/icloud/sensor.py
@@ -3,14 +3,15 @@ import logging
 from typing import Dict
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_USERNAME, DEVICE_CLASS_BATTERY, UNIT_PERCENTAGE
+from homeassistant.const import DEVICE_CLASS_BATTERY, UNIT_PERCENTAGE
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .account import IcloudDevice
-from .const import DOMAIN, SERVICE_UPDATE
+from .account import IcloudAccount, IcloudDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,23 +19,44 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:
-    """Set up iCloud devices sensors based on a config entry."""
-    username = entry.data[CONF_USERNAME]
+    """Set up device tracker for iCloud component."""
+    account = hass.data[DOMAIN][entry.unique_id]
+    tracked = set()
 
-    entities = []
-    for device in hass.data[DOMAIN][username].devices.values():
-        if device.battery_level is not None:
-            _LOGGER.debug("Adding battery sensor for %s", device.name)
-            entities.append(IcloudDeviceBatterySensor(device))
+    @callback
+    def update_account():
+        """Update the values of the account."""
+        add_entities(account, async_add_entities, tracked)
 
-    async_add_entities(entities, True)
+    account.listeners.append(
+        async_dispatcher_connect(hass, account.signal_device_new, update_account)
+    )
+
+    update_account()
+
+
+@callback
+def add_entities(account, async_add_entities, tracked):
+    """Add new tracker entities from the account."""
+    new_tracked = []
+
+    for dev_id, device in account.devices.items():
+        if dev_id in tracked or device.battery_level is None:
+            continue
+
+        new_tracked.append(IcloudDeviceBatterySensor(account, device))
+        tracked.add(dev_id)
+
+    if new_tracked:
+        async_add_entities(new_tracked, True)
 
 
 class IcloudDeviceBatterySensor(Entity):
     """Representation of a iCloud device battery sensor."""
 
-    def __init__(self, device: IcloudDevice):
+    def __init__(self, account: IcloudAccount, device: IcloudDevice):
         """Initialize the battery sensor."""
+        self._account = account
         self._device = device
         self._unsub_dispatcher = None
 
@@ -94,7 +116,7 @@ class IcloudDeviceBatterySensor(Entity):
     async def async_added_to_hass(self):
         """Register state update callback."""
         self._unsub_dispatcher = async_dispatcher_connect(
-            self.hass, SERVICE_UPDATE, self.async_write_ha_state
+            self.hass, self._account.signal_device_update, self.async_write_ha_state
         )
 
     async def async_will_remove_from_hass(self):


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fetch devices again when retrieved devices are in pending status + add devices that was not added at first setup because can't be reached (most of the time : off laptop or family devices).

It is actually causing a bug while battery status and location are not updated for hours (thanks to less fetching the iCloud API) !!!

Screenshot in the issue : #32303

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32303
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
