### PR TITLE
Fix fortigate for FortiOS 6.2

### DIFF
--- a/homeassistant/components/fortigate/device_tracker.py
+++ b/homeassistant/components/fortigate/device_tracker.py
@@ -18,12 +18,12 @@ async def async_get_scanner(hass, config):
     return scanner if scanner.success_init else None
 
 
-Device = namedtuple("Device", ["hostname", "mac"])
+Device = namedtuple("Device", ["mac_firewall_address", "mac"])
 
 
 def _build_device(device_dict):
     """Return a Device from data."""
-    return Device(device_dict["hostname"], device_dict["mac"])
+    return Device(device_dict["mac_firewall_address"], device_dict["mac"])
 
 
 class FortigateDeviceScanner(DeviceScanner):
@@ -42,7 +42,7 @@ class FortigateDeviceScanner(DeviceScanner):
 
         ret = []
         for result in results:
-            if "hostname" not in result:
+            if "mac_firewall_address" not in result:
                 continue
 
             ret.append(result)
@@ -63,7 +63,11 @@ class FortigateDeviceScanner(DeviceScanner):
     async def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         name = next(
-            (result.hostname for result in self.last_results if result.mac == device),
+            (
+                result.mac_firewall_address
+                for result in self.last_results
+                if result.mac == device
+            ),
             None,
         )
         return name
@@ -79,7 +83,7 @@ class FortigateDeviceScanner(DeviceScanner):
         # If the 'devices' configuration field is filled
         if self.devices is not None:
             last_results = [
-                device for device in all_results if device.hostname in self.devices
+                device for device in all_results if device.mac in self.devices
             ]
             _LOGGER.debug(last_results)
         # If the 'devices' configuration field is not filled


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The FortiOS 6.2 removes the device identification's reservation, so instead this is a firewall address 'mac' type.
The modified code adapts to this behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
