### PR TITLE
Allow to listen on multiple http addresses

### DIFF
--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -46,6 +46,11 @@ class TestApiConfig(unittest.TestCase):
         api_config = http.ApiConfig("1.1.1.1")
         assert api_config.base_url == "http://1.1.1.1:8123"
 
+    def test_api_base_url_with_ipv6(hass):
+        """Test setting API URL with IP."""
+        api_config = http.ApiConfig("fe80::0101:0101")
+        assert api_config.base_url == "http://[fe80::0101:0101]:8123"
+
     def test_api_base_url_with_ip_and_port(hass):
         """Test setting API URL with IP and port."""
         api_config = http.ApiConfig("1.1.1.1", 8124)
@@ -95,6 +100,15 @@ async def test_api_base_url_with_ip(hass):
     """Test setting api url."""
     result = await async_setup_component(
         hass, "http", {"http": {"server_host": "1.1.1.1"}}
+    )
+    assert result
+    assert hass.config.api.base_url == "http://1.1.1.1:8123"
+
+
+async def test_api_base_url_with_multiple_ips(hass):
+    """Test setting api url."""
+    result = await async_setup_component(
+        hass, "http", {"http": {"server_host": "1.1.1.1,fe80::0101:0101"}}
     )
     assert result
     assert hass.config.api.base_url == "http://1.1.1.1:8123"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows to configure multiple listen addresses, e.g. IPv4 and IPv6.
The first configured address will be used as base_url (if not
configured); if this is an IPv6 address, the URL will now also be
formatted correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
http:
  server_host: '0.0.0.0,::'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12155

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
