### PR TITLE
Fix bmw connected drive door_lock_state attribute error

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -120,7 +120,6 @@ class BMWConnectedDriveAccount:
         self, username: str, password: str, region_str: str, name: str, read_only
     ) -> None:
         """Initialize account."""
-
         region = get_region_from_name(region_str)
 
         self.read_only = read_only

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -110,7 +110,6 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
         vehicle_state = self._vehicle.state
         result = {
             "car": self._vehicle.name,
-            "update_time": vehicle_state.timestamp,
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -4,9 +4,11 @@ import logging
 from bimmer_connected.state import ChargingState, LockState
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import LENGTH_KILOMETERS
+from homeassistant.const import ATTR_ATTRIBUTION, LENGTH_KILOMETERS
 
 from . import DOMAIN as BMW_DOMAIN
+
+ATTRIBUTION = "Data provided by BMW Connected Drive"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,7 +109,11 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
     def device_state_attributes(self):
         """Return the state attributes of the binary sensor."""
         vehicle_state = self._vehicle.state
-        result = {"car": self._vehicle.name}
+        result = {
+            "car": self._vehicle.name,
+            "update_time": vehicle_state.timestamp,
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+        }
 
         if self._attribute == "lids":
             for lid in vehicle_state.lids:
@@ -143,7 +149,6 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
 
     def update(self):
         """Read new state data from the library."""
-
         vehicle_state = self._vehicle.state
 
         # device class opening: On means open, Off means closed
@@ -152,7 +157,7 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
             self._state = not vehicle_state.all_lids_closed
         if self._attribute == "windows":
             self._state = not vehicle_state.all_windows_closed
-        # device class safety: On means unsafe, Off means safe
+        # device class lock: On means unlocked, Off means locked
         if self._attribute == "door_lock_state":
             # Possible values: LOCKED, SECURED, SELECTIVE_LOCKED, UNLOCKED
             self._state = vehicle_state.door_lock_state not in [

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -7,8 +7,7 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import ATTR_ATTRIBUTION, LENGTH_KILOMETERS
 
 from . import DOMAIN as BMW_DOMAIN
-
-ATTRIBUTION = "Data provided by BMW Connected Drive"
+from .const import ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -1,0 +1,2 @@
+"""Const file for the BMW Connected Drive integration."""
+ATTRIBUTION = "Data provided by BMW Connected Drive"

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -71,7 +71,7 @@ class BMWLock(LockDevice):
         if self.door_lock_state_available:
             result["door_lock_state"] = vehicle_state.door_lock_state.value
             result["last_update_reason"] = vehicle_state.last_update_reason
-        return sorted(result.items())
+        return result
 
     @property
     def is_locked(self):

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -66,7 +66,6 @@ class BMWLock(LockDevice):
         vehicle_state = self._vehicle.state
         result = {
             "car": self._vehicle.name,
-            "update_time": vehicle_state.timestamp,
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
         if self.door_lock_state_available:

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -4,10 +4,17 @@ import logging
 from bimmer_connected.state import LockState
 
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    STATE_LOCKED,
+    STATE_UNKNOWN,
+    STATE_UNLOCKED,
+)
 
 from . import DOMAIN as BMW_DOMAIN
 
+ATTRIBUTION = "Data provided by BMW Connected Drive"
+DOOR_LOCK_STATE = "door_lock_state"
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -36,6 +43,9 @@ class BMWLock(LockDevice):
         self._unique_id = f"{self._vehicle.vin}-{self._attribute}"
         self._sensor_name = sensor_name
         self._state = None
+        self.door_lock_state_available = False
+        if DOOR_LOCK_STATE in self._vehicle.available_attributes:
+            self.door_lock_state_available = True
 
     @property
     def should_poll(self):
@@ -59,9 +69,18 @@ class BMWLock(LockDevice):
     def device_state_attributes(self):
         """Return the state attributes of the lock."""
         vehicle_state = self._vehicle.state
+        if self.door_lock_state_available:
+            door_lock_state = vehicle_state.door_lock_state.value
+            last_update_reason = vehicle_state.last_update_reason
+        else:
+            door_lock_state = STATE_UNKNOWN
+            last_update_reason = STATE_UNKNOWN
         return {
             "car": self._vehicle.name,
-            "door_lock_state": vehicle_state.door_lock_state.value,
+            "door_lock_state": door_lock_state,
+            "last_update_reason": last_update_reason,
+            "update_time": vehicle_state.timestamp,
+            ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 
     @property
@@ -89,7 +108,6 @@ class BMWLock(LockDevice):
 
     def update(self):
         """Update state of the lock."""
-
         _LOGGER.debug("%s: updating data for %s", self._vehicle.name, self._attribute)
         vehicle_state = self._vehicle.state
 

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -129,7 +129,6 @@ class BMWConnectedDriveSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        vehicle_state = self._vehicle.state
         return {
             "car": self._vehicle.name,
             ATTR_ATTRIBUTION: ATTRIBUTION,

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -132,7 +132,6 @@ class BMWConnectedDriveSensor(Entity):
         vehicle_state = self._vehicle.state
         return {
             "car": self._vehicle.name,
-            "update_time": vehicle_state.timestamp,
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -15,8 +15,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import DOMAIN as BMW_DOMAIN
+from .const import ATTRIBUTION
 
-ATTRIBUTION = "Data provided by BMW Connected Drive"
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_TO_HA_METRIC = {

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -4,6 +4,7 @@ import logging
 from bimmer_connected.state import ChargingState
 
 from homeassistant.const import (
+    ATTR_ATTRIBUTION,
     CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
@@ -15,6 +16,7 @@ from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import DOMAIN as BMW_DOMAIN
 
+ATTRIBUTION = "Data provided by BMW Connected Drive"
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_TO_HA_METRIC = {
@@ -99,7 +101,6 @@ class BMWConnectedDriveSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-
         vehicle_state = self._vehicle.state
         charging_state = vehicle_state.charging_status in [ChargingState.CHARGING]
 
@@ -128,7 +129,12 @@ class BMWConnectedDriveSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        return {"car": self._vehicle.name}
+        vehicle_state = self._vehicle.state
+        return {
+            "car": self._vehicle.name,
+            "update_time": vehicle_state.timestamp,
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+        }
 
     def update(self) -> None:
         """Read new state data from the library."""


### PR DESCRIPTION
## Breaking change
n/a

## Proposed change
For certain cars without `door_lock_state` info the integration would give an AttributeError.
That is being fixed in this PR.
Issues ->
#28806
https://github.com/bimmerconnected/bimmer_connected/issues/145

Besides that some extra information from the library is added to the attributes of the binary sensors, sensors and lock.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
bmw_connected_drive:
  name_of_car:
    username: USERNAME_BMW_CONNECTED_DRIVE
    password: PASSWORD_BMW_CONNECTED_DRIVE
    region: one of "north_america", "china" , "rest_of_world"

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28806 and https://github.com/bimmerconnected/bimmer_connected/issues/145
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
