### PR TITLE
Add shutter group to HomematicIP Cloud

### DIFF
--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -205,3 +205,139 @@ async def test_hmip_garage_door_tormatic(hass, default_mock_hap_factory):
     assert len(hmip_device.mock_calls) == service_call_counter + 5
     assert hmip_device.mock_calls[-1][0] == "send_door_command"
     assert hmip_device.mock_calls[-1][1] == (DoorCommand.STOP,)
+
+
+async def test_hmip_cover_shutter_group(hass, default_mock_hap_factory):
+    """Test HomematicipCoverShutteGroup."""
+    entity_id = "cover.rollos_shuttergroup"
+    entity_name = "Rollos ShutterGroup"
+    device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(test_groups=["Rollos"])
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+
+    assert ha_state.state == "closed"
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
+    service_call_counter = len(hmip_device.mock_calls)
+
+    await hass.services.async_call(
+        "cover", "open_cover", {"entity_id": entity_id}, blocking=True
+    )
+    assert len(hmip_device.mock_calls) == service_call_counter + 1
+    assert hmip_device.mock_calls[-1][0] == "set_shutter_level"
+    assert hmip_device.mock_calls[-1][1] == (0,)
+    await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_OPEN
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": entity_id, "position": "50"},
+        blocking=True,
+    )
+    assert len(hmip_device.mock_calls) == service_call_counter + 3
+    assert hmip_device.mock_calls[-1][0] == "set_shutter_level"
+    assert hmip_device.mock_calls[-1][1] == (0.5,)
+    await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0.5)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_OPEN
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
+
+    await hass.services.async_call(
+        "cover", "close_cover", {"entity_id": entity_id}, blocking=True
+    )
+    assert len(hmip_device.mock_calls) == service_call_counter + 5
+    assert hmip_device.mock_calls[-1][0] == "set_shutter_level"
+    assert hmip_device.mock_calls[-1][1] == (1,)
+    await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 1)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_CLOSED
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
+
+    await hass.services.async_call(
+        "cover", "stop_cover", {"entity_id": entity_id}, blocking=True
+    )
+    assert len(hmip_device.mock_calls) == service_call_counter + 7
+    assert hmip_device.mock_calls[-1][0] == "set_shutter_stop"
+    assert hmip_device.mock_calls[-1][1] == ()
+
+    await async_manipulate_test_data(hass, hmip_device, "shutterLevel", None)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_UNKNOWN
+
+
+async def test_hmip_cover_slats_group(hass, default_mock_hap_factory):
+    """Test slats with HomematicipCoverShutteGroup."""
+    entity_id = "cover.rollos_shuttergroup"
+    entity_name = "Rollos ShutterGroup"
+    device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(test_groups=["Rollos"])
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+    await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1)
+    ha_state = hass.states.get(entity_id)
+
+    assert ha_state.state == STATE_CLOSED
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
+    assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
+    service_call_counter = len(hmip_device.mock_calls)
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": entity_id, "position": "50"},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        "cover", "open_cover_tilt", {"entity_id": entity_id}, blocking=True
+    )
+
+    assert len(hmip_device.mock_calls) == service_call_counter + 2
+    assert hmip_device.mock_calls[-1][0] == "set_slats_level"
+    assert hmip_device.mock_calls[-1][1] == (0,)
+    await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0.5)
+    await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_OPEN
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
+    assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_tilt_position",
+        {"entity_id": entity_id, "tilt_position": "50"},
+        blocking=True,
+    )
+    assert len(hmip_device.mock_calls) == service_call_counter + 5
+    assert hmip_device.mock_calls[-1][0] == "set_slats_level"
+    assert hmip_device.mock_calls[-1][1] == (0.5,)
+    await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0.5)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_OPEN
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
+    assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
+
+    await hass.services.async_call(
+        "cover", "close_cover_tilt", {"entity_id": entity_id}, blocking=True
+    )
+    assert len(hmip_device.mock_calls) == service_call_counter + 7
+    assert hmip_device.mock_calls[-1][0] == "set_slats_level"
+    assert hmip_device.mock_calls[-1][1] == (1,)
+    await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_OPEN
+    assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
+    assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
+
+    await hass.services.async_call(
+        "cover", "stop_cover_tilt", {"entity_id": entity_id}, blocking=True
+    )
+    assert len(hmip_device.mock_calls) == service_call_counter + 9
+    assert hmip_device.mock_calls[-1][0] == "set_shutter_stop"
+    assert hmip_device.mock_calls[-1][1] == ()


### PR DESCRIPTION
## Proposed change
Add shutter group to HomematicIP Cloud


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
