### PR TITLE
Fix Spotify missing random_song

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -302,9 +302,9 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             kwargs["context_uri"] = media_id
             if self.shuffle():
                 response = self._spotify.playlist_tracks(
-                    media_id, offset=0, fields='total'
+                    media_id, offset=0, fields="total"
                 )
-                song_count = response.get('total', 1)
+                song_count = response.get("total", 1)
                 position = randint(0, song_count - 1)
                 kwargs["offset"] = {"position": position}
         else:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -306,7 +306,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
                                                      offset=0,
                                                      fields='total')
                 song_count = response.get('total', 1)
-                position = randint(0, N_songs - 1)
+                position = randint(0, song_count - 1)
                 kwargs["offset"] = {"position": position}
         else:
             _LOGGER.error("Media type %s is not supported", media_type)

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -300,11 +300,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             kwargs["uris"] = [media_id]
         elif media_type == MEDIA_TYPE_PLAYLIST:
             kwargs["context_uri"] = media_id
-            try:
-                spotify_type = media_id.split(":")[1]
-            except IndexError:
-                spotify_type = None
-            if self.shuffle and spotify_type == "playlist":
+            if self.shuffle and "playlist" in media_id:
                 response = self._spotify.playlist_tracks(
                     media_id, offset=0, fields="total"
                 )

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -105,7 +105,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         self._devices: Optional[List[dict]] = []
         self._playlist: Optional[dict] = None
         self._spotify: Spotify = None
-        self._start_random = False
 
         self.player_available = False
 
@@ -301,7 +300,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             kwargs["uris"] = [media_id]
         elif media_type == MEDIA_TYPE_PLAYLIST:
             kwargs["context_uri"] = media_id
-            if self._start_random:
+            if self.shuffle():
                 response = self._spotify.playlist_tracks(media_id,
                                                          offset=0,
                                                          fields='total')
@@ -327,7 +326,6 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
     @spotify_exception_handler
     def set_shuffle(self, shuffle: bool) -> None:
         """Enable/Disable shuffle mode."""
-        self._start_random = shuffle
         self._spotify.shuffle(shuffle)
 
     @spotify_exception_handler

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -303,8 +303,8 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             kwargs["context_uri"] = media_id
             if self._start_random:
                 response = self._spotify.playlist_tracks(media_id,
-                                                     offset=0,
-                                                     fields='total')
+                                                         offset=0,
+                                                         fields='total')
                 song_count = response.get('total', 1)
                 position = randint(0, song_count - 1)
                 kwargs["offset"] = {"position": position}

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -3,8 +3,8 @@ from asyncio import run_coroutine_threadsafe
 import datetime as dt
 from datetime import timedelta
 import logging
-from typing import Any, Callable, Dict, List, Optional
 from random import randint
+from typing import Any, Callable, Dict, List, Optional
 
 from aiohttp import ClientError
 from spotipy import Spotify, SpotifyException
@@ -301,9 +301,9 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         elif media_type == MEDIA_TYPE_PLAYLIST:
             kwargs["context_uri"] = media_id
             if self.shuffle():
-                response = self._spotify.playlist_tracks(media_id,
-                                                         offset=0,
-                                                         fields='total')
+                response = self._spotify.playlist_tracks(
+                    media_id, offset=0, fields='total'
+                )
                 song_count = response.get('total', 1)
                 position = randint(0, song_count - 1)
                 kwargs["offset"] = {"position": position}

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -300,7 +300,11 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             kwargs["uris"] = [media_id]
         elif media_type == MEDIA_TYPE_PLAYLIST:
             kwargs["context_uri"] = media_id
-            if self.shuffle:
+            try:
+                spotify_type = media_id.split(":")[1]
+            except IndexError:
+                spotify_type = None
+            if self.shuffle and spotify_type == "playlist":
                 response = self._spotify.playlist_tracks(
                     media_id, offset=0, fields="total"
                 )

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -305,7 +305,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
                 response = self._spotify.playlist_tracks(media_id,
                                                      offset=0,
                                                      fields='total')
-                N_songs = response.get('total', 1)
+                song_count = response.get('total', 1)
                 position = randint(0, N_songs - 1)
                 kwargs["offset"] = {"position": position}
         else:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -300,7 +300,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
             kwargs["uris"] = [media_id]
         elif media_type == MEDIA_TYPE_PLAYLIST:
             kwargs["context_uri"] = media_id
-            if self.shuffle():
+            if self.shuffle:
                 response = self._spotify.playlist_tracks(
                     media_id, offset=0, fields="total"
                 )


### PR DESCRIPTION
This adds a solution to the missing random_song:true attribute that was in the spotify.play_playlist service.
This fixes issue: https://github.com/home-assistant/home-assistant/issues/31607, see that issue for more details.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31607
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
