### PR TITLE
Migrate HomematicIP Cloud services to admin services

### DIFF
--- a/homeassistant/components/homematicip_cloud/services.py
+++ b/homeassistant/components/homematicip_cloud/services.py
@@ -39,17 +39,6 @@ SERVICE_DUMP_HAP_CONFIG = "dump_hap_config"
 SERVICE_RESET_ENERGY_COUNTER = "reset_energy_counter"
 SERVICE_SET_ACTIVE_CLIMATE_PROFILE = "set_active_climate_profile"
 
-HMIPC_SERVICES2 = {
-    SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION: "_async_activate_eco_mode_with_duration",
-    SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD: "_async_activate_eco_mode_with_period",
-    SERVICE_ACTIVATE_VACATION: "_async_activate_vacation",
-    SERVICE_DEACTIVATE_ECO_MODE: "SERVICE_DEACTIVATE_ECO_MODE",
-    SERVICE_DEACTIVATE_VACATION: "_async_deactivate_vacation",
-    SERVICE_DUMP_HAP_CONFIG: "_async_dump_hap_config",
-    SERVICE_RESET_ENERGY_COUNTER: "_async_reset_energy_counter",
-    SERVICE_SET_ACTIVE_CLIMATE_PROFILE: "_set_active_climate_profile",
-}
-
 HMIPC_SERVICES = [
     SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION,
     SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD,

--- a/homeassistant/components/homematicip_cloud/services.py
+++ b/homeassistant/components/homematicip_cloud/services.py
@@ -12,7 +12,10 @@ import voluptuous as vol
 from homeassistant.const import ATTR_ENTITY_ID
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import comp_entity_ids
-from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.helpers.service import (
+    async_register_admin_service,
+    verify_domain_control,
+)
 from homeassistant.helpers.typing import HomeAssistantType, ServiceCallType
 
 from .const import DOMAIN as HMIPC_DOMAIN
@@ -110,6 +113,7 @@ async def async_setup_services(hass: HomeAssistantType) -> None:
     if hass.services.async_services().get(HMIPC_DOMAIN):
         return
 
+    @verify_domain_control(hass, HMIPC_DOMAIN)
     async def async_call_hmipc_service(service: ServiceCallType):
         """Call correct HomematicIP Cloud service."""
         service_name = service.service
@@ -166,8 +170,7 @@ async def async_setup_services(hass: HomeAssistantType) -> None:
         schema=SCHEMA_DEACTIVATE_VACATION,
     )
 
-    async_register_admin_service(
-        hass=hass,
+    hass.services.async_register(
         domain=HMIPC_DOMAIN,
         service=SERVICE_SET_ACTIVE_CLIMATE_PROFILE,
         service_func=async_call_hmipc_service,

--- a/homeassistant/components/homematicip_cloud/services.py
+++ b/homeassistant/components/homematicip_cloud/services.py
@@ -131,40 +131,35 @@ async def async_setup_services(hass: HomeAssistantType) -> None:
         elif service_name == SERVICE_SET_ACTIVE_CLIMATE_PROFILE:
             await _set_active_climate_profile(hass, service)
 
-    async_register_admin_service(
-        hass=hass,
+    hass.services.async_register(
         domain=HMIPC_DOMAIN,
         service=SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION,
         service_func=async_call_hmipc_service,
         schema=SCHEMA_ACTIVATE_ECO_MODE_WITH_DURATION,
     )
 
-    async_register_admin_service(
-        hass=hass,
+    hass.services.async_register(
         domain=HMIPC_DOMAIN,
         service=SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD,
         service_func=async_call_hmipc_service,
         schema=SCHEMA_ACTIVATE_ECO_MODE_WITH_PERIOD,
     )
 
-    async_register_admin_service(
-        hass=hass,
+    hass.services.async_register(
         domain=HMIPC_DOMAIN,
         service=SERVICE_ACTIVATE_VACATION,
         service_func=async_call_hmipc_service,
         schema=SCHEMA_ACTIVATE_VACATION,
     )
 
-    async_register_admin_service(
-        hass=hass,
+    hass.services.async_register(
         domain=HMIPC_DOMAIN,
         service=SERVICE_DEACTIVATE_ECO_MODE,
         service_func=async_call_hmipc_service,
         schema=SCHEMA_DEACTIVATE_ECO_MODE,
     )
 
-    async_register_admin_service(
-        hass=hass,
+    hass.services.async_register(
         domain=HMIPC_DOMAIN,
         service=SERVICE_DEACTIVATE_VACATION,
         service_func=async_call_hmipc_service,

--- a/homeassistant/components/homematicip_cloud/services.py
+++ b/homeassistant/components/homematicip_cloud/services.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.const import ATTR_ENTITY_ID
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import comp_entity_ids
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import HomeAssistantType, ServiceCallType
 
 from .const import DOMAIN as HMIPC_DOMAIN
@@ -141,59 +142,67 @@ async def async_setup_services(hass: HomeAssistantType) -> None:
         elif service_name == SERVICE_SET_ACTIVE_CLIMATE_PROFILE:
             await _set_active_climate_profile(hass, service)
 
-    hass.services.async_register(
-        HMIPC_DOMAIN,
-        SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_ACTIVATE_ECO_MODE_WITH_DURATION,
     )
 
-    hass.services.async_register(
-        HMIPC_DOMAIN,
-        SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_ACTIVATE_ECO_MODE_WITH_PERIOD,
     )
 
-    hass.services.async_register(
-        HMIPC_DOMAIN,
-        SERVICE_ACTIVATE_VACATION,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_ACTIVATE_VACATION,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_ACTIVATE_VACATION,
     )
 
-    hass.services.async_register(
-        HMIPC_DOMAIN,
-        SERVICE_DEACTIVATE_ECO_MODE,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_DEACTIVATE_ECO_MODE,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_DEACTIVATE_ECO_MODE,
     )
 
-    hass.services.async_register(
-        HMIPC_DOMAIN,
-        SERVICE_DEACTIVATE_VACATION,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_DEACTIVATE_VACATION,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_DEACTIVATE_VACATION,
     )
 
-    hass.services.async_register(
-        HMIPC_DOMAIN,
-        SERVICE_SET_ACTIVE_CLIMATE_PROFILE,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_SET_ACTIVE_CLIMATE_PROFILE,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_SET_ACTIVE_CLIMATE_PROFILE,
     )
 
-    hass.services.async_register(
-        HMIPC_DOMAIN,
-        SERVICE_DUMP_HAP_CONFIG,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_DUMP_HAP_CONFIG,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_DUMP_HAP_CONFIG,
     )
 
-    hass.helpers.service.async_register_admin_service(
-        HMIPC_DOMAIN,
-        SERVICE_RESET_ENERGY_COUNTER,
-        async_call_hmipc_service,
+    async_register_admin_service(
+        hass=hass,
+        domain=HMIPC_DOMAIN,
+        service=SERVICE_RESET_ENERGY_COUNTER,
+        service_func=async_call_hmipc_service,
         schema=SCHEMA_RESET_ENERGY_COUNTER,
     )
 
@@ -204,7 +213,7 @@ async def async_unload_services(hass: HomeAssistantType):
         return
 
     for hmipc_service in HMIPC_SERVICES:
-        hass.services.async_remove(HMIPC_DOMAIN, hmipc_service)
+        hass.services.async_remove(domain=HMIPC_DOMAIN, service=hmipc_service)
 
 
 async def _async_activate_eco_mode_with_duration(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The user needs to be in the administrator role to execute these HomematicIP Cloud services:
- homematicip_cloud.dump_hap_config
- homematicip_cloud.reset_energy_counter

## Proposed change
Migrate HomematicIP Cloud services to admin services

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12168

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
