### PR TITLE
Refactor cert_expiry for 3.7+, retry transient errors, wait for HA HTTP

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -108,8 +108,10 @@ omit =
     homeassistant/components/canary/alarm_control_panel.py
     homeassistant/components/canary/camera.py
     homeassistant/components/cast/*
-    homeassistant/components/cert_expiry/sensor.py
+    homeassistant/components/cert_expiry/__init__.py
+    homeassistant/components/cert_expiry/errors.py
     homeassistant/components/cert_expiry/helper.py
+    homeassistant/components/cert_expiry/sensor.py
     homeassistant/components/channels/*
     homeassistant/components/cisco_ios/device_tracker.py
     homeassistant/components/cisco_mobility_express/device_tracker.py

--- a/homeassistant/components/cert_expiry/errors.py
+++ b/homeassistant/components/cert_expiry/errors.py
@@ -1,0 +1,14 @@
+"""Errors for the cert_expiry integration."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class CertExpiryException(HomeAssistantError):
+    """Base class for cert_expiry exceptions."""
+
+
+class TemporaryFailure(CertExpiryException):
+    """Temporary failure has occurred."""
+
+
+class PermanentFailure(CertExpiryException):
+    """Permanent failure has occurred."""

--- a/homeassistant/components/cert_expiry/manifest.json
+++ b/homeassistant/components/cert_expiry/manifest.json
@@ -5,5 +5,6 @@
   "requirements": [],
   "config_flow": true,
   "dependencies": [],
+  "after_dependencies": ["http"],
   "codeowners": ["@Cereal2nd", "@jjlawren"]
 }

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -158,8 +158,8 @@ class SSLCertificate(Entity):
 
         except TemporaryFailure as err:
 
-            async def scheduled_update(_):
-                await self.async_update()
+            def scheduled_update(_):
+                self.async_schedule_update_ha_state(True)
 
             _LOGGER.error(err, self.server_name, self.retry_delay)
             self._available = False

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -14,8 +14,12 @@
         "error": {
             "host_port_exists": "This host and port combination is already configured",
             "resolve_failed": "This host can not be resolved",
+            "connection_refused": "Connection refused when connecting to this host",
             "connection_timeout": "Timeout when connecting to this host",
+            "certificate_badroot": "Bad root in certificate chain",
             "certificate_error": "Certificate could not be validated",
+            "certificate_expired": "Certificate has expired",
+            "certificate_selfsigned": "Certificate is self-signed",
             "wrong_host": "Certificate does not match hostname"
         },
         "abort": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With Python 3.7+ there are new methods available in the `ssl` module which provide more detailed information on errors. This PR refactors around those messages.

Additionally, some of these errors can be considered transient, so an async retry mechanism with backoff has been added. The previous default of 12h was quite a long time to wait if a site was temporarily unavailable at startup.

Finally, the `http` integration has been marked as a dependency to hopefully resolve issues like #31964.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31964
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
