### PR TITLE
Fix Plex sensor title handling

### DIFF
--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -109,18 +109,16 @@ class PlexSensor(Entity):
             now_playing_user = f"{user} - {device}"
             now_playing_title = ""
 
-            if sess.TYPE == "episode":
+            if sess.TYPE in ["clip", "episode"]:
                 # example:
-                # "Supernatural (2005) - S01 · E13 - Route 666"
+                # "Supernatural (2005) - s01e13 - Route 666"
                 season_title = sess.grandparentTitle
-                if sess.show().year is not None:
-                    season_title += " ({0})".format(sess.show().year)
-                season_episode = "S{0}".format(sess.parentIndex)
-                if sess.index is not None:
-                    season_episode += f" · E{sess.index}"
+                if sess.year is not None:
+                    season_title += f" ({sess.year!s})"
+                season_episode = sess.seasonEpisode
                 episode_title = sess.title
-                now_playing_title = "{0} - {1} - {2}".format(
-                    season_title, season_episode, episode_title
+                now_playing_title = (
+                    f"{season_title} - {season_episode} - {episode_title}"
                 )
             elif sess.TYPE == "track":
                 # example:
@@ -128,9 +126,7 @@ class PlexSensor(Entity):
                 track_artist = sess.grandparentTitle
                 track_album = sess.parentTitle
                 track_title = sess.title
-                now_playing_title = "{0} - {1} - {2}".format(
-                    track_artist, track_album, track_title
-                )
+                now_playing_title = f"{track_artist} - {track_album} - {track_title}"
             else:
                 # example:
                 # "picture_of_last_summer_camp (2015)"

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -113,8 +113,8 @@ class PlexSensor(Entity):
                 # example:
                 # "Supernatural (2005) - s01e13 - Route 666"
                 season_title = sess.grandparentTitle
-                if sess.year is not None:
-                    season_title += f" ({sess.year!s})"
+                if sess.show().year is not None:
+                    season_title += f" ({sess.show().year!s})"
                 season_episode = sess.seasonEpisode
                 episode_title = sess.title
                 now_playing_title = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Plex `sensor` platform had a few issues when generating the titles for playing media:

1. Episode year was set to the year of series debut, not season of the episode. (This also sometimes led to random exceptions.)
2. There's a better method now to generate "s01e01" strings.
3. f-strings weren't used everywhere.
4. "clip" types weren't properly handled.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
