### PR TITLE
WIP: Separate SamsungTV remote from media player

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -1,13 +1,26 @@
 """The Samsung TV integration."""
 import socket
+import time
+from typing import Iterable, Optional
 
+import samsungctl
 import voluptuous as vol
+import websocket
 
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.components.remote import DEFAULT_DELAY_SECS, DOMAIN as REMOTE_DOMAIN
+from homeassistant.const import CONF_HOST, CONF_METHOD, CONF_NAME, CONF_PORT
+from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_ON_ACTION, DEFAULT_NAME, DOMAIN
+from .const import (
+    COMMAND_RETRY_COUNT,
+    CONF_ON_ACTION,
+    DEFAULT_NAME,
+    DOMAIN,
+    KEY_REMOTE,
+    LOGGER,
+)
 
 
 def ensure_unique_hosts(value):
@@ -61,8 +74,113 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up the Samsung TV platform."""
+    data = hass.data.setdefault(DOMAIN, {})
+    data.setdefault(entry.entry_id, {})[KEY_REMOTE] = RemoteWrapper(hass, entry)
+
+    await discovery.async_load_platform(
+        hass, REMOTE_DOMAIN, DOMAIN, entry, hass.config.as_dict(),
+    )
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, MP_DOMAIN)
     )
 
     return True
+
+
+class RemoteWrapper:
+    """Remote control helper for Samsung TV platforms."""
+
+    def __init__(self, hass, config_entry):
+        """Initialize remote control helper."""
+        self.hass = hass
+        self._last_command_sent = time.monotonic() - DEFAULT_DELAY_SECS
+        self._remote: Optional[samsungctl.Remote] = None
+        # Configuration for the Samsung library
+        self._config = {
+            "name": "HomeAssistant",
+            "description": "HomeAssistant",
+            "id": "ha.component.samsung",
+            "method": config_entry.data[CONF_METHOD],
+            "port": config_entry.data.get(CONF_PORT),
+            "host": config_entry.data[CONF_HOST],
+            "timeout": 1,
+        }
+
+    def get_remote(self, force_reconnect: bool = False) -> samsungctl.Remote:
+        """Create or return a remote control instance."""
+        if self._remote is not None:
+            if force_reconnect:
+                self.close()
+            else:
+                return self._remote
+
+        # Create a new instance to reconnect
+        try:
+            self._remote = samsungctl.Remote(self._config.copy())
+        except samsungctl.exceptions.AccessDenied:
+            # This is only happening when the auth was switched to DENY.
+            # A removed auth will lead to socket timeout because waiting for
+            # auth popup is just an open socket.
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": "reauth"}, data=self._config_entry.data,
+                )
+            )
+            raise
+
+        return self._remote
+
+    def reconnect(self) -> bool:
+        """Reconnect the remote control."""
+        try:
+            _ = self.get_remote(force_reconnect=True)
+        except (
+            samsungctl.exceptions.UnhandledResponse,
+            samsungctl.exceptions.AccessDenied,
+        ):
+            # We got a response so it's working
+            return True
+        except (OSError, websocket.WebSocketException):
+            return False
+        else:
+            return True
+
+    def close(self) -> None:
+        """Close remote connection."""
+        if self._remote is not None:
+            self._remote.close()
+            self._remote = None
+
+    def send_commands(self, commands: Iterable[str], delay: float = 0) -> None:
+        """Send commands to TV."""
+        for command in commands:
+            self.send_command(command, delay)
+
+    def send_command(self, command: str, delay: float = 0) -> None:
+        """Send a command to TV."""
+        # Wait remaining delay
+        time.sleep(max(0, self._last_command_sent + delay - time.monotonic()))
+        try:
+            # Recreate connection if it was dead
+            for _ in range(COMMAND_RETRY_COUNT):
+                try:
+                    self.get_remote().control(command)
+                    break
+                except (
+                    samsungctl.exceptions.ConnectionClosed,
+                    BrokenPipeError,
+                    websocket.WebSocketException,
+                ):
+                    # BrokenPipe can occur when the commands are sent too fast,
+                    # WebSocketException can occur when timed out.
+                    self._remote = None
+        except (
+            samsungctl.exceptions.UnhandledResponse,
+            samsungctl.exceptions.AccessDenied,
+        ):
+            # We got a response so the TV is on.
+            LOGGER.debug("Failed sending command %s", command, exc_info=True)
+        except OSError:
+            # Different reasons, e.g. hostname not resolveable.
+            pass
+        self._last_command_sent = time.monotonic()

--- a/homeassistant/components/samsungtv/const.py
+++ b/homeassistant/components/samsungtv/const.py
@@ -9,3 +9,7 @@ DEFAULT_NAME = "Samsung TV"
 CONF_MANUFACTURER = "manufacturer"
 CONF_MODEL = "model"
 CONF_ON_ACTION = "turn_on_action"
+
+COMMAND_RETRY_COUNT = 2
+
+KEY_REMOTE = "remote"

--- a/homeassistant/components/samsungtv/remote.py
+++ b/homeassistant/components/samsungtv/remote.py
@@ -1,0 +1,59 @@
+"""Support for Samsung TV remotes."""
+from typing import Iterable
+
+from homeassistant.components.remote import (
+    ATTR_DELAY_SECS,
+    DEFAULT_DELAY_SECS,
+    RemoteDevice,
+)
+from homeassistant.const import CONF_ID, CONF_NAME
+
+from .const import DOMAIN, KEY_REMOTE
+
+COMMAND_RETRY_COUNT = 2
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the remote."""
+    async_add_entities([SamsungTVRemote(discovery_info)])
+
+
+class SamsungTVRemote(RemoteDevice):
+    """Representation of a Samsung TV remote."""
+
+    def __init__(self, config_entry):
+        """Initialize the remote."""
+        self._name = config_entry.data.get(CONF_NAME)
+        self._uuid = config_entry.data.get(CONF_ID)
+        self._entry_id = config_entry.entry_id
+
+    @property
+    def _remote(self):
+        return self.hass.data[DOMAIN][self._entry_id][KEY_REMOTE]
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False
+
+    # TODO, need different than media player?
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._uuid
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def is_on(self) -> bool:
+        """Return True."""
+        return True
+
+    def send_command(self, command: Iterable[str], **kwargs) -> None:
+        """Send commands to a device."""
+        delay = kwargs.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
+        for single_command in command:
+            self._remote.send_command(single_command, delay)


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change separates remote from the Samsung TV media player. This is in order to be able to send arbitrary key commands to the TV, not just ones related to the media player.

This is an incomplete work in progress PR; it currently actually breaks stuff, as the remote should somehow be "attached" to the media player so the media player would use it, but I'm not sure what's the best way to accomplish that. Grab a direct reference to the remote in the media player on a platform discovery event, or call the remote using its services, or...

I'm posting this here before finalizing it, so I can abandon it early in case the feature would for some reason be undesirable, and in the case it is desirable, to ask for some help with finalizing it :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
