### PR TITLE
Modernize Ambient PWS config flow

### DIFF
--- a/homeassistant/components/ambient_station/.translations/en.json
+++ b/homeassistant/components/ambient_station/.translations/en.json
@@ -1,7 +1,9 @@
 {
     "config": {
+        "abort": {
+            "already_configured": "This app key is already in use."
+        },
         "error": {
-            "identifier_exists": "Application Key and/or API Key already registered",
             "invalid_key": "Invalid API Key and/or Application Key",
             "no_devices": "No devices found in account"
         },

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -23,7 +23,6 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_call_later
 
-from .config_flow import configured_instances
 from .const import (
     ATTR_LAST_DATA,
     ATTR_MONITORED_CONDITIONS,
@@ -252,9 +251,6 @@ async def async_setup(hass, config):
     # Store config for use during entry setup:
     hass.data[DOMAIN][DATA_CONFIG] = conf
 
-    if conf[CONF_APP_KEY] in configured_instances(hass):
-        return True
-
     hass.async_create_task(
         hass.config_entries.flow.async_init(
             DOMAIN,
@@ -268,6 +264,11 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up the Ambient PWS as config entry."""
+    if not config_entry.unique_id:
+        hass.config_entries.async_update_entry(
+            config_entry, unique_id=config_entry.data[CONF_APP_KEY]
+        )
+
     session = aiohttp_client.async_get_clientsession(hass)
 
     try:

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -5,35 +5,29 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
-from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
 from .const import CONF_APP_KEY, DOMAIN
 
 
-@callback
-def configured_instances(hass):
-    """Return a set of configured Ambient PWS instances."""
-    return set(
-        entry.data[CONF_APP_KEY] for entry in hass.config_entries.async_entries(DOMAIN)
-    )
-
-
-@config_entries.HANDLERS.register(DOMAIN)
-class AmbientStationFlowHandler(config_entries.ConfigFlow):
+class AmbientStationFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle an Ambient PWS config flow."""
 
     VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
-    async def _show_form(self, errors=None):
-        """Show the form to the user."""
-        data_schema = vol.Schema(
+    def __init__(self):
+        """Initialize the config flow."""
+        self.data_schema = vol.Schema(
             {vol.Required(CONF_API_KEY): str, vol.Required(CONF_APP_KEY): str}
         )
 
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, errors=errors if errors else {}
+            step_id="user",
+            data_schema=self.data_schema,
+            errors=errors if errors else {},
         )
 
     async def async_step_import(self, import_config):
@@ -42,12 +36,11 @@ class AmbientStationFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
-
         if not user_input:
             return await self._show_form()
 
-        if user_input[CONF_APP_KEY] in configured_instances(self.hass):
-            return await self._show_form({CONF_APP_KEY: "identifier_exists"})
+        await self.async_set_unique_id(user_input[CONF_APP_KEY])
+        self._abort_if_unique_id_configured()
 
         session = aiohttp_client.async_get_clientsession(self.hass)
         client = Client(user_input[CONF_API_KEY], user_input[CONF_APP_KEY], session)

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers import aiohttp_client
 
-from .const import CONF_APP_KEY, DOMAIN
+from .const import CONF_APP_KEY, DOMAIN  # pylint: disable=unused-import
 
 
 class AmbientStationFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/ambient_station/manifest.json
+++ b/homeassistant/components/ambient_station/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ambient Weather Station",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ambient_station",
-  "requirements": ["aioambient==1.0.2"],
+  "requirements": ["aioambient==1.0.4"],
   "dependencies": [],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/ambient_station/strings.json
+++ b/homeassistant/components/ambient_station/strings.json
@@ -11,9 +11,11 @@
       }
     },
     "error": {
-      "identifier_exists": "Application Key and/or API Key already registered",
       "invalid_key": "Invalid API Key and/or Application Key",
       "no_devices": "No devices found in account"
+    },
+    "abort": {
+      "already_configured": "This app key is already in use."
     }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -136,7 +136,7 @@ aio_geojson_nsw_rfs_incidents==0.3
 aio_georss_gdacs==0.3
 
 # homeassistant.components.ambient_station
-aioambient==1.0.2
+aioambient==1.0.4
 
 # homeassistant.components.asuswrt
 aioasuswrt==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -47,7 +47,7 @@ aio_geojson_nsw_rfs_incidents==0.3
 aio_georss_gdacs==0.3
 
 # homeassistant.components.ambient_station
-aioambient==1.0.2
+aioambient==1.0.4
 
 # homeassistant.components.asuswrt
 aioasuswrt==1.2.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modernizes the Ambient PWS config flow:

* Removes `configured_instances` usage (no longer needed)
* Uses built-in unique ID and abort helpers (instead of custom logic)
* Registers the domain upon config flow definition

Additionally, this PR bumps `aioambient` to 1.0.4.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
