### PR TITLE
Make SimpliSafe entities unavailable when wifi is lost

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -677,7 +677,7 @@ class SimpliSafeEntity(Entity):
         elif event.event_type == EVENT_CONNECTION_RESTORED:
             self._online = True
 
-        # It's uncertain whether SimpliSafe events wills till propagate down the
+        # It's uncertain whether SimpliSafe events will still propagate down the
         # websocket when the base station is offline. Just in case, we guard against
         # further action until connection is restored:
         if not self._online:

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -677,6 +677,9 @@ class SimpliSafeEntity(Entity):
         elif event.event_type == EVENT_CONNECTION_RESTORED:
             self._online = True
 
+        # It's uncertain whether SimpliSafe events wills till propagate down the
+        # websocket when the base station is offline. Just in case, we guard against
+        # further action until connection is restored:
         if not self._online:
             return
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -6,6 +6,8 @@ from simplipy import API
 from simplipy.errors import InvalidCredentialsError, SimplipyError
 from simplipy.websocket import (
     EVENT_CAMERA_MOTION_DETECTED,
+    EVENT_CONNECTION_LOST,
+    EVENT_CONNECTION_RESTORED,
     EVENT_DOORBELL_DETECTED,
     EVENT_ENTRY_DETECTED,
     EVENT_LOCK_LOCKED,
@@ -527,7 +529,10 @@ class SimpliSafeEntity(Entity):
         self._online = True
         self._simplisafe = simplisafe
         self._system = system
-        self.websocket_events_to_listen_for = []
+        self.websocket_events_to_listen_for = [
+            EVENT_CONNECTION_LOST,
+            EVENT_CONNECTION_RESTORED,
+        ]
 
         if serial:
             self._serial = serial
@@ -654,12 +659,28 @@ class SimpliSafeEntity(Entity):
                 ATTR_LAST_EVENT_TIMESTAMP: last_websocket_event.timestamp,
             }
         )
-        self.async_update_from_websocket_event(last_websocket_event)
+        self._async_internal_update_from_websocket_event(last_websocket_event)
 
     @callback
     def async_update_from_rest_api(self):
         """Update the entity with the provided REST API data."""
         pass
+
+    @callback
+    def _async_internal_update_from_websocket_event(self, event):
+        """Check for connection events and set offline appropriately.
+
+        Should not be called directly.
+        """
+        if event.event_type == EVENT_CONNECTION_LOST:
+            self._online = False
+        elif event.event_type == EVENT_CONNECTION_RESTORED:
+            self._online = True
+
+        if not self._online:
+            return
+
+        self.async_update_from_websocket_event(event)
 
     @callback
     def async_update_from_websocket_event(self, event):

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -190,11 +190,6 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
     @callback
     def async_update_from_rest_api(self):
         """Update the entity with the provided REST API data."""
-        if self._system.state == SystemStates.error:
-            self._online = False
-            return
-        self._online = True
-
         if self._system.version == 3:
             self._attrs.update(
                 {

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -70,11 +70,6 @@ class SimpliSafeLock(SimpliSafeEntity, LockDevice):
     @callback
     def async_update_from_rest_api(self):
         """Update the entity with the provided REST API data."""
-        if self._lock.offline or self._lock.disabled:
-            self._online = False
-            return
-
-        self._online = True
         self._attrs.update(
             {
                 ATTR_LOCK_LOW_BATTERY: self._lock.lock_low_battery,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the SimpliSafe integration to watch for loss (and restoration) of wifi connection to the base station; upon seeing these events, SimpliSafe entities are marked/unmarked `unavailable`. Additionally, the PR removes checking online/offline status via the REST API (since the above events now do the same job).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
