### PR TITLE
Explicitly set unique ids for GDACS integration

### DIFF
--- a/homeassistant/components/gdacs/__init__.py
+++ b/homeassistant/components/gdacs/__init__.py
@@ -194,7 +194,11 @@ class GdacsFeedEntityManager:
     async def _generate_entity(self, external_id):
         """Generate new entity."""
         async_dispatcher_send(
-            self._hass, self.async_event_new_entity(), self, external_id
+            self._hass,
+            self.async_event_new_entity(),
+            self,
+            self._config_entry.title,
+            external_id,
         )
 
     async def _update_entity(self, external_id):

--- a/homeassistant/components/gdacs/__init__.py
+++ b/homeassistant/components/gdacs/__init__.py
@@ -197,7 +197,7 @@ class GdacsFeedEntityManager:
             self._hass,
             self.async_event_new_entity(),
             self,
-            self._config_entry.title,
+            self._config_entry.unique_id,
             external_id,
         )
 

--- a/homeassistant/components/gdacs/geo_location.py
+++ b/homeassistant/components/gdacs/geo_location.py
@@ -55,9 +55,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
     manager = hass.data[DOMAIN][FEED][entry.entry_id]
 
     @callback
-    def async_add_geolocation(feed_manager, external_id):
+    def async_add_geolocation(feed_manager, integration_id, external_id):
         """Add gelocation entity from feed."""
-        new_entity = GdacsEvent(feed_manager, external_id)
+        new_entity = GdacsEvent(feed_manager, integration_id, external_id)
         _LOGGER.debug("Adding geolocation %s", new_entity)
         async_add_entities([new_entity], True)
 
@@ -75,9 +75,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class GdacsEvent(GeolocationEvent):
     """This represents an external event with GDACS feed data."""
 
-    def __init__(self, feed_manager, external_id):
+    def __init__(self, feed_manager, integration_id, external_id):
         """Initialize entity with data from feed entry."""
         self._feed_manager = feed_manager
+        self._integration_id = integration_id
         self._external_id = external_id
         self._title = None
         self._distance = None
@@ -171,6 +172,11 @@ class GdacsEvent(GeolocationEvent):
         if isinstance(self._vulnerability, float):
             self._vulnerability = round(self._vulnerability, 1)
         self._version = feed_entry.version
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID containing latitude/longitude and external id."""
+        return f"{self._integration_id}_{self._external_id}"
 
     @property
     def icon(self):

--- a/homeassistant/components/gdacs/sensor.py
+++ b/homeassistant/components/gdacs/sensor.py
@@ -108,6 +108,11 @@ class GdacsSensor(Entity):
         return self._total
 
     @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID containing latitude/longitude."""
+        return self.name
+
+    @property
     def name(self) -> Optional[str]:
         """Return the name of the entity."""
         return f"GDACS ({self._config_title})"

--- a/homeassistant/components/gdacs/sensor.py
+++ b/homeassistant/components/gdacs/sensor.py
@@ -28,7 +28,7 @@ PARALLEL_UPDATES = 0
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the GDACS Feed platform."""
     manager = hass.data[DOMAIN][FEED][entry.entry_id]
-    sensor = GdacsSensor(entry.entry_id, entry.title, manager)
+    sensor = GdacsSensor(entry.entry_id, entry.unique_id, entry.title, manager)
     async_add_entities([sensor])
     _LOGGER.debug("Sensor setup done")
 
@@ -36,9 +36,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class GdacsSensor(Entity):
     """This is a status sensor for the GDACS integration."""
 
-    def __init__(self, config_entry_id, config_title, manager):
+    def __init__(self, config_entry_id, config_unique_id, config_title, manager):
         """Initialize entity."""
         self._config_entry_id = config_entry_id
+        self._config_unique_id = config_unique_id
         self._config_title = config_title
         self._manager = manager
         self._status = None
@@ -110,7 +111,7 @@ class GdacsSensor(Entity):
     @property
     def unique_id(self) -> Optional[str]:
         """Return a unique ID containing latitude/longitude."""
-        return self.name
+        return self._config_unique_id
 
     @property
     def name(self) -> Optional[str]:


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the missing implementation of having unique IDs for the new GDACS integration. This overrides `unique_id` for sensor and geolocation entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
gdacs:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to ~~issue~~ PR: https://github.com/home-assistant/home-assistant/pull/31235
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
