### PR TITLE
WIP: New integration: hourly price of electricity in Spain

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -273,6 +273,7 @@ homeassistant/components/ps4/* @ktnrg45
 homeassistant/components/ptvsd/* @swamp-ig
 homeassistant/components/push/* @dgomes
 homeassistant/components/pvoutput/* @fabaff
+homeassistant/components/pvpc_hourly_pricing/* @azogue
 homeassistant/components/qld_bushfire/* @exxamalte
 homeassistant/components/qnap/* @colinodell
 homeassistant/components/quantum_gateway/* @cisasteelersfan

--- a/homeassistant/components/pvpc_hourly_pricing/.translations/en.json
+++ b/homeassistant/components/pvpc_hourly_pricing/.translations/en.json
@@ -1,0 +1,29 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Integration is already configured with an existing sensor with that name"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "name": "Sensor Name",
+                    "tariff": "Contracted tariff (1, 2, or 3 periods)"
+                },
+                "description": "This sensor uses official API to get [hourly pricing of electricity (PVPC)](https://www.esios.ree.es/es/pvpc) in Spain.\nFor more precise explanation visit the [integration docs](https://www.home-assistant.io/integrations/pvpc_hourly_pricing/).\n\nSelect the contracted rate based on the number of billing periods per day:\n- 1 period: normal\n- 2 periods: discrimination (nightly rate)\n- 3 periods: electric car (nightly rate of 3 periods)",
+                "title": "Tariff selection"
+            }
+        },
+        "title": "Hourly price of electricity in Spain (PVPC)"
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "tariff": "Change the contracted tariff (1, 2, or 3 periods)"
+                },
+                "description": "Select the contracted rate based on the number of billing periods per day:\n- 1 period: normal\n- 2 periods: discrimination (nightly rate)\n- 3 periods: electric car (nightly rate of 3 periods)",
+                "title": "Tariff change"
+            }
+        }
+    }
+}

--- a/homeassistant/components/pvpc_hourly_pricing/.translations/es.json
+++ b/homeassistant/components/pvpc_hourly_pricing/.translations/es.json
@@ -1,0 +1,29 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "La integraci\u00f3n ya est\u00e1 configurada con un sensor existente con ese nombre"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "name": "Nombre del sensor",
+                    "tariff": "Tarifa contratada (1, 2, o 3 periodos)"
+                },
+                "description": "Este sensor utiliza la API oficial de REE para obtener el [precio horario de la electricidad (PVPC)](https://www.esios.ree.es/es/pvpc) en Espa\\u00f1a.\nPara instrucciones detalladas consulte la [documentación de la integración](https://www.home-assistant.io/integrations/pvpc_hourly_pricing/).\n\nSeleccione la tarifa contratada en base al número de periodos de facturación al día:\n- 1 periodo: normal\n- 2 periodos: discriminación (tarifa nocturna)\n- 3 periodos: coche eléctrico (tarifa nocturna de 3 periodos)",
+                "title": "Selecci\u00f3n de tarifa"
+            }
+        },
+        "title": "Precio horario de la electricidad en Espa\u00f1a (PVPC)"
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "tariff": "Cambio de tarifa contratada (1, 2, o 3 periodos)"
+                },
+                "description": "Seleccione la tarifa contratada en base al número de periodos de facturación al día:\n- 1 periodo: normal\n- 2 periodos: discriminación (tarifa nocturna)\n- 3 periodos: coche eléctrico (tarifa nocturna de 3 periodos)",
+                "title": "Cambio de tarifa"
+            }
+        }
+    }
+}

--- a/homeassistant/components/pvpc_hourly_pricing/__init__.py
+++ b/homeassistant/components/pvpc_hourly_pricing/__init__.py
@@ -1,0 +1,61 @@
+"""The pvpc_hourly_pricing integration to collect Spain official electric prices."""
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+
+from .const import ATTR_TARIFF, DEFAULT_NAME, DOMAIN, PLATFORM, TARIFFS
+
+UI_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+        vol.Required(ATTR_TARIFF, default=TARIFFS[1]): vol.In(TARIFFS),
+    }
+)
+SENSOR_SCHEMA = UI_CONFIG_SCHEMA.extend(
+    {vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int}
+)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(SENSOR_SCHEMA.schema)
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: cv.ensure_list(SENSOR_SCHEMA)}, extra=vol.ALLOW_EXTRA
+)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """
+    Set up the electricity price sensor from configuration.yaml.
+
+    ```yaml
+    pvpc_hourly_pricing:
+      - name: PVPC manual ve
+        tariff: coche_electrico
+      - name: PVPC manual nocturna
+        tariff: discriminacion
+        timeout: 3
+    ```
+    """
+    for conf in config.get(DOMAIN, []):
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, data=conf, context={"source": config_entries.SOURCE_IMPORT}
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: config_entries.ConfigEntry):
+    """Set up pvpc hourly pricing from a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, PLATFORM)
+    )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: config_entries.ConfigEntry):
+    """Unload a config entry."""
+    return await hass.config_entries.async_forward_entry_unload(entry, PLATFORM)

--- a/homeassistant/components/pvpc_hourly_pricing/__init__.py
+++ b/homeassistant/components/pvpc_hourly_pricing/__init__.py
@@ -2,7 +2,6 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -18,7 +17,6 @@ UI_CONFIG_SCHEMA = vol.Schema(
 SENSOR_SCHEMA = UI_CONFIG_SCHEMA.extend(
     {vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int}
 )
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(SENSOR_SCHEMA.schema)
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: cv.ensure_list(SENSOR_SCHEMA)}, extra=vol.ALLOW_EXTRA
 )

--- a/homeassistant/components/pvpc_hourly_pricing/config_flow.py
+++ b/homeassistant/components/pvpc_hourly_pricing/config_flow.py
@@ -7,13 +7,15 @@ from homeassistant.core import callback
 from . import CONF_NAME, UI_CONFIG_SCHEMA
 from .const import ATTR_TARIFF, DOMAIN, TARIFFS
 
+DOMAIN_NAME = DOMAIN
+
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle the Options flow for `pvpc_hourly_pricing` to change the tariff."""
 
-    def __init__(self, entry: config_entries.ConfigEntry):
+    def __init__(self, config_entry: config_entries.ConfigEntry):
         """Initialize the options flow handler with the config entry to modify."""
-        self.config_entry = entry
+        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""
@@ -31,7 +33,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
 
 
-class TariffSelectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class TariffSelectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN_NAME):
     """Handle a config flow for `pvpc_hourly_pricing` to select the tariff."""
 
     VERSION = 1
@@ -56,6 +58,6 @@ class TariffSelectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(entry: config_entries.ConfigEntry):
-        """Handle tariff change via Options panel."""
-        return OptionsFlowHandler(entry)
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        """Get the options flow for this handler to make a tariff change."""
+        return OptionsFlowHandler(config_entry)

--- a/homeassistant/components/pvpc_hourly_pricing/config_flow.py
+++ b/homeassistant/components/pvpc_hourly_pricing/config_flow.py
@@ -1,0 +1,61 @@
+"""Config flow for pvpc_hourly_pricing."""
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from . import CONF_NAME, UI_CONFIG_SCHEMA
+from .const import ATTR_TARIFF, DOMAIN, TARIFFS
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle the Options flow for `pvpc_hourly_pricing` to change the tariff."""
+
+    def __init__(self, entry: config_entries.ConfigEntry):
+        """Initialize the options flow handler with the config entry to modify."""
+        self.config_entry = entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self.config_entry.data.get(CONF_NAME), data=user_input,
+            )
+
+        current_tariff = self.config_entry.data.get(ATTR_TARIFF)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {vol.Required(ATTR_TARIFF, default=current_tariff): vol.In(TARIFFS)}
+            ),
+        )
+
+
+class TariffSelectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for `pvpc_hourly_pricing` to select the tariff."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if user_input is not None:
+            if any(
+                user_input[CONF_NAME] == entry.data[CONF_NAME]
+                for entry in self._async_current_entries()
+            ):
+                return self.async_abort(reason="already_configured")
+
+            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+
+        return self.async_show_form(step_id="user", data_schema=UI_CONFIG_SCHEMA)
+
+    async def async_step_import(self, import_info):
+        """Handle import from config file."""
+        return await self.async_step_user(import_info)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(entry: config_entries.ConfigEntry):
+        """Handle tariff change via Options panel."""
+        return OptionsFlowHandler(entry)

--- a/homeassistant/components/pvpc_hourly_pricing/const.py
+++ b/homeassistant/components/pvpc_hourly_pricing/const.py
@@ -1,0 +1,7 @@
+"""Constant values for pvpc_hourly_pricing."""
+DOMAIN = "pvpc_hourly_pricing"
+PLATFORM = "sensor"
+
+ATTR_TARIFF = "tariff"
+DEFAULT_NAME = "PVPC"
+TARIFFS = ["normal", "discriminacion", "coche_electrico"]

--- a/homeassistant/components/pvpc_hourly_pricing/manifest.json
+++ b/homeassistant/components/pvpc_hourly_pricing/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "pvpc_hourly_pricing",
+  "name": "Spain electricity hourly pricing (PVPC)",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/pvpc_hourly_pricing",
+  "requirements": ["xmltodict==0.12.0"],
+  "dependencies": [],
+  "codeowners": ["@azogue"],
+  "quality_scale": "platinum"
+}

--- a/homeassistant/components/pvpc_hourly_pricing/sensor.py
+++ b/homeassistant/components/pvpc_hourly_pricing/sensor.py
@@ -1,0 +1,367 @@
+"""
+Sensor to collect the reference daily prices of electricity ('PVPC') in Spain.
+
+For more details about this platform, please refer to the documentation at
+https://www.home-assistant.io/integrations/pvpc_hourly_pricing/
+"""
+import asyncio
+from datetime import date, timedelta
+import logging
+from random import randint
+from typing import List, Optional, Tuple
+
+import aiohttp
+import async_timeout
+from dateutil.parser import parse
+from pytz import timezone
+import xmltodict
+
+from homeassistant import config_entries
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.helpers.event import (
+    async_track_point_in_time,
+    async_track_time_change,
+)
+from homeassistant.helpers.restore_state import RestoreEntity
+import homeassistant.util.dt as dt_util
+
+from .const import ATTR_TARIFF, DOMAIN, TARIFFS
+
+_LOGGER = logging.getLogger(__name__)
+
+_RESOURCE = "https://api.esios.ree.es/archives/80/download?date={day:%Y-%m-%d}"
+_ATTRIBUTION = "Data retrieved from api.esios.ree.es by REE"
+
+ATTR_PRICE = "price"
+ICON = "mdi:currency-eur"
+UNIT = "€/kWh"
+
+
+async def async_setup_platform(
+    hass: HomeAssistant, config, async_add_devices, discovery_info=None
+):
+    """
+    Set up the electricity price sensor as a sensor platform.
+
+    ```yaml
+    sensor:
+      - platform: pvpc_hourly_pricing
+        name: pvpc_manual_sensor
+        tariff: normal
+
+      - platform: pvpc_hourly_pricing
+        name: pvpc_manual_sensor_2
+        tariff: discriminacion
+        timeout: 8
+    ```
+    """
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, data=config, context={"source": config_entries.SOURCE_IMPORT}
+        )
+    )
+    return True
+
+
+async def update_listener(hass: HomeAssistant, entry: config_entries.ConfigEntry):
+    """Update selected tariff for sensor."""
+    if entry.options[ATTR_TARIFF] != entry.data[ATTR_TARIFF]:
+        entry.data[ATTR_TARIFF] = entry.options[ATTR_TARIFF]
+        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: config_entries.ConfigEntry, async_add_entities
+):
+    """Set up the electricity price sensor from config_entry."""
+    if not config_entry.update_listeners:
+        config_entry.add_update_listener(update_listener)
+
+    async_add_entities(
+        [
+            ElecPriceSensor(
+                hass,
+                websession=async_get_clientsession(hass),
+                name=config_entry.data[CONF_NAME],
+                tariff=config_entry.data[ATTR_TARIFF],
+                timeout=config_entry.data.get(CONF_TIMEOUT, 5),
+            )
+        ],
+        True,
+    )
+
+
+def extract_prices_for_tariff(
+    xml_data: str, tz: timezone, tariff: int = 2
+) -> Tuple[date, List[float]]:
+    """
+    PVPC xml data extractor.
+
+    Extract hourly prices for the selected tariff from the xml daily file download
+    of the official _Spain Electric Network_ (Red Eléctrica Española, REE)
+    for the _Voluntary Price for Small Consumers_
+    (Precio Voluntario para el Pequeño Consumidor, PVPC).
+    """
+    data = xmltodict.parse(xml_data)["PVPCDesgloseHorario"]
+
+    str_horiz = data["Horizonte"]["@v"]
+    day: date = parse(str_horiz.split("/")[0]).astimezone(tz).date()
+
+    tariff_id = f"Z0{tariff}"
+    prices = next(
+        filter(
+            lambda x: (
+                x["TerminoCosteHorario"]["@v"] == "FEU"
+                and x["TipoPrecio"]["@v"] == tariff_id
+            ),
+            data["SeriesTemporales"],
+        )
+    )
+
+    price_values = [
+        round(float(pair["Ctd"]["@v"]), 5) for pair in prices["Periodo"]["Intervalo"]
+    ]
+    return day, price_values
+
+
+class ElecPriceSensor(RestoreEntity):
+    """Class to hold the prices of electricity as a sensor."""
+
+    def __init__(self, hass, websession, name, tariff, timeout):
+        """Initialize the sensor object."""
+        self.hass = hass
+        self._websession = websession
+        self._name = name
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, self._name, hass=self.hass
+        )
+        self._tariff = tariff
+        self._timeout = timeout
+        self._num_retries = 0
+        self._state = None
+        self._attributes = None
+        self._today_prices = None
+        self._tomorrow_prices = None
+        self._init_done = False
+
+        # Update 'state' value 2 times/hour
+        self._hourly_tracker = async_track_time_change(
+            self.hass, self.async_update, second=[0], minute=[0]
+        )
+        # Update prices at random time, 3 times/hour (don't want to upset API)
+        random_minute = randint(1, 19)
+        mins_update = [random_minute + 20 * i for i in range(3)]
+        self._price_tracker = async_track_time_change(
+            self.hass, self.async_update_prices, second=[0], minute=mins_update
+        )
+
+        _LOGGER.info(
+            f"Setup of price sensor {self.name} ({self.entity_id}) "
+            f"for tariff '{self._tariff}', "
+            f"updating data at {mins_update} min, each hour"
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel listeners for sensor updates."""
+        self._hourly_tracker()
+        self._price_tracker()
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state:
+            self._state = state.state
+            self._today_prices = [
+                state.attributes[k] for k in state.attributes if k.startswith("price")
+            ]
+            _LOGGER.debug(
+                f"RestoreState[{self.entity_id}]: "
+                f"Loaded {len(self._today_prices)} prices"
+            )
+
+        self._init_done = True
+        await self.async_update_prices()
+        await self.async_update_ha_state(True)
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID."""
+        return "_".join([DOMAIN, "sensor", self.entity_id])
+
+    @property
+    def should_poll(self):
+        """Return True if entity has to be polled for state.
+
+        False if entity pushes its state to HA.
+        """
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of the price of electricity."""
+        return UNIT
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return ICON
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    def _get_current_value(self, current_hour):
+        """
+        Extract current price from today prices array.
+
+        In DST days, this array will have 23 or 25 values, instead of the expected 24.
+        """
+        if len(self._today_prices) == 23 and current_hour > 2:
+            return self._today_prices[current_hour - 1]
+        elif len(self._today_prices) == 25 and current_hour > 2:
+            return self._today_prices[current_hour + 1]
+        return self._today_prices[current_hour]
+
+    def _process_state_and_attributes(self):
+        """Generate the current state and sensor attributes."""
+        actual_hour = dt_util.now(self.hass.config.time_zone).hour
+        if self._tomorrow_prices is not None and actual_hour < 3:
+            # remove 'tomorrow prices' as now they refer to 'today'
+            self._tomorrow_prices = None
+
+        if self._today_prices is None:
+            _LOGGER.info(f"Abort process, no values!!")
+            _LOGGER.critical(f"Abort process, no values!!")
+            return
+
+        # set current price
+        self._state = self._get_current_value(actual_hour)
+
+        prices = self._today_prices.copy()
+        if self._tomorrow_prices is not None:
+            prices += self._tomorrow_prices
+
+        # generate sensor attributes
+        prices_sorted = dict(
+            sorted({i: p for i, p in enumerate(prices)}.items(), key=lambda x: x[1],)
+        )
+        attributes = {ATTR_ATTRIBUTION: _ATTRIBUTION, ATTR_TARIFF: self._tariff}
+        attributes["min price"] = min(prices)
+        attributes["min price at"] = next(iter(prices_sorted))
+        attributes["next best at"] = list(
+            filter(lambda x: x >= actual_hour, prices_sorted.keys())
+        )
+
+        for i, p in enumerate(self._today_prices):
+            attributes[f"price {i:02d}h"] = p
+        if self._tomorrow_prices is not None:
+            for i, p in enumerate(self._tomorrow_prices):
+                attributes[f"price next day {i:02d}h"] = p
+
+        self._attributes = attributes
+
+    async def async_update(self, *_args):
+        """Update the sensor state."""
+        if not self._init_done:
+            # abort until added_to_hass is finished
+            return
+
+        if self._today_prices:
+            self._process_state_and_attributes()
+            await self.async_update_ha_state()
+        else:
+            # If no prices present, download and schedule a future state update
+            self._state = None
+            _LOGGER.debug(
+                "[%s]: Downloading prices, updating after %d seconds",
+                self.entity_id,
+                self._timeout,
+            )
+            async_track_point_in_time(
+                self.hass,
+                self.async_update,
+                dt_util.now() + timedelta(seconds=self._timeout),
+            )
+            await self.async_update_prices()
+
+    async def _download_official_data(self, day: date) -> Optional[str]:
+        """Make GET request to 'api.esios.ree.es' to retrieve hourly prices."""
+        url = _RESOURCE.format(day=day)
+        try:
+            with async_timeout.timeout(self._timeout, loop=self.hass.loop):
+                resp = await self._websession.get(url)
+                if resp.status < 400:
+                    text = await resp.text()
+                    return text
+                else:
+                    _LOGGER.warning(
+                        "Request error in '%s' [status: %d]", url, resp.status
+                    )
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Timeout error requesting data from '%s'", url)
+        except aiohttp.ClientError:
+            _LOGGER.error("Client error in '%s'", url)
+        return None
+
+    async def async_update_prices(self, *args):
+        """Update electricity prices from the ESIOS API."""
+        tz = self.hass.config.time_zone
+        now = args[0].astimezone(tz) if args else dt_util.now(tz)
+        text = await self._download_official_data(now.date())
+        if text is None:
+            self._num_retries += 1
+            if self._num_retries > 3:
+                _LOGGER.error("Bad data update")
+                return
+
+            f_log = _LOGGER.warning if self._num_retries > 1 else _LOGGER.info
+            f_log("Bad update, will try again in %d s", 3 * self._timeout)
+            async_track_point_in_time(
+                self.hass,
+                self.async_update_prices,
+                dt_util.now() + timedelta(seconds=3 * self._timeout),
+            )
+            return
+
+        tariff_number = TARIFFS.index(self._tariff) + 1
+        day, prices = extract_prices_for_tariff(text, tz, tariff_number)
+        self._num_retries = 0
+        self._today_prices = prices
+
+        # At evening, it is possible to retrieve 'tomorrow' prices
+        if now.hour >= 20:
+            try:
+                text_tomorrow = await self._download_official_data(
+                    (now + timedelta(days=1)).date()
+                )
+                day_fut, prices_fut = extract_prices_for_tariff(
+                    text_tomorrow, tz, tariff_number
+                )
+                _LOGGER.debug(
+                    "Setting tomorrow (%s) prices: %s",
+                    day_fut.strftime("%Y-%m-%d"),
+                    str(prices),
+                )
+                self._tomorrow_prices = prices_fut
+                return
+            except xmltodict.expat.ExpatError:
+                _LOGGER.debug("Bad try on getting future prices")
+
+        self._tomorrow_prices = None
+        _LOGGER.debug(f"Download done for {self.entity_id}")

--- a/homeassistant/components/pvpc_hourly_pricing/sensor.py
+++ b/homeassistant/components/pvpc_hourly_pricing/sensor.py
@@ -17,7 +17,7 @@ from pytz import timezone
 import xmltodict
 
 from homeassistant import config_entries
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.components.sensor import ENTITY_ID_FORMAT, PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -29,9 +29,12 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.util.dt as dt_util
 
+from . import SENSOR_SCHEMA
 from .const import ATTR_TARIFF, DOMAIN, TARIFFS
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(SENSOR_SCHEMA.schema)
 
 _RESOURCE = "https://api.esios.ree.es/archives/80/download?date={day:%Y-%m-%d}"
 _ATTRIBUTION = "Data retrieved from api.esios.ree.es by REE"

--- a/homeassistant/components/pvpc_hourly_pricing/strings.json
+++ b/homeassistant/components/pvpc_hourly_pricing/strings.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "title": "Hourly price of electricity in Spain (PVPC)",
+    "step": {
+      "user": {
+        "title": "Tariff selection",
+        "description": "This sensor uses official API to get [hourly pricing of electricity (PVPC)](https://www.esios.ree.es/es/pvpc) in Spain.\nFor more precise explanation visit the [integration docs](https://www.home-assistant.io/integrations/pvpc_hourly_pricing/).\n\nSelect the contracted rate based on the number of billing periods per day:\n- 1 period: normal\n- 2 periods: discrimination (nightly rate)\n- 3 periods: electric car (nightly rate of 3 periods)",
+        "data": {
+          "name": "Sensor Name",
+          "tariff": "Contracted tariff (1, 2, or 3 periods)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Integration is already configured with an existing sensor with that name"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "tariff": "Change the contracted tariff (1, 2, or 3 periods)"
+        },
+        "description": "Select the contracted rate based on the number of billing periods per day:\n- 1 period: normal\n- 2 periods: discrimination (nightly rate)\n- 3 periods: electric car (nightly rate of 3 periods)",
+        "title": "Tariff change"
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -74,6 +74,7 @@ FLOWS = [
     "plex",
     "point",
     "ps4",
+    "pvpc_hourly_pricing",
     "rainmachine",
     "ring",
     "samsungtv",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2095,6 +2095,7 @@ xfinity-gateway==0.0.4
 xknx==0.11.2
 
 # homeassistant.components.bluesound
+# homeassistant.components.pvpc_hourly_pricing
 # homeassistant.components.rest
 # homeassistant.components.startca
 # homeassistant.components.ted5000

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -715,6 +715,7 @@ withings-api==2.1.3
 wled==0.2.1
 
 # homeassistant.components.bluesound
+# homeassistant.components.pvpc_hourly_pricing
 # homeassistant.components.rest
 # homeassistant.components.startca
 # homeassistant.components.ted5000

--- a/tests/components/pvpc_hourly_pricing/__init__.py
+++ b/tests/components/pvpc_hourly_pricing/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for the pvpc_hourly_pricing integration."""
+from homeassistant.components.pvpc_hourly_pricing import ATTR_TARIFF
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
+
+
+def check_valid_state(state, tariff: str):
+    """Ensure that sensor has a valid state and attributes."""
+    assert state
+    assert state.attributes[ATTR_TARIFF] == tariff
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "€/kWh"
+    # safety margins for current electricity price (it shouldn't be out of [0, 0.2])
+    assert -0.1 < float(state.state) < 0.3

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -1,0 +1,55 @@
+"""Tests for the pvpc_hourly_pricing config_flow."""
+from homeassistant import data_entry_flow
+from homeassistant.components.pvpc_hourly_pricing import ATTR_TARIFF, DOMAIN
+from homeassistant.const import CONF_NAME
+
+from . import check_valid_state
+
+
+async def test_config_flow(hass):
+    """
+    Test config flow for pvpc_hourly_pricing.
+
+    - Create a new entry with tariff "normal"
+    - Check state and attributes
+    - Use Options flow to change to tariff "coche_electrico"
+    - Check new tariff state and compare both.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_NAME: "test", ATTR_TARIFF: "normal"}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test")
+    check_valid_state(state, tariff="normal")
+
+    # get entry and min_price with tariff 'normal' to play with options flow
+    entry = result["result"]
+    min_price_normal_tariff = state.attributes["min price"]
+
+    # Use options to change tariff
+    result = await hass.config_entries.options.async_init(
+        entry.entry_id, context={"source": "user"}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={ATTR_TARIFF: "coche_electrico"}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"][ATTR_TARIFF] == "coche_electrico"
+
+    # check tariff change
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test")
+    check_valid_state(state, tariff="coche_electrico")
+
+    # Check parsing was ok by ensuring that EV is better tariff than default one
+    min_price_electric_car_tariff = state.attributes["min price"]
+    assert min_price_electric_car_tariff < min_price_normal_tariff

--- a/tests/components/pvpc_hourly_pricing/test_init.py
+++ b/tests/components/pvpc_hourly_pricing/test_init.py
@@ -1,0 +1,26 @@
+"""Tests for the pvpc_hourly_pricing component."""
+from homeassistant.components.pvpc_hourly_pricing import ATTR_TARIFF, DOMAIN
+from homeassistant.const import CONF_NAME
+from homeassistant.setup import async_setup_component
+
+from . import check_valid_state
+
+
+async def test_basic_setup(hass):
+    """Test component setup creates entry from config and first state is valid."""
+    config = {DOMAIN: [{CONF_NAME: "test", ATTR_TARIFF: "discriminacion"}]}
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test")
+    check_valid_state(state, tariff="discriminacion")
+
+
+async def test_basic_setup_as_sensor_platform(hass):
+    """Test component setup creates entry from config as a sensor platform."""
+    config_platform = {
+        "sensor": {"platform": DOMAIN, CONF_NAME: "test", ATTR_TARIFF: "normal"}
+    }
+    assert await async_setup_component(hass, "sensor", config_platform)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test")
+    check_valid_state(state, tariff="normal")


### PR DESCRIPTION
I've been using a custom_component sensor for the hourly price of electricity for almost 2 years, but after seeing it as a [feature request in the forum](), I decided to clean and update it up to current standards to propose it as new integration: **`pvpc_hourly_pricing`**

#### Description

- **Cloud polling** sensor that downloads an XML file provided by the official API of the electric network operator in Spain (REE) to extract the ['PVPC' prices](https://www.esios.ree.es/es/pvpc) for each hour of the day, in €/kWh.
- The configuration is done by selecting one of the 3 reference tariffs in Spain, with
1, 2, or 3 billing periods for each one.
- Features **config flow**, entity registry,  RestoreEntity, and options flow to change tariff
- Manual yaml config can be done as sensor platform entity or by component. (if some of these are deprecated there is no problem to remove those, I just wanted to cover all cases first)
- Minimal polling, with 3 API calls/hour at random times with smart retry; fully async
- Only 1 state change / hour (only when the price changes)
- In evening, downloads published prices for next day, to always store prices info for a window of [3, 27] hours in the future.
- Include useful state attributes to program automations to be run at best electric prices.
- Add spanish and english translations.
- Requires `xmltodict` to parse official xml file with hourly prices for each day.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

The simplest way of using it is to **add it from "Integrations"** (can be used multiple times to set sensors with different tariffs), but there is also the **possibility of manual yaml setup**, both as sensor platform entities or by component entities.

```yaml
# Example configuration.yaml as component
pvpc_hourly_pricing:
  - name: PVPC manual ve
    tariff: coche_electrico
  - name: PVPC manual nocturna
    tariff: discriminacion

# Example configuration.yaml as sensor platform
sensor:
  - platform: pvpc_hourly_pricing
    name: pvpc_manual_sensor
    tariff: normal

  - platform: pvpc_hourly_pricing
    name: pvpc_manual_sensor_2
    tariff: discriminacion
    timeout: 8
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TODO docs

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

I hope!
If not, there is no problem to change it until it reaches platinum score :)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
