### PR TITLE
Add name option for Frontier Silicon devices

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -55,14 +55,13 @@ SUPPORT_FRONTIER_SILICON = (
 DEFAULT_PORT = 80
 DEFAULT_PASSWORD = "1234"
 DEVICE_URL = "http://{0}:{1}/device"
-DEFAULT_NAME = ""
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=""): cv.string,
     }
 )
 
@@ -71,11 +70,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Frontier Silicon platform."""
     if discovery_info is not None:
         async_add_entities(
-            [
-                AFSAPIDevice(
-                    discovery_info["ssdp_description"], DEFAULT_PASSWORD, DEFAULT_NAME
-                )
-            ],
+            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD, "")],
             True,
         )
         return True

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -24,6 +24,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import (
     CONF_HOST,
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
     STATE_OFF,
@@ -54,12 +55,14 @@ SUPPORT_FRONTIER_SILICON = (
 DEFAULT_PORT = 80
 DEFAULT_PASSWORD = "1234"
 DEVICE_URL = "http://{0}:{1}/device"
+DEFAULT_NAME = ""
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
 
@@ -75,10 +78,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     password = config.get(CONF_PASSWORD)
+    name = config.get(CONF_NAME)
 
     try:
         async_add_entities(
-            [AFSAPIDevice(DEVICE_URL.format(host, port), password)], True
+            [AFSAPIDevice(DEVICE_URL.format(host, port), password, name)], True
         )
         _LOGGER.debug("FSAPI device %s:%s -> %s", host, port, password)
         return True
@@ -93,13 +97,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class AFSAPIDevice(MediaPlayerDevice):
     """Representation of a Frontier Silicon device on the network."""
 
-    def __init__(self, device_url, password):
+    def __init__(self, device_url, password, name):
         """Initialize the Frontier Silicon API device."""
         self._device_url = device_url
         self._password = password
         self._state = None
 
-        self._name = None
+        self._name = name
         self._title = None
         self._artist = None
         self._album_name = None

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -71,7 +71,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Frontier Silicon platform."""
     if discovery_info is not None:
         async_add_entities(
-            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD)], True
+            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD, DEFAULT_NAME)], True
         )
         return True
 

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -71,7 +71,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Frontier Silicon platform."""
     if discovery_info is not None:
         async_add_entities(
-            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD, DEFAULT_NAME)], True
+            [
+                AFSAPIDevice(
+                    discovery_info["ssdp_description"], DEFAULT_PASSWORD, DEFAULT_NAME
+                )
+            ],
+            True,
         )
         return True
 

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -61,7 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
-        vol.Optional(CONF_NAME, default=""): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
     }
 )
 
@@ -70,7 +70,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Frontier Silicon platform."""
     if discovery_info is not None:
         async_add_entities(
-            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD, "")],
+            [AFSAPIDevice(discovery_info["ssdp_description"], DEFAULT_PASSWORD, None)],
             True,
         )
         return True


### PR DESCRIPTION
Sometimes on start-up the component seems to be asked for the name before async_update has got it from the API resulting in the media_player becoming ‘unnamed_device’ thus ends up with a different entity ID breaking automations/Lovelace cards etc. that refer to it (and not looking good of course).

Others have reported the same issue, e.g. #18556

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/12160

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
