### PR TITLE
Speed up validate_entity_id

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -104,7 +104,7 @@ def split_entity_id(entity_id: str) -> List[str]:
     return entity_id.split(".", 1)
 
 
-VALID_ENTITY_ID = re.compile(r"[0-9a-z][a-z_]+[0-9a-z]\.[0-9a-z][0-9a-z_]+[0-9a-z]")
+VALID_ENTITY_ID = re.compile(r"^(?![_\d])[\da-z_]+(?<!_)\.(?![_\d])[\da-z_]+(?<!_)$")
 
 
 def valid_entity_id(entity_id: str) -> bool:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -104,7 +104,7 @@ def split_entity_id(entity_id: str) -> List[str]:
     return entity_id.split(".", 1)
 
 
-VALID_ENTITY_ID = re.compile(r"^(?![_\d])[\da-z_]+(?<!_)\.(?![_\d])[\da-z_]+(?<!_)$")
+VALID_ENTITY_ID = re.compile(r"^(?!.+__)(?!_)[\da-z_]+(?<!_)\.(?!_)[\da-z_]+(?<!_)$")
 
 
 def valid_entity_id(entity_id: str) -> bool:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -12,6 +12,7 @@ import functools
 import logging
 import os
 import pathlib
+import re
 import threading
 from time import monotonic
 from types import MappingProxyType
@@ -63,7 +64,7 @@ from homeassistant.exceptions import (
     ServiceNotFound,
     Unauthorized,
 )
-from homeassistant.util import location, slugify
+from homeassistant.util import location
 from homeassistant.util.async_ import fire_coroutine_threadsafe, run_callback_threadsafe
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
@@ -103,12 +104,15 @@ def split_entity_id(entity_id: str) -> List[str]:
     return entity_id.split(".", 1)
 
 
+VALID_ENTITY_ID = re.compile(r"[0-9a-z][a-z_]+[0-9a-z]\.[0-9a-z][0-9a-z_]+[0-9a-z]")
+
+
 def valid_entity_id(entity_id: str) -> bool:
     """Test if an entity ID is a valid format.
 
     Format: <domain>.<entity> where both are slugs.
     """
-    return "." in entity_id and slugify(entity_id) == entity_id.replace(".", "_", 1)
+    return VALID_ENTITY_ID.match(entity_id) is not None
 
 
 def valid_state(state: str) -> bool:

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -185,3 +185,12 @@ def _logbook_filtering(hass, last_changed, last_updated):
     list(logbook.humanify(None, yield_events(event)))
 
     return timer() - start
+
+
+@benchmark
+async def valid_entity_id(hass):
+    """Run valid entity ID a million times."""
+    start = timer()
+    for _ in range(10 ** 6):
+        core.valid_entity_id("light.kitchen")
+    return timer() - start

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1214,12 +1214,10 @@ def test_valid_entity_id():
         "_light.kitchen",
         ".kitchen",
         ".light.kitchen",
-        "1.a",
-        "1light.kitchen",
         "light_.kitchen",
         "light._kitchen",
         "light.",
-        "light.1kitchen",
+        "light.kitchen__ceiling",
         "light.kitchen_yo_",
         "light.kitchen.",
         "Light.kitchen",
@@ -1229,8 +1227,12 @@ def test_valid_entity_id():
         assert not ha.valid_entity_id(invalid), invalid
 
     for valid in [
+        "1.a",
+        "1light.kitchen",
+        "a.1",
         "a.a",
         "input_boolean.hello_world_0123",
+        "light.1kitchen",
         "light.kitchen",
         "light.something_yoo",
     ]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1220,6 +1220,8 @@ def test_valid_entity_id():
         "lightkitchen",
         ".kitchen",
         "light.",
+        ".light.kitchen",
+        "light.kitchen.",
     ]:
         assert not ha.valid_entity_id(invalid), invalid
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1211,24 +1211,27 @@ async def test_async_functions_with_callback(hass):
 def test_valid_entity_id():
     """Test valid entity ID."""
     for invalid in [
-        "light_.kitchen",
-        "Light.kitchen",
         "_light.kitchen",
+        ".kitchen",
+        ".light.kitchen",
+        "1.a",
+        "1light.kitchen",
+        "light_.kitchen",
         "light._kitchen",
+        "light.",
+        "light.1kitchen",
         "light.kitchen_yo_",
+        "light.kitchen.",
+        "Light.kitchen",
         "light.Kitchen",
         "lightkitchen",
-        ".kitchen",
-        "light.",
-        ".light.kitchen",
-        "light.kitchen.",
     ]:
         assert not ha.valid_entity_id(invalid), invalid
 
     for valid in [
-        "light.kitchen",
-        "input_boolean.hello_world_0123",
-        "light.something_yoo",
         "a.a",
+        "input_boolean.hello_world_0123",
+        "light.kitchen",
+        "light.something_yoo",
     ]:
         assert ha.valid_entity_id(valid), valid

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1206,3 +1206,27 @@ async def test_async_functions_with_callback(hass):
 
     await hass.services.async_call("test_domain", "test_service", blocking=True)
     assert len(runs) == 3
+
+
+def test_valid_entity_id():
+    """Test valid entity ID."""
+    for invalid in [
+        "light_.kitchen",
+        "Light.kitchen",
+        "_light.kitchen",
+        "light._kitchen",
+        "light.kitchen_yo_",
+        "light.Kitchen",
+        "lightkitchen",
+        ".kitchen",
+        "light.",
+    ]:
+        assert not ha.valid_entity_id(invalid), invalid
+
+    for valid in [
+        "light.kitchen",
+        "input_boolean.hello_world_0123",
+        "light.something_yoo",
+        "a.a",
+    ]:
+        assert ha.valid_entity_id(valid), valid


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #32128 @KapJI included a call tree that showed that validate entity ID has horrible performance. And we use that a lot 😱 

So I did a quick attempt to rewrite it to use regex. Included a benchmark. On my 2.9 GHz Core i7 machine it goes from 12s to 0.6s.

However, regex is not 100% correct yet. So going to fix that soonish. Just wanted to open PR to get feedback if I am missing entity IDs that need to be valid.

`<domain>.<object_id>` can have underscores, but neither can start or end with it.

To run benchmark: `hass --script benchmark valid_entity_id`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
