### PR TITLE
Audit state handling off august bridges and sensors

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -517,7 +517,12 @@ class AugustData:
         operative_locks = []
         for lock in self._locks:
             lock_detail = self._lock_detail_by_id.get(lock.device_id)
-            if lock_detail.bridge is None:
+            if lock_detail is None:
+                _LOGGER.info(
+                    "The lock %s could not be setup because the system could not fetch details about the lock.",
+                    lock.device_name,
+                )
+            elif lock_detail.bridge is None:
                 _LOGGER.info(
                     "The lock %s could not be setup because it does not have a bridge (Connect).",
                     lock.device_name,

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -363,7 +363,7 @@ class AugustData:
         """Determine if a lock has doorsense installed and can tell when the door is open or closed."""
         # We do not update here since this is not expected
         # to change until restart
-        return self._lock_detail_by_id.get(lock_id).doorsense
+        return self._lock_detail_by_id[lock_id].doorsense
 
     async def async_get_lock_status(self, lock_id):
         """Return status if the door is locked or unlocked.

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -225,6 +225,13 @@ class AugustData:
         self._door_state_by_id = {}
         self._activities_by_id = {}
 
+        # We check the locks right away so we can
+        # remove inoperative ones
+        self._update_locks_status()
+        self._update_locks_detail()
+
+        self._filter_inoperative_locks()
+
     @property
     def house_ids(self):
         """Return a list of house_ids."""
@@ -351,6 +358,12 @@ class AugustData:
         self._lock_status_by_id[lock_id] = lock_status
         self._lock_last_status_update_time_utc_by_id[lock_id] = update_start_time_utc
         return True
+
+    def lock_has_doorsense(self, lock_id):
+        """Determine if a lock has doorsense installed and can tell when the door is open or closed."""
+        # We do not update here since this is not expected
+        # to change until restart
+        return self._lock_detail_by_id.get(lock_id).doorsense
 
     async def async_get_lock_status(self, lock_id):
         """Return status if the door is locked or unlocked.
@@ -496,6 +509,28 @@ class AugustData:
             self._access_token,
             device_id,
         )
+
+    def _filter_inoperative_locks(self):
+        # Remove non-operative locks as there must
+        # be a bridge (August Connect) for them to
+        # be usable
+        operative_locks = []
+        for lock in self._locks:
+            lock_detail = self._lock_detail_by_id.get(lock.device_id)
+            if lock_detail.bridge is None:
+                _LOGGER.info(
+                    "The lock %s could not be setup because it does not have a bridge (Connect).",
+                    lock.device_name,
+                )
+            elif not lock_detail.bridge.operative:
+                _LOGGER.info(
+                    "The lock %s could not be setup because the bridge (Connect) is not operative.",
+                    lock.device_name,
+                )
+            else:
+                operative_locks.append(lock)
+
+        self._locks = operative_locks
 
 
 def _call_api_operation_that_requires_bridge(

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -363,6 +363,8 @@ class AugustData:
         """Determine if a lock has doorsense installed and can tell when the door is open or closed."""
         # We do not update here since this is not expected
         # to change until restart
+        if self._lock_detail_by_id[lock_id] is None:
+            return False
         return self._lock_detail_by_id[lock_id].doorsense
 
     async def async_get_lock_status(self, lock_id):

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -67,7 +67,9 @@ class AugustLock(LockDevice):
     async def async_update(self):
         """Get the latest state of the sensor and update activity."""
         self._lock_status = await self._data.async_get_lock_status(self._lock.device_id)
-        self._available = self._lock_status is not None
+        self._available = (
+            self._lock_status is not None and self._lock_status != LockStatus.UNKNOWN
+        )
         self._lock_detail = await self._data.async_get_lock_detail(self._lock.device_id)
 
         lock_activity = await self._data.async_get_latest_device_activity(

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the august platform."""
 import asyncio
+import unittest.mock
 from unittest.mock import MagicMock
 
 from homeassistant.components import august
@@ -11,6 +12,10 @@ from tests.components.august.mocks import (
     _mock_august_authentication,
     _mock_august_authenticator,
     _mock_august_lock,
+    _mock_doorsense_enabled_august_lock_detail,
+    _mock_doorsense_missing_august_lock_detail,
+    _mock_inoperative_august_lock_detail,
+    _mock_operative_august_lock_detail,
 )
 
 
@@ -19,7 +24,7 @@ def test_get_lock_name():
     data = MockAugustComponentData(last_lock_status_update_timestamp=1)
     lock = _mock_august_lock()
     data.set_mocked_locks([lock])
-    assert data.get_lock_name("mockdeviceid1") == "Mocked Lock 1"
+    assert data.get_lock_name("mocklockid1") == "mocklockid1 Name"
 
 
 def test_unlock_throws_august_api_http_error():
@@ -29,11 +34,12 @@ def test_unlock_throws_august_api_http_error():
     data.set_mocked_locks([lock])
     last_err = None
     try:
-        data.unlock("mockdeviceid1")
+        data.unlock("mocklockid1")
     except HomeAssistantError as err:
         last_err = err
     assert (
-        str(last_err) == "Mocked Lock 1: This should bubble up as its user consumable"
+        str(last_err)
+        == "mocklockid1 Name: This should bubble up as its user consumable"
     )
 
 
@@ -44,12 +50,39 @@ def test_lock_throws_august_api_http_error():
     data.set_mocked_locks([lock])
     last_err = None
     try:
-        data.unlock("mockdeviceid1")
+        data.unlock("mocklockid1")
     except HomeAssistantError as err:
         last_err = err
     assert (
-        str(last_err) == "Mocked Lock 1: This should bubble up as its user consumable"
+        str(last_err)
+        == "mocklockid1 Name: This should bubble up as its user consumable"
     )
+
+
+class TestAugustData(unittest.TestCase):
+    """Tests for AugustData."""
+
+    def test_inoperative_locks_are_filtered_out(self):
+        """Ensure inoperative locks do not get setup."""
+        august_operative_lock = _mock_operative_august_lock_detail("oplockid1")
+        data = _create_august_data_with_lock_details(
+            [august_operative_lock, _mock_inoperative_august_lock_detail("inoplockid1")]
+        )
+
+        self.assertEqual(len(data.locks), 1)
+        self.assertEqual(data.locks[0].device_id, "oplockid1")
+
+    def test_lock_has_doorsense(self):
+        """Check to see if a lock has doorsense."""
+        data = _create_august_data_with_lock_details(
+            [
+                _mock_doorsense_enabled_august_lock_detail("doorsenselock1"),
+                _mock_doorsense_missing_august_lock_detail("nodoorsenselock1"),
+            ]
+        )
+
+        self.assertTrue(data.lock_has_doorsense("doorsenselock1"))
+        self.assertFalse(data.lock_has_doorsense("nodoorsenselock1"))
 
 
 async def test__refresh_access_token(hass):
@@ -72,3 +105,20 @@ async def test__refresh_access_token(hass):
     authenticator.refresh_access_token.assert_called()
     assert data._access_token == "new_token"
     assert data._access_token_expires == 5678
+
+
+def _create_august_data_with_lock_details(lock_details):
+    locks = []
+    for lock in lock_details:
+        locks.append(_mock_august_lock(lock.device_id))
+    authentication = _mock_august_authentication("original_token", 1234)
+    authenticator = _mock_august_authenticator()
+    token_refresh_lock = MagicMock()
+    api = MagicMock()
+    api.get_lock_status = MagicMock(return_value=(MagicMock(), MagicMock()))
+    api.get_lock_detail = MagicMock(side_effect=lock_details)
+    api.get_operable_locks = MagicMock(return_value=locks)
+    api.get_doorbells = MagicMock(return_value=[])
+    return august.AugustData(
+        MagicMock(), api, authentication, authenticator, token_refresh_lock
+    )

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the august platform."""
 import asyncio
-import unittest.mock
 from unittest.mock import MagicMock
 
 from homeassistant.components import august
@@ -59,30 +58,28 @@ def test_lock_throws_august_api_http_error():
     )
 
 
-class TestAugustData(unittest.TestCase):
-    """Tests for AugustData."""
+def test_inoperative_locks_are_filtered_out():
+    """Ensure inoperative locks do not get setup."""
+    august_operative_lock = _mock_operative_august_lock_detail("oplockid1")
+    data = _create_august_data_with_lock_details(
+        [august_operative_lock, _mock_inoperative_august_lock_detail("inoplockid1")]
+    )
 
-    def test_inoperative_locks_are_filtered_out(self):
-        """Ensure inoperative locks do not get setup."""
-        august_operative_lock = _mock_operative_august_lock_detail("oplockid1")
-        data = _create_august_data_with_lock_details(
-            [august_operative_lock, _mock_inoperative_august_lock_detail("inoplockid1")]
-        )
+    assert len(data.locks) == 1
+    assert data.locks[0].device_id == "oplockid1"
 
-        self.assertEqual(len(data.locks), 1)
-        self.assertEqual(data.locks[0].device_id, "oplockid1")
 
-    def test_lock_has_doorsense(self):
-        """Check to see if a lock has doorsense."""
-        data = _create_august_data_with_lock_details(
-            [
-                _mock_doorsense_enabled_august_lock_detail("doorsenselock1"),
-                _mock_doorsense_missing_august_lock_detail("nodoorsenselock1"),
-            ]
-        )
+def test_lock_has_doorsense():
+    """Check to see if a lock has doorsense."""
+    data = _create_august_data_with_lock_details(
+        [
+            _mock_doorsense_enabled_august_lock_detail("doorsenselock1"),
+            _mock_doorsense_missing_august_lock_detail("nodoorsenselock1"),
+        ]
+    )
 
-        self.assertTrue(data.lock_has_doorsense("doorsenselock1"))
-        self.assertFalse(data.lock_has_doorsense("nodoorsenselock1"))
+    assert data.lock_has_doorsense("doorsenselock1") is True
+    assert data.lock_has_doorsense("nodoorsenselock1") is not True
 
 
 async def test__refresh_access_token(hass):

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -21,10 +21,7 @@ from tests.components.august.mocks import (
 
 def test__sync_lock_activity_locked_via_onetouchlock():
     """Test _sync_lock_activity locking."""
-    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
-    august_lock = _mock_august_lock()
-    data.set_mocked_locks([august_lock])
-    lock = MockAugustComponentLock(data, august_lock)
+    lock = _mocked_august_component_lock()
     lock_activity_start_timestamp = 1234
     lock_activity = MockActivity(
         action=ACTION_LOCK_ONETOUCHLOCK,
@@ -40,10 +37,7 @@ def test__sync_lock_activity_locked_via_onetouchlock():
 
 def test__sync_lock_activity_locked_via_lock():
     """Test _sync_lock_activity locking."""
-    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
-    august_lock = _mock_august_lock()
-    data.set_mocked_locks([august_lock])
-    lock = MockAugustComponentLock(data, august_lock)
+    lock = _mocked_august_component_lock()
     lock_activity_start_timestamp = 1234
     lock_activity = MockActivity(
         action=ACTION_LOCK_LOCK,
@@ -59,10 +53,7 @@ def test__sync_lock_activity_locked_via_lock():
 
 def test__sync_lock_activity_unlocked():
     """Test _sync_lock_activity unlocking."""
-    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
-    august_lock = _mock_august_lock()
-    data.set_mocked_locks([august_lock])
-    lock = MockAugustComponentLock(data, august_lock)
+    lock = _mocked_august_component_lock()
     lock_activity_timestamp = 1234
     lock_activity = MockActivity(
         action=ACTION_LOCK_UNLOCK,
@@ -110,3 +101,10 @@ def test__sync_lock_activity_ignores_old_data():
     assert lock.last_update_lock_status["activity_start_time_utc"] == dt.as_utc(
         datetime.datetime.fromtimestamp(first_lock_activity_timestamp)
     )
+
+
+def _mocked_august_component_lock():
+    data = MockAugustComponentData(last_lock_status_update_timestamp=1)
+    august_lock = _mock_august_lock()
+    data.set_mocked_locks([august_lock])
+    return MockAugustComponentLock(data, august_lock)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes #29980

* Prevent setting up august locks that do not have a bridge as they will never work

* Prevent locks showing available when their bridge is offline

* Prevent door sensors from showing available when their bridge is offline

* Prevent creating door sensors for locks that do not have them

* Prevent doorbells showing unavailable when they are in standby mode

* Set SCAN_INTERVAL for binary_sensors to 5 seconds as
  data comes in from the activity end point more frequently

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29980
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
