### PR TITLE
Improve debounce cooldown

### DIFF
--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -15,26 +15,38 @@ async def test_immediate_works(hass):
         function=CoroutineMock(side_effect=lambda: calls.append(None)),
     )
 
+    # Call when nothing happening
     await debouncer.async_call()
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is False
 
+    # Call when cooldown active setting execute at end to True
     await debouncer.async_call()
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
 
+    # Canceling debounce in cooldown
     debouncer.async_cancel()
     assert debouncer._timer_task is None
     assert debouncer._execute_at_end_of_timer is False
 
+    # Call and let timer run out
     await debouncer.async_call()
     assert len(calls) == 2
     await debouncer._handle_timer_finish()
     assert len(calls) == 2
     assert debouncer._timer_task is None
     assert debouncer._execute_at_end_of_timer is False
+
+    # Test calling doesn't execute/cooldown if currently executing.
+    await debouncer._execute_lock.acquire()
+    await debouncer.async_call()
+    assert len(calls) == 2
+    assert debouncer._timer_task is None
+    assert debouncer._execute_at_end_of_timer is False
+    debouncer._execute_lock.release()
 
 
 async def test_not_immediate_works(hass):
@@ -48,23 +60,38 @@ async def test_not_immediate_works(hass):
         function=CoroutineMock(side_effect=lambda: calls.append(None)),
     )
 
+    # Call when nothing happening
     await debouncer.async_call()
     assert len(calls) == 0
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
 
+    # Call while still on cooldown
     await debouncer.async_call()
     assert len(calls) == 0
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
 
+    # Canceling while on cooldown
     debouncer.async_cancel()
     assert debouncer._timer_task is None
     assert debouncer._execute_at_end_of_timer is False
 
+    # Call and let timer run out
     await debouncer.async_call()
     assert len(calls) == 0
     await debouncer._handle_timer_finish()
     assert len(calls) == 1
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is False
+
+    # Reset debouncer
+    debouncer.async_cancel()
+
+    # Test calling doesn't schedule if currently executing.
+    await debouncer._execute_lock.acquire()
+    await debouncer.async_call()
+    assert len(calls) == 1
     assert debouncer._timer_task is None
     assert debouncer._execute_at_end_of_timer is False
+    debouncer._execute_lock.release()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Use a lock to prevent double execution
- Schedule a timer at the end of an execution to enforce `<cooldown>` between invocations

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
