### PR TITLE
Use mujson to dynamically choose the fastest available json library

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import json
 import logging
 
+import mujson
 from sqlalchemy import (
     Boolean,
     Column,
@@ -63,13 +64,13 @@ class Events(Base):  # type: ignore
         try:
             return Event(
                 self.event_type,
-                json.loads(self.event_data),
+                mujson.loads(self.event_data),
                 EventOrigin(self.origin),
                 _process_timestamp(self.time_fired),
                 context=context,
             )
         except ValueError:
-            # When json.loads fails
+            # When mujson.loads fails
             _LOGGER.exception("Error converting to event: %s", self)
             return None
 
@@ -133,7 +134,7 @@ class States(Base):  # type: ignore
             return State(
                 self.entity_id,
                 self.state,
-                json.loads(self.attributes),
+                mujson.loads(self.attributes),
                 _process_timestamp(self.last_changed),
                 _process_timestamp(self.last_updated),
                 context=context,
@@ -142,7 +143,7 @@ class States(Base):  # type: ignore
                 temp_invalid_id_bypass=True,
             )
         except ValueError:
-            # When json.loads fails
+            # When mujson.loads fails
             _LOGGER.exception("Error converting row to state: %s", self)
             return None
 

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -9,6 +9,7 @@ from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
 import async_timeout
+import mujson
 
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, callback
@@ -61,12 +62,18 @@ def async_create_clientsession(
 
     This method must be run in the event loop.
     """
+
+    def json_dumps_str(obj: Any) -> Any:
+        res = mujson.dumps(obj)
+        return res if isinstance(res, str) else res.decode()
+
     connector = _async_get_connector(hass, verify_ssl)
 
     clientsession = aiohttp.ClientSession(
         loop=hass.loop,
         connector=connector,
         headers={USER_AGENT: SERVER_SOFTWARE},
+        json_serialize=json_dumps_str,
         **kwargs,
     )
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,6 +15,7 @@ hass-nabucasa==0.31
 home-assistant-frontend==20200220.1
 importlib-metadata==1.5.0
 jinja2>=2.10.3
+mujson==1.4
 netdisco==2.6.0
 pip>=8.0.3
 python-slugify==4.0.0
@@ -23,6 +24,7 @@ pyyaml==5.3
 requests==2.23.0
 ruamel.yaml==0.15.100
 sqlalchemy==1.3.13
+ujson==1.35
 voluptuous-serialize==2.3.0
 voluptuous==0.11.7
 zeroconf==0.24.4

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -6,6 +6,8 @@ import os
 import tempfile
 from typing import Any, Dict, List, Optional, Type, Union
 
+import mujson
+
 from homeassistant.exceptions import HomeAssistantError
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,7 +30,7 @@ def load_json(
     """
     try:
         with open(filename, encoding="utf-8") as fdesc:
-            return json.loads(fdesc.read())  # type: ignore
+            return mujson.loads(fdesc.read())  # type: ignore
     except FileNotFoundError:
         # This is not a fatal error
         _LOGGER.debug("JSON file not found: %s", filename)
@@ -97,7 +99,7 @@ def find_paths_unserializable_data(bad_data: Any) -> List[str]:
         obj, obj_path = to_process.popleft()
 
         try:
-            json.dumps(obj)
+            mujson.dumps(obj)
             continue
         except TypeError:
             pass
@@ -106,7 +108,7 @@ def find_paths_unserializable_data(bad_data: Any) -> List[str]:
             for key, value in obj.items():
                 try:
                     # Is key valid?
-                    json.dumps({key: None})
+                    mujson.dumps({key: None})
                 except TypeError:
                     invalid.append(f"{obj_path}<key: {key}>")
                 else:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -10,6 +10,8 @@ importlib-metadata==1.5.0
 jinja2>=2.10.3
 PyJWT==1.7.1
 cryptography==2.8
+mujson==1.4
+ujson==1.35
 pip>=8.0.3
 python-slugify==4.0.0
 pytz>=2019.03

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ REQUIRES = [
     "PyJWT==1.7.1",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==2.8",
+    "mujson==1.4",
+    "ujson==1.35",
     "pip>=8.0.3",
     "python-slugify==4.0.0",
     "pytz>=2019.03",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Let's try something else with #32153 which was reverted in #32185. 

`mujson` (https://github.com/mattgiles/mujson) can dynamically select what is the fastest available json library for particular operation (it checks that library function has all kwargs which are passed to the call).

`ujson` (https://pypi.org/project/ujson/) is a simple C extension which can be easily built on any platform including RPi. It's a bit slower thatn `orjson` which I used before but significantly faster than standard `json`.

Users who want to get extra performance from hass can install `orjson` manually and it will be used by `mujson`.

### ujson
<img width="960" alt="Screen Shot 2020-02-26 at 12 15 43 AM" src="https://user-images.githubusercontent.com/3767331/75299599-676a1700-582d-11ea-9fbc-c62ace8c0413.png">

### orjson
<img width="1227" alt="Screen Shot 2020-02-26 at 12 09 28 AM" src="https://user-images.githubusercontent.com/3767331/75299581-5ae5be80-582d-11ea-9d95-66c7498add9a.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
