### PR TITLE
Allow templating mqtt fan speed command value

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -129,6 +129,7 @@ ABBREVIATIONS = {
     "set_pos_t": "set_position_topic",
     "pos_t": "position_topic",
     "spd_cmd_t": "speed_command_topic",
+    "spd_cmd_tpl": "speed_command_template",
     "spd_stat_t": "speed_state_topic",
     "spd_val_tpl": "speed_value_template",
     "spds": "speeds",


### PR DESCRIPTION
I have a pedestal fan that has eight different speeds which are
shown on the front of the unit as 1 through 8. I'm running tasmota
on the fan, and the values for the speeds "on the wire" are 0 through
7. I want to present the speeds in home-assistant as they are on
the front of the unit, so I need to be able to transform the value
coming from the state topic, but also for the command topic.

Worse, this device uses a Tuya MCU, which tasmota has very green
support for. To set the speed I need to use the TuyaSend4 command,
which has a payload that has to be prefixed with the DpId, which
again, is much easier if I can template the command value.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
fan:
  - platform: mqtt
    name: "Anko HEGSM40"
    state_topic: "stat/anko_fan/POWER1"
    command_topic: "cmnd/anko_fan/POWER1"
    oscillation_state_topic: "stat/anko_fan/POWER2"
    oscillation_command_topic: "cmnd/anko_fan/POWER2"
    speed_state_topic: "stat/anko_fan/SPEED"
    speed_value_template: "{{ value.split(',')[1] | int + 1 }}"
    speed_command_topic: "cmnd/anko_fan/TuyaSend4"
    speed_command_template: "3,{{ value | int - 1 }}"
    qos: 0
    payload_on: 'ON'
    payload_off: 'OFF'
    payload_oscillation_on: 'ON'
    payload_oscillation_off: 'OFF'
    availability_topic: tele/anko_fan/LWT
    payload_available: Online
    payload_not_available: Offline
    speeds:
      - '1'
      - '2'
      - '3'
      - '4'
      - '5'
      - '6'
      - '7'
      - '8'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This works well with https://github.com/arendst/Tasmota/commit/cf27cff60297c9c093574467f6de8a744037adf1

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
