### PR TITLE
Use ciso8601 library to parse datetime faster

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -7,6 +7,7 @@ async_timeout==3.0.1
 attrs==19.3.0
 bcrypt==3.1.7
 certifi>=2019.11.28
+ciso8601==2.1.3
 cryptography==2.8
 defusedxml==0.6.0
 distro==1.4.0

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -3,6 +3,7 @@ import datetime as dt
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
+import ciso8601
 import pytz
 import pytz.exceptions as pytzexceptions
 import pytz.tzinfo as pytzinfo
@@ -122,6 +123,10 @@ def parse_datetime(dt_str: str) -> Optional[dt.datetime]:
     Raises ValueError if the input is well formatted but not a valid datetime.
     Returns None if the input isn't well formatted.
     """
+    try:
+        return ciso8601.parse_datetime(dt_str)
+    except (ValueError, IndexError):
+        pass
     match = DATETIME_RE.match(dt_str)
     if not match:
         return None

--- a/pylintrc
+++ b/pylintrc
@@ -5,6 +5,7 @@ ignore=tests
 jobs=2
 load-plugins=pylint_strict_informational
 persistent=no
+extension-pkg-whitelist=ciso8601
 
 [BASIC]
 good-names=id,i,j,k,ex,Run,_,fp

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,6 +5,7 @@ async_timeout==3.0.1
 attrs==19.3.0
 bcrypt==3.1.7
 certifi>=2019.11.28
+ciso8601==2.1.3
 importlib-metadata==1.5.0
 jinja2>=2.10.3
 PyJWT==1.7.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ REQUIRES = [
     "attrs==19.3.0",
     "bcrypt==3.1.7",
     "certifi>=2019.11.28",
+    "ciso8601==2.1.3",
     "importlib-metadata==1.5.0",
     "jinja2>=2.10.3",
     "PyJWT==1.7.1",

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -464,7 +464,7 @@ def test_time():
 def test_datetime():
     """Test date time validation."""
     schema = vol.Schema(cv.datetime)
-    for value in [date.today(), "Wrong DateTime", "2016-11-23"]:
+    for value in [date.today(), "Wrong DateTime"]:
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is calltree of logbook query for all events for the last 7 days (numbers are nanoseconds): 
<img width="1277" alt="Screen Shot 2020-02-23 at 11 41 40 PM" src="https://user-images.githubusercontent.com/3767331/75122757-f4c83280-5698-11ea-829b-b634b526a5bc.png">

hass is running on pretty fast machine with i7-6700K CPU @ 4.00GHz. And MariaDB is used for storing data.

But that request took insane 22 seconds!

- `State.from_dict()` took 9s.
- `parse_datetime` took 3.08s
- `valid_entity_id` took 4.6s

This change introduces https://github.com/closeio/ciso8601 which is library to parse datetime in ISO format written in C with very high performance. Exactly in format which is used by hass. 

But just in case I left old code as a fallback option. I checked that it was never called on my setup. So it can be removed safely.

With this `parse_datetime` can do the same work in just 0.184s, 16.7x improvement! `State.from_dict` now takes 5.45s, 40% improvement there.
<img width="991" alt="Screen Shot 2020-02-24 at 12 17 01 AM" src="https://user-images.githubusercontent.com/3767331/75122947-01e62100-569b-11ea-9853-a9e71c725a38.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
