### PR TITLE
Remove YAML config from Ring integration

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -9,12 +9,9 @@ from typing import Optional
 from oauthlib.oauth2 import AccessDeniedError
 import requests
 from ring_doorbell import Auth, Ring
-import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, __version__
+from homeassistant.const import __version__
 from homeassistant.core import HomeAssistant, callback
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.async_ import run_callback_threadsafe
 
@@ -30,18 +27,6 @@ DEFAULT_ENTITY_NAMESPACE = "ring"
 
 PLATFORMS = ("binary_sensor", "light", "sensor", "switch", "camera")
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        vol.Optional(DOMAIN): vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
 
 async def async_setup(hass, config):
     """Set up the Ring component."""
@@ -56,16 +41,6 @@ async def async_setup(hass, config):
 
     await hass.async_add_executor_job(legacy_cleanup)
 
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                "username": config[DOMAIN]["username"],
-                "password": config[DOMAIN]["password"],
-            },
-        )
-    )
     return True
 
 

--- a/homeassistant/components/ring/config_flow.py
+++ b/homeassistant/components/ring/config_flow.py
@@ -75,13 +75,6 @@ class RingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="2fa", data_schema=vol.Schema({"2fa": str}),
         )
 
-    async def async_step_import(self, user_input):
-        """Handle import."""
-        if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
-
-        return await self.async_step_user(user_input)
-
 
 class Require2FA(exceptions.HomeAssistantError):
     """Error to indicate we require 2FA."""

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -1,12 +1,10 @@
 """The tests for the Ring component."""
 from asyncio import run_coroutine_threadsafe
-from copy import deepcopy
 from datetime import timedelta
 import unittest
 
 import requests_mock
 
-from homeassistant import setup
 import homeassistant.components.ring as ring
 
 from tests.common import get_test_home_assistant, load_fixture
@@ -57,25 +55,3 @@ class TestRing(unittest.TestCase):
         ).result()
 
         assert response
-
-    @requests_mock.Mocker()
-    def test_setup_component_no_login(self, mock):
-        """Test the setup when no login is configured."""
-        mock.post(
-            "https://api.ring.com/clients_api/session",
-            text=load_fixture("ring_session.json"),
-        )
-        conf = deepcopy(VALID_CONFIG)
-        del conf["ring"]["username"]
-        assert not setup.setup_component(self.hass, ring.DOMAIN, conf)
-
-    @requests_mock.Mocker()
-    def test_setup_component_no_pwd(self, mock):
-        """Test the setup when no password is configured."""
-        mock.post(
-            "https://api.ring.com/clients_api/session",
-            text=load_fixture("ring_session.json"),
-        )
-        conf = deepcopy(VALID_CONFIG)
-        del conf["ring"]["password"]
-        assert not setup.setup_component(self.hass, ring.DOMAIN, conf)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
All Ring accounts require two-factor authentication. This means that it is no longer possible to configure it via YAML as this cannot support 2FA.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove YAML configuration from Ring because it cannot support 2FA.

Docs have already been updated: https://github.com/home-assistant/home-assistant.io/pull/12145

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
