### PR TITLE
Refactor homekit_controller to be fully asynchronous

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -1,8 +1,8 @@
 """Support for Homekit device discovery."""
 import logging
 
-import homekit
-from homekit.model.characteristics import CharacteristicsTypes
+import aiohomekit
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -94,7 +94,8 @@ class HomeKitEntity(Entity):
     def _setup_characteristic(self, char):
         """Configure an entity based on a HomeKit characteristics metadata."""
         # Build up a list of (aid, iid) tuples to poll on update()
-        self.pollable_characteristics.append((self._aid, char["iid"]))
+        if "pr" in char["perms"]:
+            self.pollable_characteristics.append((self._aid, char["iid"]))
 
         # Build a map of ctype -> iid
         short_name = CharacteristicsTypes.get_short(char["type"])
@@ -223,7 +224,7 @@ async def async_setup(hass, config):
     map_storage = hass.data[ENTITY_MAP] = EntityMapStorage(hass)
     await map_storage.async_initialize()
 
-    hass.data[CONTROLLER] = homekit.Controller()
+    hass.data[CONTROLLER] = aiohomekit.Controller()
     hass.data[KNOWN_DEVICES] = {}
 
     return True

--- a/homeassistant/components/homekit_controller/air_quality.py
+++ b/homeassistant/components/homekit_controller/air_quality.py
@@ -1,5 +1,5 @@
 """Support for HomeKit Controller air quality sensors."""
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.air_quality import AirQualityEntity
 from homeassistant.core import callback

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -1,7 +1,7 @@
 """Support for Homekit Alarm Control Panel."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.components.alarm_control_panel.const import (

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Homekit motion sensors."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_SMOKE,

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -1,7 +1,7 @@
 """Support for Homekit climate devices."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.climate import (
     DEFAULT_MAX_HUMIDITY,

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -4,8 +4,9 @@ import logging
 import os
 import re
 
-import homekit
-from homekit.controller.ip_implementation import IpPairing
+import aiohomekit
+from aiohomekit import Controller
+from aiohomekit.controller.ip import IpPairing
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -72,7 +73,7 @@ def ensure_pin_format(pin):
     """
     match = PIN_FORMAT.search(pin)
     if not match:
-        raise homekit.exceptions.MalformedPinError(f"Invalid PIN code f{pin}")
+        raise aiohomekit.exceptions.MalformedPinError(f"Invalid PIN code f{pin}")
     return "{}-{}-{}".format(*match.groups())
 
 
@@ -88,7 +89,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         self.model = None
         self.hkid = None
         self.devices = {}
-        self.controller = homekit.Controller()
+        self.controller = Controller()
         self.finish_pairing = None
 
     async def async_step_user(self, user_input=None):
@@ -97,22 +98,22 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         if user_input is not None:
             key = user_input["device"]
-            self.hkid = self.devices[key]["id"]
-            self.model = self.devices[key]["md"]
+            self.hkid = self.devices[key].device_id
+            self.model = self.devices[key].info["md"]
             await self.async_set_unique_id(
                 normalize_hkid(self.hkid), raise_on_progress=False
             )
             return await self.async_step_pair()
 
-        all_hosts = await self.hass.async_add_executor_job(self.controller.discover, 5)
+        all_hosts = await self.controller.discover_ip()
 
         self.devices = {}
         for host in all_hosts:
-            status_flags = int(host["sf"])
+            status_flags = int(host.info["sf"])
             paired = not status_flags & 0x01
             if paired:
                 continue
-            self.devices[host["name"]] = host
+            self.devices[host.info["name"]] = host
 
         if not self.devices:
             return self.async_abort(reason="no_devices")
@@ -130,10 +131,11 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         unique_id = user_input["unique_id"]
         await self.async_set_unique_id(unique_id)
 
-        records = await self.hass.async_add_executor_job(self.controller.discover, 5)
-        for record in records:
-            if normalize_hkid(record["id"]) != unique_id:
+        devices = await self.controller.discover_ip(5)
+        for device in devices:
+            if normalize_hkid(device.device_id) != unique_id:
                 continue
+            record = device.info
             return await self.async_step_zeroconf(
                 {
                     "host": record["address"],
@@ -295,55 +297,49 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             code = pair_info["pairing_code"]
             try:
                 code = ensure_pin_format(code)
-
-                await self.hass.async_add_executor_job(self.finish_pairing, code)
-
-                pairing = self.controller.pairings.get(self.hkid)
-                if pairing:
-                    return await self._entry_from_accessory(pairing)
-
-                errors["pairing_code"] = "unable_to_pair"
-            except homekit.exceptions.MalformedPinError:
+                pairing = await self.finish_pairing(code)
+                return await self._entry_from_accessory(pairing)
+            except aiohomekit.exceptions.MalformedPinError:
                 # Library claimed pin was invalid before even making an API call
                 errors["pairing_code"] = "authentication_error"
-            except homekit.AuthenticationError:
+            except aiohomekit.AuthenticationError:
                 # PairSetup M4 - SRP proof failed
                 # PairSetup M6 - Ed25519 signature verification failed
                 # PairVerify M4 - Decryption failed
                 # PairVerify M4 - Device not recognised
                 # PairVerify M4 - Ed25519 signature verification failed
                 errors["pairing_code"] = "authentication_error"
-            except homekit.UnknownError:
+            except aiohomekit.UnknownError:
                 # An error occurred on the device whilst performing this
                 # operation.
                 errors["pairing_code"] = "unknown_error"
-            except homekit.MaxPeersError:
+            except aiohomekit.MaxPeersError:
                 # The device can't pair with any more accessories.
                 errors["pairing_code"] = "max_peers_error"
-            except homekit.AccessoryNotFoundError:
+            except aiohomekit.AccessoryNotFoundError:
                 # Can no longer find the device on the network
                 return self.async_abort(reason="accessory_not_found_error")
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Pairing attempt failed with an unhandled exception")
                 errors["pairing_code"] = "pairing_failed"
 
-        start_pairing = self.controller.start_pairing
+        discovery = await self.controller.find_ip_by_device_id(self.hkid)
+
         try:
-            self.finish_pairing = await self.hass.async_add_executor_job(
-                start_pairing, self.hkid, self.hkid
-            )
-        except homekit.BusyError:
+            self.finish_pairing = await discovery.start_pairing(self.hkid)
+
+        except aiohomekit.BusyError:
             # Already performing a pair setup operation with a different
             # controller
             errors["pairing_code"] = "busy_error"
-        except homekit.MaxTriesError:
+        except aiohomekit.MaxTriesError:
             # The accessory has received more than 100 unsuccessful auth
             # attempts.
             errors["pairing_code"] = "max_tries_error"
-        except homekit.UnavailableError:
+        except aiohomekit.UnavailableError:
             # The accessory is already paired - cannot try to pair again.
             return self.async_abort(reason="already_paired")
-        except homekit.AccessoryNotFoundError:
+        except aiohomekit.AccessoryNotFoundError:
             # Can no longer find the device on the network
             return self.async_abort(reason="accessory_not_found_error")
         except Exception:  # pylint: disable=broad-except
@@ -376,9 +372,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         # the same time.
         accessories = pairing_data.pop("accessories", None)
         if not accessories:
-            accessories = await self.hass.async_add_executor_job(
-                pairing.list_accessories_and_characteristics
-            )
+            accessories = await pairing.list_accessories_and_characteristics()
 
         bridge_info = get_bridge_information(accessories)
         name = get_accessory_name(bridge_info)

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -1,7 +1,7 @@
 """Support for Homekit covers."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.cover import (
     ATTR_POSITION,

--- a/homeassistant/components/homekit_controller/fan.py
+++ b/homeassistant/components/homekit_controller/fan.py
@@ -1,7 +1,7 @@
 """Support for Homekit fans."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.fan import (
     DIRECTION_FORWARD,

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -1,7 +1,7 @@
 """Support for Homekit lights."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -1,7 +1,7 @@
 """Support for HomeKit Controller locks."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_LOCKED, STATE_UNLOCKED

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["homekit[IP]==0.15.0"],
+  "requirements": ["aiohomekit[IP]==0.2.10"],
   "dependencies": [],
   "zeroconf": ["_hap._tcp.local."],
   "codeowners": ["@Jc2k"]

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -1,5 +1,5 @@
 """Support for Homekit sensors."""
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.const import DEVICE_CLASS_BATTERY, TEMP_CELSIUS
 from homeassistant.core import callback

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -1,7 +1,7 @@
 """Support for Homekit switches."""
 import logging
 
-from homekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.core import callback

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -161,6 +161,9 @@ aioftp==0.12.0
 # homeassistant.components.harmony
 aioharmony==0.1.13
 
+# homeassistant.components.homekit_controller
+aiohomekit[IP]==0.2.10
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0
@@ -687,9 +690,6 @@ home-assistant-frontend==20200220.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.8
-
-# homeassistant.components.homekit_controller
-homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.17

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -61,6 +61,9 @@ aiobotocore==0.11.1
 # homeassistant.components.esphome
 aioesphomeapi==2.6.1
 
+# homeassistant.components.homekit_controller
+aiohomekit[IP]==0.2.10
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0
@@ -258,9 +261,6 @@ home-assistant-frontend==20200220.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.8
-
-# homeassistant.components.homekit_controller
-homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.17

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -4,14 +4,10 @@ import json
 import os
 from unittest import mock
 
-from homekit.exceptions import AccessoryNotFoundError
-from homekit.model import Accessory, get_id
-from homekit.model.characteristics import (
-    AbstractCharacteristic,
-    CharacteristicPermissions,
-    CharacteristicsTypes,
-)
-from homekit.model.services import AbstractService, ServicesTypes
+from aiohomekit.exceptions import AccessoryNotFoundError
+from aiohomekit.model import Accessory
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant import config_entries
 from homeassistant.components.homekit_controller import config_flow
@@ -40,14 +36,14 @@ class FakePairing:
         self.pairing_data = {}
         self.available = True
 
-    def list_accessories_and_characteristics(self):
+    async def list_accessories_and_characteristics(self):
         """Fake implementation of list_accessories_and_characteristics."""
         accessories = [a.to_accessory_and_service_list() for a in self.accessories]
         # replicate what happens upstream right now
         self.pairing_data["accessories"] = accessories
         return accessories
 
-    def get_characteristics(self, characteristics):
+    async def get_characteristics(self, characteristics):
         """Fake implementation of get_characteristics."""
         if not self.available:
             raise AccessoryNotFoundError("Accessory not found")
@@ -64,7 +60,7 @@ class FakePairing:
                         results[(aid, cid)] = {"value": char.get_value()}
         return results
 
-    def put_characteristics(self, characteristics):
+    async def put_characteristics(self, characteristics):
         """Fake implementation of put_characteristics."""
         for aid, cid, new_val in characteristics:
             for accessory in self.accessories:
@@ -124,45 +120,6 @@ class Helper:
         return state
 
 
-class FakeCharacteristic(AbstractCharacteristic):
-    """
-    A model of a generic HomeKit characteristic.
-
-    Base is abstract and can't be instanced directly so this subclass is
-    needed even though it doesn't add any methods.
-    """
-
-    def to_accessory_and_service_list(self):
-        """Serialize the characteristic."""
-        # Upstream doesn't correctly serialize valid_values
-        # This fix will be upstreamed and this function removed when it
-        # is fixed.
-        record = super().to_accessory_and_service_list()
-        if self.valid_values:
-            record["valid-values"] = self.valid_values
-        return record
-
-
-class FakeService(AbstractService):
-    """A model of a generic HomeKit service."""
-
-    def __init__(self, service_name):
-        """Create a fake service by its short form HAP spec name."""
-        char_type = ServicesTypes.get_uuid(service_name)
-        super().__init__(char_type, get_id())
-
-    def add_characteristic(self, name):
-        """Add a characteristic to this service by name."""
-        full_name = "public.hap.characteristic." + name
-        char = FakeCharacteristic(get_id(), full_name, None)
-        char.perms = [
-            CharacteristicPermissions.paired_read,
-            CharacteristicPermissions.paired_write,
-        ]
-        self.characteristics.append(char)
-        return char
-
-
 async def time_changed(hass, seconds):
     """Trigger time changed."""
     next_update = dt_util.utcnow() + timedelta(seconds)
@@ -176,40 +133,7 @@ async def setup_accessories_from_file(hass, path):
         load_fixture, os.path.join("homekit_controller", path)
     )
     accessories_json = json.loads(accessories_fixture)
-
-    accessories = []
-
-    for accessory_data in accessories_json:
-        accessory = Accessory("Name", "Mfr", "Model", "0001", "0.1")
-        accessory.services = []
-        accessory.aid = accessory_data["aid"]
-        for service_data in accessory_data["services"]:
-            service = FakeService("public.hap.service.accessory-information")
-            service.type = service_data["type"]
-            service.iid = service_data["iid"]
-
-            for char_data in service_data["characteristics"]:
-                char = FakeCharacteristic(1, "23", None)
-                char.type = char_data["type"]
-                char.iid = char_data["iid"]
-                char.perms = char_data["perms"]
-                char.format = char_data["format"]
-                if "description" in char_data:
-                    char.description = char_data["description"]
-                if "value" in char_data:
-                    char.value = char_data["value"]
-                if "minValue" in char_data:
-                    char.minValue = char_data["minValue"]
-                if "maxValue" in char_data:
-                    char.maxValue = char_data["maxValue"]
-                if "valid-values" in char_data:
-                    char.valid_values = char_data["valid-values"]
-                service.characteristics.append(char)
-
-            accessory.services.append(service)
-
-        accessories.append(accessory)
-
+    accessories = Accessory.setup_accessories_from_list(accessories_json)
     return accessories
 
 
@@ -217,7 +141,7 @@ async def setup_platform(hass):
     """Load the platform but with a fake Controller API."""
     config = {"discovery": {}}
 
-    with mock.patch("homekit.Controller") as controller:
+    with mock.patch("aiohomekit.Controller") as controller:
         fake_controller = controller.return_value = FakeController()
         await async_setup_component(hass, DOMAIN, config)
 
@@ -293,24 +217,24 @@ async def device_config_changed(hass, accessories):
     await hass.async_block_till_done()
 
 
-async def setup_test_component(hass, services, capitalize=False, suffix=None):
+async def setup_test_component(hass, setup_accessory, capitalize=False, suffix=None):
     """Load a fake homekit accessory based on a homekit accessory model.
 
     If capitalize is True, property names will be in upper case.
 
     If suffix is set, entityId will include the suffix
     """
+    accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
+    setup_accessory(accessory)
+
     domain = None
-    for service in services:
+    for service in accessory.services:
         service_name = ServicesTypes.get_short(service.type)
         if service_name in HOMEKIT_ACCESSORY_DISPATCH:
             domain = HOMEKIT_ACCESSORY_DISPATCH[service_name]
             break
 
     assert domain, "Cannot map test homekit services to Home Assistant domain"
-
-    accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
-    accessory.services.extend(services)
 
     config_entry, pairing = await setup_test_accessories(hass, [accessory])
     entity = "testdevice" if suffix is None else "testdevice_{}".format(suffix)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -6,7 +6,7 @@ https://github.com/home-assistant/home-assistant/issues/15336
 
 from unittest import mock
 
-from homekit import AccessoryDisconnectedError
+from aiohomekit import AccessoryDisconnectedError
 
 from homeassistant.components.climate.const import (
     SUPPORT_TARGET_HUMIDITY,

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from unittest import mock
 
-from homekit.exceptions import AccessoryDisconnectedError, EncryptionError
+from aiohomekit.exceptions import AccessoryDisconnectedError, EncryptionError
 import pytest
 
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR

--- a/tests/components/homekit_controller/test_air_quality.py
+++ b/tests/components/homekit_controller/test_air_quality.py
@@ -1,39 +1,39 @@
 """Basic checks for HomeKit air quality sensor."""
-from tests.components.homekit_controller.common import FakeService, setup_test_component
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
+from tests.components.homekit_controller.common import setup_test_component
 
 
-def create_air_quality_sensor_service():
+def create_air_quality_sensor_service(accessory):
     """Define temperature characteristics."""
-    service = FakeService("public.hap.service.sensor.air-quality")
+    service = accessory.add_service(ServicesTypes.AIR_QUALITY_SENSOR)
 
-    cur_state = service.add_characteristic("air-quality")
+    cur_state = service.add_char(CharacteristicsTypes.AIR_QUALITY)
     cur_state.value = 5
 
-    cur_state = service.add_characteristic("density.ozone")
+    cur_state = service.add_char(CharacteristicsTypes.DENSITY_OZONE)
     cur_state.value = 1111
 
-    cur_state = service.add_characteristic("density.no2")
+    cur_state = service.add_char(CharacteristicsTypes.DENSITY_NO2)
     cur_state.value = 2222
 
-    cur_state = service.add_characteristic("density.so2")
+    cur_state = service.add_char(CharacteristicsTypes.DENSITY_SO2)
     cur_state.value = 3333
 
-    cur_state = service.add_characteristic("density.pm25")
+    cur_state = service.add_char(CharacteristicsTypes.DENSITY_PM25)
     cur_state.value = 4444
 
-    cur_state = service.add_characteristic("density.pm10")
+    cur_state = service.add_char(CharacteristicsTypes.DENSITY_PM10)
     cur_state.value = 5555
 
-    cur_state = service.add_characteristic("density.voc")
+    cur_state = service.add_char(CharacteristicsTypes.DENSITY_VOC)
     cur_state.value = 6666
-
-    return service
 
 
 async def test_air_quality_sensor_read_state(hass, utcnow):
     """Test reading the state of a HomeKit temperature sensor accessory."""
-    sensor = create_air_quality_sensor_service()
-    helper = await setup_test_component(hass, [sensor])
+    helper = await setup_test_component(hass, create_air_quality_sensor_service)
 
     state = await helper.poll_and_get_state()
     assert state.state == "4444"

--- a/tests/components/homekit_controller/test_alarm_control_panel.py
+++ b/tests/components/homekit_controller/test_alarm_control_panel.py
@@ -1,34 +1,34 @@
 """Basic checks for HomeKitalarm_control_panel."""
-from tests.components.homekit_controller.common import FakeService, setup_test_component
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
+from tests.components.homekit_controller.common import setup_test_component
 
 CURRENT_STATE = ("security-system", "security-system-state.current")
 TARGET_STATE = ("security-system", "security-system-state.target")
 
 
-def create_security_system_service():
+def create_security_system_service(accessory):
     """Define a security-system characteristics as per page 219 of HAP spec."""
-    service = FakeService("public.hap.service.security-system")
+    service = accessory.add_service(ServicesTypes.SECURITY_SYSTEM)
 
-    cur_state = service.add_characteristic("security-system-state.current")
+    cur_state = service.add_char(CharacteristicsTypes.SECURITY_SYSTEM_STATE_CURRENT)
     cur_state.value = 0
 
-    targ_state = service.add_characteristic("security-system-state.target")
+    targ_state = service.add_char(CharacteristicsTypes.SECURITY_SYSTEM_STATE_TARGET)
     targ_state.value = 0
 
     # According to the spec, a battery-level characteristic is normally
     # part of a separate service. However as the code was written (which
     # predates this test) the battery level would have to be part of the lock
     # service as it is here.
-    targ_state = service.add_characteristic("battery-level")
+    targ_state = service.add_char(CharacteristicsTypes.BATTERY_LEVEL)
     targ_state.value = 50
-
-    return service
 
 
 async def test_switch_change_alarm_state(hass, utcnow):
     """Test that we can turn a HomeKit alarm on and off again."""
-    alarm_control_panel = create_security_system_service()
-    helper = await setup_test_component(hass, [alarm_control_panel])
+    helper = await setup_test_component(hass, create_security_system_service)
 
     await hass.services.async_call(
         "alarm_control_panel",
@@ -65,8 +65,7 @@ async def test_switch_change_alarm_state(hass, utcnow):
 
 async def test_switch_read_alarm_state(hass, utcnow):
     """Test that we can read the state of a HomeKit alarm accessory."""
-    alarm_control_panel = create_security_system_service()
-    helper = await setup_test_component(hass, [alarm_control_panel])
+    helper = await setup_test_component(hass, create_security_system_service)
 
     helper.characteristics[CURRENT_STATE].value = 0
     state = await helper.poll_and_get_state()

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -1,25 +1,25 @@
 """Basic checks for HomeKit motion sensors and contact sensors."""
-from tests.components.homekit_controller.common import FakeService, setup_test_component
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
+from tests.components.homekit_controller.common import setup_test_component
 
 MOTION_DETECTED = ("motion", "motion-detected")
 CONTACT_STATE = ("contact", "contact-state")
 SMOKE_DETECTED = ("smoke", "smoke-detected")
 
 
-def create_motion_sensor_service():
+def create_motion_sensor_service(accessory):
     """Define motion characteristics as per page 225 of HAP spec."""
-    service = FakeService("public.hap.service.sensor.motion")
+    service = accessory.add_service(ServicesTypes.MOTION_SENSOR)
 
-    cur_state = service.add_characteristic("motion-detected")
+    cur_state = service.add_char(CharacteristicsTypes.MOTION_DETECTED)
     cur_state.value = 0
-
-    return service
 
 
 async def test_motion_sensor_read_state(hass, utcnow):
     """Test that we can read the state of a HomeKit motion sensor accessory."""
-    sensor = create_motion_sensor_service()
-    helper = await setup_test_component(hass, [sensor])
+    helper = await setup_test_component(hass, create_motion_sensor_service)
 
     helper.characteristics[MOTION_DETECTED].value = False
     state = await helper.poll_and_get_state()
@@ -30,20 +30,17 @@ async def test_motion_sensor_read_state(hass, utcnow):
     assert state.state == "on"
 
 
-def create_contact_sensor_service():
+def create_contact_sensor_service(accessory):
     """Define contact characteristics."""
-    service = FakeService("public.hap.service.sensor.contact")
+    service = accessory.add_service(ServicesTypes.CONTACT_SENSOR)
 
-    cur_state = service.add_characteristic("contact-state")
+    cur_state = service.add_char(CharacteristicsTypes.CONTACT_STATE)
     cur_state.value = 0
-
-    return service
 
 
 async def test_contact_sensor_read_state(hass, utcnow):
     """Test that we can read the state of a HomeKit contact accessory."""
-    sensor = create_contact_sensor_service()
-    helper = await setup_test_component(hass, [sensor])
+    helper = await setup_test_component(hass, create_contact_sensor_service)
 
     helper.characteristics[CONTACT_STATE].value = 0
     state = await helper.poll_and_get_state()
@@ -54,20 +51,17 @@ async def test_contact_sensor_read_state(hass, utcnow):
     assert state.state == "on"
 
 
-def create_smoke_sensor_service():
+def create_smoke_sensor_service(accessory):
     """Define smoke sensor characteristics."""
-    service = FakeService("public.hap.service.sensor.smoke")
+    service = accessory.add_service(ServicesTypes.SMOKE_SENSOR)
 
-    cur_state = service.add_characteristic("smoke-detected")
+    cur_state = service.add_char(CharacteristicsTypes.SMOKE_DETECTED)
     cur_state.value = 0
-
-    return service
 
 
 async def test_smoke_sensor_read_state(hass, utcnow):
     """Test that we can read the state of a HomeKit contact accessory."""
-    sensor = create_smoke_sensor_service()
-    helper = await setup_test_component(hass, [sensor])
+    helper = await setup_test_component(hass, create_smoke_sensor_service)
 
     helper.characteristics[SMOKE_DETECTED].value = 0
     state = await helper.poll_and_get_state()

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,41 +1,55 @@
 """Tests for homekit_controller config flow."""
+from asyncio import Future
 import json
 from unittest import mock
 
-import homekit
+import aiohomekit
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 import pytest
 
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 
 from tests.common import MockConfigEntry
-from tests.components.homekit_controller.common import (
-    Accessory,
-    FakeService,
-    setup_platform,
-)
+from tests.components.homekit_controller.common import Accessory, setup_platform
+
+
+def succeed(retval=None):
+    """Mock a successful coroutine return value."""
+    future = Future()
+    future.set_result(retval)
+    return future
+
+
+def fail(exception):
+    """Mock a failing coroutine."""
+    future = Future()
+    future.set_exception(exception)
+    return future
+
 
 PAIRING_START_FORM_ERRORS = [
-    (homekit.BusyError, "busy_error"),
-    (homekit.MaxTriesError, "max_tries_error"),
+    (aiohomekit.BusyError, "busy_error"),
+    (aiohomekit.MaxTriesError, "max_tries_error"),
     (KeyError, "pairing_failed"),
 ]
 
 PAIRING_START_ABORT_ERRORS = [
-    (homekit.AccessoryNotFoundError, "accessory_not_found_error"),
-    (homekit.UnavailableError, "already_paired"),
+    (aiohomekit.AccessoryNotFoundError, "accessory_not_found_error"),
+    (aiohomekit.UnavailableError, "already_paired"),
 ]
 
 PAIRING_FINISH_FORM_ERRORS = [
-    (homekit.exceptions.MalformedPinError, "authentication_error"),
-    (homekit.MaxPeersError, "max_peers_error"),
-    (homekit.AuthenticationError, "authentication_error"),
-    (homekit.UnknownError, "unknown_error"),
+    (aiohomekit.exceptions.MalformedPinError, "authentication_error"),
+    (aiohomekit.MaxPeersError, "max_peers_error"),
+    (aiohomekit.AuthenticationError, "authentication_error"),
+    (aiohomekit.UnknownError, "unknown_error"),
     (KeyError, "pairing_failed"),
 ]
 
 PAIRING_FINISH_ABORT_ERRORS = [
-    (homekit.AccessoryNotFoundError, "accessory_not_found_error")
+    (aiohomekit.AccessoryNotFoundError, "accessory_not_found_error")
 ]
 
 INVALID_PAIRING_CODES = [
@@ -60,13 +74,21 @@ VALID_PAIRING_CODES = [
 ]
 
 
-def _setup_flow_handler(hass):
+def _setup_flow_handler(hass, pairing=None):
     flow = config_flow.HomekitControllerFlowHandler()
     flow.hass = hass
     flow.context = {}
 
+    finish_pairing = mock.Mock()
+    finish_pairing.return_value = succeed(pairing)
+
+    discovery = mock.Mock()
+    discovery.device_id = "00:00:00:00:00:00"
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
     flow.controller = mock.Mock()
     flow.controller.pairings = {}
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
 
     return flow
 
@@ -81,7 +103,7 @@ async def _setup_flow_zeroconf(hass, discovery_info):
 @pytest.mark.parametrize("pairing_code", INVALID_PAIRING_CODES)
 def test_invalid_pairing_codes(pairing_code):
     """Test ensure_pin_format raises for an invalid pin code."""
-    with pytest.raises(homekit.exceptions.MalformedPinError):
+    with pytest.raises(aiohomekit.exceptions.MalformedPinError):
         config_flow.ensure_pin_format(pairing_code)
 
 
@@ -106,6 +128,13 @@ async def test_discovery_works(hass):
 
     flow = _setup_flow_handler(hass)
 
+    finish_pairing = mock.Mock()
+
+    discovery = mock.Mock()
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
+
     # Device is discovered
     result = await flow.async_step_zeroconf(discovery_info)
     assert result["type"] == "form"
@@ -120,21 +149,27 @@ async def test_discovery_works(hass):
     result = await flow.async_step_pair({})
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
-    assert flow.controller.start_pairing.call_count == 1
+    assert discovery.start_pairing.call_count == 1
 
     pairing = mock.Mock(pairing_data={"AccessoryPairingID": "00:00:00:00:00:00"})
 
-    pairing.list_accessories_and_characteristics.return_value = [
-        {
-            "aid": 1,
-            "services": [
-                {
-                    "characteristics": [{"type": "23", "value": "Koogeek-LS1-20833F"}],
-                    "type": "3e",
-                }
-            ],
-        }
-    ]
+    pairing.list_accessories_and_characteristics.return_value = succeed(
+        [
+            {
+                "aid": 1,
+                "services": [
+                    {
+                        "characteristics": [
+                            {"type": "23", "value": "Koogeek-LS1-20833F"}
+                        ],
+                        "type": "3e",
+                    }
+                ],
+            }
+        ]
+    )
+
+    finish_pairing.return_value = succeed(pairing)
 
     # Pairing doesn't error error and pairing results
     flow.controller.pairings = {"00:00:00:00:00:00": pairing}
@@ -155,6 +190,13 @@ async def test_discovery_works_upper_case(hass):
 
     flow = _setup_flow_handler(hass)
 
+    finish_pairing = mock.Mock()
+
+    discovery = mock.Mock()
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
+
     # Device is discovered
     result = await flow.async_step_zeroconf(discovery_info)
     assert result["type"] == "form"
@@ -169,21 +211,27 @@ async def test_discovery_works_upper_case(hass):
     result = await flow.async_step_pair({})
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
-    assert flow.controller.start_pairing.call_count == 1
+    assert discovery.start_pairing.call_count == 1
 
     pairing = mock.Mock(pairing_data={"AccessoryPairingID": "00:00:00:00:00:00"})
 
-    pairing.list_accessories_and_characteristics.return_value = [
-        {
-            "aid": 1,
-            "services": [
-                {
-                    "characteristics": [{"type": "23", "value": "Koogeek-LS1-20833F"}],
-                    "type": "3e",
-                }
-            ],
-        }
-    ]
+    pairing.list_accessories_and_characteristics.return_value = succeed(
+        [
+            {
+                "aid": 1,
+                "services": [
+                    {
+                        "characteristics": [
+                            {"type": "23", "value": "Koogeek-LS1-20833F"}
+                        ],
+                        "type": "3e",
+                    }
+                ],
+            }
+        ]
+    )
+
+    finish_pairing.return_value = succeed(pairing)
 
     flow.controller.pairings = {"00:00:00:00:00:00": pairing}
     result = await flow.async_step_pair({"pairing_code": "111-22-333"})
@@ -203,6 +251,13 @@ async def test_discovery_works_missing_csharp(hass):
 
     flow = _setup_flow_handler(hass)
 
+    finish_pairing = mock.Mock()
+
+    discovery = mock.Mock()
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
+
     # Device is discovered
     result = await flow.async_step_zeroconf(discovery_info)
     assert result["type"] == "form"
@@ -217,21 +272,27 @@ async def test_discovery_works_missing_csharp(hass):
     result = await flow.async_step_pair({})
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
-    assert flow.controller.start_pairing.call_count == 1
+    assert discovery.start_pairing.call_count == 1
 
     pairing = mock.Mock(pairing_data={"AccessoryPairingID": "00:00:00:00:00:00"})
 
-    pairing.list_accessories_and_characteristics.return_value = [
-        {
-            "aid": 1,
-            "services": [
-                {
-                    "characteristics": [{"type": "23", "value": "Koogeek-LS1-20833F"}],
-                    "type": "3e",
-                }
-            ],
-        }
-    ]
+    pairing.list_accessories_and_characteristics.return_value = succeed(
+        [
+            {
+                "aid": 1,
+                "services": [
+                    {
+                        "characteristics": [
+                            {"type": "23", "value": "Koogeek-LS1-20833F"}
+                        ],
+                        "type": "3e",
+                    }
+                ],
+            }
+        ]
+    )
+
+    finish_pairing.return_value = succeed(pairing)
 
     flow.controller.pairings = {"00:00:00:00:00:00": pairing}
 
@@ -390,39 +451,6 @@ async def test_discovery_already_configured_config_change(hass):
     assert conn.async_refresh_entity_map.call_args == mock.call(2)
 
 
-async def test_pair_unable_to_pair(hass):
-    """Pairing completed without exception, but didn't create a pairing."""
-    discovery_info = {
-        "name": "TestDevice",
-        "host": "127.0.0.1",
-        "port": 8080,
-        "properties": {"md": "TestDevice", "id": "00:00:00:00:00:00", "c#": 1, "sf": 1},
-    }
-
-    flow = _setup_flow_handler(hass)
-
-    # Device is discovered
-    result = await flow.async_step_zeroconf(discovery_info)
-    assert result["type"] == "form"
-    assert result["step_id"] == "pair"
-    assert flow.context == {
-        "hkid": "00:00:00:00:00:00",
-        "title_placeholders": {"name": "TestDevice"},
-        "unique_id": "00:00:00:00:00:00",
-    }
-
-    # User initiates pairing - device enters pairing mode and displays code
-    result = await flow.async_step_pair({})
-    assert result["type"] == "form"
-    assert result["step_id"] == "pair"
-    assert flow.controller.start_pairing.call_count == 1
-
-    # Pairing doesn't error but no pairing object is generated
-    result = await flow.async_step_pair({"pairing_code": "111-22-333"})
-    assert result["type"] == "form"
-    assert result["errors"]["pairing_code"] == "unable_to_pair"
-
-
 @pytest.mark.parametrize("exception,expected", PAIRING_START_ABORT_ERRORS)
 async def test_pair_abort_errors_on_start(hass, exception, expected):
     """Test various pairing errors."""
@@ -435,6 +463,11 @@ async def test_pair_abort_errors_on_start(hass, exception, expected):
 
     flow = _setup_flow_handler(hass)
 
+    discovery = mock.Mock()
+    discovery.start_pairing.return_value = fail(exception("error"))
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
+
     # Device is discovered
     result = await flow.async_step_zeroconf(discovery_info)
     assert result["type"] == "form"
@@ -446,10 +479,7 @@ async def test_pair_abort_errors_on_start(hass, exception, expected):
     }
 
     # User initiates pairing - device refuses to enter pairing mode
-    with mock.patch.object(flow.controller, "start_pairing") as start_pairing:
-        start_pairing.side_effect = exception("error")
-        result = await flow.async_step_pair({})
-
+    result = await flow.async_step_pair({})
     assert result["type"] == "abort"
     assert result["reason"] == expected
     assert flow.context == {
@@ -471,6 +501,11 @@ async def test_pair_form_errors_on_start(hass, exception, expected):
 
     flow = _setup_flow_handler(hass)
 
+    discovery = mock.Mock()
+    discovery.start_pairing.return_value = fail(exception("error"))
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
+
     # Device is discovered
     result = await flow.async_step_zeroconf(discovery_info)
     assert result["type"] == "form"
@@ -482,10 +517,7 @@ async def test_pair_form_errors_on_start(hass, exception, expected):
     }
 
     # User initiates pairing - device refuses to enter pairing mode
-    with mock.patch.object(flow.controller, "start_pairing") as start_pairing:
-        start_pairing.side_effect = exception("error")
-        result = await flow.async_step_pair({})
-
+    result = await flow.async_step_pair({})
     assert result["type"] == "form"
     assert result["errors"]["pairing_code"] == expected
     assert flow.context == {
@@ -507,6 +539,14 @@ async def test_pair_abort_errors_on_finish(hass, exception, expected):
 
     flow = _setup_flow_handler(hass)
 
+    finish_pairing = mock.Mock()
+    finish_pairing.return_value = fail(exception("error"))
+
+    discovery = mock.Mock()
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
+
     # Device is discovered
     result = await flow.async_step_zeroconf(discovery_info)
     assert result["type"] == "form"
@@ -521,10 +561,9 @@ async def test_pair_abort_errors_on_finish(hass, exception, expected):
     result = await flow.async_step_pair({})
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
-    assert flow.controller.start_pairing.call_count == 1
+    assert discovery.start_pairing.call_count == 1
 
     # User submits code - pairing fails but can be retried
-    flow.finish_pairing.side_effect = exception("error")
     result = await flow.async_step_pair({"pairing_code": "111-22-333"})
     assert result["type"] == "abort"
     assert result["reason"] == expected
@@ -547,6 +586,14 @@ async def test_pair_form_errors_on_finish(hass, exception, expected):
 
     flow = _setup_flow_handler(hass)
 
+    finish_pairing = mock.Mock()
+    finish_pairing.return_value = fail(exception("error"))
+
+    discovery = mock.Mock()
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
+
     # Device is discovered
     result = await flow.async_step_zeroconf(discovery_info)
     assert result["type"] == "form"
@@ -561,10 +608,9 @@ async def test_pair_form_errors_on_finish(hass, exception, expected):
     result = await flow.async_step_pair({})
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
-    assert flow.controller.start_pairing.call_count == 1
+    assert discovery.start_pairing.call_count == 1
 
     # User submits code - pairing fails but can be retried
-    flow.finish_pairing.side_effect = exception("error")
     result = await flow.async_step_pair({"pairing_code": "111-22-333"})
     assert result["type"] == "form"
     assert result["errors"]["pairing_code"] == expected
@@ -588,17 +634,21 @@ async def test_import_works(hass):
 
     pairing = mock.Mock(pairing_data={"AccessoryPairingID": "00:00:00:00:00:00"})
 
-    pairing.list_accessories_and_characteristics.return_value = [
-        {
-            "aid": 1,
-            "services": [
-                {
-                    "characteristics": [{"type": "23", "value": "Koogeek-LS1-20833F"}],
-                    "type": "3e",
-                }
-            ],
-        }
-    ]
+    pairing.list_accessories_and_characteristics.return_value = succeed(
+        [
+            {
+                "aid": 1,
+                "services": [
+                    {
+                        "characteristics": [
+                            {"type": "23", "value": "Koogeek-LS1-20833F"}
+                        ],
+                        "type": "3e",
+                    }
+                ],
+            }
+        ]
+    )
 
     flow = _setup_flow_handler(hass)
 
@@ -653,22 +703,34 @@ async def test_user_works(hass):
     }
 
     pairing = mock.Mock(pairing_data={"AccessoryPairingID": "00:00:00:00:00:00"})
-    pairing.list_accessories_and_characteristics.return_value = [
-        {
-            "aid": 1,
-            "services": [
-                {
-                    "characteristics": [{"type": "23", "value": "Koogeek-LS1-20833F"}],
-                    "type": "3e",
-                }
-            ],
-        }
-    ]
+    pairing.list_accessories_and_characteristics.return_value = succeed(
+        [
+            {
+                "aid": 1,
+                "services": [
+                    {
+                        "characteristics": [
+                            {"type": "23", "value": "Koogeek-LS1-20833F"}
+                        ],
+                        "type": "3e",
+                    }
+                ],
+            }
+        ]
+    )
 
     flow = _setup_flow_handler(hass)
 
+    finish_pairing = mock.Mock()
+    finish_pairing.return_value = succeed(pairing)
+
+    discovery = mock.Mock()
+    discovery.info = discovery_info
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
     flow.controller.pairings = {"00:00:00:00:00:00": pairing}
-    flow.controller.discover.return_value = [discovery_info]
+    flow.controller.discover_ip.return_value = succeed([discovery])
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
 
     result = await flow.async_step_user()
     assert result["type"] == "form"
@@ -688,7 +750,7 @@ async def test_user_no_devices(hass):
     """Test user initiated pairing where no devices discovered."""
     flow = _setup_flow_handler(hass)
 
-    flow.controller.discover.return_value = []
+    flow.controller.discover_ip.return_value = succeed([])
     result = await flow.async_step_user()
 
     assert result["type"] == "abort"
@@ -709,7 +771,10 @@ async def test_user_no_unpaired_devices(hass):
         "sf": 0,
     }
 
-    flow.controller.discover.return_value = [discovery_info]
+    discovery = mock.Mock()
+    discovery.info = discovery_info
+
+    flow.controller.discover_ip.return_value = succeed([discovery])
     result = await flow.async_step_user()
 
     assert result["type"] == "abort"
@@ -718,12 +783,10 @@ async def test_user_no_unpaired_devices(hass):
 
 async def test_parse_new_homekit_json(hass):
     """Test migrating recent .homekit/pairings.json files."""
-    service = FakeService("public.hap.service.lightbulb")
-    on_char = service.add_characteristic("on")
-    on_char.value = 1
-
     accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
-    accessory.services.append(service)
+    service = accessory.add_service(ServicesTypes.LIGHTBULB)
+    on_char = service.add_char(CharacteristicsTypes.ON)
+    on_char.value = 0
 
     fake_controller = await setup_platform(hass)
     pairing = fake_controller.add([accessory])
@@ -766,12 +829,10 @@ async def test_parse_new_homekit_json(hass):
 
 async def test_parse_old_homekit_json(hass):
     """Test migrating original .homekit/hk-00:00:00:00:00:00 files."""
-    service = FakeService("public.hap.service.lightbulb")
-    on_char = service.add_characteristic("on")
-    on_char.value = 1
-
     accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
-    accessory.services.append(service)
+    service = accessory.add_service(ServicesTypes.LIGHTBULB)
+    on_char = service.add_char(CharacteristicsTypes.ON)
+    on_char.value = 0
 
     fake_controller = await setup_platform(hass)
     pairing = fake_controller.add([accessory])
@@ -818,12 +879,10 @@ async def test_parse_old_homekit_json(hass):
 
 async def test_parse_overlapping_homekit_json(hass):
     """Test migrating .homekit/pairings.json files when hk- exists too."""
-    service = FakeService("public.hap.service.lightbulb")
-    on_char = service.add_characteristic("on")
-    on_char.value = 1
-
     accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
-    accessory.services.append(service)
+    service = accessory.add_service(ServicesTypes.LIGHTBULB)
+    on_char = service.add_char(CharacteristicsTypes.ON)
+    on_char.value = 0
 
     fake_controller = await setup_platform(hass)
     pairing = fake_controller.add([accessory])
@@ -857,7 +916,6 @@ async def test_parse_overlapping_homekit_json(hass):
     pairing_cls_imp = (
         "homeassistant.components.homekit_controller.config_flow.IpPairing"
     )
-
     with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
         with mock.patch("builtins.open", side_effect=side_effects):
@@ -894,22 +952,37 @@ async def test_unignore_works(hass):
     }
 
     pairing = mock.Mock(pairing_data={"AccessoryPairingID": "00:00:00:00:00:00"})
-    pairing.list_accessories_and_characteristics.return_value = [
-        {
-            "aid": 1,
-            "services": [
-                {
-                    "characteristics": [{"type": "23", "value": "Koogeek-LS1-20833F"}],
-                    "type": "3e",
-                }
-            ],
-        }
-    ]
+    pairing.list_accessories_and_characteristics.return_value = succeed(
+        [
+            {
+                "aid": 1,
+                "services": [
+                    {
+                        "characteristics": [
+                            {"type": "23", "value": "Koogeek-LS1-20833F"}
+                        ],
+                        "type": "3e",
+                    }
+                ],
+            }
+        ]
+    )
+
+    finish_pairing = mock.Mock()
+
+    discovery = mock.Mock()
+    discovery.device_id = "00:00:00:00:00:00"
+    discovery.info = discovery_info
+    discovery.start_pairing.return_value = succeed(finish_pairing)
+
+    finish_pairing.return_value = succeed(pairing)
 
     flow = _setup_flow_handler(hass)
 
     flow.controller.pairings = {"00:00:00:00:00:00": pairing}
-    flow.controller.discover.return_value = [discovery_info]
+    flow.controller.discover_ip.return_value = succeed([discovery])
+
+    flow.controller.find_ip_by_device_id.return_value = succeed(discovery)
 
     result = await flow.async_step_unignore({"unique_id": "00:00:00:00:00:00"})
     assert result["type"] == "form"
@@ -924,7 +997,6 @@ async def test_unignore_works(hass):
     result = await flow.async_step_pair({})
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
-    assert flow.controller.start_pairing.call_count == 1
 
     # Pairing finalized
     result = await flow.async_step_pair({"pairing_code": "111-22-333"})
@@ -949,8 +1021,12 @@ async def test_unignore_ignores_missing_devices(hass):
         "sf": 1,
     }
 
+    discovery = mock.Mock()
+    discovery.device_id = "00:00:00:00:00:00"
+    discovery.info = discovery_info
+
     flow = _setup_flow_handler(hass)
-    flow.controller.discover.return_value = [discovery_info]
+    flow.controller.discover_ip.return_value = succeed([discovery])
 
     result = await flow.async_step_unignore({"unique_id": "00:00:00:00:00:01"})
     assert result["type"] == "abort"

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for homekit_controller config flow."""
-from asyncio import Future
 import json
 from unittest import mock
 
@@ -14,14 +13,6 @@ from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 
 from tests.common import MockConfigEntry
 from tests.components.homekit_controller.common import Accessory, setup_platform
-
-
-def fail(exception):
-    """Mock a failing coroutine."""
-    future = Future()
-    future.set_exception(exception)
-    return future
-
 
 PAIRING_START_FORM_ERRORS = [
     (aiohomekit.BusyError, "busy_error"),
@@ -465,7 +456,7 @@ async def test_pair_abort_errors_on_start(hass, exception, expected):
     flow = _setup_flow_handler(hass)
 
     discovery = mock.Mock()
-    discovery.start_pairing.return_value = fail(exception("error"))
+    discovery.start_pairing = asynctest.CoroutineMock(side_effect=exception("error"))
 
     flow.controller.find_ip_by_device_id = asynctest.CoroutineMock(
         return_value=discovery
@@ -505,7 +496,7 @@ async def test_pair_form_errors_on_start(hass, exception, expected):
     flow = _setup_flow_handler(hass)
 
     discovery = mock.Mock()
-    discovery.start_pairing.return_value = fail(exception("error"))
+    discovery.start_pairing = asynctest.CoroutineMock(side_effect=exception("error"))
 
     flow.controller.find_ip_by_device_id = asynctest.CoroutineMock(
         return_value=discovery
@@ -544,8 +535,7 @@ async def test_pair_abort_errors_on_finish(hass, exception, expected):
 
     flow = _setup_flow_handler(hass)
 
-    finish_pairing = asynctest.CoroutineMock()
-    finish_pairing.return_value = fail(exception("error"))
+    finish_pairing = asynctest.CoroutineMock(side_effect=exception("error"))
 
     discovery = mock.Mock()
     discovery.start_pairing = asynctest.CoroutineMock(return_value=finish_pairing)
@@ -593,8 +583,7 @@ async def test_pair_form_errors_on_finish(hass, exception, expected):
 
     flow = _setup_flow_handler(hass)
 
-    finish_pairing = asynctest.CoroutineMock()
-    finish_pairing.return_value = fail(exception("error"))
+    finish_pairing = asynctest.CoroutineMock(side_effect=exception("error"))
 
     discovery = mock.Mock()
     discovery.start_pairing = asynctest.CoroutineMock(return_value=finish_pairing)
@@ -730,8 +719,7 @@ async def test_user_works(hass):
 
     flow = _setup_flow_handler(hass)
 
-    finish_pairing = asynctest.CoroutineMock()
-    finish_pairing.return_value = pairing
+    finish_pairing = asynctest.CoroutineMock(return_value=pairing)
 
     discovery = mock.Mock()
     discovery.info = discovery_info

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -1,7 +1,10 @@
 """Basic checks for HomeKitSwitch."""
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 
-from tests.components.homekit_controller.common import FakeService, setup_test_component
+from tests.components.homekit_controller.common import setup_test_component
 
 LIGHT_ON = ("lightbulb", "on")
 LIGHT_BRIGHTNESS = ("lightbulb", "brightness")
@@ -10,37 +13,37 @@ LIGHT_SATURATION = ("lightbulb", "saturation")
 LIGHT_COLOR_TEMP = ("lightbulb", "color-temperature")
 
 
-def create_lightbulb_service():
+def create_lightbulb_service(accessory):
     """Define lightbulb characteristics."""
-    service = FakeService("public.hap.service.lightbulb")
+    service = accessory.add_service(ServicesTypes.LIGHTBULB)
 
-    on_char = service.add_characteristic("on")
+    on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0
 
-    brightness = service.add_characteristic("brightness")
+    brightness = service.add_char(CharacteristicsTypes.BRIGHTNESS)
     brightness.value = 0
 
     return service
 
 
-def create_lightbulb_service_with_hs():
+def create_lightbulb_service_with_hs(accessory):
     """Define a lightbulb service with hue + saturation."""
-    service = create_lightbulb_service()
+    service = create_lightbulb_service(accessory)
 
-    hue = service.add_characteristic("hue")
+    hue = service.add_char(CharacteristicsTypes.HUE)
     hue.value = 0
 
-    saturation = service.add_characteristic("saturation")
+    saturation = service.add_char(CharacteristicsTypes.SATURATION)
     saturation.value = 0
 
     return service
 
 
-def create_lightbulb_service_with_color_temp():
+def create_lightbulb_service_with_color_temp(accessory):
     """Define a lightbulb service with color temp."""
-    service = create_lightbulb_service()
+    service = create_lightbulb_service(accessory)
 
-    color_temp = service.add_characteristic("color-temperature")
+    color_temp = service.add_char(CharacteristicsTypes.COLOR_TEMPERATURE)
     color_temp.value = 0
 
     return service
@@ -48,8 +51,7 @@ def create_lightbulb_service_with_color_temp():
 
 async def test_switch_change_light_state(hass, utcnow):
     """Test that we can turn a HomeKit light on and off again."""
-    bulb = create_lightbulb_service_with_hs()
-    helper = await setup_test_component(hass, [bulb])
+    helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
     await hass.services.async_call(
         "light",
@@ -71,8 +73,7 @@ async def test_switch_change_light_state(hass, utcnow):
 
 async def test_switch_change_light_state_color_temp(hass, utcnow):
     """Test that we can turn change color_temp."""
-    bulb = create_lightbulb_service_with_color_temp()
-    helper = await setup_test_component(hass, [bulb])
+    helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
     await hass.services.async_call(
         "light",
@@ -87,8 +88,7 @@ async def test_switch_change_light_state_color_temp(hass, utcnow):
 
 async def test_switch_read_light_state(hass, utcnow):
     """Test that we can read the state of a HomeKit light accessory."""
-    bulb = create_lightbulb_service_with_hs()
-    helper = await setup_test_component(hass, [bulb])
+    helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
     # Initial state is that the light is off
     state = await helper.poll_and_get_state()
@@ -112,8 +112,7 @@ async def test_switch_read_light_state(hass, utcnow):
 
 async def test_switch_read_light_state_color_temp(hass, utcnow):
     """Test that we can read the color_temp of a  light accessory."""
-    bulb = create_lightbulb_service_with_color_temp()
-    helper = await setup_test_component(hass, [bulb])
+    helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
     # Initial state is that the light is off
     state = await helper.poll_and_get_state()
@@ -132,8 +131,7 @@ async def test_switch_read_light_state_color_temp(hass, utcnow):
 
 async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
     """Test transition to and from unavailable state."""
-    bulb = create_lightbulb_service_with_color_temp()
-    helper = await setup_test_component(hass, [bulb])
+    helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
     # Initial state is that the light is off
     state = await helper.poll_and_get_state()
@@ -158,8 +156,7 @@ async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
 
 async def test_light_unloaded(hass, utcnow):
     """Test entity and HKDevice are correctly unloaded."""
-    bulb = create_lightbulb_service_with_color_temp()
-    helper = await setup_test_component(hass, [bulb])
+    helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
     # Initial state is that the light is off
     state = await helper.poll_and_get_state()

--- a/tests/components/homekit_controller/test_lock.py
+++ b/tests/components/homekit_controller/test_lock.py
@@ -1,25 +1,28 @@
 """Basic checks for HomeKitLock."""
-from tests.components.homekit_controller.common import FakeService, setup_test_component
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
+from tests.components.homekit_controller.common import setup_test_component
 
 LOCK_CURRENT_STATE = ("lock-mechanism", "lock-mechanism.current-state")
 LOCK_TARGET_STATE = ("lock-mechanism", "lock-mechanism.target-state")
 
 
-def create_lock_service():
+def create_lock_service(accessory):
     """Define a lock characteristics as per page 219 of HAP spec."""
-    service = FakeService("public.hap.service.lock-mechanism")
+    service = accessory.add_service(ServicesTypes.LOCK_MECHANISM)
 
-    cur_state = service.add_characteristic("lock-mechanism.current-state")
+    cur_state = service.add_char(CharacteristicsTypes.LOCK_MECHANISM_CURRENT_STATE)
     cur_state.value = 0
 
-    targ_state = service.add_characteristic("lock-mechanism.target-state")
+    targ_state = service.add_char(CharacteristicsTypes.LOCK_MECHANISM_TARGET_STATE)
     targ_state.value = 0
 
     # According to the spec, a battery-level characteristic is normally
     # part of a separate service. However as the code was written (which
     # predates this test) the battery level would have to be part of the lock
     # service as it is here.
-    targ_state = service.add_characteristic("battery-level")
+    targ_state = service.add_char(CharacteristicsTypes.BATTERY_LEVEL)
     targ_state.value = 50
 
     return service
@@ -27,8 +30,7 @@ def create_lock_service():
 
 async def test_switch_change_lock_state(hass, utcnow):
     """Test that we can turn a HomeKit lock on and off again."""
-    lock = create_lock_service()
-    helper = await setup_test_component(hass, [lock])
+    helper = await setup_test_component(hass, create_lock_service)
 
     await hass.services.async_call(
         "lock", "lock", {"entity_id": "lock.testdevice"}, blocking=True
@@ -43,8 +45,7 @@ async def test_switch_change_lock_state(hass, utcnow):
 
 async def test_switch_read_lock_state(hass, utcnow):
     """Test that we can read the state of a HomeKit lock accessory."""
-    lock = create_lock_service()
-    helper = await setup_test_component(hass, [lock])
+    helper = await setup_test_component(hass, create_lock_service)
 
     helper.characteristics[LOCK_CURRENT_STATE].value = 0
     helper.characteristics[LOCK_TARGET_STATE].value = 0

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -1,5 +1,8 @@
 """Basic checks for HomeKit sensor."""
-from tests.components.homekit_controller.common import FakeService, setup_test_component
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
+from tests.components.homekit_controller.common import setup_test_component
 
 TEMPERATURE = ("temperature", "temperature.current")
 HUMIDITY = ("humidity", "relative-humidity.current")
@@ -10,57 +13,49 @@ CHARGING_STATE = ("battery", "charging-state")
 LO_BATT = ("battery", "status-lo-batt")
 
 
-def create_temperature_sensor_service():
+def create_temperature_sensor_service(accessory):
     """Define temperature characteristics."""
-    service = FakeService("public.hap.service.sensor.temperature")
+    service = accessory.add_service(ServicesTypes.TEMPERATURE_SENSOR)
 
-    cur_state = service.add_characteristic("temperature.current")
+    cur_state = service.add_char(CharacteristicsTypes.TEMPERATURE_CURRENT)
     cur_state.value = 0
 
-    return service
 
-
-def create_humidity_sensor_service():
+def create_humidity_sensor_service(accessory):
     """Define humidity characteristics."""
-    service = FakeService("public.hap.service.sensor.humidity")
+    service = accessory.add_service(ServicesTypes.HUMIDITY_SENSOR)
 
-    cur_state = service.add_characteristic("relative-humidity.current")
+    cur_state = service.add_char(CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT)
     cur_state.value = 0
 
-    return service
 
-
-def create_light_level_sensor_service():
+def create_light_level_sensor_service(accessory):
     """Define light level characteristics."""
-    service = FakeService("public.hap.service.sensor.light")
+    service = accessory.add_service(ServicesTypes.LIGHT_SENSOR)
 
-    cur_state = service.add_characteristic("light-level.current")
+    cur_state = service.add_char(CharacteristicsTypes.LIGHT_LEVEL_CURRENT)
     cur_state.value = 0
 
-    return service
 
-
-def create_carbon_dioxide_level_sensor_service():
+def create_carbon_dioxide_level_sensor_service(accessory):
     """Define carbon dioxide level characteristics."""
-    service = FakeService("public.hap.service.sensor.carbon-dioxide")
+    service = accessory.add_service(ServicesTypes.CARBON_DIOXIDE_SENSOR)
 
-    cur_state = service.add_characteristic("carbon-dioxide.level")
+    cur_state = service.add_char(CharacteristicsTypes.CARBON_DIOXIDE_LEVEL)
     cur_state.value = 0
 
-    return service
 
-
-def create_battery_level_sensor():
+def create_battery_level_sensor(accessory):
     """Define battery level characteristics."""
-    service = FakeService("public.hap.service.battery")
+    service = accessory.add_service(ServicesTypes.BATTERY_SERVICE)
 
-    cur_state = service.add_characteristic("battery-level")
+    cur_state = service.add_char(CharacteristicsTypes.BATTERY_LEVEL)
     cur_state.value = 100
 
-    low_battery = service.add_characteristic("status-lo-batt")
+    low_battery = service.add_char(CharacteristicsTypes.STATUS_LO_BATT)
     low_battery.value = 0
 
-    charging_state = service.add_characteristic("charging-state")
+    charging_state = service.add_char(CharacteristicsTypes.CHARGING_STATE)
     charging_state.value = 0
 
     return service
@@ -68,8 +63,9 @@ def create_battery_level_sensor():
 
 async def test_temperature_sensor_read_state(hass, utcnow):
     """Test reading the state of a HomeKit temperature sensor accessory."""
-    sensor = create_temperature_sensor_service()
-    helper = await setup_test_component(hass, [sensor], suffix="temperature")
+    helper = await setup_test_component(
+        hass, create_temperature_sensor_service, suffix="temperature"
+    )
 
     helper.characteristics[TEMPERATURE].value = 10
     state = await helper.poll_and_get_state()
@@ -82,8 +78,9 @@ async def test_temperature_sensor_read_state(hass, utcnow):
 
 async def test_humidity_sensor_read_state(hass, utcnow):
     """Test reading the state of a HomeKit humidity sensor accessory."""
-    sensor = create_humidity_sensor_service()
-    helper = await setup_test_component(hass, [sensor], suffix="humidity")
+    helper = await setup_test_component(
+        hass, create_humidity_sensor_service, suffix="humidity"
+    )
 
     helper.characteristics[HUMIDITY].value = 10
     state = await helper.poll_and_get_state()
@@ -96,8 +93,9 @@ async def test_humidity_sensor_read_state(hass, utcnow):
 
 async def test_light_level_sensor_read_state(hass, utcnow):
     """Test reading the state of a HomeKit temperature sensor accessory."""
-    sensor = create_light_level_sensor_service()
-    helper = await setup_test_component(hass, [sensor], suffix="light_level")
+    helper = await setup_test_component(
+        hass, create_light_level_sensor_service, suffix="light_level"
+    )
 
     helper.characteristics[LIGHT_LEVEL].value = 10
     state = await helper.poll_and_get_state()
@@ -110,8 +108,9 @@ async def test_light_level_sensor_read_state(hass, utcnow):
 
 async def test_carbon_dioxide_level_sensor_read_state(hass, utcnow):
     """Test reading the state of a HomeKit carbon dioxide sensor accessory."""
-    sensor = create_carbon_dioxide_level_sensor_service()
-    helper = await setup_test_component(hass, [sensor], suffix="co2")
+    helper = await setup_test_component(
+        hass, create_carbon_dioxide_level_sensor_service, suffix="co2"
+    )
 
     helper.characteristics[CARBON_DIOXIDE_LEVEL].value = 10
     state = await helper.poll_and_get_state()
@@ -124,8 +123,9 @@ async def test_carbon_dioxide_level_sensor_read_state(hass, utcnow):
 
 async def test_battery_level_sensor(hass, utcnow):
     """Test reading the state of a HomeKit battery level sensor."""
-    sensor = create_battery_level_sensor()
-    helper = await setup_test_component(hass, [sensor], suffix="battery")
+    helper = await setup_test_component(
+        hass, create_battery_level_sensor, suffix="battery"
+    )
 
     helper.characteristics[BATTERY_LEVEL].value = 100
     state = await helper.poll_and_get_state()
@@ -140,8 +140,9 @@ async def test_battery_level_sensor(hass, utcnow):
 
 async def test_battery_charging(hass, utcnow):
     """Test reading the state of a HomeKit battery's charging state."""
-    sensor = create_battery_level_sensor()
-    helper = await setup_test_component(hass, [sensor], suffix="battery")
+    helper = await setup_test_component(
+        hass, create_battery_level_sensor, suffix="battery"
+    )
 
     helper.characteristics[BATTERY_LEVEL].value = 0
     helper.characteristics[CHARGING_STATE].value = 1
@@ -155,8 +156,9 @@ async def test_battery_charging(hass, utcnow):
 
 async def test_battery_low(hass, utcnow):
     """Test reading the state of a HomeKit battery's low state."""
-    sensor = create_battery_level_sensor()
-    helper = await setup_test_component(hass, [sensor], suffix="battery")
+    helper = await setup_test_component(
+        hass, create_battery_level_sensor, suffix="battery"
+    )
 
     helper.characteristics[LO_BATT].value = 0
     helper.characteristics[BATTERY_LEVEL].value = 1

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -1,11 +1,13 @@
 """Basic checks for entity map storage."""
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
 from homeassistant import config_entries
 from homeassistant.components.homekit_controller import async_remove_entry
 from homeassistant.components.homekit_controller.const import ENTITY_MAP
 
 from tests.common import flush_store
 from tests.components.homekit_controller.common import (
-    FakeService,
     setup_platform,
     setup_test_component,
 )
@@ -57,18 +59,16 @@ async def test_storage_is_removed_idempotent(hass):
     assert hkid not in entity_map.storage_data
 
 
-def create_lightbulb_service():
+def create_lightbulb_service(accessory):
     """Define lightbulb characteristics."""
-    service = FakeService("public.hap.service.lightbulb")
-    on_char = service.add_characteristic("on")
+    service = accessory.add_service(ServicesTypes.LIGHTBULB)
+    on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0
-    return service
 
 
 async def test_storage_is_updated_on_add(hass, hass_storage, utcnow):
     """Test entity map storage is cleaned up on adding an accessory."""
-    bulb = create_lightbulb_service()
-    await setup_test_component(hass, [bulb])
+    await setup_test_component(hass, create_lightbulb_service)
 
     entity_map = hass.data[ENTITY_MAP]
     hkid = "00:00:00:00:00:00"
@@ -83,8 +83,7 @@ async def test_storage_is_updated_on_add(hass, hass_storage, utcnow):
 
 async def test_storage_is_removed_on_config_entry_removal(hass, utcnow):
     """Test entity map storage is cleaned up on config entry removal."""
-    bulb = create_lightbulb_service()
-    await setup_test_component(hass, [bulb])
+    await setup_test_component(hass, create_lightbulb_service)
 
     hkid = "00:00:00:00:00:00"
 

--- a/tests/components/homekit_controller/test_switch.py
+++ b/tests/components/homekit_controller/test_switch.py
@@ -1,12 +1,25 @@
 """Basic checks for HomeKitSwitch."""
+
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
 from tests.components.homekit_controller.common import setup_test_component
+
+
+def create_switch_service(accessory):
+    """Define outlet characteristics."""
+    service = accessory.add_service(ServicesTypes.OUTLET)
+
+    on_char = service.add_char(CharacteristicsTypes.ON)
+    on_char.value = False
+
+    outlet_in_use = service.add_char(CharacteristicsTypes.OUTLET_IN_USE)
+    outlet_in_use.value = False
 
 
 async def test_switch_change_outlet_state(hass, utcnow):
     """Test that we can turn a HomeKit outlet on and off again."""
-    from homekit.model.services import OutletService
-
-    helper = await setup_test_component(hass, [OutletService()])
+    helper = await setup_test_component(hass, create_switch_service)
 
     await hass.services.async_call(
         "switch", "turn_on", {"entity_id": "switch.testdevice"}, blocking=True
@@ -21,9 +34,7 @@ async def test_switch_change_outlet_state(hass, utcnow):
 
 async def test_switch_read_outlet_state(hass, utcnow):
     """Test that we can read the state of a HomeKit outlet accessory."""
-    from homekit.model.services import OutletService
-
-    helper = await setup_test_component(hass, [OutletService()])
+    helper = await setup_test_component(hass, create_switch_service)
 
     # Initial state is that the switch is off and the outlet isn't in use
     switch_1 = await helper.poll_and_get_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Unsure whether to add anything here. homekit_controller will switch from using a synchronous and blocking implementation of the homekit protocol to using a fully asynchronous one. This should be seamless and no configuration changes are required. But it is obviously a riskier change than usual so should be highlighted?


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

homekit_controller currently using a synchronous dependency for speaking the HomeKit protocol and I want to change this:

 * So I can support (in a future PR) HomeKit events (e.g. homekit remotes will trigger automations in near real time, HA UI will update immediately to changes on your accessories themselves)
 * To support devices that send unsolicited events that the sync code can't handle (sync connection can only be in RPC mode or event mode)
 * So I can get a high integration quality score
 * So I can eventually support BLE accessories via aioble or similiar

This is a long running branch for me - the first working prototype has been running since Jul 2019. Much time has been spent testing it since then and getting it ready. And I think we might nearly be there.

Note to reviewers - I plan to do follow up PR's for things which I felt didn't belong in this PR:

 * [ ] Supporting characteristic state update events
 * [ ] Supporting homekit remotes and buttons with device triggers
 * [ ] Updating config flow tests to use `hass.config_entries.flow.async_init` etc which I think is best practice now?
 * [ ] Tidy up the test accessory fixtures and make them more representative of real devices


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24094 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
