### PR TITLE
Add entity ID to input_number warning

### DIFF
--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -288,47 +288,22 @@ class InputNumber(RestoreEntity):
     async def async_set_value(self, value):
         """Set new value."""
         num_value = float(value)
+
         if num_value < self._minimum or num_value > self._maximum:
-            _LOGGER.warning(
-                "Invalid value for %s: %s (range %s - %s)",
-                self.entity_id,
-                num_value,
-                self._minimum,
-                self._maximum,
+            raise vol.Invalid(
+                f"Invalid value for {self.entity_id}: {value} (range {self._minimum} - {self._maximum})"
             )
-            return
+
         self._current_value = num_value
         self.async_write_ha_state()
 
     async def async_increment(self):
         """Increment value."""
-        new_value = self._current_value + self._step
-        if new_value > self._maximum:
-            _LOGGER.warning(
-                "Invalid value for %s: %s (range %s - %s)",
-                self.entity_id,
-                new_value,
-                self._minimum,
-                self._maximum,
-            )
-            return
-        self._current_value = new_value
-        self.async_write_ha_state()
+        await self.async_set_value(min(self._current_value + self._step, self._maximum))
 
     async def async_decrement(self):
         """Decrement value."""
-        new_value = self._current_value - self._step
-        if new_value < self._minimum:
-            _LOGGER.warning(
-                "Invalid value for %s: %s (range %s - %s)",
-                self.entity_id,
-                new_value,
-                self._minimum,
-                self._maximum,
-            )
-            return
-        self._current_value = new_value
-        self.async_write_ha_state()
+        await self.async_set_value(max(self._current_value - self._step, self._minimum))
 
     async def async_update_config(self, config: typing.Dict) -> None:
         """Handle when the config is updated."""

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -290,7 +290,8 @@ class InputNumber(RestoreEntity):
         num_value = float(value)
         if num_value < self._minimum or num_value > self._maximum:
             _LOGGER.warning(
-                "Invalid value: %s (range %s - %s)",
+                "Invalid value for %s: %s (range %s - %s)",
+                self.entity_id,
                 num_value,
                 self._minimum,
                 self._maximum,
@@ -304,7 +305,8 @@ class InputNumber(RestoreEntity):
         new_value = self._current_value + self._step
         if new_value > self._maximum:
             _LOGGER.warning(
-                "Invalid value: %s (range %s - %s)",
+                "Invalid value for %s: %s (range %s - %s)",
+                self.entity_id,
                 new_value,
                 self._minimum,
                 self._maximum,
@@ -318,7 +320,8 @@ class InputNumber(RestoreEntity):
         new_value = self._current_value - self._step
         if new_value < self._minimum:
             _LOGGER.warning(
-                "Invalid value: %s (range %s - %s)",
+                "Invalid value for %s: %s (range %s - %s)",
+                self.entity_id,
                 new_value,
                 self._minimum,
                 self._maximum,

--- a/homeassistant/components/input_number/reproduce_state.py
+++ b/homeassistant/components/input_number/reproduce_state.py
@@ -3,6 +3,8 @@ import asyncio
 import logging
 from typing import Iterable, Optional
 
+import voluptuous as vol
+
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Context, State
 from homeassistant.helpers.typing import HomeAssistantType
@@ -37,9 +39,13 @@ async def _async_reproduce_state(
     service = SERVICE_SET_VALUE
     service_data = {ATTR_ENTITY_ID: state.entity_id, ATTR_VALUE: state.state}
 
-    await hass.services.async_call(
-        DOMAIN, service, service_data, context=context, blocking=True
-    )
+    try:
+        await hass.services.async_call(
+            DOMAIN, service, service_data, context=context, blocking=True
+        )
+    except vol.Invalid as err:
+        # If value out of range.
+        _LOGGER.warning("Unable to reproduce state for %s: %s", state.entity_id, err)
 
 
 async def async_reproduce_states(

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -110,7 +110,7 @@ async def test_config(hass):
         assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
 
 
-async def test_set_value(hass):
+async def test_set_value(hass, caplog):
     """Test set_value method."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_1": {"initial": 50, "min": 0, "max": 100}}}
@@ -134,6 +134,10 @@ async def test_set_value(hass):
 
     set_value(hass, entity_id, "110")
     await hass.async_block_till_done()
+    assert (
+        "Invalid value for input_number.test_1: 110.0 (range 0.0 - 100.0)"
+        in caplog.text
+    )
 
     state = hass.states.get(entity_id)
     assert 70 == float(state.state)

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.input_number import (
     ATTR_VALUE,
@@ -21,7 +22,6 @@ from homeassistant.const import (
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry
-from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_restore_cache
@@ -63,38 +63,36 @@ def storage_setup(hass, hass_storage):
     return _storage
 
 
-@bind_hass
-def set_value(hass, entity_id, value):
+async def set_value(hass, entity_id, value):
     """Set input_number to value.
 
     This is a legacy helper method. Do not use it for new tests.
     """
-    hass.async_create_task(
-        hass.services.async_call(
-            DOMAIN, SERVICE_SET_VALUE, {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value}
-        )
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+        blocking=True,
     )
 
 
-@bind_hass
-def increment(hass, entity_id):
+async def increment(hass, entity_id):
     """Increment value of entity.
 
     This is a legacy helper method. Do not use it for new tests.
     """
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_INCREMENT, {ATTR_ENTITY_ID: entity_id})
+    await hass.services.async_call(
+        DOMAIN, SERVICE_INCREMENT, {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
 
 
-@bind_hass
-def decrement(hass, entity_id):
+async def decrement(hass, entity_id):
     """Decrement value of entity.
 
     This is a legacy helper method. Do not use it for new tests.
     """
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_DECREMENT, {ATTR_ENTITY_ID: entity_id})
+    await hass.services.async_call(
+        DOMAIN, SERVICE_DECREMENT, {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
 
 
@@ -120,23 +118,21 @@ async def test_set_value(hass, caplog):
     state = hass.states.get(entity_id)
     assert 50 == float(state.state)
 
-    set_value(hass, entity_id, "30.4")
-    await hass.async_block_till_done()
+    await set_value(hass, entity_id, "30.4")
 
     state = hass.states.get(entity_id)
     assert 30.4 == float(state.state)
 
-    set_value(hass, entity_id, "70")
-    await hass.async_block_till_done()
+    await set_value(hass, entity_id, "70")
 
     state = hass.states.get(entity_id)
     assert 70 == float(state.state)
 
-    set_value(hass, entity_id, "110")
-    await hass.async_block_till_done()
-    assert (
-        "Invalid value for input_number.test_1: 110.0 (range 0.0 - 100.0)"
-        in caplog.text
+    with pytest.raises(vol.Invalid) as excinfo:
+        await set_value(hass, entity_id, "110")
+
+    assert "Invalid value for input_number.test_1: 110.0 (range 0.0 - 100.0)" in str(
+        excinfo.value
     )
 
     state = hass.states.get(entity_id)
@@ -153,13 +149,13 @@ async def test_increment(hass):
     state = hass.states.get(entity_id)
     assert 50 == float(state.state)
 
-    increment(hass, entity_id)
+    await increment(hass, entity_id)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert 51 == float(state.state)
 
-    increment(hass, entity_id)
+    await increment(hass, entity_id)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -176,13 +172,13 @@ async def test_decrement(hass):
     state = hass.states.get(entity_id)
     assert 50 == float(state.state)
 
-    decrement(hass, entity_id)
+    await decrement(hass, entity_id)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert 49 == float(state.state)
 
-    decrement(hass, entity_id)
+    await decrement(hass, entity_id)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Passing an out of range value to input_number.set_value will now raise a validation error. Incrementing/decrementing an input_number will no longer cause warnings.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Make increment/decrement calls for input_number no longer print warnings but instead clamp values to min/max.
- Setting value to a value that is out of range for an input_number will now raise a validation error.

Fixes #22527

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
