### PR TITLE
Fix vizio bug to use 'get' to get volume_step since it is optional

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -180,7 +180,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if entry.data[CONF_NAME] != import_config[CONF_NAME]:
                     updated_name[CONF_NAME] = import_config[CONF_NAME]
 
-                if entry.data[CONF_VOLUME_STEP] != import_config[CONF_VOLUME_STEP]:
+                if entry.data.get(
+                    CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP
+                ) != import_config.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP):
                     updated_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
 
                 if updated_options or updated_name:

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -180,10 +180,11 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if entry.data[CONF_NAME] != import_config[CONF_NAME]:
                     updated_name[CONF_NAME] = import_config[CONF_NAME]
 
-                if entry.data.get(
+                import_volume_step = import_config.get(
                     CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP
-                ) != import_config.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP):
-                    updated_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
+                )
+                if entry.data.get(CONF_VOLUME_STEP) != import_volume_step:
+                    updated_options[CONF_VOLUME_STEP] = import_volume_step
 
                 if updated_options or updated_name:
                     new_data = entry.data.copy()

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -300,15 +300,15 @@ async def test_import_flow_update_options(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_IMPORT},
-        data=vol.Schema(VIZIO_SCHEMA)(MOCK_IMPORT_VALID_TV_CONFIG),
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
     )
     await hass.async_block_till_done()
 
-    assert result["result"].options == {CONF_VOLUME_STEP: VOLUME_STEP}
+    assert result["result"].options == {CONF_VOLUME_STEP: DEFAULT_VOLUME_STEP}
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     entry_id = result["result"].entry_id
 
-    updated_config = MOCK_IMPORT_VALID_TV_CONFIG.copy()
+    updated_config = MOCK_SPEAKER_CONFIG.copy()
     updated_config[CONF_VOLUME_STEP] = VOLUME_STEP + 1
     result = await hass.config_entries.flow.async_init(
         DOMAIN,


### PR DESCRIPTION
## Proposed change
Tediore in Discord reported the following bug:
```
2020-02-22 21:44:37 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 109, in async_init
    result = await self._async_handle_step(flow, flow.init_step, data)
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 172, in _async_handle_step
    result: Dict = await getattr(flow, method)(user_input)
  File "/usr/src/homeassistant/homeassistant/components/vizio/config_flow.py", line 180, in async_step_import
    if entry.data[CONF_VOLUME_STEP] != import_config[CONF_VOLUME_STEP]:
KeyError: 'volume_step'
```

This is happening because `volume_step` is optional but the code assumes that it always exists. This change prevents that error from occurring by using get and providing a default volume_step when none is provided


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
