### PR TITLE
Modernize SimpliSafe config flow

### DIFF
--- a/homeassistant/components/simplisafe/.translations/en.json
+++ b/homeassistant/components/simplisafe/.translations/en.json
@@ -1,5 +1,8 @@
 {
     "config": {
+        "abort": {
+            "already_configured": "This SimpliSafe account is already in use."
+        },
         "error": {
             "identifier_exists": "Account already registered",
             "invalid_credentials": "Invalid credentials"

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -14,6 +14,9 @@
     "error": {
       "identifier_exists": "Account already registered",
       "invalid_credentials": "Invalid credentials"
+    },
+    "abort": {
+      "already_configured": "This SimpliSafe account is already in use."
     }
   }
 }

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.simplisafe import DOMAIN, config_flow
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 
 from tests.common import MockConfigEntry, mock_coro
@@ -20,12 +21,27 @@ async def test_duplicate_error(hass):
     """Test that errors are shown when duplicates are added."""
     conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
 
-    MockConfigEntry(domain=DOMAIN, data=conf).add_to_hass(hass)
-    flow = config_flow.SimpliSafeFlowHandler()
-    flow.hass = hass
+    MockConfigEntry(domain=DOMAIN, unique_id="user@email.com", data=conf).add_to_hass(
+        hass
+    )
 
-    result = await flow.async_step_user(user_input=conf)
-    assert result["errors"] == {CONF_USERNAME: "identifier_exists"}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_get_configured_instances(hass):
+    """Test retrieving all configured instances."""
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
+
+    MockConfigEntry(domain=DOMAIN, unique_id="user@email.com", data=conf).add_to_hass(
+        hass
+    )
+
+    assert len(config_flow.configured_instances(hass)) == 1
 
 
 async def test_invalid_credentials(hass):
@@ -36,6 +52,7 @@ async def test_invalid_credentials(hass):
 
     flow = config_flow.SimpliSafeFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     with patch(
         "simplipy.API.login_via_credentials",
@@ -49,6 +66,7 @@ async def test_show_form(hass):
     """Test that the form is served with no input."""
     flow = config_flow.SimpliSafeFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     result = await flow.async_step_user(user_input=None)
 
@@ -62,6 +80,7 @@ async def test_step_import(hass):
 
     flow = config_flow.SimpliSafeFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     mop = mock_open(read_data=json.dumps({"refresh_token": "12345"}))
 
@@ -91,6 +110,7 @@ async def test_step_user(hass):
 
     flow = config_flow.SimpliSafeFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     mop = mock_open(read_data=json.dumps({"refresh_token": "12345"}))
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modernizes the SimpliSafe config flow:

* Removes `OrderedDict` usage (no longer needed)
* Uses built-in unique ID and abort helpers (instead of custom logic)
* Registers the domain upon config flow definition

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
