### PR TITLE
Revert "Use orjson to parse json faster (#32153)"

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import json
 import logging
 
-import orjson
 from sqlalchemy import (
     Boolean,
     Column,
@@ -64,7 +63,7 @@ class Events(Base):  # type: ignore
         try:
             return Event(
                 self.event_type,
-                orjson.loads(self.event_data),
+                json.loads(self.event_data),
                 EventOrigin(self.origin),
                 _process_timestamp(self.time_fired),
                 context=context,
@@ -134,7 +133,7 @@ class States(Base):  # type: ignore
             return State(
                 self.entity_id,
                 self.state,
-                orjson.loads(self.attributes),
+                json.loads(self.attributes),
                 _process_timestamp(self.last_changed),
                 _process_timestamp(self.last_updated),
                 context=context,

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -9,7 +9,6 @@ from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
 import async_timeout
-import orjson
 
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, callback
@@ -68,7 +67,6 @@ def async_create_clientsession(
         loop=hass.loop,
         connector=connector,
         headers={USER_AGENT: SERVER_SOFTWARE},
-        json_serialize=lambda x: orjson.dumps(x).decode(),
         **kwargs,
     )
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,6 @@ home-assistant-frontend==20200220.1
 importlib-metadata==1.5.0
 jinja2>=2.10.3
 netdisco==2.6.0
-orjson==2.5.1
 pip>=8.0.3
 python-slugify==4.0.0
 pytz>=2019.03

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -6,8 +6,6 @@ import os
 import tempfile
 from typing import Any, Dict, List, Optional, Type, Union
 
-import orjson
-
 from homeassistant.exceptions import HomeAssistantError
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,7 +28,7 @@ def load_json(
     """
     try:
         with open(filename, encoding="utf-8") as fdesc:
-            return orjson.loads(fdesc.read())  # type: ignore
+            return json.loads(fdesc.read())  # type: ignore
     except FileNotFoundError:
         # This is not a fatal error
         _LOGGER.debug("JSON file not found: %s", filename)
@@ -99,7 +97,7 @@ def find_paths_unserializable_data(bad_data: Any) -> List[str]:
         obj, obj_path = to_process.popleft()
 
         try:
-            orjson.dumps(obj)
+            json.dumps(obj)
             continue
         except TypeError:
             pass
@@ -108,7 +106,7 @@ def find_paths_unserializable_data(bad_data: Any) -> List[str]:
             for key, value in obj.items():
                 try:
                     # Is key valid?
-                    orjson.dumps({key: None})
+                    json.dumps({key: None})
                 except TypeError:
                     invalid.append(f"{obj_path}<key: {key}>")
                 else:

--- a/pylintrc
+++ b/pylintrc
@@ -5,7 +5,7 @@ ignore=tests
 jobs=2
 load-plugins=pylint_strict_informational
 persistent=no
-extension-pkg-whitelist=ciso8601,orjson
+extension-pkg-whitelist=ciso8601
 
 [BASIC]
 good-names=id,i,j,k,ex,Run,_,fp

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -10,7 +10,6 @@ importlib-metadata==1.5.0
 jinja2>=2.10.3
 PyJWT==1.7.1
 cryptography==2.8
-orjson==2.5.1
 pip>=8.0.3
 python-slugify==4.0.0
 pytz>=2019.03

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ REQUIRES = [
     "PyJWT==1.7.1",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==2.8",
-    "orjson==2.5.1",
     "pip>=8.0.3",
     "python-slugify==4.0.0",
     "pytz>=2019.03",


### PR DESCRIPTION
This reverts #32153 (commit 2365e2e8cf60f6e86e9033f27082750526825209)

>Realized this is using Rust, which means a big pain point for the community to install on RPi's in a venv. I will have to revert this PR.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
