### PR TITLE
Improve Vizio fix to avoid KeyError

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -180,11 +180,8 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if entry.data[CONF_NAME] != import_config[CONF_NAME]:
                     updated_name[CONF_NAME] = import_config[CONF_NAME]
 
-                import_volume_step = import_config.get(
-                    CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP
-                )
-                if entry.data.get(CONF_VOLUME_STEP) != import_volume_step:
-                    updated_options[CONF_VOLUME_STEP] = import_volume_step
+                if entry.data.get(CONF_VOLUME_STEP) != import_config[CONF_VOLUME_STEP]:
+                    updated_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
 
                 if updated_options or updated_name:
                     new_data = entry.data.copy()

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -56,15 +56,18 @@ async def async_setup_entry(
     volume_step = config_entry.options.get(
         CONF_VOLUME_STEP, config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
     )
+
+    params = {}
     if not config_entry.options:
-        hass.config_entries.async_update_entry(
-            config_entry, options={CONF_VOLUME_STEP: volume_step}
-        )
+        params["options"] = {CONF_VOLUME_STEP: volume_step}
 
     if not config_entry.data.get(CONF_VOLUME_STEP):
         new_data = config_entry.data.copy()
         new_data.update({CONF_VOLUME_STEP: volume_step})
-        hass.config_entries.async_update_entry(config_entry, data=new_data)
+        params["data"] = new_data
+
+    if params:
+        hass.config_entries.async_update_entry(config_entry, **params)
 
     device = VizioAsync(
         DEVICE_ID,

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -61,6 +61,11 @@ async def async_setup_entry(
             config_entry, options={CONF_VOLUME_STEP: volume_step}
         )
 
+    if not config_entry.data.get(CONF_VOLUME_STEP):
+        new_data = config_entry.data.copy()
+        new_data.update({CONF_VOLUME_STEP: volume_step})
+        hass.config_entries.async_update_entry(config_entry, data=new_data)
+
     device = VizioAsync(
         DEVICE_ID,
         host,


### PR DESCRIPTION
## Proposed change
In #32151 I fixed a bug that occurred when the config entry data dictionary did not have `volume_step`. @MartinHjelmare identified that the change I made was redundant in that I was falling back to the DEFAULT_VOLUME_STEP when checking the config, but that is unnecessary because config validation already guarantees that the `volume_step` parameter is in the config dictionary, so this change fixes that. As part of looking into this, I also realized that I did not set `volume_step` in the data dictionary on initialization, which means that the second import (e.g. on a restart) would always set it. I have updated the logic to always ensure it is included in the config entry data.

This should go out with 0.106 along with the other linked PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
