### PR TITLE
Fix overdue filter replacement in vallox ventilation

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -121,12 +121,15 @@ async def async_setup(hass, config):
     # The vallox hardware expects quite strict timings for websocket
     # requests. Timings that machines with less processing power, like
     # Raspberries, cannot live up to during the busy start phase of Home
-    # Asssistant. Hence, async_add_entities() for fan and sensor in respective
-    # code will be called with update_before_add=False to intentionally delay
-    # the first request, increasing chance that it is issued only when the
-    # machine is less busy again.
+    # Assistant. Hence, async_add_entities() for fan, sensor and binary sensor
+    # in respective code will be called with update_before_add=False to
+    # intentionally delay the first request, increasing chance that it is
+    # issued only when the machine is less busy again.
     hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, {}, config))
     hass.async_create_task(async_load_platform(hass, "fan", DOMAIN, {}, config))
+    hass.async_create_task(
+        async_load_platform(hass, "binary_sensor", DOMAIN, {}, config)
+    )
 
     async_track_time_interval(hass, state_proxy.async_update, SCAN_INTERVAL)
 

--- a/homeassistant/components/vallox/binary_sensor.py
+++ b/homeassistant/components/vallox/binary_sensor.py
@@ -1,0 +1,113 @@
+"""Support for the Vallox ventilation unit binary sensors."""
+
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import DOMAIN, SIGNAL_VALLOX_STATE_UPDATE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the binary sensor device."""
+    if discovery_info is None:
+        return
+
+    name = hass.data[DOMAIN]["name"]
+    state_proxy = hass.data[DOMAIN]["state_proxy"]
+
+    binary_sensors = [
+        ValloxFilterOverdueBinarySensor(
+            name=f"{name} filter overdue",
+            state_proxy=state_proxy,
+            metric_key="A_CYC_REMAINING_TIME_FOR_FILTER",
+            device_class=None,
+            icon="mdi:filter",
+        )
+    ]
+
+    async_add_entities(binary_sensors, update_before_add=False)
+
+
+class ValloxBinarySensor(BinarySensorDevice):
+    """Representation of a binary sensor device."""
+
+    def __init__(self, name, state_proxy, metric_key, device_class, icon):
+        """Initialize the binary sensor."""
+        self._name = name
+        self._state_proxy = state_proxy
+        self._metric_key = metric_key
+        self._device_class = device_class
+        self._icon = icon
+        self._is_on = False
+        self._available = False
+
+    @property
+    def should_poll(self):
+        """Do not poll the device."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._is_on
+
+    @property
+    def available(self):
+        """Return true when state is known."""
+        return self._available
+
+    async def async_added_to_hass(self):
+        """Call to update."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_VALLOX_STATE_UPDATE, self._update_callback
+        )
+
+    @callback
+    def _update_callback(self):
+        """Call update method."""
+        self.async_schedule_update_ha_state(True)
+
+    async def async_update(self):
+        """Fetch state from the ventilation unit."""
+        try:
+            self._is_on = self._state_proxy.fetch_metric(self._metric_key)
+            self._available = True
+
+        except (OSError, KeyError) as err:
+            self._available = False
+            _LOGGER.error("Error updating sensor: %s", err)
+
+
+class ValloxFilterOverdueBinarySensor(ValloxBinarySensor):
+    """Child class for filter due signalling."""
+
+    async def async_update(self):
+        """Fetch state from the ventilation unit."""
+        try:
+            days_remaining = int(self._state_proxy.fetch_metric(self._metric_key))
+            if days_remaining == 0:
+                self._is_on = True
+                self._available = True
+
+        except (OSError, KeyError) as err:
+            self._available = False
+            _LOGGER.error("Error updating sensor: %s", err)

--- a/homeassistant/components/vallox/binary_sensor.py
+++ b/homeassistant/components/vallox/binary_sensor.py
@@ -104,9 +104,12 @@ class ValloxFilterOverdueBinarySensor(ValloxBinarySensor):
         """Fetch state from the ventilation unit."""
         try:
             days_remaining = int(self._state_proxy.fetch_metric(self._metric_key))
+            self._available = True
+
             if days_remaining == 0:
                 self._is_on = True
-                self._available = True
+            else:
+                self._is_on = False
 
         except (OSError, KeyError) as err:
             self._available = False

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -223,14 +223,22 @@ class ValloxFilterRemainingSensor(ValloxSensor):
         """Fetch state from the ventilation unit."""
         try:
             days_remaining = int(self._state_proxy.fetch_metric(self._metric_key))
-            days_remaining_delta = timedelta(days=days_remaining)
+            if days_remaining == 0:
+                self._device_class = None
+                self._state = "overdue"
+                self._available = True
+            else:
+                self._device_class = DEVICE_CLASS_TIMESTAMP
+                days_remaining_delta = timedelta(days=days_remaining)
 
-            # Since only a delta of days is received from the device, fix the
-            # time so the timestamp does not change with every update.
-            now = datetime.utcnow().replace(hour=13, minute=0, second=0, microsecond=0)
+                # Since only a delta of days is received from the device, fix the
+                # time so the timestamp does not change with every update.
+                now = datetime.utcnow().replace(
+                    hour=13, minute=0, second=0, microsecond=0
+                )
 
-            self._state = (now + days_remaining_delta).isoformat()
-            self._available = True
+                self._state = (now + days_remaining_delta).isoformat()
+                self._available = True
 
         except (OSError, KeyError) as err:
             self._available = False

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -224,11 +224,8 @@ class ValloxFilterRemainingSensor(ValloxSensor):
         try:
             days_remaining = int(self._state_proxy.fetch_metric(self._metric_key))
             if days_remaining == 0:
-                self._device_class = None
-                self._state = "overdue"
-                self._available = True
+                self._available = False
             else:
-                self._device_class = DEVICE_CLASS_TIMESTAMP
                 days_remaining_delta = timedelta(days=days_remaining)
 
                 # Since only a delta of days is received from the device, fix the


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current handling of A_CYC_REMAINING_TIME_FOR_FILTER of vallox ventilation units is faulty in the case that the filter change is overdue. In this case the ventilation unit will return the value 0 which in the end leads to the message that the filter change is due in 13 hours.
This change reacts on the overdue state by changing the sensors state to "overdue".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I don't know if this is the home assistant way to handle this case (changing device_class at runtime) but I think you understand the issue. Please don't hesitate to point my to the envisaged handling.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
