### PR TITLE
Change get_entity to return a extended entry, add inputs to default conf

### DIFF
--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -114,7 +114,7 @@ async def websocket_update_entity(hass, connection, msg):
         )
     else:
         connection.send_message(
-            websocket_api.result_message(msg["id"], _entry_dict(entry))
+            websocket_api.result_message(msg["id"], _entry_ext_dict(entry))
         )
 
 
@@ -160,16 +160,9 @@ def _entry_dict(entry):
 @callback
 def _entry_ext_dict(entry):
     """Convert entry to API format."""
-    return {
-        "config_entry_id": entry.config_entry_id,
-        "device_id": entry.device_id,
-        "disabled_by": entry.disabled_by,
-        "entity_id": entry.entity_id,
-        "name": entry.name,
-        "icon": entry.icon,
-        "platform": entry.platform,
-        "original_name": entry.original_name,
-        "original_icon": entry.original_icon,
-        "unique_id": entry.unique_id,
-        "capabilities": entry.capabilities,
-    }
+    data = _entry_dict(entry)
+    data["original_name"] = entry.original_name
+    data["original_icon"] = entry.original_icon
+    data["unique_id"] = entry.unique_id
+    data["capabilities"] = entry.capabilities
+    return data

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -57,7 +57,9 @@ async def websocket_get_entity(hass, connection, msg):
         )
         return
 
-    connection.send_message(websocket_api.result_message(msg["id"], _entry_dict(entry)))
+    connection.send_message(
+        websocket_api.result_message(msg["id"], _entry_ext_dict(entry))
+    )
 
 
 @require_admin
@@ -152,6 +154,22 @@ def _entry_dict(entry):
         "name": entry.name,
         "icon": entry.icon,
         "platform": entry.platform,
+    }
+
+
+@callback
+def _entry_ext_dict(entry):
+    """Convert entry to API format."""
+    return {
+        "config_entry_id": entry.config_entry_id,
+        "device_id": entry.device_id,
+        "disabled_by": entry.disabled_by,
+        "entity_id": entry.entity_id,
+        "name": entry.name,
+        "icon": entry.icon,
+        "platform": entry.platform,
         "original_name": entry.original_name,
         "original_icon": entry.original_icon,
+        "unique_id": entry.unique_id,
+        "capabilities": entry.capabilities,
     }

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -19,7 +19,12 @@
     "system_health",
     "updater",
     "zeroconf",
-    "zone"
+    "zone",
+    "input_boolean",
+    "input_datetime",
+    "input_text",
+    "input_number",
+    "input_select"
   ],
   "codeowners": []
 }

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -42,8 +42,6 @@ async def test_list_entities(hass, client):
             "entity_id": "test_domain.name",
             "name": "Hello World",
             "icon": None,
-            "original_name": None,
-            "original_icon": None,
             "platform": "test_platform",
         },
         {
@@ -53,8 +51,6 @@ async def test_list_entities(hass, client):
             "entity_id": "test_domain.no_name",
             "name": None,
             "icon": None,
-            "original_name": None,
-            "original_icon": None,
             "platform": "test_platform",
         },
     ]
@@ -94,6 +90,8 @@ async def test_get_entity(hass, client):
         "icon": None,
         "original_name": None,
         "original_icon": None,
+        "capabilities": None,
+        "unique_id": "1234",
     }
 
     await client.send_json(
@@ -115,6 +113,8 @@ async def test_get_entity(hass, client):
         "icon": None,
         "original_name": None,
         "original_icon": None,
+        "capabilities": None,
+        "unique_id": "6789",
     }
 
 
@@ -165,6 +165,8 @@ async def test_update_entity(hass, client):
         "icon": "icon:after update",
         "original_name": None,
         "original_icon": None,
+        "capabilities": None,
+        "unique_id": "1234",
     }
 
     state = hass.states.get("test_domain.world")
@@ -208,6 +210,8 @@ async def test_update_entity(hass, client):
         "icon": "icon:after update",
         "original_name": None,
         "original_icon": None,
+        "capabilities": None,
+        "unique_id": "1234",
     }
 
 
@@ -254,6 +258,8 @@ async def test_update_entity_no_changes(hass, client):
         "icon": None,
         "original_name": None,
         "original_icon": None,
+        "capabilities": None,
+        "unique_id": "1234",
     }
 
     state = hass.states.get("test_domain.world")
@@ -329,6 +335,8 @@ async def test_update_entity_id(hass, client):
         "icon": None,
         "original_name": None,
         "original_icon": None,
+        "capabilities": None,
+        "unique_id": "1234",
     }
 
     assert hass.states.get("test_domain.world") is None


### PR DESCRIPTION
Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds some properties to the get entity registry command and adds the input components to default config so they can be used from the frontend.

For https://github.com/home-assistant/home-assistant-polymer/pull/4940

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
