### PR TITLE
Modernize WWLLN config flow

### DIFF
--- a/homeassistant/components/wwlln/.translations/en.json
+++ b/homeassistant/components/wwlln/.translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
-        "error": {
-            "identifier_exists": "Location already registered"
+        "abort": {
+            "already_configured": "This location is already registered.",
+            "window_too_small": "A too-small window will cause Home Assistant to miss events."
         },
         "step": {
             "user": {

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -2,39 +2,28 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_RADIUS,
-    CONF_UNIT_SYSTEM,
-    CONF_UNIT_SYSTEM_IMPERIAL,
-    CONF_UNIT_SYSTEM_METRIC,
-)
-from homeassistant.core import callback
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_WINDOW, DEFAULT_RADIUS, DEFAULT_WINDOW, DOMAIN
+from .const import (  # pylint: disable=unused-import
+    CONF_WINDOW,
+    DEFAULT_RADIUS,
+    DEFAULT_WINDOW,
+    DOMAIN,
+    LOGGER,
+)
 
 
-@callback
-def configured_instances(hass):
-    """Return a set of configured WWLLN instances."""
-    return set(
-        "{0}, {1}".format(entry.data[CONF_LATITUDE], entry.data[CONF_LONGITUDE])
-        for entry in hass.config_entries.async_entries(DOMAIN)
-    )
-
-
-@config_entries.HANDLERS.register(DOMAIN)
-class WWLLNFlowHandler(config_entries.ConfigFlow):
+class WWLLNFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a WWLLN config flow."""
 
     VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def _show_form(self, errors=None):
-        """Show the form to the user."""
-        data_schema = vol.Schema(
+    @property
+    def data_schema(self):
+        """Return the data schema for the user form."""
+        return vol.Schema(
             {
                 vol.Optional(
                     CONF_LATITUDE, default=self.hass.config.latitude
@@ -46,12 +35,26 @@ class WWLLNFlowHandler(config_entries.ConfigFlow):
             }
         )
 
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, errors=errors or {}
+            step_id="user", data_schema=self.data_schema, errors=errors or {}
         )
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
+        default_window_seconds = DEFAULT_WINDOW.total_seconds()
+        if (
+            import_config.get(CONF_WINDOW)
+            and import_config[CONF_WINDOW] < default_window_seconds
+        ):
+            LOGGER.error(
+                "Refusing to use too-small window (%s < %s)",
+                import_config[CONF_WINDOW],
+                default_window_seconds,
+            )
+            return self.async_abort(reason="window_too_small")
+
         return await self.async_step_user(import_config)
 
     async def async_step_user(self, user_input=None):
@@ -59,25 +62,22 @@ class WWLLNFlowHandler(config_entries.ConfigFlow):
         if not user_input:
             return await self._show_form()
 
-        identifier = "{0}, {1}".format(
-            user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE]
+        latitude = user_input.get(CONF_LATITUDE, self.hass.config.latitude)
+        longitude = user_input.get(CONF_LONGITUDE, self.hass.config.longitude)
+
+        identifier = f"{latitude}, {longitude}"
+
+        await self.async_set_unique_id(identifier)
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=identifier,
+            data={
+                CONF_LATITUDE: latitude,
+                CONF_LONGITUDE: longitude,
+                CONF_RADIUS: user_input.get(CONF_RADIUS, DEFAULT_RADIUS),
+                CONF_WINDOW: user_input.get(
+                    CONF_WINDOW, DEFAULT_WINDOW.total_seconds()
+                ),
+            },
         )
-        if identifier in configured_instances(self.hass):
-            return await self._show_form({"base": "identifier_exists"})
-
-        if self.hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL:
-            user_input[CONF_UNIT_SYSTEM] = CONF_UNIT_SYSTEM_IMPERIAL
-        else:
-            user_input[CONF_UNIT_SYSTEM] = CONF_UNIT_SYSTEM_METRIC
-
-        # When importing from `configuration.yaml`, we give the user
-        # flexibility by allowing the `window` parameter to be any type
-        # of time period. This will always return a timedelta; unfortunately,
-        # timedeltas aren't JSON-serializable, so we can't store them in a
-        # config entry as-is; instead, we save the total seconds as an int:
-        if CONF_WINDOW in user_input:
-            user_input[CONF_WINDOW] = user_input[CONF_WINDOW].total_seconds()
-        else:
-            user_input[CONF_WINDOW] = DEFAULT_WINDOW.total_seconds()
-
-        return self.async_create_entry(title=identifier, data=user_input)

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -45,7 +45,7 @@ class WWLLNFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a config entry from configuration.yaml."""
         default_window_seconds = DEFAULT_WINDOW.total_seconds()
         if (
-            import_config.get(CONF_WINDOW)
+            CONF_WINDOW in import_config
             and import_config[CONF_WINDOW] < default_window_seconds
         ):
             LOGGER.error(

--- a/homeassistant/components/wwlln/const.py
+++ b/homeassistant/components/wwlln/const.py
@@ -1,5 +1,8 @@
 """Define constants for the WWLLN integration."""
 from datetime import timedelta
+import logging
+
+LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "wwlln"
 

--- a/homeassistant/components/wwlln/geo_location.py
+++ b/homeassistant/components/wwlln/geo_location.py
@@ -1,6 +1,5 @@
 """Support for WWLLN geo location events."""
 from datetime import timedelta
-import logging
 
 from aiowwlln.errors import WWLLNError
 
@@ -10,7 +9,6 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_RADIUS,
-    CONF_UNIT_SYSTEM,
     CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
@@ -23,9 +21,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.dt import utc_from_timestamp
 
-from .const import CONF_WINDOW, DATA_CLIENT, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .const import CONF_WINDOW, DATA_CLIENT, DOMAIN, LOGGER
 
 ATTR_EXTERNAL_ID = "external_id"
 ATTR_PUBLICATION_DATE = "publication_date"
@@ -49,7 +45,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entry.data[CONF_LONGITUDE],
         entry.data[CONF_RADIUS],
         entry.data[CONF_WINDOW],
-        entry.data[CONF_UNIT_SYSTEM],
     )
     await manager.async_init()
 
@@ -66,7 +61,6 @@ class WWLLNEventManager:
         longitude,
         radius,
         window_seconds,
-        unit_system,
     ):
         """Initialize."""
         self._async_add_entities = async_add_entities
@@ -79,8 +73,7 @@ class WWLLNEventManager:
         self._strikes = {}
         self._window = timedelta(seconds=window_seconds)
 
-        self._unit_system = unit_system
-        if unit_system == CONF_UNIT_SYSTEM_IMPERIAL:
+        if hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL:
             self._unit = LENGTH_MILES
         else:
             self._unit = LENGTH_KILOMETERS
@@ -88,7 +81,7 @@ class WWLLNEventManager:
     @callback
     def _create_events(self, ids_to_create):
         """Create new geo location events."""
-        _LOGGER.debug("Going to create %s", ids_to_create)
+        LOGGER.debug("Going to create %s", ids_to_create)
         events = []
         for strike_id in ids_to_create:
             strike = self._strikes[strike_id]
@@ -107,7 +100,7 @@ class WWLLNEventManager:
     @callback
     def _remove_events(self, ids_to_remove):
         """Remove old geo location events."""
-        _LOGGER.debug("Going to remove %s", ids_to_remove)
+        LOGGER.debug("Going to remove %s", ids_to_remove)
         for strike_id in ids_to_remove:
             async_dispatcher_send(self._hass, SIGNAL_DELETE_ENTITY.format(strike_id))
 
@@ -123,18 +116,18 @@ class WWLLNEventManager:
 
     async def async_update(self):
         """Refresh data."""
-        _LOGGER.debug("Refreshing WWLLN data")
+        LOGGER.debug("Refreshing WWLLN data")
 
         try:
             self._strikes = await self._client.within_radius(
                 self._latitude,
                 self._longitude,
                 self._radius,
-                unit=self._unit_system,
+                unit=self._hass.config.units.name,
                 window=self._window,
             )
         except WWLLNError as err:
-            _LOGGER.error("Error while updating WWLLN data: %s", err)
+            LOGGER.error("Error while updating WWLLN data: %s", err)
             return
 
         new_strike_ids = set(self._strikes)

--- a/homeassistant/components/wwlln/strings.json
+++ b/homeassistant/components/wwlln/strings.json
@@ -11,8 +11,9 @@
         }
       }
     },
-    "error": {
-      "identifier_exists": "Location already registered"
+    "abort": {
+      "already_configured": "This location is already registered.",
+      "window_too_small": "A too-small window will cause Home Assistant to miss events."
     }
   }
 }

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -7,9 +7,8 @@ from homeassistant.components.wwlln import (
     DATA_CLIENT,
     DOMAIN,
     async_setup_entry,
-    config_flow,
 )
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 
 from tests.common import MockConfigEntry
@@ -33,11 +32,9 @@ async def test_duplicate_error(hass, config_entry):
 
 async def test_show_form(hass):
     """Test that the form is served with no input."""
-    flow = config_flow.WWLLNFlowHandler()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_USER}
-
-    result = await flow.async_step_user(user_input=None)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER},
+    )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
@@ -51,11 +48,10 @@ async def test_step_import(hass):
         CONF_RADIUS: 25,
     }
 
-    flow = config_flow.WWLLNFlowHandler()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_USER}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+    )
 
-    result = await flow.async_step_import(import_config=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "39.128712, -104.9812612"
     assert result["data"] == {
@@ -75,11 +71,10 @@ async def test_step_import_too_small_window(hass):
         CONF_WINDOW: 60,
     }
 
-    flow = config_flow.WWLLNFlowHandler()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_USER}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+    )
 
-    result = await flow.async_step_import(import_config=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "window_too_small"
 
@@ -88,11 +83,10 @@ async def test_step_user(hass):
     """Test that the user step works."""
     conf = {CONF_LATITUDE: 39.128712, CONF_LONGITUDE: -104.9812612, CONF_RADIUS: 25}
 
-    flow = config_flow.WWLLNFlowHandler()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_USER}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
 
-    result = await flow.async_step_user(user_input=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "39.128712, -104.9812612"
     assert result["data"] == {
@@ -111,11 +105,10 @@ async def test_different_unit_system(hass):
         CONF_RADIUS: 25,
     }
 
-    flow = config_flow.WWLLNFlowHandler()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_USER}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
 
-    result = await flow.async_step_user(user_input=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "39.128712, -104.9812612"
     assert result["data"] == {
@@ -135,11 +128,10 @@ async def test_custom_window(hass):
         CONF_WINDOW: 7200,
     }
 
-    flow = config_flow.WWLLNFlowHandler()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_USER}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
 
-    result = await flow.async_step_user(user_input=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "39.128712, -104.9812612"
     assert result["data"] == {

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -1,6 +1,4 @@
 """Define tests for the WWLLN config flow."""
-from datetime import timedelta
-
 from asynctest import patch
 
 from homeassistant import data_entry_flow
@@ -11,30 +9,33 @@ from homeassistant.components.wwlln import (
     async_setup_entry,
     config_flow,
 )
-from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_RADIUS,
-    CONF_UNIT_SYSTEM,
-)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
+
+from tests.common import MockConfigEntry
 
 
 async def test_duplicate_error(hass, config_entry):
     """Test that errors are shown when duplicates are added."""
     conf = {CONF_LATITUDE: 39.128712, CONF_LONGITUDE: -104.9812612, CONF_RADIUS: 25}
 
-    config_entry.add_to_hass(hass)
-    flow = config_flow.WWLLNFlowHandler()
-    flow.hass = hass
+    MockConfigEntry(
+        domain=DOMAIN, unique_id="39.128712, -104.9812612", data=conf
+    ).add_to_hass(hass)
 
-    result = await flow.async_step_user(user_input=conf)
-    assert result["errors"] == {"base": "identifier_exists"}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_show_form(hass):
     """Test that the form is served with no input."""
     flow = config_flow.WWLLNFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     result = await flow.async_step_user(user_input=None)
 
@@ -44,18 +45,15 @@ async def test_show_form(hass):
 
 async def test_step_import(hass):
     """Test that the import step works."""
-    # `configuration.yaml` will always return a timedelta for the `window`
-    # parameter, FYI:
     conf = {
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
-        CONF_UNIT_SYSTEM: "metric",
-        CONF_WINDOW: timedelta(minutes=10),
     }
 
     flow = config_flow.WWLLNFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     result = await flow.async_step_import(import_config=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -64,9 +62,26 @@ async def test_step_import(hass):
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
-        CONF_UNIT_SYSTEM: "metric",
-        CONF_WINDOW: 600.0,
+        CONF_WINDOW: 3600.0,
     }
+
+
+async def test_step_import_too_small_window(hass):
+    """Test that the import step with a too-small window is aborted."""
+    conf = {
+        CONF_LATITUDE: 39.128712,
+        CONF_LONGITUDE: -104.9812612,
+        CONF_RADIUS: 25,
+        CONF_WINDOW: 60,
+    }
+
+    flow = config_flow.WWLLNFlowHandler()
+    flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
+
+    result = await flow.async_step_import(import_config=conf)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "window_too_small"
 
 
 async def test_step_user(hass):
@@ -75,6 +90,7 @@ async def test_step_user(hass):
 
     flow = config_flow.WWLLNFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     result = await flow.async_step_user(user_input=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -83,7 +99,29 @@ async def test_step_user(hass):
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
-        CONF_UNIT_SYSTEM: "metric",
+        CONF_WINDOW: 3600.0,
+    }
+
+
+async def test_different_unit_system(hass):
+    """Test that the config flow picks up the HASS unit system."""
+    conf = {
+        CONF_LATITUDE: 39.128712,
+        CONF_LONGITUDE: -104.9812612,
+        CONF_RADIUS: 25,
+    }
+
+    flow = config_flow.WWLLNFlowHandler()
+    flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
+
+    result = await flow.async_step_user(user_input=conf)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "39.128712, -104.9812612"
+    assert result["data"] == {
+        CONF_LATITUDE: 39.128712,
+        CONF_LONGITUDE: -104.9812612,
+        CONF_RADIUS: 25,
         CONF_WINDOW: 3600.0,
     }
 
@@ -94,11 +132,12 @@ async def test_custom_window(hass):
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
-        CONF_WINDOW: timedelta(hours=2),
+        CONF_WINDOW: 7200,
     }
 
     flow = config_flow.WWLLNFlowHandler()
     flow.hass = hass
+    flow.context = {"source": SOURCE_USER}
 
     result = await flow.async_step_user(user_input=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -107,7 +146,6 @@ async def test_custom_window(hass):
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
-        CONF_UNIT_SYSTEM: "metric",
         CONF_WINDOW: 7200,
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modernizes the `wwlln` config flow by making the following improvements:

* Removes configured_instances usage (no longer needed)
* Uses built-in unique ID and abort helpers (instead of custom logic)
* Registers the domain upon config flow definition
* Removes storage of unit system (since that can be retrieved via `hass.config`)
* Improves how the config entry stores data (less unnecessary type-casting)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
wwlln:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
