### PR TITLE
Refactor Certificate Expiry Sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -107,8 +107,10 @@ omit =
     homeassistant/components/canary/alarm_control_panel.py
     homeassistant/components/canary/camera.py
     homeassistant/components/cast/*
-    homeassistant/components/cert_expiry/sensor.py
+    homeassistant/components/cert_expiry/__init__.py
+    homeassistant/components/cert_expiry/errors.py
     homeassistant/components/cert_expiry/helper.py
+    homeassistant/components/cert_expiry/sensor.py
     homeassistant/components/channels/*
     homeassistant/components/cisco_ios/device_tracker.py
     homeassistant/components/cisco_mobility_express/device_tracker.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -107,8 +107,6 @@ omit =
     homeassistant/components/canary/alarm_control_panel.py
     homeassistant/components/canary/camera.py
     homeassistant/components/cast/*
-    homeassistant/components/cert_expiry/__init__.py
-    homeassistant/components/cert_expiry/errors.py
     homeassistant/components/cert_expiry/helper.py
     homeassistant/components/cert_expiry/sensor.py
     homeassistant/components/channels/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -108,7 +108,6 @@ omit =
     homeassistant/components/canary/camera.py
     homeassistant/components/cast/*
     homeassistant/components/cert_expiry/helper.py
-    homeassistant/components/cert_expiry/sensor.py
     homeassistant/components/channels/*
     homeassistant/components/cisco_ios/device_tracker.py
     homeassistant/components/cisco_mobility_express/device_tracker.py

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -55,13 +55,10 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             if await self._test_connection(user_input):
-                title = host + (f":{port}" if port != DEFAULT_PORT else "")
+                title_port = f":{port}" if port != DEFAULT_PORT else ""
+                title = f"{host}{title_port}"
                 return self.async_create_entry(
-                    title=title,
-                    data={
-                        CONF_HOST: user_input[CONF_HOST],
-                        CONF_PORT: user_input.get(CONF_PORT, DEFAULT_PORT),
-                    },
+                    title=title, data={CONF_HOST: host, CONF_PORT: port},
                 )
             if (  # pylint: disable=no-member
                 self.context["source"] == config_entries.SOURCE_IMPORT

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -1,6 +1,5 @@
 """Config flow for the Cert Expiry platform."""
 import logging
-import socket
 
 import voluptuous as vol
 
@@ -34,13 +33,8 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             return True
         except TemporaryFailure as err:
-            cause = type(err.__cause__)
-            if cause is socket.gaierror:
-                self._errors[CONF_HOST] = "resolve_failed"
-            elif cause is socket.timeout:
-                self._errors[CONF_HOST] = "connection_timeout"
-            elif cause is ConnectionRefusedError:
-                self._errors[CONF_HOST] = "connection_refused"
+            cause = err.args[1]
+            self._errors[CONF_HOST] = cause
         except ValidationFailure:
             return True
         return False

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -7,7 +7,12 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
 from .const import DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
-from .errors import TemporaryFailure, ValidationFailure
+from .errors import (
+    ConnectionRefused,
+    ConnectionTimeout,
+    ResolveFailed,
+    ValidationFailure,
+)
 from .helper import get_cert_time_to_expiry
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,9 +37,12 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_PORT, DEFAULT_PORT),
             )
             return True
-        except TemporaryFailure as err:
-            cause = err.args[1]
-            self._errors[CONF_HOST] = cause
+        except ResolveFailed:
+            self._errors[CONF_HOST] = "resolve_failed"
+        except ConnectionTimeout:
+            self._errors[CONF_HOST] = "connection_timeout"
+        except ConnectionRefused:
+            self._errors[CONF_HOST] = "connection_refused"
         except ValidationFailure:
             return True
         return False

--- a/homeassistant/components/cert_expiry/const.py
+++ b/homeassistant/components/cert_expiry/const.py
@@ -1,6 +1,5 @@
 """Const for Cert Expiry."""
 
 DOMAIN = "cert_expiry"
-DEFAULT_NAME = "SSL Certificate Expiry"
 DEFAULT_PORT = 443
 TIMEOUT = 10.0

--- a/homeassistant/components/cert_expiry/errors.py
+++ b/homeassistant/components/cert_expiry/errors.py
@@ -12,3 +12,15 @@ class TemporaryFailure(CertExpiryException):
 
 class ValidationFailure(CertExpiryException):
     """Certificate validation failure has occurred."""
+
+
+class ResolveFailed(TemporaryFailure):
+    """Name resolution failed."""
+
+
+class ConnectionTimeout(TemporaryFailure):
+    """Network connection timed out."""
+
+
+class ConnectionRefused(TemporaryFailure):
+    """Network connection refused."""

--- a/homeassistant/components/cert_expiry/errors.py
+++ b/homeassistant/components/cert_expiry/errors.py
@@ -1,0 +1,14 @@
+"""Errors for the cert_expiry integration."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class CertExpiryException(HomeAssistantError):
+    """Base class for cert_expiry exceptions."""
+
+
+class TemporaryFailure(CertExpiryException):
+    """Temporary failure has occurred."""
+
+
+class ValidationFailure(CertExpiryException):
+    """Certificate validation failure has occurred."""

--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -22,16 +22,16 @@ async def get_cert_time_to_expiry(hass, hostname, port):
     """Return the certificate's time to expiry in days."""
     try:
         cert = await hass.async_add_executor_job(get_cert, hostname, port)
-    except socket.gaierror as err:
-        raise TemporaryFailure(f"Cannot resolve hostname: {hostname}") from err
-    except socket.timeout as err:
+    except socket.gaierror:
+        raise TemporaryFailure(f"Cannot resolve hostname: {hostname}", "resolve_failed")
+    except socket.timeout:
         raise TemporaryFailure(
-            f"Connection timeout with server: {hostname}:{port}"
-        ) from err
-    except ConnectionRefusedError as err:
+            f"Connection timeout with server: {hostname}:{port}", "connection_timeout"
+        )
+    except ConnectionRefusedError:
         raise TemporaryFailure(
-            f"Connection refused by server: {hostname}:{port}"
-        ) from err
+            f"Connection refused by server: {hostname}:{port}", "connection_refused"
+        )
     except ssl.CertificateError as err:
         raise ValidationFailure(err.verify_message)
     except ssl.SSLError as err:

--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -1,12 +1,14 @@
 """Helper functions for the Cert Expiry platform."""
+from datetime import datetime
 import socket
 import ssl
 
 from .const import TIMEOUT
+from .errors import TemporaryFailure, ValidationFailure
 
 
 def get_cert(host, port):
-    """Get the ssl certificate for the host and port combination."""
+    """Get the certificate for the host and port combination."""
     ctx = ssl.create_default_context()
     address = (host, port)
     with socket.create_connection(address, timeout=TIMEOUT) as sock:
@@ -14,3 +16,28 @@ def get_cert(host, port):
             # pylint disable: https://github.com/PyCQA/pylint/issues/3166
             cert = ssock.getpeercert()  # pylint: disable=no-member
             return cert
+
+
+async def get_cert_time_to_expiry(hass, hostname, port):
+    """Return the certificate's time to expiry in days."""
+    try:
+        cert = await hass.async_add_executor_job(get_cert, hostname, port)
+    except socket.gaierror as err:
+        raise TemporaryFailure(f"Cannot resolve hostname: {hostname}") from err
+    except socket.timeout as err:
+        raise TemporaryFailure(
+            f"Connection timeout with server: {hostname}:{port}"
+        ) from err
+    except ConnectionRefusedError as err:
+        raise TemporaryFailure(
+            f"Connection refused by server: {hostname}:{port}"
+        ) from err
+    except ssl.CertificateError as err:
+        raise ValidationFailure(err.verify_message)
+    except ssl.SSLError as err:
+        raise ValidationFailure(err.args[0])
+
+    ts_seconds = ssl.cert_time_to_seconds(cert["notAfter"])
+    timestamp = datetime.fromtimestamp(ts_seconds)
+    expiry = timestamp - datetime.today()
+    return expiry.days

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -75,7 +75,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         pass
 
     async_add_entities(
-        [SSLCertificate(hass, entry.title, hostname, port, days, error)], False,
+        [SSLCertificate(hass, hostname, port, days, error)], False,
     )
     return True
 
@@ -83,7 +83,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class SSLCertificate(Entity):
     """Implementation of the certificate expiry sensor."""
 
-    def __init__(self, hass, sensor_name, server_name, server_port, days, error):
+    def __init__(self, hass, server_name, server_port, days, error):
         """Initialize the sensor."""
         self.hass = hass
         self.server_name = server_name

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -1,8 +1,6 @@
 """Counter for the days until an HTTPS (TLS) certificate will expire."""
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
-import socket
-import ssl
 
 import voluptuous as vol
 
@@ -16,11 +14,15 @@ from homeassistant.const import (
     TIME_DAYS,
 )
 from homeassistant.core import callback
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.util import dt as dt_util
 
-from .const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN
-from .helper import get_cert
+from .const import DEFAULT_PORT, DOMAIN
+from .errors import TemporaryFailure, ValidationFailure
+from .helper import get_cert_time_to_expiry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +31,7 @@ SCAN_INTERVAL = timedelta(hours=12)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME): cv.string,  # Deprecated
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     }
 )
@@ -39,24 +41,41 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up certificate expiry sensor."""
 
     @callback
+    def schedule_import(_):
+        """Schedule delayed import after HA is fully started."""
+        import_time = dt_util.utcnow() + timedelta(seconds=30)
+        async_track_point_in_utc_time(hass, do_import, import_time)
+
+    @callback
     def do_import(_):
-        """Process YAML import after HA is fully started."""
+        """Process YAML import."""
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config)
             )
         )
 
-    # Delay to avoid validation during setup in case we're checking our own cert.
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_import)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, schedule_import)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Add cert-expiry entry."""
+    days = 0
+    error = None
+    hostname = entry.data[CONF_HOST]
+    port = entry.data[CONF_PORT]
+
+    try:
+        days = await get_cert_time_to_expiry(hass, hostname, port)
+    except TemporaryFailure as err:
+        _LOGGER.error(err)
+        raise PlatformNotReady
+    except ValidationFailure as err:
+        error = err
+        pass
+
     async_add_entities(
-        [SSLCertificate(entry.title, entry.data[CONF_HOST], entry.data[CONF_PORT])],
-        False,
-        # Don't update in case we're checking our own cert.
+        [SSLCertificate(hass, entry.title, hostname, port, days, error)], False,
     )
     return True
 
@@ -64,14 +83,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class SSLCertificate(Entity):
     """Implementation of the certificate expiry sensor."""
 
-    def __init__(self, sensor_name, server_name, server_port):
+    def __init__(self, hass, sensor_name, server_name, server_port, days, error):
         """Initialize the sensor."""
+        self.hass = hass
         self.server_name = server_name
         self.server_port = server_port
-        self._name = sensor_name
-        self._state = None
+        display_port = f":{server_port}" if server_port != DEFAULT_PORT else ""
+        self._name = f"Cert Expiry ({self.server_name}{display_port})"
         self._available = False
+        self._error = error
+        self._state = None
         self._valid = False
+        if days is not None:
+            self._state = days
+            self._available = True
+            self._valid = True
 
     @property
     def name(self):
@@ -103,50 +129,42 @@ class SSLCertificate(Entity):
         """Return the availability of the sensor."""
         return self._available
 
-    async def async_added_to_hass(self):
-        """Once the entity is added we should update to get the initial data loaded."""
-
-        @callback
-        def do_update(_):
-            """Run the update method when the start event was fired."""
-            self.async_schedule_update_ha_state(True)
-
-        if self.hass.is_running:
-            self.async_schedule_update_ha_state(True)
-        else:
-            # Delay until HA is fully started in case we're checking our own cert.
-            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_update)
-
-    def update(self):
+    async def async_update(self):
         """Fetch the certificate information."""
         try:
-            cert = get_cert(self.server_name, self.server_port)
-        except socket.gaierror:
-            _LOGGER.error("Cannot resolve hostname: %s", self.server_name)
+            days_to_expiry = await get_cert_time_to_expiry(
+                self.hass, self.server_name, self.server_port
+            )
+        except TemporaryFailure as err:
+            _LOGGER.error(err)
             self._available = False
+            self._error = err
             self._valid = False
             return
-        except socket.timeout:
-            _LOGGER.error("Connection timeout with server: %s", self.server_name)
-            self._available = False
-            self._valid = False
-            return
-        except (ssl.CertificateError, ssl.SSLError):
+        except ValidationFailure as err:
+            _LOGGER.error(
+                "Certificate validation error: %s [%s]", self.server_name, err
+            )
             self._available = True
+            self._error = err
             self._state = 0
             self._valid = False
             return
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Unknown error checking %s:%s", self.server_name, self.server_port
+            )
+            self._available = False
+            self._error = "Unknown"
+            self._valid = False
+            return
 
-        ts_seconds = ssl.cert_time_to_seconds(cert["notAfter"])
-        timestamp = datetime.fromtimestamp(ts_seconds)
-        expiry = timestamp - datetime.today()
         self._available = True
-        self._state = expiry.days
+        self._error = None
+        self._state = days_to_expiry
         self._valid = True
 
     @property
     def device_state_attributes(self):
         """Return additional sensor state attributes."""
-        attr = {"is_valid": self._valid}
-
-        return attr
+        return {"is_valid": self._valid, "error": str(self._error)}

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -43,7 +43,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     @callback
     def schedule_import(_):
         """Schedule delayed import after HA is fully started."""
-        import_time = dt_util.utcnow() + timedelta(seconds=30)
+        import_time = dt_util.utcnow() + timedelta(seconds=10)
         async_track_point_in_utc_time(hass, do_import, import_time)
 
     @callback

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -78,7 +78,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
         raise PlatformNotReady
     except ValidationFailure as err:
         error = err
-        pass
 
     async_add_entities(
         [SSLCertificate(hass, hostname, port, days, error)], False,
@@ -96,13 +95,11 @@ class SSLCertificate(Entity):
         self.server_port = server_port
         display_port = f":{server_port}" if server_port != DEFAULT_PORT else ""
         self._name = f"Cert Expiry ({self.server_name}{display_port})"
-        self._available = False
+        self._available = True
         self._error = error
-        self._state = None
+        self._state = days
         self._valid = False
-        if days is not None:
-            self._state = days
-            self._available = True
+        if error is None:
             self._valid = True
 
     @property

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -68,6 +68,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
     hostname = entry.data[CONF_HOST]
     port = entry.data[CONF_PORT]
 
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(entry, unique_id=f"{hostname}:{port}")
+
     try:
         days = await get_cert_time_to_expiry(hass, hostname, port)
     except TemporaryFailure as err:

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -72,7 +72,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     try:
         days = await get_cert_time_to_expiry(hass, hostname, port)
     except TemporaryFailure as err:
-        _LOGGER.error(err)
+        _LOGGER.error(err.args[0])
         raise PlatformNotReady
     except ValidationFailure as err:
         error = err
@@ -136,7 +136,7 @@ class SSLCertificate(Entity):
                 self.hass, self.server_name, self.server_port
             )
         except TemporaryFailure as err:
-            _LOGGER.error(err)
+            _LOGGER.error(err.args[0])
             self._available = False
             return
         except ValidationFailure as err:

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -72,7 +72,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     try:
         days = await get_cert_time_to_expiry(hass, hostname, port)
     except TemporaryFailure as err:
-        _LOGGER.error(err.args[0])
+        _LOGGER.error(err)
         raise PlatformNotReady
     except ValidationFailure as err:
         error = err

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -28,12 +28,15 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(hours=12)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME): cv.string,  # Deprecated
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    }
+PLATFORM_SCHEMA = vol.All(
+    cv.deprecated(CONF_NAME, invalidation_version="0.109"),
+    PLATFORM_SCHEMA.extend(
+        {
+            vol.Required(CONF_HOST): cv.string,
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        }
+    ),
 )
 
 

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -17,7 +17,7 @@
             "connection_refused": "Connection refused when connecting to host"
         },
         "abort": {
-            "host_port_exists": "This host and port combination is already configured",
+            "already_configured": "This host and port combination is already configured",
             "import_failed": "Import from config failed"
         }
     }

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -12,14 +12,13 @@
             }
         },
         "error": {
-            "host_port_exists": "This host and port combination is already configured",
             "resolve_failed": "This host can not be resolved",
             "connection_timeout": "Timeout when connecting to this host",
-            "certificate_error": "Certificate could not be validated",
-            "wrong_host": "Certificate does not match hostname"
+            "connection_refused": "Connection refused when connecting to host"
         },
         "abort": {
-            "host_port_exists": "This host and port combination is already configured"
+            "host_port_exists": "This host and port combination is already configured",
+            "import_failed": "Import from config failed"
         }
     }
 }

--- a/tests/components/cert_expiry/const.py
+++ b/tests/components/cert_expiry/const.py
@@ -1,0 +1,3 @@
+"""Constants for cert_expiry tests."""
+PORT = 443
+HOST = "example.com"

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -6,10 +6,8 @@ from unittest.mock import patch
 from asynctest import patch as asyncpatch
 
 from homeassistant import data_entry_flow
-from homeassistant.components.cert_expiry import config_flow
-from homeassistant.components.cert_expiry.const import DEFAULT_PORT
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.components.cert_expiry.const import DEFAULT_PORT, DOMAIN
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_UNAVAILABLE
 
 from tests.common import MockConfigEntry
 
@@ -19,95 +17,173 @@ GET_CERT_METHOD = "homeassistant.components.cert_expiry.helper.get_cert"
 GET_CERT_TIME_METHOD = (
     "homeassistant.components.cert_expiry.config_flow.get_cert_time_to_expiry"
 )
-
-
-def init_config_flow(hass, source=SOURCE_USER):
-    """Init a configuration flow."""
-    flow = config_flow.CertexpiryConfigFlow()
-    flow.hass = hass
-    flow.context = {"source": source}
-    return flow
+GET_SENSOR_CERT_TIME_METHOD = (
+    "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry"
+)
 
 
 async def test_user(hass):
     """Test user config."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_user()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    # test with all provided
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
-        result = await flow.async_step_user({CONF_HOST: HOST, CONF_PORT: PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == HOST
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == PORT
-
-
-async def test_user_with_bad_cert(hass):
-    """Test user config."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    # import with certification validation error
-    with patch(GET_CERT_METHOD, side_effect=ssl.SSLError("some error")):
-        result = await flow.async_step_user({CONF_HOST: HOST, CONF_PORT: PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == HOST
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == PORT
-
-
-async def test_import(hass):
-    """Test import step."""
-    flow = init_config_flow(hass, source=SOURCE_IMPORT)
-
-    # import with only host
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
-        result = await flow.async_step_import({CONF_HOST: HOST})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == HOST
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == DEFAULT_PORT
-
-    # import with host and port
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
-        result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == HOST
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == PORT
-
-    # import with host and non-default port
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
-        result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: 888})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == f"{HOST}:888"
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == 888
-
-    # import legacy config with name
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
-        result = await flow.async_step_import(
-            {CONF_NAME: "legacy", CONF_HOST: HOST, CONF_PORT: PORT}
+    with asyncpatch(GET_CERT_TIME_METHOD):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: HOST, CONF_PORT: PORT}
         )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
+    assert result["result"].unique_id == f"{HOST}:{PORT}"
+
+    with asyncpatch(GET_SENSOR_CERT_TIME_METHOD, return_value=100):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "100"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+
+
+async def test_user_with_bad_cert(hass):
+    """Test user config with bad certificate."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    with patch(GET_CERT_METHOD, side_effect=ssl.SSLError("some error")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: HOST, CONF_PORT: PORT}
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
+    assert result["result"].unique_id == f"{HOST}:{PORT}"
+
+    with patch(GET_CERT_METHOD, side_effect=ssl.SSLError("some error")):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "0"
+    assert state.attributes.get("error") == "some error"
+    assert not state.attributes.get("is_valid")
+
+
+async def test_import_host_only(hass):
+    """Test import with host only."""
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "import"}, data={CONF_HOST: HOST}
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+    assert result["result"].unique_id == f"{HOST}:{DEFAULT_PORT}"
+
+    with asyncpatch(GET_SENSOR_CERT_TIME_METHOD, return_value=100):
+        await hass.async_block_till_done()
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+    assert state.state == "100"
+
+
+async def test_import_host_and_port(hass):
+    """Test import with host and port."""
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "import"},
+            data={CONF_HOST: HOST, CONF_PORT: PORT},
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
+    assert result["result"].unique_id == f"{HOST}:{PORT}"
+
+    with asyncpatch(GET_SENSOR_CERT_TIME_METHOD, return_value=100):
+        await hass.async_block_till_done()
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+    assert state.state == "100"
+
+
+async def test_import_non_default_port(hass):
+    """Test import with host and non-default port."""
+    with asyncpatch(GET_CERT_TIME_METHOD):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "import"}, data={CONF_HOST: HOST, CONF_PORT: 888}
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == f"{HOST}:888"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == 888
+    assert result["result"].unique_id == f"{HOST}:888"
+
+    with asyncpatch(GET_SENSOR_CERT_TIME_METHOD, return_value=100):
+        await hass.async_block_till_done()
+    state = hass.states.get("sensor.cert_expiry_example_com_888")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+    assert state.state == "100"
+
+
+async def test_import_with_name(hass):
+    """Test import with name (deprecated)."""
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "import"},
+            data={CONF_NAME: "legacy", CONF_HOST: HOST, CONF_PORT: PORT},
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
+    assert result["result"].unique_id == f"{HOST}:{PORT}"
+
+    with asyncpatch(GET_SENSOR_CERT_TIME_METHOD, return_value=100):
+        await hass.async_block_till_done()
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+    assert state.state == "100"
 
 
 async def test_bad_import(hass):
     """Test import step."""
-    flow = init_config_flow(hass, source=SOURCE_IMPORT)
-
     with patch(GET_CERT_METHOD, side_effect=ConnectionRefusedError()):
-        result = await flow.async_step_import({CONF_HOST: HOST})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "import"}, data={CONF_HOST: HOST}
+        )
+
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "import_failed"
 
@@ -115,45 +191,47 @@ async def test_bad_import(hass):
 async def test_abort_if_already_setup(hass):
     """Test we abort if the cert is already setup."""
     MockConfigEntry(
-        domain="cert_expiry", data={CONF_PORT: DEFAULT_PORT, CONF_HOST: HOST},
+        domain="cert_expiry",
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
     ).add_to_hass(hass)
 
-    # Test with import source
-    flow = init_config_flow(hass, source=SOURCE_IMPORT)
-
-    # Should fail, same HOST and PORT (default)
-    result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: DEFAULT_PORT})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "import"}, data={CONF_HOST: HOST, CONF_PORT: PORT}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "host_port_exists"
+    assert result["reason"] == "already_configured"
 
-    # Test with user source
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    # Should fail, same HOST and PORT (default)
-    result = await flow.async_step_user({CONF_HOST: HOST, CONF_PORT: DEFAULT_PORT})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}, data={CONF_HOST: HOST, CONF_PORT: PORT}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "host_port_exists"
+    assert result["reason"] == "already_configured"
 
 
 async def test_abort_on_socket_failed(hass):
     """Test we abort of we have errors during socket creation."""
-    flow = init_config_flow(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
 
     with patch(GET_CERT_METHOD, side_effect=socket.gaierror()):
-        result = await flow.async_step_user({CONF_HOST: HOST})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: HOST}
+        )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {CONF_HOST: "resolve_failed"}
 
     with patch(GET_CERT_METHOD, side_effect=socket.timeout()):
-        result = await flow.async_step_user({CONF_HOST: HOST})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: HOST}
+        )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {CONF_HOST: "connection_timeout"}
 
     with patch(GET_CERT_METHOD, side_effect=ConnectionRefusedError):
-        result = await flow.async_step_user({CONF_HOST: HOST})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: HOST}
+        )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {CONF_HOST: "connection_refused"}

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -83,7 +83,7 @@ async def test_user_with_bad_cert(hass):
 
 async def test_import_host_only(hass):
     """Test import with host only."""
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+    with asyncpatch(GET_CERT_TIME_METHOD):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "import"}, data={CONF_HOST: HOST}
         )
@@ -106,7 +106,7 @@ async def test_import_host_only(hass):
 
 async def test_import_host_and_port(hass):
     """Test import with host and port."""
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+    with asyncpatch(GET_CERT_TIME_METHOD):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": "import"},
@@ -154,7 +154,7 @@ async def test_import_non_default_port(hass):
 
 async def test_import_with_name(hass):
     """Test import with name (deprecated)."""
-    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+    with asyncpatch(GET_CERT_TIME_METHOD):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": "import"},

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -3,38 +3,33 @@ import socket
 import ssl
 from unittest.mock import patch
 
-import pytest
+from asynctest import patch as asyncpatch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.cert_expiry import config_flow
-from homeassistant.components.cert_expiry.const import DEFAULT_NAME, DEFAULT_PORT
+from homeassistant.components.cert_expiry.const import DEFAULT_PORT
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import MockConfigEntry
 
-NAME = "Cert Expiry test 1 2 3"
 PORT = 443
 HOST = "example.com"
+GET_CERT_METHOD = "homeassistant.components.cert_expiry.helper.get_cert"
+GET_CERT_TIME_METHOD = (
+    "homeassistant.components.cert_expiry.config_flow.get_cert_time_to_expiry"
+)
 
 
-@pytest.fixture(name="test_connect")
-def mock_controller():
-    """Mock a successful _prt_in_configuration_exists."""
-    with patch(
-        "homeassistant.components.cert_expiry.config_flow.CertexpiryConfigFlow._test_connection",
-        side_effect=lambda *_: mock_coro(True),
-    ):
-        yield
-
-
-def init_config_flow(hass):
+def init_config_flow(hass, source=SOURCE_USER):
     """Init a configuration flow."""
     flow = config_flow.CertexpiryConfigFlow()
     flow.hass = hass
+    flow.context = {"source": source}
     return flow
 
 
-async def test_user(hass, test_connect):
+async def test_user(hass):
     """Test user config."""
     flow = init_config_flow(hass)
 
@@ -42,113 +37,123 @@ async def test_user(hass, test_connect):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    # tets with all provided
-    result = await flow.async_step_user(
-        {CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT}
-    )
+    # test with all provided
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await flow.async_step_user({CONF_HOST: HOST, CONF_PORT: PORT})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == NAME
+    assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
 
 
-async def test_import(hass, test_connect):
-    """Test import step."""
+async def test_user_with_bad_cert(hass):
+    """Test user config."""
     flow = init_config_flow(hass)
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # import with certification validation error
+    with patch(GET_CERT_METHOD, side_effect=ssl.SSLError("some error")):
+        result = await flow.async_step_user({CONF_HOST: HOST, CONF_PORT: PORT})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
+
+
+async def test_import(hass):
+    """Test import step."""
+    flow = init_config_flow(hass, source=SOURCE_IMPORT)
 
     # import with only host
-    result = await flow.async_step_import({CONF_HOST: HOST})
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await flow.async_step_import({CONF_HOST: HOST})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
+    assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == DEFAULT_PORT
 
-    # import with host and name
-    result = await flow.async_step_import({CONF_HOST: HOST, CONF_NAME: NAME})
+    # import with host and port
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == NAME
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == DEFAULT_PORT
-
-    # improt with host and port
-    result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
+    assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
 
-    # import with all
-    result = await flow.async_step_import(
-        {CONF_HOST: HOST, CONF_PORT: PORT, CONF_NAME: NAME}
-    )
+    # import with host and non-default port
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: 888})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == NAME
+    assert result["title"] == f"{HOST}:888"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == 888
+
+    # import legacy config with name
+    with asyncpatch(GET_CERT_TIME_METHOD, return_value=1):
+        result = await flow.async_step_import(
+            {CONF_NAME: "legacy", CONF_HOST: HOST, CONF_PORT: PORT}
+        )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
 
 
-async def test_abort_if_already_setup(hass, test_connect):
+async def test_bad_import(hass):
+    """Test import step."""
+    flow = init_config_flow(hass, source=SOURCE_IMPORT)
+
+    with patch(GET_CERT_METHOD, side_effect=ConnectionRefusedError()):
+        result = await flow.async_step_import({CONF_HOST: HOST})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "import_failed"
+
+
+async def test_abort_if_already_setup(hass):
     """Test we abort if the cert is already setup."""
-    flow = init_config_flow(hass)
     MockConfigEntry(
-        domain="cert_expiry",
-        data={CONF_PORT: DEFAULT_PORT, CONF_NAME: NAME, CONF_HOST: HOST},
+        domain="cert_expiry", data={CONF_PORT: DEFAULT_PORT, CONF_HOST: HOST},
     ).add_to_hass(hass)
 
+    # Test with import source
+    flow = init_config_flow(hass, source=SOURCE_IMPORT)
+
     # Should fail, same HOST and PORT (default)
-    result = await flow.async_step_import(
-        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT}
-    )
+    result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: DEFAULT_PORT})
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "host_port_exists"
 
-    # Should be the same HOST and PORT (default)
-    result = await flow.async_step_user(
-        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_HOST: "host_port_exists"}
+    # Test with user source
+    flow = init_config_flow(hass)
 
-    # SHOULD pass, same Host diff PORT
-    result = await flow.async_step_import(
-        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: 888}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == NAME
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == 888
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # Should fail, same HOST and PORT (default)
+    result = await flow.async_step_user({CONF_HOST: HOST, CONF_PORT: DEFAULT_PORT})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "host_port_exists"
 
 
 async def test_abort_on_socket_failed(hass):
     """Test we abort of we have errors during socket creation."""
     flow = init_config_flow(hass)
 
-    with patch("socket.create_connection", side_effect=socket.gaierror()):
+    with patch(GET_CERT_METHOD, side_effect=socket.gaierror()):
         result = await flow.async_step_user({CONF_HOST: HOST})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_HOST: "resolve_failed"}
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "resolve_failed"}
 
-    with patch("socket.create_connection", side_effect=socket.timeout()):
+    with patch(GET_CERT_METHOD, side_effect=socket.timeout()):
         result = await flow.async_step_user({CONF_HOST: HOST})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_HOST: "connection_timeout"}
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "connection_timeout"}
 
-    with patch(
-        "socket.create_connection",
-        side_effect=ssl.CertificateError(f"{HOST} doesn't match somethingelse.com"),
-    ):
+    with patch(GET_CERT_METHOD, side_effect=ConnectionRefusedError):
         result = await flow.async_step_user({CONF_HOST: HOST})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_HOST: "wrong_host"}
-
-    with patch(
-        "socket.create_connection", side_effect=ssl.CertificateError("different error")
-    ):
-        result = await flow.async_step_user({CONF_HOST: HOST})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_HOST: "certificate_error"}
-
-    with patch("socket.create_connection", side_effect=ssl.SSLError()):
-        result = await flow.async_step_user({CONF_HOST: HOST})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_HOST: "certificate_error"}
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "connection_refused"}

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -1,4 +1,4 @@
-"""Tests for the Cert Expiry sensors."""
+"""Tests for Cert Expiry setup."""
 from datetime import timedelta
 
 from asynctest import patch

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -1,0 +1,87 @@
+"""Tests for the Cert Expiry sensors."""
+from datetime import timedelta
+
+from asynctest import patch
+
+from homeassistant.components import cert_expiry
+from homeassistant.components.cert_expiry.const import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from .const import HOST, PORT
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_setup_with_config(hass):
+    """Test setup component with config."""
+    config = {
+        SENSOR_DOMAIN: [
+            {"platform": DOMAIN, CONF_HOST: HOST, CONF_PORT: PORT},
+            {"platform": DOMAIN, CONF_HOST: HOST, CONF_PORT: 888},
+        ],
+    }
+    assert await async_setup_component(hass, SENSOR_DOMAIN, config) is True
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    next_update = dt_util.utcnow() + timedelta(seconds=20)
+    async_fire_time_changed(hass, next_update)
+
+    with patch(
+        "homeassistant.components.cert_expiry.config_flow.get_cert_time_to_expiry",
+        return_value=100,
+    ), patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=100,
+    ):
+        await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_update_unique_id(hass):
+    """Test updating a config entry without a unique_id."""
+    entry = MockConfigEntry(
+        domain="cert_expiry", data={CONF_HOST: HOST, CONF_PORT: PORT},
+    )
+    assert not entry.unique_id
+
+    with patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=100,
+    ):
+        entry.add_to_hass(hass)
+        assert await cert_expiry.async_setup_entry(hass, entry) is True
+        await hass.async_block_till_done()
+
+    assert entry.unique_id == f"{HOST}:{PORT}"
+
+
+async def test_unload_config_entry(hass):
+    """Test unloading a config entry."""
+    entry = MockConfigEntry(
+        domain="cert_expiry",
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=100,
+    ):
+        entry.add_to_hass(hass)
+        assert await cert_expiry.async_setup_entry(hass, entry) is True
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state.state == "100"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+
+    assert await cert_expiry.async_unload_entry(hass, entry)
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is None

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -3,9 +3,9 @@ from datetime import timedelta
 
 from asynctest import patch
 
-from homeassistant.components import cert_expiry
 from homeassistant.components.cert_expiry.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -44,44 +44,51 @@ async def test_setup_with_config(hass):
 
 async def test_update_unique_id(hass):
     """Test updating a config entry without a unique_id."""
-    entry = MockConfigEntry(
-        domain="cert_expiry", data={CONF_HOST: HOST, CONF_PORT: PORT},
-    )
-    assert not entry.unique_id
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST, CONF_PORT: PORT})
+    entry.add_to_hass(hass)
+
+    config_entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(config_entries) == 1
+    assert not config_entries[0].unique_id
 
     with patch(
         "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
         return_value=100,
     ):
-        entry.add_to_hass(hass)
-        assert await cert_expiry.async_setup_entry(hass, entry) is True
+        assert await async_setup_component(hass, DOMAIN, {}) is True
         await hass.async_block_till_done()
 
-    assert entry.unique_id == f"{HOST}:{PORT}"
+    assert config_entries[0].state == ENTRY_STATE_LOADED
+    assert config_entries[0].unique_id == f"{HOST}:{PORT}"
 
 
 async def test_unload_config_entry(hass):
     """Test unloading a config entry."""
     entry = MockConfigEntry(
-        domain="cert_expiry",
+        domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
         unique_id=f"{HOST}:{PORT}",
     )
+    entry.add_to_hass(hass)
+
+    config_entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(config_entries) == 1
 
     with patch(
         "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
         return_value=100,
     ):
-        entry.add_to_hass(hass)
-        assert await cert_expiry.async_setup_entry(hass, entry) is True
+        assert await async_setup_component(hass, DOMAIN, {}) is True
         await hass.async_block_till_done()
 
+    assert config_entries[0].state == ENTRY_STATE_LOADED
     state = hass.states.get("sensor.cert_expiry_example_com")
     assert state.state == "100"
     assert state.attributes.get("error") == "None"
     assert state.attributes.get("is_valid")
 
-    assert await cert_expiry.async_unload_entry(hass, entry)
+    await hass.config_entries.async_unload(config_entries[0].entry_id)
 
+    assert config_entries[0].state == ENTRY_STATE_NOT_LOADED
     state = hass.states.get("sensor.cert_expiry_example_com")
     assert state is None

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -49,7 +49,8 @@ async def test_update_unique_id(hass):
 
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
-    assert not config_entries[0].unique_id
+    assert entry is config_entries[0]
+    assert not entry.unique_id
 
     with patch(
         "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
@@ -58,8 +59,8 @@ async def test_update_unique_id(hass):
         assert await async_setup_component(hass, DOMAIN, {}) is True
         await hass.async_block_till_done()
 
-    assert config_entries[0].state == ENTRY_STATE_LOADED
-    assert config_entries[0].unique_id == f"{HOST}:{PORT}"
+    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.unique_id == f"{HOST}:{PORT}"
 
 
 async def test_unload_config_entry(hass):
@@ -73,6 +74,7 @@ async def test_unload_config_entry(hass):
 
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
+    assert entry is config_entries[0]
 
     with patch(
         "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
@@ -81,14 +83,14 @@ async def test_unload_config_entry(hass):
         assert await async_setup_component(hass, DOMAIN, {}) is True
         await hass.async_block_till_done()
 
-    assert config_entries[0].state == ENTRY_STATE_LOADED
+    assert entry.state == ENTRY_STATE_LOADED
     state = hass.states.get("sensor.cert_expiry_example_com")
     assert state.state == "100"
     assert state.attributes.get("error") == "None"
     assert state.attributes.get("is_valid")
 
-    await hass.config_entries.async_unload(config_entries[0].entry_id)
+    await hass.config_entries.async_unload(entry.entry_id)
 
-    assert config_entries[0].state == ENTRY_STATE_NOT_LOADED
+    assert entry.state == ENTRY_STATE_NOT_LOADED
     state = hass.states.get("sensor.cert_expiry_example_com")
     assert state is None

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -1,0 +1,211 @@
+"""Tests for the Cert Expiry sensors."""
+from datetime import timedelta
+import socket
+import ssl
+
+from asynctest import patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT, STATE_UNAVAILABLE
+import homeassistant.util.dt as dt_util
+
+from .const import HOST, PORT
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_async_setup_entry(hass):
+    """Test async_setup_entry."""
+    entry = MockConfigEntry(
+        domain="cert_expiry",
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=100,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "100"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+
+
+async def test_async_setup_entry_bad_cert(hass):
+    """Test async_setup_entry with a bad/expired cert."""
+    entry = MockConfigEntry(
+        domain="cert_expiry",
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.helper.get_cert",
+        side_effect=ssl.SSLError("some error"),
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "0"
+    assert state.attributes.get("error") == "some error"
+    assert not state.attributes.get("is_valid")
+
+
+async def test_async_setup_entry_host_unavailable(hass):
+    """Test async_setup_entry when host is unavailable."""
+    entry = MockConfigEntry(
+        domain="cert_expiry",
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.helper.get_cert",
+        side_effect=socket.gaierror,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is None
+
+    next_update = dt_util.utcnow() + timedelta(seconds=45)
+    async_fire_time_changed(hass, next_update)
+    with patch(
+        "homeassistant.components.cert_expiry.helper.get_cert",
+        side_effect=socket.gaierror,
+    ):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is None
+
+
+async def test_update_sensor(hass):
+    """Test async_update for sensor."""
+    entry = MockConfigEntry(
+        domain="cert_expiry",
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=100,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "100"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+
+    next_update = dt_util.utcnow() + timedelta(hours=12)
+    async_fire_time_changed(hass, next_update)
+
+    with patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=99,
+    ):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "99"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+
+
+async def test_update_sensor_network_errors(hass):
+    """Test async_update for sensor."""
+    entry = MockConfigEntry(
+        domain="cert_expiry",
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=100,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "100"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+
+    next_update = dt_util.utcnow() + timedelta(hours=12)
+    async_fire_time_changed(hass, next_update)
+
+    with patch(
+        "homeassistant.components.cert_expiry.helper.get_cert",
+        side_effect=socket.gaierror,
+    ):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state.state == STATE_UNAVAILABLE
+
+    next_update = dt_util.utcnow() + timedelta(hours=12)
+    async_fire_time_changed(hass, next_update)
+
+    with patch(
+        "homeassistant.components.cert_expiry.sensor.get_cert_time_to_expiry",
+        return_value=99,
+    ):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "99"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+
+    next_update = dt_util.utcnow() + timedelta(hours=12)
+    async_fire_time_changed(hass, next_update)
+
+    with patch(
+        "homeassistant.components.cert_expiry.helper.get_cert",
+        side_effect=ssl.SSLError("something bad"),
+    ):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "0"
+    assert state.attributes.get("error") == "something bad"
+    assert not state.attributes.get("is_valid")
+
+    next_update = dt_util.utcnow() + timedelta(hours=12)
+    async_fire_time_changed(hass, next_update)
+
+    with patch(
+        "homeassistant.components.cert_expiry.helper.get_cert", side_effect=Exception()
+    ):
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The `name` configuration option has been deprecated and is no longer used by the integration. An improved default entity & display naming scheme is provided. Name and entity_id overrides should be handled via the frontend.

Configurations using `name` will marked broken with the 0.109 release.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on feedback received in https://github.com/home-assistant/home-assistant/pull/32001, I've taken a different approach on fixing `cert_expiry` which has led to several changes:
- Uses richer exceptions available in `ssl` starting with Python 3.7 and passes along new human-readable errors.
- Allows adding currently failing domains via config flow
- Retries temporary errors on startup to handle race conditions (e.g., checking HA's own cert)
- Delays YAML imports until after HA is fully started (since imports do not retry)
- Deprecates "name" configuration option and uses a descriptive default (non-breaking)
- Gives entity names better defaults (`sensor.cert_expiry_google_com` instead of `sensor.ssl_certificate_expiry` or `sensor.google`)
- Names config entries with domain instead of default of "SSL Certificate Expiry"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: cert_expiry
    host: google.com
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31964
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12178

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
