### PR TITLE
Allow subscription with single-level wildcard (+)

### DIFF
--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -39,11 +39,15 @@ def _parse_topic(topic, subscribe_topic):
     Async friendly.
     """
     subscription = subscribe_topic.split("/")
-    try:
-        user_index = subscription.index("#")
-    except ValueError:
+
+    user_index = None
+    for index, segment in enumerate(subscription):
+        if segment in ("#", "+"):
+            user_index = index
+            break
+    if user_index is None:
         _LOGGER.error("Can't parse subscription topic: '%s'", subscribe_topic)
-        raise
+        raise ValueError("Topic does not contain # or + segment")
 
     topic_list = topic.split("/")
     try:

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -1516,6 +1516,26 @@ async def test_customized_mqtt_topic(hass, setup_comp):
     assert_location_latitude(hass, LOCATION_MESSAGE["lat"])
 
 
+async def test_customized_mqtt_topic_single_level(hass, setup_comp):
+    """Test subscribing to a custom mqtt topic."""
+    await setup_owntracks(hass, {CONF_MQTT_TOPIC: "mytracks/+/+"})
+
+    topic = "mytracks/{}/{}".format(USER, DEVICE)
+
+    await send_message(hass, topic, LOCATION_MESSAGE)
+    assert_location_latitude(hass, LOCATION_MESSAGE["lat"])
+
+
+async def test_customized_mqtt_topic_no_wildcard(hass, setup_comp):
+    """Test subscribing to a custom mqtt topic without a wildcard segment."""
+    topic = "mytracks/{}/{}".format(USER, DEVICE)
+
+    await setup_owntracks(hass, {CONF_MQTT_TOPIC: topic})
+
+    await send_message(hass, topic, LOCATION_MESSAGE)
+    assert hass.states.get(DEVICE_TRACKER_STATE) is None
+
+
 async def test_region_mapping(hass, setup_comp):
     """Test region to zone mapping."""
     await setup_owntracks(hass, {CONF_REGION_MAPPING: {"foo": "inner"}})


### PR DESCRIPTION
## Proposed change

The owntracks MQTT topic subscription currently requires a multi-level wildcard (e.g., `owntracks/#`). However, if the user is only interested in location events, it is valid to subscribe to a topic in the form `owntracks/+/+`.

This pull request adds support for subscribing to topics in the form `owntracks/+/+`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io