### PR TITLE
Add support for simultaneous runs of Script helper

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -395,10 +395,8 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
 
         try:
             await self.action_script.async_run(variables, trigger_context)
-        except Exception as err:  # pylint: disable=broad-except
-            self.action_script.async_log_exception(
-                _LOGGER, f"Error while executing automation {self.entity_id}", err
-            )
+        except Exception:  # pylint: disable=broad-except
+            pass
 
         self._last_triggered = utcnow()
         await self.async_update_ha_state()
@@ -508,7 +506,9 @@ async def _async_process_config(hass, config, component):
             hidden = config_block[CONF_HIDE_ENTITY]
             initial_state = config_block.get(CONF_INITIAL_STATE)
 
-            action_script = script.Script(hass, config_block.get(CONF_ACTION, {}), name)
+            action_script = script.Script(
+                hass, config_block.get(CONF_ACTION, {}), name, logger=_LOGGER
+            )
 
             if CONF_CONDITION in config_block:
                 cond_func = await _async_process_if(hass, config, config_block)

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -274,12 +274,11 @@ class ScriptEntity(ToggleEntity):
 
     async def async_turn_off(self, **kwargs):
         """Turn script off."""
-        self.script.async_stop()
+        await self.script.async_stop()
 
     async def async_will_remove_from_hass(self):
         """Stop script and remove service when it will be removed from Home Assistant."""
-        if self.script.is_running:
-            self.script.async_stop()
+        await self.script.async_stop()
 
         # remove service
         self.hass.services.async_remove(DOMAIN, self.object_id)

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -231,7 +231,9 @@ class ScriptEntity(ToggleEntity):
         """Initialize the script."""
         self.object_id = object_id
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
-        self.script = Script(hass, sequence, name, self.async_update_ha_state)
+        self.script = Script(
+            hass, sequence, name, self.async_update_ha_state, logger=_LOGGER
+        )
 
     @property
     def should_poll(self):
@@ -268,13 +270,7 @@ class ScriptEntity(ToggleEntity):
             {ATTR_NAME: self.script.name, ATTR_ENTITY_ID: self.entity_id},
             context=context,
         )
-        try:
-            await self.script.async_run(kwargs.get(ATTR_VARIABLES), context)
-        except Exception as err:
-            self.script.async_log_exception(
-                _LOGGER, f"Error executing script {self.entity_id}", err
-            )
-            raise err
+        await self.script.async_run(kwargs.get(ATTR_VARIABLES), context)
 
     async def async_turn_off(self, **kwargs):
         """Turn script off."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,10 +1,11 @@
 """Helpers to execute scripts."""
+from abc import ABC, abstractmethod
 import asyncio
 from contextlib import suppress
 from datetime import datetime
 from itertools import islice
 import logging
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, cast
 
 import voluptuous as vol
 
@@ -31,12 +32,9 @@ from homeassistant.helpers.event import (
     async_track_template,
 )
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util.async_ import run_callback_threadsafe
-import homeassistant.util.dt as date_util
+from homeassistant.util.dt import utcnow
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
-
-_LOGGER = logging.getLogger(__name__)
 
 CONF_ALIAS = "alias"
 CONF_SERVICE = "service"
@@ -50,7 +48,6 @@ CONF_WAIT_TEMPLATE = "wait_template"
 CONF_CONTINUE = "continue_on_timeout"
 CONF_SCENE = "scene"
 
-
 ACTION_DELAY = "delay"
 ACTION_WAIT_TEMPLATE = "wait_template"
 ACTION_CHECK_CONDITION = "condition"
@@ -58,6 +55,30 @@ ACTION_FIRE_EVENT = "event"
 ACTION_CALL_SERVICE = "call_service"
 ACTION_DEVICE_AUTOMATION = "device"
 ACTION_ACTIVATE_SCENE = "scene"
+
+IF_RUNNING_ERROR = "error"
+IF_RUNNING_IGNORE = "ignore"
+IF_RUNNING_PARALLEL = "parallel"
+IF_RUNNING_RESTART = "restart"
+# First choice is default
+IF_RUNNING_CHOICES = [
+    IF_RUNNING_PARALLEL,
+    IF_RUNNING_ERROR,
+    IF_RUNNING_IGNORE,
+    IF_RUNNING_RESTART,
+]
+
+RUN_MODE_BACKGROUND = "background"
+RUN_MODE_BLOCKING = "blocking"
+RUN_MODE_LEGACY = "legacy"
+# First choice is default
+RUN_MODE_CHOICES = [
+    RUN_MODE_BACKGROUND,
+    RUN_MODE_BLOCKING,
+    RUN_MODE_LEGACY,
+]
+
+_LOG_EXCEPTION = logging.ERROR + 1
 
 
 def _determine_action(action):
@@ -81,16 +102,6 @@ def _determine_action(action):
         return ACTION_ACTIVATE_SCENE
 
     return ACTION_CALL_SERVICE
-
-
-def call_from_config(
-    hass: HomeAssistant,
-    config: ConfigType,
-    variables: Optional[Sequence] = None,
-    context: Optional[Context] = None,
-) -> None:
-    """Call a script based on a config entry."""
-    Script(hass, cv.SCRIPT_SCHEMA(config)).run(variables, context)
 
 
 async def async_validate_action_config(
@@ -121,6 +132,413 @@ class _SuspendScript(Exception):
     """Throw if script needs to suspend."""
 
 
+class _ScriptRunBase(ABC):
+    """Common data & methods for managing asynchronous run of Script sequence."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        script: "Script",
+        variables: Optional[Sequence],
+        context: Optional[Context],
+    ) -> None:
+        self._hass = hass
+        self._script = script
+        self._variables = variables
+        self._context = context
+        self._last_action = None
+        self._step = -1
+        self._action = None
+
+    @property
+    def _change_listener(self):
+        return self._script._change_listener  # pylint: disable=protected-access
+
+    @property
+    def _config_cache(self):
+        return self._script._config_cache  # pylint: disable=protected-access
+
+    @property
+    def name(self):
+        """Return script name."""
+        return self._script.name
+
+    @property
+    def last_action(self):
+        """Return last action."""
+        return self._last_action
+
+    @last_action.setter
+    def last_action(self, value):
+        self._last_action = value
+
+    @abstractmethod
+    async def async_run(self) -> None:
+        """Run script."""
+
+    async def _async_run(self, start):
+        for self._step, self._action in islice(
+            enumerate(self._script.sequence), start, None
+        ):
+            try:
+                await getattr(self, f"_async_{_determine_action(self._action)}_step")()
+            except _SuspendScript:
+                raise
+            except _StopScript:
+                break
+            except Exception as err:
+                self._log_exception(err)
+                self._stop()
+                # Pass exception on.
+                raise
+
+        self._stop()
+        if self._change_listener:
+            self._hass.async_add_job(self._change_listener)
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop script run."""
+
+    def _stop(self):
+        self._script._runs.remove(self)  # pylint: disable=protected-access
+
+    def _log_exception(self, exception):
+        action_type = _determine_action(self._action)
+
+        error = str(exception)
+        level = logging.ERROR
+
+        if isinstance(exception, vol.Invalid):
+            error_desc = "Invalid data"
+
+        elif isinstance(exception, exceptions.TemplateError):
+            error_desc = "Error rendering template"
+
+        elif isinstance(exception, exceptions.Unauthorized):
+            error_desc = "Unauthorized"
+
+        elif isinstance(exception, exceptions.ServiceNotFound):
+            error_desc = "Service not found"
+
+        else:
+            error_desc = "Unexpected error"
+            level = _LOG_EXCEPTION
+
+        self._log(
+            "Error executing script. %s for %s at pos %s: %s",
+            error_desc,
+            action_type,
+            self._step + 1,
+            error,
+            level=level,
+        )
+
+    @abstractmethod
+    async def _async_delay_step(self):
+        """Handle delay."""
+
+    def _start_delay_step(self):
+        try:
+            delay = vol.All(cv.time_period, cv.positive_timedelta)(
+                template.render_complex(self._action[CONF_DELAY], self._variables)
+            )
+        except (exceptions.TemplateError, vol.Invalid) as ex:
+            self._raise(
+                "Error rendering %s delay template: %s",
+                self.name,
+                ex,
+                exception=_StopScript,
+            )
+
+        self.last_action = self._action.get(CONF_ALIAS, f"delay {delay}")
+        self._log("Executing step %s", self.last_action)
+
+        return delay
+
+    @abstractmethod
+    async def _async_wait_template_step(self):
+        """Handle a wait template."""
+
+    def _start_wait_template_step(self, async_script_wait):
+        wait_template = self._action[CONF_WAIT_TEMPLATE]
+        wait_template.hass = self._hass
+
+        self.last_action = self._action.get(CONF_ALIAS, "wait template")
+        self._log("Executing step %s", self.last_action)
+
+        # check if condition already okay
+        if condition.async_template(self._hass, wait_template, self._variables):
+            return None
+
+        return async_track_template(
+            self._hass, wait_template, async_script_wait, self._variables
+        )
+
+    async def _async_call_service_step(self):
+        """Call the service specified in the action."""
+        self.last_action = self._action.get(CONF_ALIAS, "call service")
+        self._log("Executing step %s", self.last_action)
+        await service.async_call_from_config(
+            self._hass,
+            self._action,
+            blocking=True,
+            variables=self._variables,
+            validate_config=False,
+            context=self._context,
+        )
+
+    async def _async_device_step(self):
+        """Perform the device automation specified in the action."""
+        self.last_action = self._action.get(CONF_ALIAS, "device automation")
+        self._log("Executing step %s", self.last_action)
+        platform = await device_automation.async_get_device_automation_platform(
+            self._hass, self._action[CONF_DOMAIN], "action"
+        )
+        await platform.async_call_action_from_config(
+            self._hass, self._action, self._variables, self._context
+        )
+
+    async def _async_scene_step(self):
+        """Activate the scene specified in the action."""
+        self.last_action = self._action.get(CONF_ALIAS, "activate scene")
+        self._log("Executing step %s", self.last_action)
+        await self._hass.services.async_call(
+            scene.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._action[CONF_SCENE]},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def _async_event_step(self):
+        """Fire an event."""
+        self.last_action = self._action.get(CONF_ALIAS, self._action[CONF_EVENT])
+        self._log("Executing step %s", self.last_action)
+        event_data = dict(self._action.get(CONF_EVENT_DATA, {}))
+        if CONF_EVENT_DATA_TEMPLATE in self._action:
+            try:
+                event_data.update(
+                    template.render_complex(
+                        self._action[CONF_EVENT_DATA_TEMPLATE], self._variables
+                    )
+                )
+            except exceptions.TemplateError as ex:
+                self._log(
+                    "Error rendering event data template: %s", ex, level=logging.ERROR
+                )
+
+        self._hass.bus.async_fire(
+            self._action[CONF_EVENT], event_data, context=self._context
+        )
+
+    async def _async_condition_step(self):
+        """Test if condition is matching."""
+        config_cache_key = frozenset((k, str(v)) for k, v in self._action.items())
+        config = self._config_cache.get(config_cache_key)
+        if not config:
+            config = await condition.async_from_config(self._hass, self._action, False)
+            self._config_cache[config_cache_key] = config
+
+        self.last_action = self._action.get(CONF_ALIAS, self._action[CONF_CONDITION])
+        check = config(self._hass, self._variables)
+        self._log("Test condition %s: %s", self.last_action, check)
+        if not check:
+            raise _StopScript
+
+    def _log(self, msg, *args, level=logging.INFO):
+        self._script._log(msg, *args, level=level)  # pylint: disable=protected-access
+
+    def _raise(self, msg, *args, exception=None):
+        # pylint: disable=protected-access
+        self._script._raise(msg, *args, exception=exception)
+
+
+class _ScriptRun(_ScriptRunBase):
+    """Manage asynchronous run of Script sequence."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        script: "Script",
+        variables: Optional[Sequence],
+        context: Optional[Context],
+    ) -> None:
+        super().__init__(hass, script, variables, context)
+        self.task: Optional[asyncio.Task] = None
+
+    async def async_run(self) -> None:
+        """Run script."""
+        self._log("Running script")
+        await self._async_run(0)
+
+    def stop(self) -> None:
+        """Stop script run."""
+        cast(asyncio.Task, self.task).cancel()
+        self._stop()
+
+    async def _async_delay_step(self):
+        """Handle delay."""
+        await asyncio.sleep(self._start_delay_step())
+
+    async def _async_wait_template_step(self):
+        """Handle a wait template."""
+
+        @callback
+        def async_script_wait(entity_id, from_s, to_s):
+            """Handle script after template condition is true."""
+            nonlocal done
+            done.set()
+
+        unsub = self._start_wait_template_step(async_script_wait)
+        if not unsub:
+            return
+
+        timeout = self._action.get(CONF_TIMEOUT)
+        done = asyncio.Event()
+        try:
+            await asyncio.wait_for(done.wait(), timeout)
+        except asyncio.TimeoutError:
+            if not self._action.get(CONF_CONTINUE, True):
+                self._log("Timeout reached, abort script.")
+                raise _StopScript
+        finally:
+            unsub()
+
+
+class _LegacyScriptRun(_ScriptRunBase):
+    """Manage asynchronous run of legacy Script sequence."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        script: "Script",
+        variables: Optional[Sequence],
+        context: Optional[Context],
+        shared: Optional["_LegacyScriptRun"],
+    ) -> None:
+        super().__init__(hass, script, variables, context)
+        if shared:
+            self._shared = shared
+        else:
+            # To implement legacy behavior we need to share the following "run state"
+            # amongst all runs, so it will only exist in the first instantiation of
+            # concurrent runs, and the rest will use it, too.
+            self._current = -1
+            self._async_listeners: List[CALLBACK_TYPE] = []
+
+            self._shared = self
+
+    @property
+    def last_action(self):
+        return self._shared._last_action  # pylint: disable=protected-access
+
+    @last_action.setter
+    def last_action(self, value):
+        self._shared._last_action = value  # pylint: disable=protected-access
+
+    @property
+    def _cur(self):
+        return self._shared._current  # pylint: disable=protected-access
+
+    @_cur.setter
+    def _cur(self, value):
+        self._shared._current = value  # pylint: disable=protected-access
+
+    @property
+    def _async_listener(self):
+        return self._shared._async_listeners  # pylint: disable=protected-access
+
+    async def async_run(self) -> None:
+        """Run script."""
+        if self._cur == -1:
+            self._log("Running script")
+            self._cur = 0
+
+        # Unregister callback if we were in a delay or wait but turn on is
+        # called again. In that case we just continue execution.
+        self._async_remove_listener()
+
+        try:
+            await self._async_run(self._cur)
+        except _SuspendScript:
+            # Store next step to take and notify change listeners
+            self._cur = self._step + 1
+            if self._change_listener:
+                self._hass.async_add_job(self._change_listener)
+            return
+
+    def stop(self):
+        """Stop running script."""
+        self._cur = -1
+        self._async_remove_listener()
+        super()._stop()
+
+    def _stop(self):
+        self._cur = -1
+        self.last_action = None
+        self._script._runs.clear()  # pylint: disable=protected-access
+
+    async def _async_delay_step(self):
+        """Handle delay."""
+        delay = self._start_delay_step()
+
+        @callback
+        def async_script_delay(now):
+            """Handle delay."""
+            with suppress(ValueError):
+                self._async_listener.remove(unsub)
+            self._hass.async_create_task(self.async_run())
+
+        unsub = async_track_point_in_utc_time(
+            self._hass, async_script_delay, utcnow() + delay
+        )
+        self._async_listener.append(unsub)
+        raise _SuspendScript
+
+    async def _async_wait_template_step(self):
+        """Handle a wait template."""
+
+        @callback
+        def async_script_wait(entity_id, from_s, to_s):
+            """Handle script after template condition is true."""
+            self._async_remove_listener()
+            self._hass.async_create_task(self.async_run())
+
+        @callback
+        def async_script_timeout(now):
+            """Call after timeout is retrieve."""
+            with suppress(ValueError):
+                self._async_listener.remove(unsub)
+
+            # Check if we want to continue to execute
+            # the script after the timeout
+            if self._action.get(CONF_CONTINUE, True):
+                self._hass.async_create_task(self.async_run())
+            else:
+                self._log("Timeout reached, abort script.")
+                self.stop()
+
+        unsub_wait = self._start_wait_template_step(async_script_wait)
+        if not unsub_wait:
+            return
+        self._async_listener.append(unsub_wait)
+
+        if CONF_TIMEOUT in self._action:
+            unsub = async_track_point_in_utc_time(
+                self._hass, async_script_timeout, utcnow() + self._action[CONF_TIMEOUT]
+            )
+            self._async_listener.append(unsub)
+
+        raise _SuspendScript
+
+    def _async_remove_listener(self):
+        """Remove listeners, if any."""
+        for unsub in self._async_listener:
+            unsub()
+        self._async_listener.clear()
+
+
 class Script:
     """Representation of a script."""
 
@@ -130,39 +548,51 @@ class Script:
         sequence: Sequence[Dict[str, Any]],
         name: Optional[str] = None,
         change_listener: Optional[Callable[..., Any]] = None,
+        if_running: Optional[str] = None,
+        run_mode: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Initialize the script."""
-        self.hass = hass
+        self._logger = logger or logging.getLogger(__name__)
+        self._hass = hass
         self.sequence = sequence
         template.attach(hass, self.sequence)
         self.name = name
         self._change_listener = change_listener
-        self._cur = -1
-        self._exception_step: Optional[int] = None
-        self.last_action = None
         self.last_triggered: Optional[datetime] = None
         self.can_cancel = any(
             CONF_DELAY in action or CONF_WAIT_TEMPLATE in action
             for action in self.sequence
         )
-        self._async_listener: List[CALLBACK_TYPE] = []
+        if not if_running and not run_mode:
+            self._if_running = IF_RUNNING_PARALLEL
+            self._run_mode = RUN_MODE_LEGACY
+        elif if_running and run_mode == RUN_MODE_LEGACY:
+            self._raise('Cannot use if_running if run_mode is "legacy"')
+        else:
+            self._if_running = if_running or IF_RUNNING_CHOICES[0]
+            self._run_mode = run_mode or RUN_MODE_CHOICES[0]
+        self._runs: List[_ScriptRunBase] = []
         self._config_cache: Dict[Set[Tuple], Callable[..., bool]] = {}
-        self._actions = {
-            ACTION_DELAY: self._async_delay,
-            ACTION_WAIT_TEMPLATE: self._async_wait_template,
-            ACTION_CHECK_CONDITION: self._async_check_condition,
-            ACTION_FIRE_EVENT: self._async_fire_event,
-            ACTION_CALL_SERVICE: self._async_call_service,
-            ACTION_DEVICE_AUTOMATION: self._async_device_automation,
-            ACTION_ACTIVATE_SCENE: self._async_activate_scene,
-        }
         self._referenced_entities: Optional[Set[str]] = None
         self._referenced_devices: Optional[Set[str]] = None
+
+    def set_logger(self, logger):
+        """Set logger use by script helper."""
+        self._logger = logger
+
+    @property
+    def last_action(self):
+        """Return last action."""
+        try:
+            return self._runs[0].last_action
+        except IndexError:
+            return None
 
     @property
     def is_running(self) -> bool:
         """Return true if script is on."""
-        return self._cur != -1
+        return len(self._runs) > 0
 
     @property
     def referenced_devices(self):
@@ -223,288 +653,63 @@ class Script:
     def run(self, variables=None, context=None):
         """Run script."""
         asyncio.run_coroutine_threadsafe(
-            self.async_run(variables, context), self.hass.loop
+            self.async_run(variables, context), self._hass.loop
         ).result()
 
     async def async_run(
         self, variables: Optional[Sequence] = None, context: Optional[Context] = None
-    ) -> None:
-        """Run script.
+    ) -> bool:
+        """Run script."""
+        if self.is_running:
+            if self._if_running == IF_RUNNING_IGNORE:
+                self._log("Skipping script")
+                return False
+            if self._if_running == IF_RUNNING_ERROR:
+                self._raise("Already running")
+            if self._if_running == IF_RUNNING_RESTART:
+                self._log("Restarting script")
+                self.async_stop()
 
-        This method is a coroutine.
-        """
-        self.last_triggered = date_util.utcnow()
-        if self._cur == -1:
-            self._log("Running script")
-            self._cur = 0
-
-        # Unregister callback if we were in a delay or wait but turn on is
-        # called again. In that case we just continue execution.
-        self._async_remove_listener()
-
-        for cur, action in islice(enumerate(self.sequence), self._cur, None):
-            try:
-                await self._handle_action(action, variables, context)
-            except _SuspendScript:
-                # Store next step to take and notify change listeners
-                self._cur = cur + 1
-                if self._change_listener:
-                    self.hass.async_add_job(self._change_listener)
-                return
-            except _StopScript:
-                break
-            except Exception:
-                # Store the step that had an exception
-                self._exception_step = cur
-                # Set script to not running
-                self._cur = -1
-                self.last_action = None
-                # Pass exception on.
-                raise
-
-        # Set script to not-running.
-        self._cur = -1
-        self.last_action = None
-        if self._change_listener:
-            self.hass.async_add_job(self._change_listener)
-
-    def stop(self) -> None:
-        """Stop running script."""
-        run_callback_threadsafe(self.hass.loop, self.async_stop).result()
+        self.last_triggered = utcnow()
+        if self._run_mode == RUN_MODE_LEGACY:
+            if self.is_running:
+                shared = cast(Optional[_LegacyScriptRun], self._runs[0])
+            else:
+                shared = None
+            run = cast(
+                _ScriptRunBase,
+                _LegacyScriptRun(self._hass, self, variables, context, shared),
+            )
+            self._runs.append(run)
+            await run.async_run()
+        else:
+            run = cast(_ScriptRunBase, _ScriptRun(self._hass, self, variables, context))
+            self._runs.append(run)
+            cast(_ScriptRun, run).task = self._hass.async_create_task(run.async_run())
+            if self._run_mode == RUN_MODE_BLOCKING:
+                await cast(asyncio.Task, cast(_ScriptRun, run).task)
+        return True
 
     @callback
     def async_stop(self) -> None:
         """Stop running script."""
-        if self._cur == -1:
+        if not self.is_running:
             return
-
-        self._cur = -1
-        self._async_remove_listener()
+        for run in self._runs:
+            run.stop()
         if self._change_listener:
-            self.hass.async_add_job(self._change_listener)
+            self._hass.async_add_job(self._change_listener)
 
-    @callback
-    def async_log_exception(self, logger, message_base, exception):
-        """Log an exception for this script.
-
-        Should only be called on exceptions raised by this scripts async_run.
-        """
-        step = self._exception_step
-        action = self.sequence[step]
-        action_type = _determine_action(action)
-
-        error = None
-        meth = logger.error
-
-        if isinstance(exception, vol.Invalid):
-            error_desc = "Invalid data"
-
-        elif isinstance(exception, exceptions.TemplateError):
-            error_desc = "Error rendering template"
-
-        elif isinstance(exception, exceptions.Unauthorized):
-            error_desc = "Unauthorized"
-
-        elif isinstance(exception, exceptions.ServiceNotFound):
-            error_desc = "Service not found"
-
+    def _log(self, msg, *args, level=logging.INFO):
+        if self.name:
+            msg = f"{self.name}: {msg}"
+        if level == _LOG_EXCEPTION:
+            self._logger.exception(msg, *args)
         else:
-            # Print the full stack trace, unknown error
-            error_desc = "Unknown error"
-            meth = logger.exception
-            error = ""
+            self._logger.log(level, msg, *args)
 
-        if error is None:
-            error = str(exception)
-
-        meth(
-            "%s. %s for %s at pos %s: %s",
-            message_base,
-            error_desc,
-            action_type,
-            step + 1,
-            error,
-        )
-
-    async def _handle_action(self, action, variables, context):
-        """Handle an action."""
-        await self._actions[_determine_action(action)](action, variables, context)
-
-    async def _async_delay(self, action, variables, context):
-        """Handle delay."""
-        # Call ourselves in the future to continue work
-        unsub = None
-
-        @callback
-        def async_script_delay(now):
-            """Handle delay."""
-            with suppress(ValueError):
-                self._async_listener.remove(unsub)
-
-            self.hass.async_create_task(self.async_run(variables, context))
-
-        delay = action[CONF_DELAY]
-
-        try:
-            if isinstance(delay, template.Template):
-                delay = vol.All(cv.time_period, cv.positive_timedelta)(
-                    delay.async_render(variables)
-                )
-            elif isinstance(delay, dict):
-                delay_data = {}
-                delay_data.update(template.render_complex(delay, variables))
-                delay = cv.time_period(delay_data)
-        except (exceptions.TemplateError, vol.Invalid) as ex:
-            _LOGGER.error("Error rendering '%s' delay template: %s", self.name, ex)
-            raise _StopScript
-
-        self.last_action = action.get(CONF_ALIAS, f"delay {delay}")
-        self._log("Executing step %s" % self.last_action)
-
-        unsub = async_track_point_in_utc_time(
-            self.hass, async_script_delay, date_util.utcnow() + delay
-        )
-        self._async_listener.append(unsub)
-        raise _SuspendScript
-
-    async def _async_wait_template(self, action, variables, context):
-        """Handle a wait template."""
-        # Call ourselves in the future to continue work
-        wait_template = action[CONF_WAIT_TEMPLATE]
-        wait_template.hass = self.hass
-
-        self.last_action = action.get(CONF_ALIAS, "wait template")
-        self._log("Executing step %s" % self.last_action)
-
-        # check if condition already okay
-        if condition.async_template(self.hass, wait_template, variables):
-            return
-
-        @callback
-        def async_script_wait(entity_id, from_s, to_s):
-            """Handle script after template condition is true."""
-            self._async_remove_listener()
-            self.hass.async_create_task(self.async_run(variables, context))
-
-        self._async_listener.append(
-            async_track_template(self.hass, wait_template, async_script_wait, variables)
-        )
-
-        if CONF_TIMEOUT in action:
-            self._async_set_timeout(
-                action, variables, context, action.get(CONF_CONTINUE, True)
-            )
-
-        raise _SuspendScript
-
-    async def _async_call_service(self, action, variables, context):
-        """Call the service specified in the action.
-
-        This method is a coroutine.
-        """
-        self.last_action = action.get(CONF_ALIAS, "call service")
-        self._log("Executing step %s" % self.last_action)
-        await service.async_call_from_config(
-            self.hass,
-            action,
-            blocking=True,
-            variables=variables,
-            validate_config=False,
-            context=context,
-        )
-
-    async def _async_device_automation(self, action, variables, context):
-        """Perform the device automation specified in the action.
-
-        This method is a coroutine.
-        """
-        self.last_action = action.get(CONF_ALIAS, "device automation")
-        self._log("Executing step %s" % self.last_action)
-        platform = await device_automation.async_get_device_automation_platform(
-            self.hass, action[CONF_DOMAIN], "action"
-        )
-        await platform.async_call_action_from_config(
-            self.hass, action, variables, context
-        )
-
-    async def _async_activate_scene(self, action, variables, context):
-        """Activate the scene specified in the action.
-
-        This method is a coroutine.
-        """
-        self.last_action = action.get(CONF_ALIAS, "activate scene")
-        self._log("Executing step %s" % self.last_action)
-        await self.hass.services.async_call(
-            scene.DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: action[CONF_SCENE]},
-            blocking=True,
-            context=context,
-        )
-
-    async def _async_fire_event(self, action, variables, context):
-        """Fire an event."""
-        self.last_action = action.get(CONF_ALIAS, action[CONF_EVENT])
-        self._log("Executing step %s" % self.last_action)
-        event_data = dict(action.get(CONF_EVENT_DATA, {}))
-        if CONF_EVENT_DATA_TEMPLATE in action:
-            try:
-                event_data.update(
-                    template.render_complex(action[CONF_EVENT_DATA_TEMPLATE], variables)
-                )
-            except exceptions.TemplateError as ex:
-                _LOGGER.error("Error rendering event data template: %s", ex)
-
-        self.hass.bus.async_fire(action[CONF_EVENT], event_data, context=context)
-
-    async def _async_check_condition(self, action, variables, context):
-        """Test if condition is matching."""
-        config_cache_key = frozenset((k, str(v)) for k, v in action.items())
-        config = self._config_cache.get(config_cache_key)
-        if not config:
-            config = await condition.async_from_config(self.hass, action, False)
-            self._config_cache[config_cache_key] = config
-
-        self.last_action = action.get(CONF_ALIAS, action[CONF_CONDITION])
-        check = config(self.hass, variables)
-        self._log(f"Test condition {self.last_action}: {check}")
-
-        if not check:
-            raise _StopScript
-
-    def _async_set_timeout(self, action, variables, context, continue_on_timeout):
-        """Schedule a timeout to abort or continue script."""
-        timeout = action[CONF_TIMEOUT]
-        unsub = None
-
-        @callback
-        def async_script_timeout(now):
-            """Call after timeout is retrieve."""
-            with suppress(ValueError):
-                self._async_listener.remove(unsub)
-
-            # Check if we want to continue to execute
-            # the script after the timeout
-            if continue_on_timeout:
-                self.hass.async_create_task(self.async_run(variables, context))
-            else:
-                self._log("Timeout reached, abort script.")
-                self.async_stop()
-
-        unsub = async_track_point_in_utc_time(
-            self.hass, async_script_timeout, date_util.utcnow() + timeout
-        )
-        self._async_listener.append(unsub)
-
-    def _async_remove_listener(self):
-        """Remove point in time listener, if any."""
-        for unsub in self._async_listener:
-            unsub()
-        self._async_listener.clear()
-
-    def _log(self, msg):
-        """Logger helper."""
-        if self.name is not None:
-            msg = f"Script {self.name}: {msg}"
-
-        _LOGGER.info(msg)
+    def _raise(self, msg, *args, exception=None):
+        if not exception:
+            exception = exceptions.HomeAssistantError
+        self._log(msg, *args, level=logging.ERROR)
+        raise exception(msg % args)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -73,12 +73,13 @@ RUN_MODE_BLOCKING = "blocking"
 RUN_MODE_LEGACY = "legacy"
 # First choice is default
 RUN_MODE_CHOICES = [
-    RUN_MODE_BACKGROUND,
     RUN_MODE_BLOCKING,
+    RUN_MODE_BACKGROUND,
     RUN_MODE_LEGACY,
 ]
 
 _LOG_EXCEPTION = logging.ERROR + 1
+_TIMEOUT_MSG = "Timeout reached, abort script."
 
 
 def _determine_action(action):
@@ -133,7 +134,7 @@ class _SuspendScript(Exception):
 
 
 class _ScriptRunBase(ABC):
-    """Common data & methods for managing asynchronous run of Script sequence."""
+    """Common data & methods for managing Script sequence run."""
 
     def __init__(
         self,
@@ -146,62 +147,31 @@ class _ScriptRunBase(ABC):
         self._script = script
         self._variables = variables
         self._context = context
-        self._last_action = None
         self._step = -1
-        self._action = None
+        self._action: Optional[Dict[str, Any]] = None
 
-    @property
-    def _change_listener(self):
-        return self._script._change_listener  # pylint: disable=protected-access
+    def _changed(self):
+        self._script._changed()  # pylint: disable=protected-access
 
     @property
     def _config_cache(self):
         return self._script._config_cache  # pylint: disable=protected-access
 
-    @property
-    def name(self):
-        """Return script name."""
-        return self._script.name
-
-    @property
-    def last_action(self):
-        """Return last action."""
-        return self._last_action
-
-    @last_action.setter
-    def last_action(self, value):
-        self._last_action = value
-
     @abstractmethod
     async def async_run(self) -> None:
         """Run script."""
 
-    async def _async_run(self, start):
-        for self._step, self._action in islice(
-            enumerate(self._script.sequence), start, None
-        ):
-            try:
-                await getattr(self, f"_async_{_determine_action(self._action)}_step")()
-            except _SuspendScript:
-                raise
-            except _StopScript:
-                break
-            except Exception as err:
+    async def _async_step(self):
+        try:
+            await getattr(self, f"_async_{_determine_action(self._action)}_step")()
+        except Exception as err:
+            if not isinstance(err, (_SuspendScript, _StopScript)):
                 self._log_exception(err)
-                self._stop()
-                # Pass exception on.
-                raise
-
-        self._stop()
-        if self._change_listener:
-            self._hass.async_add_job(self._change_listener)
+            raise
 
     @abstractmethod
-    def stop(self) -> None:
+    async def async_stop(self) -> None:
         """Stop script run."""
-
-    def _stop(self):
-        self._script._runs.remove(self)  # pylint: disable=protected-access
 
     def _log_exception(self, exception):
         action_type = _determine_action(self._action)
@@ -246,13 +216,13 @@ class _ScriptRunBase(ABC):
         except (exceptions.TemplateError, vol.Invalid) as ex:
             self._raise(
                 "Error rendering %s delay template: %s",
-                self.name,
+                self._script.name,
                 ex,
                 exception=_StopScript,
             )
 
-        self.last_action = self._action.get(CONF_ALIAS, f"delay {delay}")
-        self._log("Executing step %s", self.last_action)
+        self._script.last_action = self._action.get(CONF_ALIAS, f"delay {delay}")
+        self._log("Executing step %s", self._script.last_action)
 
         return delay
 
@@ -264,8 +234,8 @@ class _ScriptRunBase(ABC):
         wait_template = self._action[CONF_WAIT_TEMPLATE]
         wait_template.hass = self._hass
 
-        self.last_action = self._action.get(CONF_ALIAS, "wait template")
-        self._log("Executing step %s", self.last_action)
+        self._script.last_action = self._action.get(CONF_ALIAS, "wait template")
+        self._log("Executing step %s", self._script.last_action)
 
         # check if condition already okay
         if condition.async_template(self._hass, wait_template, self._variables):
@@ -277,8 +247,8 @@ class _ScriptRunBase(ABC):
 
     async def _async_call_service_step(self):
         """Call the service specified in the action."""
-        self.last_action = self._action.get(CONF_ALIAS, "call service")
-        self._log("Executing step %s", self.last_action)
+        self._script.last_action = self._action.get(CONF_ALIAS, "call service")
+        self._log("Executing step %s", self._script.last_action)
         await service.async_call_from_config(
             self._hass,
             self._action,
@@ -290,8 +260,8 @@ class _ScriptRunBase(ABC):
 
     async def _async_device_step(self):
         """Perform the device automation specified in the action."""
-        self.last_action = self._action.get(CONF_ALIAS, "device automation")
-        self._log("Executing step %s", self.last_action)
+        self._script.last_action = self._action.get(CONF_ALIAS, "device automation")
+        self._log("Executing step %s", self._script.last_action)
         platform = await device_automation.async_get_device_automation_platform(
             self._hass, self._action[CONF_DOMAIN], "action"
         )
@@ -301,8 +271,8 @@ class _ScriptRunBase(ABC):
 
     async def _async_scene_step(self):
         """Activate the scene specified in the action."""
-        self.last_action = self._action.get(CONF_ALIAS, "activate scene")
-        self._log("Executing step %s", self.last_action)
+        self._script.last_action = self._action.get(CONF_ALIAS, "activate scene")
+        self._log("Executing step %s", self._script.last_action)
         await self._hass.services.async_call(
             scene.DOMAIN,
             SERVICE_TURN_ON,
@@ -313,8 +283,10 @@ class _ScriptRunBase(ABC):
 
     async def _async_event_step(self):
         """Fire an event."""
-        self.last_action = self._action.get(CONF_ALIAS, self._action[CONF_EVENT])
-        self._log("Executing step %s", self.last_action)
+        self._script.last_action = self._action.get(
+            CONF_ALIAS, self._action[CONF_EVENT]
+        )
+        self._log("Executing step %s", self._script.last_action)
         event_data = dict(self._action.get(CONF_EVENT_DATA, {}))
         if CONF_EVENT_DATA_TEMPLATE in self._action:
             try:
@@ -340,9 +312,11 @@ class _ScriptRunBase(ABC):
             config = await condition.async_from_config(self._hass, self._action, False)
             self._config_cache[config_cache_key] = config
 
-        self.last_action = self._action.get(CONF_ALIAS, self._action[CONF_CONDITION])
+        self._script.last_action = self._action.get(
+            CONF_ALIAS, self._action[CONF_CONDITION]
+        )
         check = config(self._hass, self._variables)
-        self._log("Test condition %s: %s", self.last_action, check)
+        self._log("Test condition %s: %s", self._script.last_action, check)
         if not check:
             raise _StopScript
 
@@ -355,7 +329,7 @@ class _ScriptRunBase(ABC):
 
 
 class _ScriptRun(_ScriptRunBase):
-    """Manage asynchronous run of Script sequence."""
+    """Manage Script sequence run."""
 
     def __init__(
         self,
@@ -365,21 +339,34 @@ class _ScriptRun(_ScriptRunBase):
         context: Optional[Context],
     ) -> None:
         super().__init__(hass, script, variables, context)
-        self.task: Optional[asyncio.Task] = None
+        self._stop = asyncio.Event()
+        self._stopped = asyncio.Event()
 
-    async def async_run(self) -> None:
-        """Run script."""
+    async def _async_run(self) -> None:
         self._log("Running script")
-        await self._async_run(0)
+        try:
+            for self._step, self._action in enumerate(self._script.sequence):
+                if self._stop.is_set():
+                    break
+                await self._async_step()
+        except _StopScript:
+            pass
+        finally:
+            if not self._stop.is_set():
+                self._changed()
+            self._script._runs.remove(self)  # pylint: disable=protected-access
+            self._stopped.set()
 
-    def stop(self) -> None:
+    async def async_stop(self) -> None:
         """Stop script run."""
-        cast(asyncio.Task, self.task).cancel()
-        self._stop()
+        self._stop.set()
+        await self._stopped.wait()
 
     async def _async_delay_step(self):
         """Handle delay."""
-        await asyncio.sleep(self._start_delay_step())
+        await asyncio.wait(
+            {self._stop.wait()}, timeout=self._start_delay_step().total_seconds()
+        )
 
     async def _async_wait_template_step(self):
         """Handle a wait template."""
@@ -394,20 +381,49 @@ class _ScriptRun(_ScriptRunBase):
         if not unsub:
             return
 
-        timeout = self._action.get(CONF_TIMEOUT)
+        try:
+            timeout = self._action[CONF_TIMEOUT].total_seconds()
+        except KeyError:
+            timeout = None
         done = asyncio.Event()
         try:
-            await asyncio.wait_for(done.wait(), timeout)
+            await asyncio.wait_for(
+                asyncio.wait(
+                    {self._stop.wait(), done.wait()},
+                    return_when=asyncio.FIRST_COMPLETED,
+                ),
+                timeout,
+            )
         except asyncio.TimeoutError:
             if not self._action.get(CONF_CONTINUE, True):
-                self._log("Timeout reached, abort script.")
+                self._log(_TIMEOUT_MSG)
                 raise _StopScript
         finally:
             unsub()
 
 
+class _BackgroundScriptRun(_ScriptRun):
+    """Manage background Script sequence run."""
+
+    async def async_run(self) -> None:
+        """Run script."""
+        self._hass.async_create_task(self._async_run())
+
+
+class _BlockingScriptRun(_ScriptRun):
+    """Manage blocking Script sequence run."""
+
+    async def async_run(self) -> None:
+        """Run script."""
+        try:
+            await asyncio.shield(self._async_run())
+        except asyncio.CancelledError:
+            await self.async_stop()
+            raise
+
+
 class _LegacyScriptRun(_ScriptRunBase):
-    """Manage asynchronous run of legacy Script sequence."""
+    """Manage legacy Script sequence run."""
 
     def __init__(
         self,
@@ -426,16 +442,7 @@ class _LegacyScriptRun(_ScriptRunBase):
             # concurrent runs, and the rest will use it, too.
             self._current = -1
             self._async_listeners: List[CALLBACK_TYPE] = []
-
             self._shared = self
-
-    @property
-    def last_action(self):
-        return self._shared._last_action  # pylint: disable=protected-access
-
-    @last_action.setter
-    def last_action(self, value):
-        self._shared._last_action = value  # pylint: disable=protected-access
 
     @property
     def _cur(self):
@@ -459,24 +466,33 @@ class _LegacyScriptRun(_ScriptRunBase):
         # called again. In that case we just continue execution.
         self._async_remove_listener()
 
+        suspended = False
         try:
-            await self._async_run(self._cur)
+            for self._step, self._action in islice(
+                enumerate(self._script.sequence), self._cur, None
+            ):
+                await self._async_step()
+        except _StopScript:
+            pass
         except _SuspendScript:
             # Store next step to take and notify change listeners
             self._cur = self._step + 1
-            if self._change_listener:
-                self._hass.async_add_job(self._change_listener)
+            suspended = True
+            return
+        finally:
+            if self._cur != -1:
+                self._changed()
+            if not suspended:
+                self._script.last_action = None
+                await self.async_stop()
+
+    async def async_stop(self) -> None:
+        """Stop script run."""
+        if self._cur == -1:
             return
 
-    def stop(self):
-        """Stop running script."""
         self._cur = -1
         self._async_remove_listener()
-        super()._stop()
-
-    def _stop(self):
-        self._cur = -1
-        self.last_action = None
         self._script._runs.clear()  # pylint: disable=protected-access
 
     async def _async_delay_step(self):
@@ -516,8 +532,8 @@ class _LegacyScriptRun(_ScriptRunBase):
             if self._action.get(CONF_CONTINUE, True):
                 self._hass.async_create_task(self.async_run())
             else:
-                self._log("Timeout reached, abort script.")
-                self.stop()
+                self._log(_TIMEOUT_MSG)
+                self._hass.async_create_task(self.async_stop())
 
         unsub_wait = self._start_wait_template_step(async_script_wait)
         if not unsub_wait:
@@ -559,6 +575,7 @@ class Script:
         template.attach(hass, self.sequence)
         self.name = name
         self._change_listener = change_listener
+        self.last_action = None
         self.last_triggered: Optional[datetime] = None
         self.can_cancel = any(
             CONF_DELAY in action or CONF_WAIT_TEMPLATE in action
@@ -577,17 +594,13 @@ class Script:
         self._referenced_entities: Optional[Set[str]] = None
         self._referenced_devices: Optional[Set[str]] = None
 
-    def set_logger(self, logger):
-        """Set logger use by script helper."""
-        self._logger = logger
+    def _changed(self):
+        if self._change_listener:
+            self._hass.async_add_job(self._change_listener)
 
-    @property
-    def last_action(self):
-        """Return last action."""
-        try:
-            return self._runs[0].last_action
-        except IndexError:
-            return None
+    def set_logger(self, logger):
+        """Set logger used by script helper."""
+        self._logger = logger
 
     @property
     def is_running(self) -> bool:
@@ -664,6 +677,7 @@ class Script:
             if self._if_running == IF_RUNNING_IGNORE:
                 self._log("Skipping script")
                 return False
+
             if self._if_running == IF_RUNNING_ERROR:
                 self._raise("Already running")
             if self._if_running == IF_RUNNING_RESTART:
@@ -676,29 +690,24 @@ class Script:
                 shared = cast(Optional[_LegacyScriptRun], self._runs[0])
             else:
                 shared = None
-            run = cast(
-                _ScriptRunBase,
-                _LegacyScriptRun(self._hass, self, variables, context, shared),
+            run: _ScriptRunBase = _LegacyScriptRun(
+                self._hass, self, variables, context, shared
             )
-            self._runs.append(run)
-            await run.async_run()
         else:
-            run = cast(_ScriptRunBase, _ScriptRun(self._hass, self, variables, context))
-            self._runs.append(run)
-            cast(_ScriptRun, run).task = self._hass.async_create_task(run.async_run())
-            if self._run_mode == RUN_MODE_BLOCKING:
-                await cast(asyncio.Task, cast(_ScriptRun, run).task)
+            if self._run_mode == RUN_MODE_BACKGROUND:
+                run = _BackgroundScriptRun(self._hass, self, variables, context)
+            else:
+                run = _BlockingScriptRun(self._hass, self, variables, context)
+        self._runs.append(run)
+        await run.async_run()
         return True
 
-    @callback
-    def async_stop(self) -> None:
+    async def async_stop(self) -> None:
         """Stop running script."""
         if not self.is_running:
             return
-        for run in self._runs:
-            run.stop()
-        if self._change_listener:
-            self._hass.async_add_job(self._change_listener)
+        await asyncio.shield(asyncio.gather(*(run.async_stop() for run in self._runs)))
+        self._changed()
 
     def _log(self, msg, *args, level=logging.INFO):
         if self.name:

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 import homeassistant.components.demo.notify as demo
 import homeassistant.components.notify as notify
 from homeassistant.core import callback
-from homeassistant.helpers import discovery, script
+from homeassistant.helpers import discovery
 from homeassistant.setup import setup_component
 
 from tests.common import assert_setup_component, get_test_home_assistant
@@ -121,7 +121,7 @@ class TestNotifyDemo(unittest.TestCase):
     def test_calling_notify_from_script_loaded_from_yaml_without_title(self):
         """Test if we can call a notify from a script."""
         self._setup_notify()
-        conf = {
+        step = {
             "service": "notify.notify",
             "data": {
                 "data": {
@@ -130,8 +130,8 @@ class TestNotifyDemo(unittest.TestCase):
             },
             "data_template": {"message": "Test 123 {{ 2 + 2 }}\n"},
         }
-
-        script.call_from_config(self.hass, conf)
+        setup_component(self.hass, "script", {"script": {"test": {"sequence": step}}})
+        self.hass.services.call("script", "test")
         self.hass.block_till_done()
         assert len(self.events) == 1
         assert {
@@ -144,7 +144,7 @@ class TestNotifyDemo(unittest.TestCase):
     def test_calling_notify_from_script_loaded_from_yaml_with_title(self):
         """Test if we can call a notify from a script."""
         self._setup_notify()
-        conf = {
+        step = {
             "service": "notify.notify",
             "data": {
                 "data": {
@@ -153,8 +153,8 @@ class TestNotifyDemo(unittest.TestCase):
             },
             "data_template": {"message": "Test 123 {{ 2 + 2 }}\n", "title": "Test"},
         }
-
-        script.call_from_config(self.hass, conf)
+        setup_component(self.hass, "script", {"script": {"test": {"sequence": step}}})
+        self.hass.services.call("script", "test")
         self.hass.block_till_done()
         assert len(self.events) == 1
         assert {

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -21,80 +21,94 @@ from tests.common import async_fire_time_changed
 
 ENTITY_ID = "script.test"
 
+_ALL_RUN_MODES = [None, "background", "blocking"]
 
-async def test_firing_event(hass):
+
+async def test_firing_event_basic(hass):
     """Test the firing of events."""
     event = "test_event"
     context = Context()
-    calls = []
 
     @callback
     def record_event(event):
         """Add recorded event to set."""
-        calls.append(event)
+        events.append(event)
 
     hass.bus.async_listen(event, record_event)
 
-    script_obj = script.Script(
-        hass, cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
-    )
+    schema = cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
 
-    await script_obj.async_run(context=context)
+    # For this one test we'll make sure "legacy" works the same as None.
+    for run_mode in _ALL_RUN_MODES + ["legacy"]:
+        events = []
 
-    await hass.async_block_till_done()
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-    assert len(calls) == 1
-    assert calls[0].context is context
-    assert calls[0].data.get("hello") == "world"
-    assert not script_obj.can_cancel
+        assert not script_obj.can_cancel
+
+        await script_obj.async_run(context=context)
+
+        await hass.async_block_till_done()
+
+        assert len(events) == 1
+        assert events[0].context is context
+        assert events[0].data.get("hello") == "world"
+        assert not script_obj.can_cancel
 
 
 async def test_firing_event_template(hass):
     """Test the firing of events."""
     event = "test_event"
     context = Context()
-    calls = []
 
     @callback
     def record_event(event):
         """Add recorded event to set."""
-        calls.append(event)
+        events.append(event)
 
     hass.bus.async_listen(event, record_event)
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            {
-                "event": event,
-                "event_data_template": {
-                    "dict": {
-                        1: "{{ is_world }}",
-                        2: "{{ is_world }}{{ is_world }}",
-                        3: "{{ is_world }}{{ is_world }}{{ is_world }}",
-                    },
-                    "list": ["{{ is_world }}", "{{ is_world }}{{ is_world }}"],
+    schema = cv.SCRIPT_SCHEMA(
+        {
+            "event": event,
+            "event_data_template": {
+                "dict": {
+                    1: "{{ is_world }}",
+                    2: "{{ is_world }}{{ is_world }}",
+                    3: "{{ is_world }}{{ is_world }}{{ is_world }}",
                 },
-            }
-        ),
+                "list": ["{{ is_world }}", "{{ is_world }}{{ is_world }}"],
+            },
+        }
     )
 
-    await script_obj.async_run({"is_world": "yes"}, context=context)
+    for run_mode in _ALL_RUN_MODES:
+        events = []
 
-    await hass.async_block_till_done()
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-    assert len(calls) == 1
-    assert calls[0].context is context
-    assert calls[0].data == {
-        "dict": {1: "yes", 2: "yesyes", 3: "yesyesyes"},
-        "list": ["yes", "yesyes"],
-    }
-    assert not script_obj.can_cancel
+        assert not script_obj.can_cancel
+
+        await script_obj.async_run({"is_world": "yes"}, context=context)
+
+        await hass.async_block_till_done()
+
+        assert len(events) == 1
+        assert events[0].context is context
+        assert events[0].data == {
+            "dict": {1: "yes", 2: "yesyes", 3: "yesyesyes"},
+            "list": ["yes", "yesyes"],
+        }
 
 
-async def test_calling_service(hass):
+async def test_calling_service_basic(hass):
     """Test the calling of a service."""
-    calls = []
     context = Context()
 
     @callback
@@ -104,20 +118,76 @@ async def test_calling_service(hass):
 
     hass.services.async_register("test", "script", record_call)
 
-    await script.Script(
-        hass, cv.SCRIPT_SCHEMA({"service": "test.script", "data": {"hello": "world"}})
-    ).async_run(context=context)
+    schema = cv.SCRIPT_SCHEMA({"service": "test.script", "data": {"hello": "world"}})
 
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        calls = []
 
-    assert len(calls) == 1
-    assert calls[0].context is context
-    assert calls[0].data.get("hello") == "world"
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        assert not script_obj.can_cancel
+
+        await script_obj.async_run(context=context)
+
+        await hass.async_block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].context is context
+        assert calls[0].data.get("hello") == "world"
+
+
+async def test_cancel_no_wait(hass, caplog):
+    """Test stopping script."""
+    event = "test_event"
+
+    async def async_simulate_long_service(service):
+        """Simulate a service that takes a not insignificant time."""
+        await asyncio.sleep(0.01)
+
+    hass.services.async_register("test", "script", async_simulate_long_service)
+
+    @callback
+    def monitor_event(event):
+        """Signal event happened."""
+        event_sem.release()
+
+    hass.bus.async_listen(event, monitor_event)
+
+    schema = cv.SCRIPT_SCHEMA([{"event": event}, {"service": "test.script"}])
+
+    for run_mode in _ALL_RUN_MODES:
+        event_sem = asyncio.Semaphore(0)
+
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        tasks = []
+        for _ in range(3):
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            tasks.append(hass.async_create_task(event_sem.acquire()))
+        await asyncio.wait_for(asyncio.gather(*tasks), 1)
+
+        # Can't assert just yet because we haven't verified stopping works yet.
+        # If assert fails we can hang test if async_stop doesn't work.
+        script_was_runing = script_obj.is_running
+
+        await script_obj.async_stop()
+        await hass.async_block_till_done()
+
+        assert script_was_runing
+        assert not script_obj.is_running
 
 
 async def test_activating_scene(hass):
     """Test the activation of a scene."""
-    calls = []
     context = Context()
 
     @callback
@@ -127,20 +197,29 @@ async def test_activating_scene(hass):
 
     hass.services.async_register(scene.DOMAIN, SERVICE_TURN_ON, record_call)
 
-    await script.Script(hass, cv.SCRIPT_SCHEMA({"scene": "scene.hello"})).async_run(
-        context=context
-    )
+    schema = cv.SCRIPT_SCHEMA({"scene": "scene.hello"})
 
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        calls = []
 
-    assert len(calls) == 1
-    assert calls[0].context is context
-    assert calls[0].data.get(ATTR_ENTITY_ID) == "scene.hello"
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        assert not script_obj.can_cancel
+
+        await script_obj.async_run(context=context)
+
+        await hass.async_block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].context is context
+        assert calls[0].data.get(ATTR_ENTITY_ID) == "scene.hello"
 
 
 async def test_calling_service_template(hass):
     """Test the calling of a service."""
-    calls = []
     context = Context()
 
     @callback
@@ -150,162 +229,179 @@ async def test_calling_service_template(hass):
 
     hass.services.async_register("test", "script", record_call)
 
-    await script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            {
-                "service_template": """
-                {% if True %}
-                    test.script
+    schema = cv.SCRIPT_SCHEMA(
+        {
+            "service_template": """
+            {% if True %}
+                test.script
+            {% else %}
+                test.not_script
+            {% endif %}""",
+            "data_template": {
+                "hello": """
+                {% if is_world == 'yes' %}
+                    world
                 {% else %}
-                    test.not_script
-                {% endif %}""",
-                "data_template": {
-                    "hello": """
-                    {% if is_world == 'yes' %}
-                        world
-                    {% else %}
-                        not world
-                    {% endif %}
-                """
-                },
+                    not world
+                {% endif %}
+            """
             },
-        ),
-    ).async_run({"is_world": "yes"}, context=context)
+        }
+    )
 
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        calls = []
 
-    assert len(calls) == 1
-    assert calls[0].context is context
-    assert calls[0].data.get("hello") == "world"
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        assert not script_obj.can_cancel
+
+        await script_obj.async_run({"is_world": "yes"}, context=context)
+
+        await hass.async_block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].context is context
+        assert calls[0].data.get("hello") == "world"
 
 
-async def test_legacy_no_wait(hass):
-    """Test the legacy behavior with no wait in script."""
-    calls = []
+async def test_multiple_runs_no_wait(hass):
+    """Test multiple runs with no wait in script."""
     logger = logging.getLogger("TEST")
 
-    async def async_simulate_service(service):
-        """Simulate a service that takes a non-significant time."""
+    async def async_simulate_long_service(service):
+        """Simulate a service that takes a not insignificant time."""
 
         @callback
-        def done(event):
-            nonlocal waiting
+        def service_done_cb(event):
             logger.debug("simulated service (%s:%s) done", fire, listen)
-            waiting = False
+            service_done.set()
 
         calls.append(service)
+
         fire = service.data.get("fire")
         listen = service.data.get("listen")
         logger.debug("simulated service (%s:%s) started", fire, listen)
 
-        unsub = hass.bus.async_listen(listen, done)
+        service_done = asyncio.Event()
+        unsub = hass.bus.async_listen(listen, service_done_cb)
+
         hass.bus.async_fire(fire)
 
-        waiting = True
-        while waiting:
-            await asyncio.sleep(0)
+        await service_done.wait()
         unsub()
 
-    hass.services.async_register("test", "script", async_simulate_service)
+    hass.services.async_register("test", "script", async_simulate_long_service)
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {
-                    "service": "test.script",
-                    "data_template": {"fire": "{{ fire1 }}", "listen": "{{ listen1 }}"},
-                },
-                {
-                    "service": "test.script",
-                    "data_template": {"fire": "{{ fire2 }}", "listen": "{{ listen2 }}"},
-                },
-            ],
-        ),
+    heard_event = asyncio.Event()
+
+    @callback
+    def heard_event_cb(event):
+        logger.debug("heard: %s", event)
+        heard_event.set()
+
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {
+                "service": "test.script",
+                "data_template": {"fire": "{{ fire1 }}", "listen": "{{ listen1 }}"},
+            },
+            {
+                "service": "test.script",
+                "data_template": {"fire": "{{ fire2 }}", "listen": "{{ listen2 }}"},
+            },
+        ]
     )
 
-    async def async_sequence_test():
-        @callback
-        def done(event):
-            nonlocal waiting
-            logger.debug("sequencer heard: %s", event)
-            waiting = False
+    for run_mode in _ALL_RUN_MODES:
+        calls = []
+        heard_event.clear()
 
-        logger.debug("sequencer starting 1st script")
-        hass.async_run_job(
-            script_obj.async_run(
-                {"fire1": "1", "listen1": "2", "fire2": "3", "listen2": "4"}
-            )
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        # Start script twice in such a way that second run will be started while first
+        # run is in the middle of the first service call.
+
+        unsub = hass.bus.async_listen("1", heard_event_cb)
+
+        logger.debug("starting 1st script")
+        coro = script_obj.async_run(
+            {"fire1": "1", "listen1": "2", "fire2": "3", "listen2": "4"}
         )
+        if run_mode == "background":
+            await coro
+        else:
+            hass.async_create_task(coro)
+        await asyncio.wait_for(heard_event.wait(), 1)
 
-        waiting = True
-        unsub = hass.bus.async_listen("1", done)
-        while waiting:
-            await asyncio.sleep(0)
         unsub()
 
-        logger.debug("sequencer starting 2nd script")
-        hass.async_run_job(
-            script_obj.async_run(
-                {"fire1": "2", "listen1": "3", "fire2": "4", "listen2": "4"}
-            )
+        logger.debug("starting 2nd script")
+        await script_obj.async_run(
+            {"fire1": "2", "listen1": "3", "fire2": "4", "listen2": "4"}
         )
 
-    hass.async_run_job(async_sequence_test())
+        await hass.async_block_till_done()
 
-    await hass.async_block_till_done()
-
-    assert len(calls) == 4
+        assert len(calls) == 4
 
 
-async def test_delay(hass):
+async def test_delay_basic(hass):
     """Test the delay."""
-    event = "test_event"
-    events = []
-    context = Context()
     delay_alias = "delay step"
+    delay_started_flag = asyncio.Event()
 
     @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
+    def delay_started_cb():
+        delay_started_flag.set()
 
-    hass.bus.async_listen(event, record_event)
+    delay = timedelta(milliseconds=10)
+    schema = cv.SCRIPT_SCHEMA({"delay": delay, "alias": delay_alias})
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"delay": {"seconds": 5}, "alias": delay_alias},
-                {"event": event},
-            ]
-        ),
-    )
+    for run_mode in _ALL_RUN_MODES:
+        delay_started_flag.clear()
 
-    await script_obj.async_run(context=context)
-    await hass.async_block_till_done()
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=delay_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=delay_started_cb, run_mode=run_mode
+            )
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == delay_alias
-    assert len(events) == 1
+        assert script_obj.can_cancel
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(delay_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
-    assert len(events) == 2
-    assert events[0].context is context
-    assert events[1].context is context
+            assert script_obj.is_running
+            assert script_obj.last_action == delay_alias
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + delay
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            assert script_obj.last_action is None
 
 
-async def test_legacy_with_delay(hass):
-    """Test the legacy behavior with a delay in script."""
+async def test_multiple_runs_delay(hass):
+    """Test multiple runs with delay in script."""
     event = "test_event"
-    events = []
+    delay_started_flag = asyncio.Event()
 
     @callback
     def record_event(event):
@@ -314,70 +410,105 @@ async def test_legacy_with_delay(hass):
 
     hass.bus.async_listen(event, record_event)
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [{"event": event}, {"delay": {"seconds": 5}}, {"event": event}]
-        ),
+    @callback
+    def delay_started_cb():
+        delay_started_flag.set()
+
+    delay = timedelta(milliseconds=10)
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event, "event_data": {"value": 1}},
+            {"delay": delay},
+            {"event": event, "event_data": {"value": 2}},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        events = []
+        delay_started_flag.clear()
 
-    assert script_obj.is_running
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=delay_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=delay_started_cb, run_mode=run_mode
+            )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(delay_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
-    assert len(events) == 2
+            assert script_obj.is_running
+            assert len(events) == 1
+            assert events[-1].data["value"] == 1
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            # Start second run of script while first run is in a delay.
+            await script_obj.async_run()
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + delay
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            if run_mode in (None, "legacy"):
+                assert len(events) == 2
+            else:
+                assert len(events) == 4
+                assert events[-3].data["value"] == 1
+                assert events[-2].data["value"] == 2
+            assert events[-1].data["value"] == 2
 
 
-async def test_delay_template(hass):
+async def test_delay_template_ok(hass):
     """Test the delay as a template."""
-    event = "test_event"
-    events = []
-    delay_alias = "delay step"
+    delay_started_flag = asyncio.Event()
 
     @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
+    def delay_started_cb():
+        delay_started_flag.set()
 
-    hass.bus.async_listen(event, record_event)
+    schema = cv.SCRIPT_SCHEMA({"delay": "00:00:{{ 1 }}"})
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"delay": "00:00:{{ 5 }}", "alias": delay_alias},
-                {"event": event},
-            ]
-        ),
-    )
+    for run_mode in _ALL_RUN_MODES:
+        delay_started_flag.clear()
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=delay_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=delay_started_cb, run_mode=run_mode
+            )
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == delay_alias
-    assert len(events) == 1
+        assert script_obj.can_cancel
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(delay_started_flag.wait(), 1)
+            assert script_obj.is_running
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + timedelta(seconds=1)
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
 
-    assert not script_obj.is_running
-    assert len(events) == 2
+            assert not script_obj.is_running
 
 
-async def test_delay_invalid_template(hass, caplog):
+async def test_delay_template_invalid(hass, caplog):
     """Test the delay as a template that fails."""
     event = "test_event"
-    events = []
 
     @callback
     def record_event(event):
@@ -386,74 +517,82 @@ async def test_delay_invalid_template(hass, caplog):
 
     hass.bus.async_listen(event, record_event)
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"delay": "{{ invalid_delay }}"},
-                {"delay": {"seconds": 5}},
-                {"event": event},
-            ]
-        ),
-        logger=logging.getLogger("TEST"),
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event},
+            {"delay": "{{ invalid_delay }}"},
+            {"delay": {"seconds": 5}},
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
-    # TODO: Check error message???
-    assert any(
-        rec.levelname == "ERROR" and rec.name == "TEST" for rec in caplog.records
-    )
+    for run_mode in _ALL_RUN_MODES:
+        events = []
 
-    assert not script_obj.is_running
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+        start_idx = len(caplog.records)
+
+        await script_obj.async_run()
+        await hass.async_block_till_done()
+
+        assert any(
+            rec.levelname == "ERROR" and "Error rendering" in rec.message
+            for rec in caplog.records[start_idx:]
+        )
+
+        assert not script_obj.is_running
+        assert len(events) == 1
 
 
-async def test_delay_complex_template(hass):
+async def test_delay_template_complex_ok(hass):
     """Test the delay with a working complex template."""
-    event = "test_event"
-    events = []
-    delay_alias = "delay step"
+    delay_started_flag = asyncio.Event()
 
     @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
+    def delay_started_cb():
+        delay_started_flag.set()
 
-    hass.bus.async_listen(event, record_event)
+    milliseconds = 10
+    schema = cv.SCRIPT_SCHEMA({"delay": {"milliseconds": "{{ milliseconds }}"}})
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"delay": {"seconds": "{{ 5 }}"}, "alias": delay_alias},
-                {"event": event},
-            ]
-        ),
-    )
+    for run_mode in _ALL_RUN_MODES:
+        delay_started_flag.clear()
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=delay_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=delay_started_cb, run_mode=run_mode
+            )
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == delay_alias
-    assert len(events) == 1
+        assert script_obj.can_cancel
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+        try:
+            coro = script_obj.async_run({"milliseconds": milliseconds})
+            if run_mode == "background":
+                await coro
+            else:
+                hass.async_create_task(coro)
+            await asyncio.wait_for(delay_started_flag.wait(), 1)
+            assert script_obj.is_running
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + timedelta(milliseconds=milliseconds)
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
 
-    assert not script_obj.is_running
-    assert len(events) == 2
+            assert not script_obj.is_running
 
 
-async def test_delay_complex_invalid_template(hass, caplog):
+async def test_delay_template_complex_invalid(hass, caplog):
     """Test the delay with a complex template that fails."""
     event = "test_event"
-    events = []
 
     @callback
     def record_event(event):
@@ -462,35 +601,44 @@ async def test_delay_complex_invalid_template(hass, caplog):
 
     hass.bus.async_listen(event, record_event)
 
-    # TODO: Use invalid timedelta???
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"delay": {"seconds": "{{ invalid_delay }}"}},
-                {"delay": {"seconds": "{{ 5 }}"}},
-                {"event": event},
-            ]
-        ),
-        logger=logging.getLogger("TEST"),
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event},
+            {"delay": {"seconds": "{{ invalid_delay }}"}},
+            {"delay": {"seconds": 5}},
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
-    # TODO: Check error message???
-    assert any(
-        rec.levelname == "ERROR" and rec.name == "TEST" for rec in caplog.records
-    )
+    for run_mode in _ALL_RUN_MODES:
+        events = []
 
-    assert not script_obj.is_running
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+        start_idx = len(caplog.records)
+
+        await script_obj.async_run()
+        await hass.async_block_till_done()
+
+        assert any(
+            rec.levelname == "ERROR" and "Error rendering" in rec.message
+            for rec in caplog.records[start_idx:]
+        )
+
+        assert not script_obj.is_running
+        assert len(events) == 1
 
 
-async def test_cancel_while_delay(hass):
+async def test_cancel_delay(hass):
     """Test the cancelling while the delay is present."""
+    delay_started_flag = asyncio.Event()
     event = "test_event"
-    events = []
+
+    @callback
+    def delay_started_cb():
+        delay_started_flag.set()
 
     @callback
     def record_event(event):
@@ -499,80 +647,101 @@ async def test_cancel_while_delay(hass):
 
     hass.bus.async_listen(event, record_event)
 
-    script_obj = script.Script(
-        hass, cv.SCRIPT_SCHEMA([{"delay": {"seconds": 5}}, {"event": event}])
-    )
+    delay = timedelta(milliseconds=10)
+    schema = cv.SCRIPT_SCHEMA([{"delay": delay}, {"event": event}])
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        delay_started_flag.clear()
+        events = []
 
-    assert script_obj.is_running
-    assert len(events) == 0
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=delay_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=delay_started_cb, run_mode=run_mode
+            )
 
-    await script_obj.async_stop()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(delay_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
+            assert script_obj.is_running
+            assert len(events) == 0
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            await script_obj.async_stop()
 
-    # Make sure the script is really stopped.
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+            assert not script_obj.is_running
 
-    assert not script_obj.is_running
-    assert len(events) == 0
+            # Make sure the script is really stopped.
+
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + delay
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            assert len(events) == 0
 
 
-async def test_wait_template(hass):
+async def test_wait_template_basic(hass):
     """Test the wait template."""
-    event = "test_event"
-    events = []
-    context = Context()
     wait_alias = "wait step"
+    wait_started_flag = asyncio.Event()
 
     @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
+    def wait_started_cb():
+        wait_started_flag.set()
 
-    hass.bus.async_listen(event, record_event)
-
-    hass.states.async_set("switch.test", "on")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "wait_template": "{{states.switch.test.state == 'off'}}",
-                    "alias": wait_alias,
-                },
-                {"event": event},
-            ]
-        ),
+    schema = cv.SCRIPT_SCHEMA(
+        {
+            "wait_template": "{{ states.switch.test.state == 'off' }}",
+            "alias": wait_alias,
+        }
     )
 
-    await script_obj.async_run(context=context)
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        wait_started_flag.clear()
+        hass.states.async_set("switch.test", "on")
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == wait_alias
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=wait_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=wait_started_cb, run_mode=run_mode
+            )
 
-    hass.states.async_set("switch.test", "off")
-    await hass.async_block_till_done()
+        assert script_obj.can_cancel
 
-    assert not script_obj.is_running
-    assert len(events) == 2
-    assert events[0].context is context
-    assert events[1].context is context
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+            assert script_obj.is_running
+            assert script_obj.last_action == wait_alias
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            hass.states.async_set("switch.test", "off")
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            assert script_obj.last_action is None
 
 
-async def test_legacy_with_wait_template(hass):
-    """Test the legacy behavior with a wait_template in script."""
+async def test_multiple_runs_wait_template(hass):
+    """Test multiple runs with wait_template in script."""
     event = "test_event"
-    events = []
+    wait_started_flag = asyncio.Event()
 
     @callback
     def record_event(event):
@@ -581,37 +750,70 @@ async def test_legacy_with_wait_template(hass):
 
     hass.bus.async_listen(event, record_event)
 
-    hass.states.async_set("switch.test", "on")
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"wait_template": "{{states.switch.test.state == 'off'}}"},
-                {"event": event},
-            ]
-        ),
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event, "event_data": {"value": 1}},
+            {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+            {"event": event, "event_data": {"value": 2}},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        events = []
+        wait_started_flag.clear()
+        hass.states.async_set("switch.test", "on")
 
-    assert script_obj.is_running
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=wait_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=wait_started_cb, run_mode=run_mode
+            )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
-    assert len(events) == 2
+            assert script_obj.is_running
+            assert len(events) == 1
+            assert events[-1].data["value"] == 1
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            # Start second run of script while first run is in wait_template.
+            if run_mode == "blocking":
+                hass.async_create_task(script_obj.async_run())
+            else:
+                await script_obj.async_run()
+            hass.states.async_set("switch.test", "off")
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            if run_mode in (None, "legacy"):
+                assert len(events) == 2
+            else:
+                assert len(events) == 4
+                assert events[-3].data["value"] == 1
+                assert events[-2].data["value"] == 2
+            assert events[-1].data["value"] == 2
 
 
-async def test_wait_template_cancel(hass):
-    """Test the wait template cancel action."""
+async def test_cancel_wait_template(hass):
+    """Test the cancelling while wait_template is present."""
+    wait_started_flag = asyncio.Event()
     event = "test_event"
-    events = []
-    wait_alias = "wait step"
+
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
 
     @callback
     def record_event(event):
@@ -620,46 +822,54 @@ async def test_wait_template_cancel(hass):
 
     hass.bus.async_listen(event, record_event)
 
-    hass.states.async_set("switch.test", "on")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "wait_template": "{{states.switch.test.state == 'off'}}",
-                    "alias": wait_alias,
-                },
-                {"event": event},
-            ]
-        ),
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        wait_started_flag.clear()
+        events = []
+        hass.states.async_set("switch.test", "on")
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == wait_alias
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=wait_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=wait_started_cb, run_mode=run_mode
+            )
 
-    await script_obj.async_stop()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
-    assert len(events) == 1
+            assert script_obj.is_running
+            assert len(events) == 0
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            await script_obj.async_stop()
 
-    hass.states.async_set("switch.test", "off")
-    await hass.async_block_till_done()
+            assert not script_obj.is_running
 
-    assert not script_obj.is_running
-    assert len(events) == 1
+            # Make sure the script is really stopped.
+
+            hass.states.async_set("switch.test", "off")
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            assert len(events) == 0
 
 
 async def test_wait_template_not_schedule(hass):
     """Test the wait template with correct condition."""
     event = "test_event"
-    events = []
 
     @callback
     def record_event(event):
@@ -670,30 +880,33 @@ async def test_wait_template_not_schedule(hass):
 
     hass.states.async_set("switch.test", "on")
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"wait_template": "{{states.switch.test.state == 'on'}}"},
-                {"event": event},
-            ]
-        ),
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event},
+            {"wait_template": "{{ states.switch.test.state == 'on' }}"},
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        events = []
 
-    assert not script_obj.is_running
-    assert script_obj.can_cancel
-    assert len(events) == 2
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        await script_obj.async_run()
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
 
 
 async def test_wait_template_timeout_halt(hass):
     """Test the wait template, halt on timeout."""
     event = "test_event"
-    events = []
-    wait_alias = "wait step"
+    wait_started_flag = asyncio.Event()
 
     @callback
     def record_event(event):
@@ -702,45 +915,61 @@ async def test_wait_template_timeout_halt(hass):
 
     hass.bus.async_listen(event, record_event)
 
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
+
     hass.states.async_set("switch.test", "on")
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "wait_template": "{{states.switch.test.state == 'off'}}",
-                    "continue_on_timeout": False,
-                    "timeout": 5,
-                    "alias": wait_alias,
-                },
-                {"event": event},
-            ]
-        ),
+    timeout = timedelta(milliseconds=10)
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {
+                "wait_template": "{{ states.switch.test.state == 'off' }}",
+                "continue_on_timeout": False,
+                "timeout": timeout,
+            },
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        events = []
+        wait_started_flag.clear()
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == wait_alias
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=wait_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=wait_started_cb, run_mode=run_mode
+            )
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
-    assert len(events) == 1
+            assert script_obj.is_running
+            assert len(events) == 0
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + timeout
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            assert len(events) == 0
 
 
 async def test_wait_template_timeout_continue(hass):
     """Test the wait template with continuing the script."""
     event = "test_event"
-    events = []
-    wait_alias = "wait step"
+    wait_started_flag = asyncio.Event()
 
     @callback
     def record_event(event):
@@ -749,45 +978,61 @@ async def test_wait_template_timeout_continue(hass):
 
     hass.bus.async_listen(event, record_event)
 
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
+
     hass.states.async_set("switch.test", "on")
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "wait_template": "{{states.switch.test.state == 'off'}}",
-                    "timeout": 5,
-                    "continue_on_timeout": True,
-                    "alias": wait_alias,
-                },
-                {"event": event},
-            ]
-        ),
+    timeout = timedelta(milliseconds=10)
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {
+                "wait_template": "{{ states.switch.test.state == 'off' }}",
+                "continue_on_timeout": True,
+                "timeout": timeout,
+            },
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        events = []
+        wait_started_flag.clear()
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == wait_alias
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=wait_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=wait_started_cb, run_mode=run_mode
+            )
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
-    assert len(events) == 2
+            assert script_obj.is_running
+            assert len(events) == 0
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + timeout
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            assert len(events) == 1
 
 
 async def test_wait_template_timeout_default(hass):
-    """Test the wait template with default contiune."""
+    """Test the wait template with default continue."""
     event = "test_event"
-    events = []
-    wait_alias = "wait step"
+    wait_started_flag = asyncio.Event()
 
     @callback
     def record_event(event):
@@ -796,128 +1041,99 @@ async def test_wait_template_timeout_default(hass):
 
     hass.bus.async_listen(event, record_event)
 
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
+
     hass.states.async_set("switch.test", "on")
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "wait_template": "{{states.switch.test.state == 'off'}}",
-                    "timeout": 5,
-                    "alias": wait_alias,
-                },
-                {"event": event},
-            ]
-        ),
+    timeout = timedelta(milliseconds=10)
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {
+                "wait_template": "{{ states.switch.test.state == 'off' }}",
+                "timeout": timeout,
+            },
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
+    for run_mode in _ALL_RUN_MODES:
+        events = []
+        wait_started_flag.clear()
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == wait_alias
-    assert len(events) == 1
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=wait_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=wait_started_cb, run_mode=run_mode
+            )
 
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+        try:
+            if run_mode == "background":
+                await script_obj.async_run()
+            else:
+                hass.async_create_task(script_obj.async_run())
+            await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-    assert not script_obj.is_running
-    assert len(events) == 2
+            assert script_obj.is_running
+            assert len(events) == 0
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            if run_mode in (None, "legacy"):
+                future = dt_util.utcnow() + timeout
+                async_fire_time_changed(hass, future)
+            await hass.async_block_till_done()
+
+            assert not script_obj.is_running
+            assert len(events) == 1
 
 
 async def test_wait_template_variables(hass):
     """Test the wait template with variables."""
-    event = "test_event"
-    events = []
-    wait_alias = "wait step"
+    wait_started_flag = asyncio.Event()
 
     @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
+    def wait_started_cb():
+        wait_started_flag.set()
 
-    hass.bus.async_listen(event, record_event)
+    schema = cv.SCRIPT_SCHEMA({"wait_template": "{{ is_state(data, 'off') }}"})
 
-    hass.states.async_set("switch.test", "on")
+    for run_mode in _ALL_RUN_MODES:
+        wait_started_flag.clear()
+        hass.states.async_set("switch.test", "on")
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {"wait_template": "{{is_state(data, 'off')}}", "alias": wait_alias},
-                {"event": event},
-            ]
-        ),
-    )
+        if run_mode is None:
+            script_obj = script.Script(hass, schema, change_listener=wait_started_cb)
+        else:
+            script_obj = script.Script(
+                hass, schema, change_listener=wait_started_cb, run_mode=run_mode
+            )
 
-    await script_obj.async_run({"data": "switch.test"})
-    await hass.async_block_till_done()
+        assert script_obj.can_cancel
 
-    assert script_obj.is_running
-    assert script_obj.can_cancel
-    assert script_obj.last_action == wait_alias
-    assert len(events) == 1
+        try:
+            coro = script_obj.async_run({"data": "switch.test"})
+            if run_mode == "background":
+                await coro
+            else:
+                hass.async_create_task(coro)
+            await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-    hass.states.async_set("switch.test", "off")
-    await hass.async_block_till_done()
+            assert script_obj.is_running
+        except (AssertionError, asyncio.TimeoutError):
+            await script_obj.async_stop()
+            raise
+        else:
+            hass.states.async_set("switch.test", "off")
+            await hass.async_block_till_done()
 
-    assert not script_obj.is_running
-    assert len(events) == 2
-
-
-async def test_passing_variables_to_script(hass):
-    """Test if we can pass variables to script."""
-    calls = []
-
-    @callback
-    def record_call(service):
-        """Add recorded event to set."""
-        calls.append(service)
-
-    hass.services.async_register("test", "script", record_call)
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {
-                    "service": "test.script",
-                    "data_template": {"hello": "{{ greeting }}"},
-                },
-                {"delay": "{{ delay_period }}"},
-                {
-                    "service": "test.script",
-                    "data_template": {"hello": "{{ greeting2 }}"},
-                },
-            ]
-        ),
-    )
-
-    await script_obj.async_run(
-        {"greeting": "world", "greeting2": "universe", "delay_period": "00:00:05"}
-    )
-
-    await hass.async_block_till_done()
-
-    assert script_obj.is_running
-    assert len(calls) == 1
-    assert calls[-1].data["hello"] == "world"
-
-    future = dt_util.utcnow() + timedelta(seconds=5)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-
-    assert not script_obj.is_running
-    assert len(calls) == 2
-    assert calls[-1].data["hello"] == "universe"
+            assert not script_obj.is_running
 
 
-async def test_condition(hass):
+async def test_condition_basic(hass):
     """Test if we can use conditions in a script."""
     event = "test_event"
     events = []
@@ -929,31 +1145,39 @@ async def test_condition(hass):
 
     hass.bus.async_listen(event, record_event)
 
-    hass.states.async_set("test.entity", "hello")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "condition": "template",
-                    "value_template": '{{ states.test.entity.state == "hello" }}',
-                },
-                {"event": event},
-            ]
-        ),
+    schema = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event},
+            {
+                "condition": "template",
+                "value_template": "{{ states.test.entity.state == 'hello' }}",
+            },
+            {"event": event},
+        ]
     )
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
-    assert len(events) == 2
+    for run_mode in _ALL_RUN_MODES:
+        events = []
+        hass.states.async_set("test.entity", "hello")
 
-    hass.states.async_set("test.entity", "goodbye")
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-    await script_obj.async_run()
-    await hass.async_block_till_done()
-    assert len(events) == 3
+        assert not script_obj.can_cancel
+
+        await script_obj.async_run()
+        await hass.async_block_till_done()
+
+        assert len(events) == 2
+
+        hass.states.async_set("test.entity", "goodbye")
+
+        await script_obj.async_run()
+        await hass.async_block_till_done()
+
+        assert len(events) == 3
 
 
 @asynctest.patch("homeassistant.helpers.script.condition.async_from_config")
@@ -992,7 +1216,7 @@ async def test_condition_created_once(async_from_config, hass):
     assert len(script_obj._config_cache) == 1
 
 
-async def test_all_conditions_cached(hass):
+async def test_condition_all_cached(hass):
     """Test that multiple conditions get cached."""
     event = "test_event"
     events = []
@@ -1033,55 +1257,63 @@ async def test_last_triggered(hass):
     """Test the last_triggered."""
     event = "test_event"
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [{"event": event}, {"delay": {"seconds": 5}}, {"event": event}]
-        ),
-    )
+    schema = cv.SCRIPT_SCHEMA({"event": event})
 
-    assert script_obj.last_triggered is None
+    for run_mode in _ALL_RUN_MODES:
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-    time = dt_util.utcnow()
-    with mock.patch("homeassistant.helpers.script.utcnow", return_value=time):
-        await script_obj.async_run()
-        await hass.async_block_till_done()
+        assert script_obj.last_triggered is None
 
-    assert script_obj.last_triggered == time
+        time = dt_util.utcnow()
+        with mock.patch("homeassistant.helpers.script.utcnow", return_value=time):
+            await script_obj.async_run()
+            await hass.async_block_till_done()
+
+        assert script_obj.last_triggered == time
 
 
 async def test_propagate_error_service_not_found(hass):
     """Test that a script aborts when a service is not found."""
-    events = []
+    event = "test_event"
 
     @callback
     def record_event(event):
         events.append(event)
 
-    hass.bus.async_listen("test_event", record_event)
+    hass.bus.async_listen(event, record_event)
 
-    script_obj = script.Script(
-        hass, cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": "test_event"}])
-    )
+    schema = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
 
-    with pytest.raises(exceptions.ServiceNotFound):
-        await script_obj.async_run()
+    run_modes = _ALL_RUN_MODES
+    if "background" in run_modes:
+        run_modes.remove("background")
+    for run_mode in run_modes:
+        events = []
 
-    assert len(events) == 0
-    assert not script_obj.is_running
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        with pytest.raises(exceptions.ServiceNotFound):
+            await script_obj.async_run()
+
+        assert len(events) == 0
+        assert not script_obj.is_running
 
 
 async def test_propagate_error_invalid_service_data(hass):
     """Test that a script aborts when we send invalid service data."""
-    events = []
+    event = "test_event"
 
     @callback
     def record_event(event):
         events.append(event)
 
-    hass.bus.async_listen("test_event", record_event)
-
-    calls = []
+    hass.bus.async_listen(event, record_event)
 
     @callback
     def record_call(service):
@@ -1092,32 +1324,39 @@ async def test_propagate_error_invalid_service_data(hass):
         "test", "script", record_call, schema=vol.Schema({"text": str})
     )
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [{"service": "test.script", "data": {"text": 1}}, {"event": "test_event"}]
-        ),
+    schema = cv.SCRIPT_SCHEMA(
+        [{"service": "test.script", "data": {"text": 1}}, {"event": event}]
     )
 
-    with pytest.raises(vol.Invalid):
-        await script_obj.async_run()
+    run_modes = _ALL_RUN_MODES
+    if "background" in run_modes:
+        run_modes.remove("background")
+    for run_mode in run_modes:
+        events = []
+        calls = []
 
-    assert len(events) == 0
-    assert len(calls) == 0
-    assert not script_obj.is_running
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        with pytest.raises(vol.Invalid):
+            await script_obj.async_run()
+
+        assert len(events) == 0
+        assert len(calls) == 0
+        assert not script_obj.is_running
 
 
 async def test_propagate_error_service_exception(hass):
     """Test that a script aborts when a service throws an exception."""
-    events = []
+    event = "test_event"
 
     @callback
     def record_event(event):
         events.append(event)
 
-    hass.bus.async_listen("test_event", record_event)
-
-    calls = []
+    hass.bus.async_listen(event, record_event)
 
     @callback
     def record_call(service):
@@ -1126,16 +1365,24 @@ async def test_propagate_error_service_exception(hass):
 
     hass.services.async_register("test", "script", record_call)
 
-    script_obj = script.Script(
-        hass, cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": "test_event"}])
-    )
+    schema = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
 
-    with pytest.raises(ValueError):
-        await script_obj.async_run()
+    run_modes = _ALL_RUN_MODES
+    if "background" in run_modes:
+        run_modes.remove("background")
+    for run_mode in run_modes:
+        events = []
 
-    assert len(events) == 0
-    assert len(calls) == 0
-    assert not script_obj.is_running
+        if run_mode is None:
+            script_obj = script.Script(hass, schema)
+        else:
+            script_obj = script.Script(hass, schema, run_mode=run_mode)
+
+        with pytest.raises(ValueError):
+            await script_obj.async_run()
+
+        assert len(events) == 0
+        assert not script_obj.is_running
 
 
 async def test_referenced_entities():
@@ -1192,3 +1439,307 @@ async def test_referenced_devices():
     assert script_obj.referenced_devices == {"script-dev-id", "condition-dev-id"}
     # Test we cache results.
     assert script_obj.referenced_devices is script_obj.referenced_devices
+
+
+async def test_if_running_with_legacy_run_mode(hass, caplog):
+    """Test using if_running with run_mode='legacy'."""
+    # TODO: REMOVE
+    if _ALL_RUN_MODES == [None]:
+        return
+
+    with pytest.raises(exceptions.HomeAssistantError):
+        script.Script(
+            hass,
+            [],
+            if_running="ignore",
+            run_mode="legacy",
+            logger=logging.getLogger("TEST"),
+        )
+    assert any(
+        rec.levelname == "ERROR"
+        and rec.name == "TEST"
+        and all(text in rec.message for text in ("if_running", "legacy"))
+        for rec in caplog.records
+    )
+
+
+async def test_if_running_ignore(hass, caplog):
+    """Test overlapping runs with if_running='ignore'."""
+    # TODO: REMOVE
+    if _ALL_RUN_MODES == [None]:
+        return
+
+    event = "test_event"
+    events = []
+    wait_started_flag = asyncio.Event()
+
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
+
+    hass.bus.async_listen(event, record_event)
+
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
+
+    hass.states.async_set("switch.test", "on")
+
+    script_obj = script.Script(
+        hass,
+        cv.SCRIPT_SCHEMA(
+            [
+                {"event": event, "event_data": {"value": 1}},
+                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+                {"event": event, "event_data": {"value": 2}},
+            ]
+        ),
+        change_listener=wait_started_cb,
+        if_running="ignore",
+        run_mode="background",
+        logger=logging.getLogger("TEST"),
+    )
+
+    try:
+        await script_obj.async_run()
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 1
+        assert events[0].data["value"] == 1
+
+        # Start second run of script while first run is suspended in wait_template.
+        # This should ignore second run.
+
+        await script_obj.async_run()
+
+        assert script_obj.is_running
+        assert any(
+            rec.levelname == "INFO" and rec.name == "TEST" and "Skipping" in rec.message
+            for rec in caplog.records
+        )
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+        assert events[1].data["value"] == 2
+
+
+async def test_if_running_error(hass, caplog):
+    """Test overlapping runs with if_running='error'."""
+    # TODO: REMOVE
+    if _ALL_RUN_MODES == [None]:
+        return
+
+    event = "test_event"
+    events = []
+    wait_started_flag = asyncio.Event()
+
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
+
+    hass.bus.async_listen(event, record_event)
+
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
+
+    hass.states.async_set("switch.test", "on")
+
+    script_obj = script.Script(
+        hass,
+        cv.SCRIPT_SCHEMA(
+            [
+                {"event": event, "event_data": {"value": 1}},
+                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+                {"event": event, "event_data": {"value": 2}},
+            ]
+        ),
+        change_listener=wait_started_cb,
+        if_running="error",
+        run_mode="background",
+        logger=logging.getLogger("TEST"),
+    )
+
+    try:
+        await script_obj.async_run()
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 1
+        assert events[0].data["value"] == 1
+
+        # Start second run of script while first run is suspended in wait_template.
+        # This should cause an error.
+
+        with pytest.raises(exceptions.HomeAssistantError):
+            await script_obj.async_run()
+
+        assert script_obj.is_running
+        assert any(
+            rec.levelname == "ERROR"
+            and rec.name == "TEST"
+            and "Already running" in rec.message
+            for rec in caplog.records
+        )
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+        assert events[1].data["value"] == 2
+
+
+async def test_if_running_restart(hass, caplog):
+    """Test overlapping runs with if_running='restart'."""
+    # TODO: REMOVE
+    if _ALL_RUN_MODES == [None]:
+        return
+
+    event = "test_event"
+    events = []
+    wait_started_flag = asyncio.Event()
+
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
+
+    hass.bus.async_listen(event, record_event)
+
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
+
+    hass.states.async_set("switch.test", "on")
+
+    script_obj = script.Script(
+        hass,
+        cv.SCRIPT_SCHEMA(
+            [
+                {"event": event, "event_data": {"value": 1}},
+                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+                {"event": event, "event_data": {"value": 2}},
+            ]
+        ),
+        change_listener=wait_started_cb,
+        if_running="restart",
+        run_mode="background",
+        logger=logging.getLogger("TEST"),
+    )
+
+    try:
+        await script_obj.async_run()
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 1
+        assert events[0].data["value"] == 1
+
+        # Start second run of script while first run is suspended in wait_template.
+        # This should stop first run then start a new run.
+
+        wait_started_flag.clear()
+        await script_obj.async_run()
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 2
+        assert events[1].data["value"] == 1
+        assert any(
+            rec.levelname == "INFO"
+            and rec.name == "TEST"
+            and "Restarting" in rec.message
+            for rec in caplog.records
+        )
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 3
+        assert events[2].data["value"] == 2
+
+
+async def test_if_running_parallel(hass):
+    """Test overlapping runs with if_running='parallel'."""
+    # TODO: REMOVE
+    if _ALL_RUN_MODES == [None]:
+        return
+
+    event = "test_event"
+    events = []
+    wait_started_flag = asyncio.Event()
+
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
+
+    hass.bus.async_listen(event, record_event)
+
+    @callback
+    def wait_started_cb():
+        wait_started_flag.set()
+
+    hass.states.async_set("switch.test", "on")
+
+    script_obj = script.Script(
+        hass,
+        cv.SCRIPT_SCHEMA(
+            [
+                {"event": event, "event_data": {"value": 1}},
+                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+                {"event": event, "event_data": {"value": 2}},
+            ]
+        ),
+        change_listener=wait_started_cb,
+        if_running="parallel",
+        run_mode="background",
+        logger=logging.getLogger("TEST"),
+    )
+
+    try:
+        await script_obj.async_run()
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 1
+        assert events[0].data["value"] == 1
+
+        # Start second run of script while first run is suspended in wait_template.
+        # This should start a new, independent run.
+
+        wait_started_flag.clear()
+        await script_obj.async_run()
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 2
+        assert events[1].data["value"] == 1
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 4
+        assert events[2].data["value"] == 2
+        assert events[3].data["value"] == 2

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -509,7 +509,7 @@ async def test_cancel_while_delay(hass):
     assert script_obj.is_running
     assert len(events) == 0
 
-    script_obj.async_stop()
+    await script_obj.async_stop()
 
     assert not script_obj.is_running
 
@@ -644,7 +644,7 @@ async def test_wait_template_cancel(hass):
     assert script_obj.last_action == wait_alias
     assert len(events) == 1
 
-    script_obj.async_stop()
+    await script_obj.async_stop()
 
     assert not script_obj.is_running
     assert len(events) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Script helper (i.e., `homeassistant.helpers.script`) is used by several integrations to implement Home Assistant's [Script Syntax](https://www.home-assistant.io/docs/scripts/), the most notable being `automation` & `script`. However the current behavior, when run multiple times simultaneously (e.g., via an automation that is triggered quickly), is at best unexpected, and worse, requires clumsy workarounds. (More on that below.)

This PR is the first step towards resolving those issues. It improves the Script helper to properly support multiple, simultaneous runs, with options to provide usage flexibility. However, by default, it implements the current behavior to avoid breakage. The intention is to ultimately remove the so-called "legacy" behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #31364 
- Link to documentation pull request: 

### Background
See PR #31740. It was a first attempt at resolving these issues and contains a description of the problems related to the current behavior of the Script helper, as well as YAML for an example automation that is affected by it. However it was decided to break up the changes into smaller chunks, this being the first.

Although not mentioned in the other PR, the typical workaround is to move the automation's `action` sequence into a script, and then in the automation's `action` section invoke the new script like this:
```yaml
action:
- service: script.turn_off
  entity_id: script.new
- service: script.new
```
This is an attempt to implement the new `restart` behavior described below.

Also, there currently isn't an easy way to call a script completly "synchronously" if it contains a `delay` or `wait_template`. The typical workaround to effectively make a script synchronous is to use an `input_boolean`. It would first be turned on by the "caller", then the caller would use a `wait_template` to wait for it to be turned off, which would done by the last step of the called script. This is an attempt to implement the new `blocking` behavior described below.

### New Script helper options
#### if_running
- Controls what happens if Script run (i.e., `async_run` called) while previous run has not yet completed.
- Values:
  - `error` Raise an exception
  - `ignore` Return without doing anything (previous run continues as-is)
  - `parallel` Start run in new task
  - `restart` Stop previous run before starting new run
#### run_mode
- Controls when call to `async_run` will return.
- Values:
  - `background` Returns immediately
  - `legacy` Implements previous behavior, which is to return when done, or when suspended by `delay` or `wait_template`, whichever comes first
  - `blocking` Returns when run has completed
#### Defaults
- If neither is specified, default is `run_mode=legacy` (and `if_running` is not used.)
- Otherwise, defaults are `if_running=parallel` and `run_mode=blocking`.
> Note: If `run_mode` is set to `legacy` then `if_running` must be `None`.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
