### PR TITLE
Fix bug in ecobee integration

### DIFF
--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -96,9 +96,7 @@ class EcobeeData:
             await self._hass.async_add_executor_job(self.ecobee.update)
             _LOGGER.debug("Updating ecobee")
         except ExpiredTokenError:
-            _LOGGER.warning(
-                "Ecobee update failed; attempting to refresh expired tokens"
-            )
+            _LOGGER.debug("Refreshing expired ecobee tokens")
             await self.refresh()
 
     async def refresh(self) -> bool:
@@ -113,7 +111,7 @@ class EcobeeData:
                 },
             )
             return True
-        _LOGGER.error("Error updating ecobee tokens")
+        _LOGGER.error("Error refreshing ecobee tokens")
         return False
 
 

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -4,6 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecobee",
   "dependencies": [],
-  "requirements": ["python-ecobee-api==0.1.4"],
+  "requirements": ["python-ecobee-api==0.2.1"],
   "codeowners": ["@marthoc"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1559,7 +1559,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.4
+python-ecobee-api==0.2.1
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -560,7 +560,7 @@ pysonos==0.0.24
 pyspcwebgw==0.4.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.4
+python-ecobee-api==0.2.1
 
 # homeassistant.components.darksky
 python-forecastio==1.4.0


### PR DESCRIPTION
## Breaking change
Not a breaking change.

## Proposed change
Fixes the bug identified in #28531.

## Type of change
- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
No configuration.yaml entry as the integration is configured via config entry.

## Additional information
This PR fixes or closes issue: fixes #28531. 

Before config entries, ecobee authentication tokens were stored in a file called ecobee.conf that was stored in the Home Assistant config directory. On HA startup, the ecobee component would read the tokens from this file and use them to authenticate. The python library took care of retrieving the tokens from ecobee, storing them in the file, and (importantly) refreshing them and updating ecobee.conf with the new tokens if the old tokens became stale. If HA was shut down, on the next startup, ecobee.conf would contain the most recent tokens as the python library had been updating that file each time the tokens were refreshed.

Moving ecobee to using config entries meant that the tokens would now be stored in the entry itself, rather than in ecobee.conf. From a logic perspective, this meant that HA itself would now need to be in charge of refreshing the tokens and updating the config entry with any refreshed tokens. Easy enough, and this logic was added.

However, the python library still contained logic as though it was responsible for refreshing tokens. On a failed API access attempt (because of connectivity issues or otherwise), the library would (without being prompted by the logic in HA) retry the failed call but also (and the origin of the bug) attempt to refresh the authentication tokens. If this succeeded, HA would go on using the correct tokens for the time being, but, when those tokens became stale (as they do every 3600 seconds/1 hour) the attempt by HA to refresh them would fail as the tokens in the config entry had been invalidated by the issuing of new tokens to the request made by the python library, and HA was presenting those stale tokens on the refresh request.

This explains why this issue is not cropping up for everyone - if you have no connectivity issues to ecobee (i.e. calls to the API don't fail), then the library would never independently refresh your tokens and this error would not happen.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
