### PR TITLE
Deprecate homekit_controller .homekit folder

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -233,7 +233,7 @@ async def async_setup(hass, config):
         _LOGGER.warning(
             (
                 "Legacy homekit_controller state found in %s. Support for reading "
-                "the folder is deprecated and will be removed in 0.108.0."
+                "the folder is deprecated and will be removed in 0.109.0."
             ),
             dothomekit_dir,
         )

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -228,12 +228,12 @@ async def async_setup(hass, config):
     hass.data[CONTROLLER] = aiohomekit.Controller()
     hass.data[KNOWN_DEVICES] = {}
 
-    dothomekit_dir = os.path.join(hass.config.path(), ".homekit")
+    dothomekit_dir = hass.config.path(".homekit")
     if os.path.exists(dothomekit_dir):
         _LOGGER.warning(
             (
                 "Legacy homekit_controller state found in %s. Support for reading "
-                "the folder is deprecated and will be removed in a future release."
+                "the folder is deprecated and will be removed in 0.108.0."
             ),
             dothomekit_dir,
         )

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -1,5 +1,6 @@
 """Support for Homekit device discovery."""
 import logging
+import os
 
 import aiohomekit
 from aiohomekit.model.characteristics import CharacteristicsTypes
@@ -226,6 +227,16 @@ async def async_setup(hass, config):
 
     hass.data[CONTROLLER] = aiohomekit.Controller()
     hass.data[KNOWN_DEVICES] = {}
+
+    dothomekit_dir = os.path.join(hass.config.path(), ".homekit")
+    if os.path.exists(dothomekit_dir):
+        _LOGGER.warning(
+            (
+                "Legacy homekit_controller state found in %s. Support for reading "
+                "the folder is deprecated and will be removed in a future release."
+            ),
+            dothomekit_dir,
+        )
 
     return True
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

Support for homekit_controller's legacy pairing data folder `.homekit` has been deprecated. This has not been how pairings are saved since Home Assistant 0.94. In 0.109.0 we plan to remove this code. If you are running Home Assistant 0.94 or later this does not affect you - your pairings were already migrated to config entries. If you are running an older release and do not upgrade soon you will not be able to automatically migrate your existing pairings at upgrade time and will have to manually re-pair them.  

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Home Assistant currently tries to load pairing information from the `.homekit` folder when it sees a device that is paired but doesn't have a config entry. The is compatibility code from before homekit_controller supported config entries, and its been there for just under a year. I would like to deprecate it and then remove it after a couple of releases to simplify the code a bit.

Anyone running Home Assistant from after May 2019 would be unaffected as their .homekit folder will already be migrated. This would only affect people migrating from Home Assistant of that age directly to a version where support has been removed. The would have to repair their accessories via config flow.

CC @MartinHjelmare as discussed in #32141

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
