### PR TITLE
Refactor away deprecated homekit_controller test helpers

### DIFF
--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -7,6 +7,7 @@ https://github.com/home-assistant/home-assistant/issues/15336
 from unittest import mock
 
 from aiohomekit import AccessoryDisconnectedError
+from aiohomekit.testing import FakePairing
 
 from homeassistant.components.climate.const import (
     SUPPORT_TARGET_HUMIDITY,
@@ -15,7 +16,6 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 
 from tests.components.homekit_controller.common import (
-    FakePairing,
     Helper,
     device_config_changed,
     setup_accessories_from_file,

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest import mock
 
 from aiohomekit.exceptions import AccessoryDisconnectedError, EncryptionError
+from aiohomekit.testing import FakePairing
 import pytest
 
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
@@ -11,7 +12,6 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 from tests.components.homekit_controller.common import (
-    FakePairing,
     Helper,
     setup_accessories_from_file,
     setup_test_accessories,

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -505,8 +505,11 @@ async def test_parse_new_homekit_json(hass):
     on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0
 
+    accessories = Accessories()
+    accessories.add_accessory(accessory)
+
     fake_controller = await setup_platform(hass)
-    pairing = fake_controller.add([accessory])
+    pairing = await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
     pairing.pairing_data = {"AccessoryPairingID": "00:00:00:00:00:00"}
 
     mock_path = mock.Mock()
@@ -551,8 +554,11 @@ async def test_parse_old_homekit_json(hass):
     on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0
 
+    accessories = Accessories()
+    accessories.add_accessory(accessory)
+
     fake_controller = await setup_platform(hass)
-    pairing = fake_controller.add([accessory])
+    pairing = await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
     pairing.pairing_data = {"AccessoryPairingID": "00:00:00:00:00:00"}
 
     mock_path = mock.Mock()
@@ -601,8 +607,11 @@ async def test_parse_overlapping_homekit_json(hass):
     on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0
 
+    accessories = Accessories()
+    accessories.add_accessory(accessory)
+
     fake_controller = await setup_platform(hass)
-    pairing = fake_controller.add([accessory])
+    pairing = await fake_controller.add_paired_device(accessories)
     pairing.pairing_data = {"AccessoryPairingID": "00:00:00:00:00:00"}
 
     mock_listdir = mock.Mock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This is a test only change to remove some test helper classes - `FakePairing` and `FakeController`. Upstream has better implementations which we are already using in the config flow tests, this just finishes the migration.

This is a precursor to my branch to enable support for HomeKit push events (don't want to re-implement a bunch of test infrastructure downstream).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
