### PR TITLE
Add sighthound save image

### DIFF
--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -110,7 +110,6 @@ class SighthoundEntity(ImageProcessingEntity):
 
     def save_image(self, image, people, directory):
         """Save a timestamped image with bounding boxes around targets."""
-
         img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
         draw = ImageDraw.Draw(img)
 
@@ -119,7 +118,6 @@ class SighthoundEntity(ImageProcessingEntity):
                 person["boundingBox"], self._image_width, self._image_height
             )
             draw_box(draw, box, self._image_width, self._image_height)
-
         latest_save_path = directory + "{}_latest.jpg".format(self._name)
         img.save(latest_save_path)
 

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -109,7 +109,8 @@ class SighthoundEntity(ImageProcessingEntity):
 
     def save_image(self, image, people, directory):
         """Save a timestamped image with bounding boxes around targets."""
-        img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
+        img = Image.open(io.BytesIO(bytearray(image)))
+        # img = img.convert("RGB") # TODO add a patch
         draw = ImageDraw.Draw(img)
 
         for person in people:

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -109,8 +109,7 @@ class SighthoundEntity(ImageProcessingEntity):
 
     def save_image(self, image, people, directory):
         """Save a timestamped image with bounding boxes around targets."""
-        img = Image.open(io.BytesIO(bytearray(image)))
-        # img = img.convert("RGB") # TODO add a patch
+        img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
         draw = ImageDraw.Draw(img)
 
         for person in people:

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -1,7 +1,7 @@
 """Person detection using Sighthound cloud service."""
 import io
 import logging
-import os
+from pathlib import Path
 
 from PIL import Image, ImageDraw
 import simplehound.core as hound
@@ -53,7 +53,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     save_file_folder = config.get(CONF_SAVE_FILE_FOLDER)
     if save_file_folder:
-        save_file_folder = os.path.join(save_file_folder, "")  # If no trailing / add it
+        save_file_folder = Path(save_file_folder)
 
     entities = []
     for camera in config[CONF_SOURCE]:
@@ -79,8 +79,7 @@ class SighthoundEntity(ImageProcessingEntity):
         self._state = None
         self._image_width = None
         self._image_height = None
-        if save_file_folder:
-            self._save_file_folder = save_file_folder
+        self._save_file_folder = save_file_folder
 
     def process_image(self, image):
         """Process an image."""
@@ -93,7 +92,7 @@ class SighthoundEntity(ImageProcessingEntity):
         self._image_height = metadata["image_height"]
         for person in people:
             self.fire_person_detected_event(person)
-        if hasattr(self, "_save_file_folder") and self._state > 0:
+        if self._save_file_folder and self._state > 0:
             self.save_image(image, people, self._save_file_folder)
 
     def fire_person_detected_event(self, person):
@@ -118,7 +117,7 @@ class SighthoundEntity(ImageProcessingEntity):
                 person["boundingBox"], self._image_width, self._image_height
             )
             draw_box(draw, box, self._image_width, self._image_height)
-        latest_save_path = directory + "{}_latest.jpg".format(self._name)
+        latest_save_path = directory / f"{self._name}_latest.jpg"
         img.save(latest_save_path)
 
     @property

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -1,6 +1,9 @@
 """Person detection using Sighthound cloud service."""
+import io
 import logging
+import os
 
+from PIL import Image, ImageDraw
 import simplehound.core as hound
 import voluptuous as vol
 
@@ -14,6 +17,7 @@ from homeassistant.components.image_processing import (
 from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY
 from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.pil import draw_box
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +26,7 @@ EVENT_PERSON_DETECTED = "sighthound.person_detected"
 ATTR_BOUNDING_BOX = "bounding_box"
 ATTR_PEOPLE = "people"
 CONF_ACCOUNT_TYPE = "account_type"
+CONF_SAVE_FILE_FOLDER = "save_file_folder"
 DEV = "dev"
 PROD = "prod"
 
@@ -29,6 +34,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_API_KEY): cv.string,
         vol.Optional(CONF_ACCOUNT_TYPE, default=DEV): vol.In([DEV, PROD]),
+        vol.Optional(CONF_SAVE_FILE_FOLDER): cv.isdir,
     }
 )
 
@@ -45,10 +51,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.error("Sighthound error %s setup aborted", exc)
         return
 
+    save_file_folder = config.get(CONF_SAVE_FILE_FOLDER)
+    if save_file_folder:
+        save_file_folder = os.path.join(save_file_folder, "")  # If no trailing / add it
+
     entities = []
     for camera in config[CONF_SOURCE]:
         sighthound = SighthoundEntity(
-            api, camera[CONF_ENTITY_ID], camera.get(CONF_NAME)
+            api, camera[CONF_ENTITY_ID], camera.get(CONF_NAME), save_file_folder
         )
         entities.append(sighthound)
     add_entities(entities)
@@ -57,7 +67,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class SighthoundEntity(ImageProcessingEntity):
     """Create a sighthound entity."""
 
-    def __init__(self, api, camera_entity, name):
+    def __init__(self, api, camera_entity, name, save_file_folder):
         """Init."""
         self._api = api
         self._camera = camera_entity
@@ -69,6 +79,8 @@ class SighthoundEntity(ImageProcessingEntity):
         self._state = None
         self._image_width = None
         self._image_height = None
+        if save_file_folder:
+            self._save_file_folder = save_file_folder
 
     def process_image(self, image):
         """Process an image."""
@@ -81,6 +93,8 @@ class SighthoundEntity(ImageProcessingEntity):
         self._image_height = metadata["image_height"]
         for person in people:
             self.fire_person_detected_event(person)
+        if hasattr(self, "_save_file_folder") and self._state > 0:
+            self.save_image(image, people, self._save_file_folder)
 
     def fire_person_detected_event(self, person):
         """Send event with detected total_persons."""
@@ -93,6 +107,21 @@ class SighthoundEntity(ImageProcessingEntity):
                 ),
             },
         )
+
+    def save_image(self, image, people, directory):
+        """Save a timestamped image with bounding boxes around targets."""
+
+        img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
+        draw = ImageDraw.Draw(img)
+
+        for person in people:
+            box = hound.bbox_to_tf_style(
+                person["boundingBox"], self._image_width, self._image_height
+            )
+            draw_box(draw, box, self._image_width, self._image_height)
+
+        latest_save_path = directory + "{}_latest.jpg".format(self._name)
+        img.save(latest_save_path)
 
     @property
     def camera_entity(self):

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -98,15 +98,18 @@ async def test_process_image(hass, mock_image, mock_detections):
 
 async def test_save_image(hass, mock_image, mock_detections):
     """Save a processed image."""
-    VALID_CONFIG[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
+    VALID_CONFIG_SAVE_FILE = VALID_CONFIG.copy()
+    VALID_CONFIG_SAVE_FILE[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
 
-    with patch("PIL.Image.open") as pil_img:
+    with patch(
+        "homeassistant.components.sighthound.image_processing.Image.open"
+    ) as pil_img_open:
+        pil_img = pil_img_open.return_value
         data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
         await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
         await hass.async_block_till_done()
         state = hass.states.get(VALID_ENTITY_ID)
         assert state.state == "2"
-        pil_img.save.assert_called()
-        # pil_img.save.assert_called_with("test.jpg")  # kwargs={format: "JPEG"}
+        assert pil_img.save.call_count == 1

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -99,8 +99,7 @@ async def test_process_image(hass, mock_image, mock_detections):
 
 async def test_save_image(hass, mock_image, mock_detections):
     """Save a processed image."""
-    VALID_CONFIG_SAVE_FILE = deepcopy(VALID_CONFIG)  # this fails
-    # VALID_CONFIG_SAVE_FILE = VALID_CONFIG.copy()  # this passes
+    VALID_CONFIG_SAVE_FILE = deepcopy(VALID_CONFIG)
     VALID_CONFIG_SAVE_FILE[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
@@ -109,6 +108,7 @@ async def test_save_image(hass, mock_image, mock_detections):
         "homeassistant.components.sighthound.image_processing.Image.open"
     ) as pil_img_open:
         pil_img = pil_img_open.return_value
+        pil_img = pil_img.convert.return_value
         data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
         await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
         await hass.async_block_till_done()

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -12,7 +12,7 @@ from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
 
-TEST_DIR = os.path.join(os.path.dirname(__file__))
+TEST_DIR = os.path.dirname(__file__)
 
 VALID_CONFIG = {
     ip.DOMAIN: {

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -99,9 +99,9 @@ async def test_process_image(hass, mock_image, mock_detections):
 
 async def test_save_image(hass, mock_image, mock_detections):
     """Save a processed image."""
-    VALID_CONFIG_SAVE_FILE = deepcopy(VALID_CONFIG)
-    VALID_CONFIG_SAVE_FILE[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
-    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    valid_config_save_file = deepcopy(VALID_CONFIG)
+    valid_config_save_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
+    await async_setup_component(hass, ip.DOMAIN, valid_config_save_file)
     assert hass.states.get(VALID_ENTITY_ID)
 
     with patch(

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -59,13 +59,6 @@ def mock_image():
         yield image
 
 
-@pytest.fixture
-def mock_pil_img():
-    """Return a mock PIL image."""
-    with patch("PIL.Image.open") as pil_img:
-        yield pil_img
-
-
 async def test_bad_api_key(hass, caplog):
     """Catch bad api key."""
     with patch("simplehound.core.cloud.detect", side_effect=hound.SimplehoundException):
@@ -103,13 +96,13 @@ async def test_process_image(hass, mock_image, mock_detections):
     assert len(person_events) == 2
 
 
-async def test_save_image(hass, mock_image, mock_detections, mock_pil_img):
+async def test_save_image(hass, mock_image, mock_detections):
     """Save a processed image."""
     VALID_CONFIG[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
 
-    with patch("PIL.Image.Image") as pil_img:
+    with patch("PIL.Image.open") as pil_img:
         data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
         await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
         await hass.async_block_till_done()

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -1,4 +1,5 @@
 """Tests for the Sighthound integration."""
+from copy import deepcopy
 import os
 from unittest.mock import patch
 
@@ -98,7 +99,8 @@ async def test_process_image(hass, mock_image, mock_detections):
 
 async def test_save_image(hass, mock_image, mock_detections):
     """Save a processed image."""
-    VALID_CONFIG_SAVE_FILE = VALID_CONFIG.copy()
+    VALID_CONFIG_SAVE_FILE = deepcopy(VALID_CONFIG)  # this fails
+    # VALID_CONFIG_SAVE_FILE = VALID_CONFIG.copy()  # this passes
     VALID_CONFIG_SAVE_FILE[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)


### PR DESCRIPTION
## Proposed change
Adds a config option which enables saving of an annotated image. I've not added a test as unsure how to test this safely, looking for recommendations. Docs PR [home-assistant/home-assistant.io#11887](https://github.com/home-assistant/home-assistant.io/pull/11887)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
image_processing:
  - platform: sighthound
    api_key: my_key
    save_file_folder: /my_dir
    source:
      - entity_id: camera.local_file
```

## Additional information
I cannot get my head around how to test this, advice requested

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
