### PR TITLE
Bump simplisafe-python to 8.1.1

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -1,12 +1,8 @@
 """Support for SimpliSafe alarm systems."""
 import asyncio
-from dataclasses import InitVar, asdict, dataclass, field
-from datetime import datetime
 import logging
-from typing import Optional
 
 from simplipy import API
-from simplipy.entity import EntityTypes
 from simplipy.errors import InvalidCredentialsError, SimplipyError, WebsocketError
 from simplipy.websocket import (
     EVENT_CAMERA_MOTION_DETECTED,
@@ -15,7 +11,6 @@ from simplipy.websocket import (
     EVENT_LOCK_LOCKED,
     EVENT_LOCK_UNLOCKED,
     EVENT_MOTION_DETECTED,
-    get_event_type_from_payload,
 )
 import voluptuous as vol
 
@@ -38,7 +33,6 @@ from homeassistant.helpers.service import (
     async_register_admin_service,
     verify_domain_control,
 )
-from homeassistant.util.dt import utc_from_timestamp
 
 from .config_flow import configured_instances
 from .const import (
@@ -77,10 +71,14 @@ WEBSOCKET_EVENTS_TO_TRIGGER_HASS_EVENT = [
     EVENT_MOTION_DETECTED,
 ]
 
+ATTR_LAST_EVENT_CHANGED_BY = "last_event_changed_by"
 ATTR_LAST_EVENT_INFO = "last_event_info"
 ATTR_LAST_EVENT_SENSOR_NAME = "last_event_sensor_name"
+ATTR_LAST_EVENT_SENSOR_SERIAL = "last_event_sensor_serial"
 ATTR_LAST_EVENT_SENSOR_TYPE = "last_event_sensor_type"
 ATTR_LAST_EVENT_TIMESTAMP = "last_event_timestamp"
+ATTR_LAST_EVENT_TYPE = "last_event_type"
+ATTR_LAST_EVENT_TYPE = "last_event_type"
 ATTR_PIN_LABEL = "label"
 ATTR_PIN_LABEL_OR_VALUE = "label_or_pin"
 ATTR_PIN_VALUE = "pin"
@@ -317,46 +315,6 @@ async def async_unload_entry(hass, entry):
     return True
 
 
-@dataclass(frozen=True)
-class SimpliSafeWebsocketEvent:
-    """Define a representation of a parsed websocket event."""
-
-    event_data: InitVar[dict]
-
-    changed_by: Optional[str] = field(init=False)
-    event_type: Optional[str] = field(init=False)
-    info: str = field(init=False)
-    sensor_name: str = field(init=False)
-    sensor_serial: str = field(init=False)
-    sensor_type: EntityTypes = field(init=False)
-    system_id: int = field(init=False)
-    timestamp: datetime = field(init=False)
-
-    def __post_init__(self, event_data):
-        """Initialize."""
-        object.__setattr__(self, "changed_by", event_data["pinName"])
-        object.__setattr__(self, "event_type", get_event_type_from_payload(event_data))
-        object.__setattr__(self, "info", event_data["info"])
-        object.__setattr__(self, "sensor_name", event_data["sensorName"])
-        object.__setattr__(self, "sensor_serial", event_data["sensorSerial"])
-        try:
-            object.__setattr__(
-                self, "sensor_type", EntityTypes(event_data["sensorType"]).name
-            )
-        except ValueError:
-            _LOGGER.warning(
-                'Encountered unknown entity type: %s ("%s"). Please report it at'
-                "https://github.com/home-assistant/home-assistant/issues.",
-                event_data["sensorType"],
-                event_data["sensorName"],
-            )
-            object.__setattr__(self, "sensor_type", None)
-        object.__setattr__(self, "system_id", event_data["sid"])
-        object.__setattr__(
-            self, "timestamp", utc_from_timestamp(event_data["eventTimestamp"])
-        )
-
-
 class SimpliSafeWebsocket:
     """Define a SimpliSafe websocket "manager" object."""
 
@@ -410,15 +368,11 @@ class SimpliSafeWebsocket:
         """Define a handler to fire when the websocket is disconnected."""
         _LOGGER.info("Disconnected from websocket")
 
-    def _on_event(self, data):
+    def _on_event(self, event):
         """Define a handler to fire when a new SimpliSafe event arrives."""
-        event = SimpliSafeWebsocketEvent(data)
         _LOGGER.debug("New websocket event: %s", event)
-        self.last_events[data["sid"]] = event
-        async_dispatcher_send(self._hass, TOPIC_UPDATE.format(data["sid"]))
-
-        if event.event_type in WEBSOCKET_EVENTS_TO_TRIGGER_HASS_EVENT:
-            self._hass.bus.async_fire(EVENT_SIMPLISAFE_EVENT, event_data=asdict(event))
+        self.last_events[event.system_id] = event
+        async_dispatcher_send(self._hass, TOPIC_UPDATE.format(event.system_id))
 
         _LOGGER.debug("Resetting websocket watchdog")
         self._websocket_watchdog_listener()
@@ -426,6 +380,28 @@ class SimpliSafeWebsocket:
             self._hass, DEFAULT_WATCHDOG_SECONDS, self._async_websocket_reconnect
         )
         self._websocket_reconnect_delay = DEFAULT_SOCKET_MIN_RETRY
+
+        if event.event_type not in WEBSOCKET_EVENTS_TO_TRIGGER_HASS_EVENT:
+            return
+
+        if event.sensor_type:
+            sensor_type = event.sensor_type.name
+        else:
+            sensor_type = None
+
+        self._hass.bus.async_fire(
+            EVENT_SIMPLISAFE_EVENT,
+            event_data={
+                ATTR_LAST_EVENT_CHANGED_BY: event.changed_by,
+                ATTR_LAST_EVENT_TYPE: event.event_type,
+                ATTR_LAST_EVENT_INFO: event.info,
+                ATTR_LAST_EVENT_SENSOR_NAME: event.sensor_name,
+                ATTR_LAST_EVENT_SENSOR_SERIAL: event.sensor_serial,
+                ATTR_LAST_EVENT_SENSOR_TYPE: sensor_type,
+                ATTR_SYSTEM_ID: event.system_id,
+                ATTR_LAST_EVENT_TIMESTAMP: event.timestamp,
+            },
+        )
 
     async def async_websocket_connect(self):
         """Register handlers and connect to the websocket."""
@@ -669,11 +645,17 @@ class SimpliSafeEntity(Entity):
             return
 
         self._last_processed_websocket_event = last_websocket_event
+
+        if last_websocket_event.sensor_type:
+            sensor_type = last_websocket_event.sensor_type.name
+        else:
+            sensor_type = None
+
         self._attrs.update(
             {
                 ATTR_LAST_EVENT_INFO: last_websocket_event.info,
                 ATTR_LAST_EVENT_SENSOR_NAME: last_websocket_event.sensor_name,
-                ATTR_LAST_EVENT_SENSOR_TYPE: last_websocket_event.sensor_type,
+                ATTR_LAST_EVENT_SENSOR_TYPE: sensor_type,
                 ATTR_LAST_EVENT_TIMESTAMP: last_websocket_event.timestamp,
             }
         )

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==7.3.0"],
+  "requirements": ["simplisafe-python==8.1.1"],
   "dependencies": [],
   "codeowners": ["@bachya"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1830,7 +1830,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==7.3.0
+simplisafe-python==8.1.1
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -623,7 +623,7 @@ sentry-sdk==0.13.5
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==7.3.0
+simplisafe-python==8.1.1
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `simplisafe-python` to 8.1.1. This moves handling of the websocket `dataclass` into the library itself (so that HASS doesn't have to worry about it).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
