### PR TITLE
Add sighthound timestamped file

### DIFF
--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -66,7 +66,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             camera[CONF_ENTITY_ID],
             camera.get(CONF_NAME),
             save_file_folder,
-            config.get(CONF_SAVE_TIMESTAMPTED_FILE),
+            config[CONF_SAVE_TIMESTAMPTED_FILE],
         )
         entities.append(sighthound)
     add_entities(entities)

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -3,7 +3,7 @@ import io
 import logging
 from pathlib import Path
 
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, UnidentifiedImageError
 import simplehound.core as hound
 import voluptuous as vol
 
@@ -17,6 +17,7 @@ from homeassistant.components.image_processing import (
 from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY
 from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 from homeassistant.util.pil import draw_box
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,6 +28,8 @@ ATTR_BOUNDING_BOX = "bounding_box"
 ATTR_PEOPLE = "people"
 CONF_ACCOUNT_TYPE = "account_type"
 CONF_SAVE_FILE_FOLDER = "save_file_folder"
+CONF_SAVE_TIMESTAMPTED_FILE = "save_timestamped_file"
+DATETIME_FORMAT = "%Y-%m-%d_%H:%M:%S"
 DEV = "dev"
 PROD = "prod"
 
@@ -35,6 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_API_KEY): cv.string,
         vol.Optional(CONF_ACCOUNT_TYPE, default=DEV): vol.In([DEV, PROD]),
         vol.Optional(CONF_SAVE_FILE_FOLDER): cv.isdir,
+        vol.Optional(CONF_SAVE_TIMESTAMPTED_FILE, default=False): cv.boolean,
     }
 )
 
@@ -58,7 +62,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     entities = []
     for camera in config[CONF_SOURCE]:
         sighthound = SighthoundEntity(
-            api, camera[CONF_ENTITY_ID], camera.get(CONF_NAME), save_file_folder
+            api,
+            camera[CONF_ENTITY_ID],
+            camera.get(CONF_NAME),
+            save_file_folder,
+            config.get(CONF_SAVE_TIMESTAMPTED_FILE),
         )
         entities.append(sighthound)
     add_entities(entities)
@@ -67,7 +75,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class SighthoundEntity(ImageProcessingEntity):
     """Create a sighthound entity."""
 
-    def __init__(self, api, camera_entity, name, save_file_folder):
+    def __init__(
+        self, api, camera_entity, name, save_file_folder, save_timestamped_file
+    ):
         """Init."""
         self._api = api
         self._camera = camera_entity
@@ -77,15 +87,19 @@ class SighthoundEntity(ImageProcessingEntity):
             camera_name = split_entity_id(camera_entity)[1]
             self._name = f"sighthound_{camera_name}"
         self._state = None
+        self._last_detection = None
         self._image_width = None
         self._image_height = None
         self._save_file_folder = save_file_folder
+        self._save_timestamped_file = save_timestamped_file
 
     def process_image(self, image):
         """Process an image."""
         detections = self._api.detect(image)
         people = hound.get_people(detections)
         self._state = len(people)
+        if self._state > 0:
+            self._last_detection = dt_util.now().strftime(DATETIME_FORMAT)
 
         metadata = hound.get_metadata(detections)
         self._image_width = metadata["image_width"]
@@ -109,7 +123,11 @@ class SighthoundEntity(ImageProcessingEntity):
 
     def save_image(self, image, people, directory):
         """Save a timestamped image with bounding boxes around targets."""
-        img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
+        try:
+            img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
+        except UnidentifiedImageError:
+            _LOGGER.warning("Unable to process image, bad data")
+            return
         draw = ImageDraw.Draw(img)
 
         for person in people:
@@ -117,8 +135,14 @@ class SighthoundEntity(ImageProcessingEntity):
                 person["boundingBox"], self._image_width, self._image_height
             )
             draw_box(draw, box, self._image_width, self._image_height)
+
         latest_save_path = directory / f"{self._name}_latest.jpg"
         img.save(latest_save_path)
+
+        if self._save_timestamped_file:
+            timestamp_save_path = directory / f"{self._name}_{self._last_detection}.jpg"
+            img.save(timestamp_save_path)
+            _LOGGER.info("Sighthound saved file %s", timestamp_save_path)
 
     @property
     def camera_entity(self):
@@ -144,3 +168,11 @@ class SighthoundEntity(ImageProcessingEntity):
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         return ATTR_PEOPLE
+
+    @property
+    def device_state_attributes(self):
+        """Return the attributes."""
+        attr = {}
+        if self._last_detection:
+            attr["last_person"] = self._last_detection
+        return attr

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -126,7 +126,7 @@ class SighthoundEntity(ImageProcessingEntity):
         try:
             img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
         except UnidentifiedImageError:
-            _LOGGER.warning("Unable to process image, bad data")
+            _LOGGER.warning("Sighthound unable to process image, bad data")
             return
         draw = ImageDraw.Draw(img)
 

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -130,16 +130,10 @@ async def test_catch_bad_image(
     await async_setup_component(hass, ip.DOMAIN, valid_config_save_file)
     assert hass.states.get(VALID_ENTITY_ID)
 
-    with mock.patch(
-        "homeassistant.components.sighthound.image_processing.Image.open"
-    ) as pil_img_open:
-        pil_img = pil_img_open.return_value
-        pil_img = pil_img.convert.return_value
-        data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
-        await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
-        await hass.async_block_till_done()
-        assert pil_img.save.call_count == 0
-        assert "Sighthound unable to process image" in caplog.text
+    data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
+    await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
+    await hass.async_block_till_done()
+    assert "Sighthound unable to process image" in caplog.text
 
 
 async def test_save_image(hass, mock_image, mock_detections):

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -115,3 +115,24 @@ async def test_save_image(hass, mock_image, mock_detections):
         state = hass.states.get(VALID_ENTITY_ID)
         assert state.state == "2"
         assert pil_img.save.call_count == 1
+
+
+async def test_save_timestamped_image(hass, mock_image, mock_detections):
+    """Save a processed image."""
+    valid_config_save_ts_file = deepcopy(VALID_CONFIG)
+    valid_config_save_ts_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
+    valid_config_save_ts_file[ip.DOMAIN].update({sh.CONF_SAVE_TIMESTAMPTED_FILE: True})
+    await async_setup_component(hass, ip.DOMAIN, valid_config_save_ts_file)
+    assert hass.states.get(VALID_ENTITY_ID)
+
+    with patch(
+        "homeassistant.components.sighthound.image_processing.Image.open"
+    ) as pil_img_open:
+        pil_img = pil_img_open.return_value
+        pil_img = pil_img.convert.return_value
+        data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
+        await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
+        await hass.async_block_till_done()
+        state = hass.states.get(VALID_ENTITY_ID)
+        assert state.state == "2"
+        assert pil_img.save.call_count == 2

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -125,7 +125,9 @@ async def test_catch_bad_image(
     hass, caplog, mock_image, mock_detections, mock_bad_image_data
 ):
     """Process an image."""
-    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    valid_config_save_file = deepcopy(VALID_CONFIG)
+    valid_config_save_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
+    await async_setup_component(hass, ip.DOMAIN, valid_config_save_file)
     assert hass.states.get(VALID_ENTITY_ID)
 
     with mock.patch(


### PR DESCRIPTION
## Proposed change
Adds optional saving of a timestamped file, which is useful for reviewing historical processing. Additionally adds a `last person` detection time attribute.
Finally, we are catching bad image data and blocking processing in that case.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
image_processing:
  - platform: sighthound
    api_key: my_key
    save_file_folder: /config/www/
    save_timestamped_file: True
    source:
      - entity_id: camera.local_file
```

## Additional information
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/12183

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
