### PR TITLE
Bump ZHA quirks and add skip configuration support

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -194,8 +194,7 @@ class ZigbeeChannel(LogMixin):
 
     async def async_configure(self):
         """Set cluster binding and attribute reporting."""
-        # Xiaomi devices don't need this and it disrupts pairing
-        if self._zha_device.manufacturer != "LUMI":
+        if not self._zha_device.skip_configuration:
             await self.bind()
             if self.cluster.is_server:
                 for report_config in self._report_config:
@@ -203,8 +202,9 @@ class ZigbeeChannel(LogMixin):
                         report_config["attr"], report_config["config"]
                     )
                     await asyncio.sleep(uniform(0.1, 0.5))
-
-        self.debug("finished channel configuration")
+            self.debug("finished channel configuration")
+        else:
+            self.debug("skipping channel configuration")
         self._status = ChannelStatus.CONFIGURED
 
     async def async_initialize(self, from_cache):
@@ -264,7 +264,7 @@ class ZigbeeChannel(LogMixin):
     def log(self, level, msg, *args):
         """Log a message."""
         msg = f"[%s:%s]: {msg}"
-        args = (self.device.nwk, self._id,) + args
+        args = (self.device.nwk, self._id) + args
         _LOGGER.log(level, msg, *args)
 
     def __getattr__(self, name):

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -146,9 +146,8 @@ class IASZoneChannel(ZigbeeChannel):
 
     async def async_configure(self):
         """Configure IAS device."""
-        # Xiaomi devices don't need this and it disrupts pairing
-        if self._zha_device.manufacturer == "LUMI":
-            self.debug("finished IASZoneChannel configuration")
+        if self._zha_device.skip_configuration:
+            self.debug("skipping IASZoneChannel configuration")
             return
 
         self.debug("started IASZoneChannel configuration")

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -214,6 +214,11 @@ class ZHADevice(LogMixin):
                     return True
 
     @property
+    def skip_configuration(self):
+        """Return true if the device should not issue configuration related commands."""
+        return self._zigpy_device.skip_configuration
+
+    @property
     def gateway(self):
         """Return the gateway for this device."""
         return self._zha_gateway

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
     "bellows-homeassistant==0.13.2",
-    "zha-quirks==0.0.32",
+    "zha-quirks==0.0.33",
     "zigpy-cc==0.1.0",
     "zigpy-deconz==0.7.0",
     "zigpy-homeassistant==0.13.2",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2130,7 +2130,7 @@ zengge==0.2
 zeroconf==0.24.4
 
 # homeassistant.components.zha
-zha-quirks==0.0.32
+zha-quirks==0.0.33
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -732,7 +732,7 @@ yahooweather==0.10
 zeroconf==0.24.4
 
 # homeassistant.components.zha
-zha-quirks==0.0.32
+zha-quirks==0.0.33
 
 # homeassistant.components.zha
 zigpy-cc==0.1.0

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -72,6 +72,7 @@ class FakeDevice:
         self.last_seen = time.time()
         self.status = 2
         self.initializing = False
+        self.skip_configuration = False
         self.manufacturer = manufacturer
         self.model = model
         self.node_desc = zigpy.zdo.types.NodeDescriptor()


### PR DESCRIPTION
## Proposed change
This PR bumps the version of the ZHA quirks module and it adds support for skipping configuration for devices that violate the Zigbee spec. This corrects joins for new Xioami devices that do honor the specification such as the new Xiaomi illumination sensors and the Opple remotes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
