### PR TITLE
Dynalite listener for config entry update

### DIFF
--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -1,6 +1,4 @@
 """Support for the Dynalite networks."""
-import asyncio
-
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -108,25 +108,27 @@ async def async_setup(hass, config):
     return True
 
 
+async def async_entry_changed(hass, entry):
+    """Reload entry since the data has changed."""
+    LOGGER.debug("Reloading entry %s", entry.data)
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
 async def async_setup_entry(hass, entry):
     """Set up a bridge from a config entry."""
     LOGGER.debug("Setting up entry %s", entry.data)
-
     bridge = DynaliteBridge(hass, entry.data)
-
     if not await bridge.async_setup():
         LOGGER.error("Could not set up bridge for entry %s", entry.data)
         return False
-
     if not await bridge.try_connection():
         LOGGER.errot("Could not connect with entry %s", entry)
         raise ConfigEntryNotReady
-
     hass.data[DOMAIN][entry.entry_id] = bridge
-
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "light")
     )
+    entry.add_update_listener(async_entry_changed)
     return True
 
 

--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -113,8 +113,6 @@ async def async_setup(hass, config):
 async def async_entry_changed(hass, entry):
     """Reload entry since the data has changed."""
     LOGGER.debug("Reconfiguring entry %s", entry.data)
-    while entry.state == "not_loaded":
-        await asyncio.sleep(1)
     bridge = hass.data[DOMAIN][entry.entry_id]
     await bridge.reload_config(entry.data)
     LOGGER.debug("Reconfiguring entry finished %s", entry.data)

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -33,7 +33,21 @@ class DynaliteBridge:
     async def async_setup(self):
         """Set up a Dynalite bridge."""
         # Configure the dynalite devices
+        LOGGER.debug(
+            "Setting up bridge - host %s, config %s",
+            self.host,
+            self.dynalite_devices.config,
+        )
         return await self.dynalite_devices.async_setup()
+
+    async def reload_config(self, config):
+        """Reconfigure a bridge when config changes."""
+        LOGGER.debug(
+            "Setting up bridge - host %s, config %s",
+            self.host,
+            self.dynalite_devices.config,
+        )
+        await self.dynalite_devices.async_configure(config)
 
     def update_signal(self, device=None):
         """Create signal to use to trigger entity update."""

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -25,29 +25,21 @@ class DynaliteBridge:
         self.host = config[CONF_HOST]
         # Configure the dynalite devices
         self.dynalite_devices = DynaliteDevices(
-            config=config,
             newDeviceFunc=self.add_devices_when_registered,
             updateDeviceFunc=self.update_device,
         )
+        self.dynalite_devices.configure(config)
 
     async def async_setup(self):
         """Set up a Dynalite bridge."""
         # Configure the dynalite devices
-        LOGGER.debug(
-            "Setting up bridge - host %s, config %s",
-            self.host,
-            self.dynalite_devices.config,
-        )
+        LOGGER.debug("Setting up bridge - host %s", self.host)
         return await self.dynalite_devices.async_setup()
 
     async def reload_config(self, config):
         """Reconfigure a bridge when config changes."""
-        LOGGER.debug(
-            "Setting up bridge - host %s, config %s",
-            self.host,
-            self.dynalite_devices.config,
-        )
-        await self.dynalite_devices.async_configure(config)
+        LOGGER.debug("Setting up bridge - host %s, config %s", self.host, config)
+        self.dynalite_devices.configure(config)
 
     def update_signal(self, device=None):
         """Create signal to use to trigger entity update."""

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -22,9 +22,8 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a new bridge as a config entry."""
         LOGGER.debug("Starting async_step_import - %s", import_info)
         host = import_info[CONF_HOST]
-        for entry_id in self.hass.data.get(DOMAIN, {}):
-            if self.hass.data[DOMAIN][entry_id].host == host:
-                entry = self.hass.config_entries.async_get_entry(entry_id)
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data[CONF_HOST] == host:
                 if entry.data != import_info:
                     self.hass.config_entries.async_update_entry(entry, data=import_info)
                 return self.async_abort(reason="already_configured")

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -22,7 +22,7 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a new bridge as a config entry."""
         LOGGER.debug("Starting async_step_import - %s", import_info)
         host = import_info[CONF_HOST]
-        for entry_id in self.hass.data[DOMAIN]:
+        for entry_id in self.hass.data.get(DOMAIN, {}):
             if self.hass.data[DOMAIN][entry_id].host == host:
                 entry = self.hass.config_entries.async_get_entry(entry_id)
                 if entry.data != import_info:

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -22,10 +22,8 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a new bridge as a config entry."""
         LOGGER.debug("Starting async_step_import - %s", import_info)
         host = import_info[CONF_HOST]
-        LOGGER.debug("XXX before unique_id")
         await self.async_set_unique_id(host)
         self._abort_if_unique_id_configured(import_info)
-        LOGGER.debug("XXX after unique_id")
         # New entry
         bridge = DynaliteBridge(self.hass, import_info)
         if not await bridge.async_setup():

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -22,8 +22,12 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a new bridge as a config entry."""
         LOGGER.debug("Starting async_step_import - %s", import_info)
         host = import_info[CONF_HOST]
-        await self.async_set_unique_id(host)
-        self._abort_if_unique_id_configured(import_info)
+        for entry_id in self.hass.data[DOMAIN]:
+            if self.hass.data[DOMAIN][entry_id].host == host:
+                entry = self.hass.config_entries.async_get_entry(entry_id)
+                if entry.data != import_info:
+                    self.hass.config_entries.async_update_entry(entry, data=import_info)
+                return
         # New entry
         bridge = DynaliteBridge(self.hass, import_info)
         if not await bridge.async_setup():

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -27,7 +27,7 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 entry = self.hass.config_entries.async_get_entry(entry_id)
                 if entry.data != import_info:
                     self.hass.config_entries.async_update_entry(entry, data=import_info)
-                return
+                return self.async_abort(reason="already_configured")
         # New entry
         bridge = DynaliteBridge(self.hass, import_info)
         if not await bridge.async_setup():

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -22,8 +22,10 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a new bridge as a config entry."""
         LOGGER.debug("Starting async_step_import - %s", import_info)
         host = import_info[CONF_HOST]
+        LOGGER.debug("XXX before unique_id")
         await self.async_set_unique_id(host)
         self._abort_if_unique_id_configured(import_info)
+        LOGGER.debug("XXX after unique_id")
         # New entry
         bridge = DynaliteBridge(self.hass, import_info)
         if not await bridge.async_setup():

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -5,5 +5,5 @@
     "documentation": "https://www.home-assistant.io/integrations/dynalite",
     "dependencies": [],
     "codeowners": ["@ziv1234"],
-    "requirements": ["dynalite_devices==0.1.22"]
+    "requirements": ["dynalite_devices==0.1.25"]
 }

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -5,5 +5,5 @@
     "documentation": "https://www.home-assistant.io/integrations/dynalite",
     "dependencies": [],
     "codeowners": ["@ziv1234"],
-    "requirements": ["dynalite_devices==0.1.25"]
+    "requirements": ["dynalite_devices==0.1.26"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -456,7 +456,7 @@ dsmr_parser==0.18
 dweepy==0.3.0
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.25
+dynalite_devices==0.1.26
 
 # homeassistant.components.rainforest_eagle
 eagle200_reader==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -456,7 +456,7 @@ dsmr_parser==0.18
 dweepy==0.3.0
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.22
+dynalite_devices==0.1.25
 
 # homeassistant.components.rainforest_eagle
 eagle200_reader==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -168,7 +168,7 @@ distro==1.4.0
 dsmr_parser==0.18
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.22
+dynalite_devices==0.1.25
 
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -168,7 +168,7 @@ distro==1.4.0
 dsmr_parser==0.18
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.25
+dynalite_devices==0.1.26
 
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4

--- a/tests/components/dynalite/common.py
+++ b/tests/components/dynalite/common.py
@@ -1,0 +1,9 @@
+"""Common functions for the Dynalite tests."""
+
+from homeassistant.components import dynalite
+
+
+def get_bridge_from_hass(hass_obj):
+    """Get the bridge from hass.data."""
+    key = next(iter(hass_obj.data[dynalite.DOMAIN]))
+    return hass_obj.data[dynalite.DOMAIN][key]

--- a/tests/components/dynalite/test_bridge.py
+++ b/tests/components/dynalite/test_bridge.py
@@ -2,7 +2,7 @@
 from unittest.mock import Mock, call
 
 from asynctest import patch
-from dynalite_lib import CONF_ALL
+from dynalite_devices_lib import CONF_ALL
 import pytest
 
 from homeassistant.components import dynalite

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -95,5 +95,4 @@ async def test_existing_update(hass):
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
     bridge = get_bridge_from_hass(hass)
-    assert old_bridge is not bridge
     assert bridge.dynalite_devices.config.get("aaa") == "bbb"

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -4,6 +4,8 @@ from asynctest import patch
 from homeassistant import config_entries
 from homeassistant.components import dynalite
 
+from .common import get_bridge_from_hass
+
 from tests.common import MockConfigEntry
 
 
@@ -70,21 +72,28 @@ async def test_existing(hass):
 async def test_existing_update(hass):
     """Test when the entry exists with the same config."""
     host = "1.2.3.4"
-    mock_entry = MockConfigEntry(
-        domain=dynalite.DOMAIN, unique_id=host, data={dynalite.CONF_HOST: host}
-    )
-    mock_entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
         return_value=True,
     ), patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.available", True
     ):
+        assert await hass.config_entries.flow.async_init(
+            dynalite.DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={dynalite.CONF_HOST: host},
+        )
+        await hass.async_block_till_done()
+        old_bridge = get_bridge_from_hass(hass)
+        assert "aaa" not in old_bridge.dynalite_devices.config
         result = await hass.config_entries.flow.async_init(
             dynalite.DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
             data={dynalite.CONF_HOST: host, "aaa": "bbb"},
         )
+        await hass.async_block_till_done()
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert mock_entry.data.get("aaa") == "bbb"
+    bridge = get_bridge_from_hass(hass)
+    assert old_bridge is not bridge
+    assert bridge.dynalite_devices.config.get("aaa") == "bbb"

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -72,6 +72,8 @@ async def test_existing(hass):
 async def test_existing_update(hass):
     """Test when the entry exists with the same config."""
     host = "1.2.3.4"
+    port1 = 7777
+    port2 = 8888
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
         return_value=True,
@@ -81,18 +83,18 @@ async def test_existing_update(hass):
         assert await hass.config_entries.flow.async_init(
             dynalite.DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={dynalite.CONF_HOST: host},
+            data={dynalite.CONF_HOST: host, dynalite.CONF_PORT: port1},
         )
         await hass.async_block_till_done()
         old_bridge = get_bridge_from_hass(hass)
-        assert "aaa" not in old_bridge.dynalite_devices.config
+        assert old_bridge.dynalite_devices.port == port1
         result = await hass.config_entries.flow.async_init(
             dynalite.DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={dynalite.CONF_HOST: host, "aaa": "bbb"},
+            data={dynalite.CONF_HOST: host, dynalite.CONF_PORT: port2},
         )
         await hass.async_block_till_done()
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
     bridge = get_bridge_from_hass(hass)
-    assert bridge.dynalite_devices.config.get("aaa") == "bbb"
+    assert bridge.dynalite_devices.port == port2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change
## Proposed change
<!-- 
added a listener to config entry update to reload the library config
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
