### PR TITLE
Modbus remove unnecessary get calls

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -159,10 +159,10 @@ def setup(hass, config):
 
     def write_register(service):
         """Write Modbus registers."""
-        unit = int(float(service.data.get(ATTR_UNIT)))
-        address = int(float(service.data.get(ATTR_ADDRESS)))
-        value = service.data.get(ATTR_VALUE)
-        client_name = service.data.get(ATTR_HUB)
+        unit = int(float(service.data[ATTR_UNIT]))
+        address = int(float(service.data[ATTR_ADDRESS]))
+        value = service.data[ATTR_VALUE]
+        client_name = service.data[ATTR_HUB]
         if isinstance(value, list):
             hub_collect[client_name].write_registers(
                 unit, address, [int(float(i)) for i in value]
@@ -172,10 +172,10 @@ def setup(hass, config):
 
     def write_coil(service):
         """Write Modbus coil."""
-        unit = service.data.get(ATTR_UNIT)
-        address = service.data.get(ATTR_ADDRESS)
-        state = service.data.get(ATTR_STATE)
-        client_name = service.data.get(ATTR_HUB)
+        unit = service.data[ATTR_UNIT]
+        address = service.data[ATTR_ADDRESS]
+        state = service.data[ATTR_STATE]
+        client_name = service.data[ATTR_HUB]
         hub_collect[client_name].write_coil(unit, address, state)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_modbus)

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -25,8 +25,8 @@ CONF_INPUTS = "inputs"
 CONF_INPUT_TYPE = "input_type"
 CONF_ADDRESS = "address"
 
-INPUT_TYPE_COIL = "coil"
-INPUT_TYPE_DISCRETE = "discrete_input"
+DEFAULT_INPUT_TYPE_COIL = "coil"
+DEFAULT_INPUT_TYPE_DISCRETE = "discrete_input"
 
 PLATFORM_SCHEMA = vol.All(
     cv.deprecated(CONF_DEPRECATED_COILS, CONF_INPUTS),
@@ -43,8 +43,10 @@ PLATFORM_SCHEMA = vol.All(
                             vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
                             vol.Optional(CONF_SLAVE): cv.positive_int,
                             vol.Optional(
-                                CONF_INPUT_TYPE, default=INPUT_TYPE_COIL
-                            ): vol.In([INPUT_TYPE_COIL, INPUT_TYPE_DISCRETE]),
+                                CONF_INPUT_TYPE, default=DEFAULT_INPUT_TYPE_COIL
+                            ): vol.In(
+                                [DEFAULT_INPUT_TYPE_COIL, DEFAULT_INPUT_TYPE_DISCRETE]
+                            ),
                         }
                     ),
                 )
@@ -57,16 +59,16 @@ PLATFORM_SCHEMA = vol.All(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
-    for entry in config.get(CONF_INPUTS):
-        hub = hass.data[MODBUS_DOMAIN][entry.get(CONF_HUB)]
+    for entry in config[CONF_INPUTS]:
+        hub = hass.data[MODBUS_DOMAIN][entry[CONF_HUB]]
         sensors.append(
             ModbusBinarySensor(
                 hub,
-                entry.get(CONF_NAME),
+                entry[CONF_NAME],
                 entry.get(CONF_SLAVE),
-                entry.get(CONF_ADDRESS),
+                entry[CONF_ADDRESS],
                 entry.get(CONF_DEVICE_CLASS),
-                entry.get(CONF_INPUT_TYPE),
+                entry[CONF_INPUT_TYPE],
             )
         )
 
@@ -110,7 +112,7 @@ class ModbusBinarySensor(BinarySensorDevice):
     def update(self):
         """Update the state of the sensor."""
         try:
-            if self._input_type == INPUT_TYPE_COIL:
+            if self._input_type == DEFAULT_INPUT_TYPE_COIL:
                 result = self._hub.read_coils(self._slave, self._address, 1)
             else:
                 result = self._hub.read_discrete_inputs(self._slave, self._address, 1)

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -17,8 +17,8 @@ from homeassistant.components.modbus.sensor import (
     DATA_TYPE_FLOAT,
     DATA_TYPE_INT,
     DATA_TYPE_UINT,
-    REGISTER_TYPE_HOLDING,
-    REGISTER_TYPE_INPUT,
+    DEFAULT_REGISTER_TYPE_HOLDING,
+    DEFAULT_REGISTER_TYPE_INPUT,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
@@ -72,7 +72,7 @@ async def run_test(hass, mock_hub, register_config, register_words, expected):
 
     # Setup inputs for the sensor
     read_result = ReadResult(register_words)
-    if register_config.get(CONF_REGISTER_TYPE) == REGISTER_TYPE_INPUT:
+    if register_config.get(CONF_REGISTER_TYPE) == DEFAULT_REGISTER_TYPE_INPUT:
         mock_hub.read_input_registers.return_value = read_result
     else:
         mock_hub.read_holding_registers.return_value = read_result
@@ -310,7 +310,7 @@ async def test_two_word_input_register(hass, mock_hub):
     """Test reaging of input register."""
     register_config = {
         CONF_COUNT: 2,
-        CONF_REGISTER_TYPE: REGISTER_TYPE_INPUT,
+        CONF_REGISTER_TYPE: DEFAULT_REGISTER_TYPE_INPUT,
         CONF_DATA_TYPE: DATA_TYPE_UINT,
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
@@ -329,7 +329,7 @@ async def test_two_word_holding_register(hass, mock_hub):
     """Test reaging of holding register."""
     register_config = {
         CONF_COUNT: 2,
-        CONF_REGISTER_TYPE: REGISTER_TYPE_HOLDING,
+        CONF_REGISTER_TYPE: DEFAULT_REGISTER_TYPE_HOLDING,
         CONF_DATA_TYPE: DATA_TYPE_UINT,
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
@@ -348,7 +348,7 @@ async def test_float_data_type(hass, mock_hub):
     """Test floating point register data type."""
     register_config = {
         CONF_COUNT: 2,
-        CONF_REGISTER_TYPE: REGISTER_TYPE_HOLDING,
+        CONF_REGISTER_TYPE: DEFAULT_REGISTER_TYPE_HOLDING,
         CONF_DATA_TYPE: DATA_TYPE_FLOAT,
         CONF_SCALE: 1,
         CONF_OFFSET: 0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change cleans up Modbus component:
- All occurrences of `REGISTER_TYPE` and `INPUT_TYPE` are prefixed with `DEFAULT`
- All values (except optional parameters without default value) are accessed directly without `dict.get()` calls

This approach was suggested in PR #31944 for Modbus Climate. Now I did the same for remaining entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
