### PR TITLE
homekit_controller test cleanups

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -3,7 +3,6 @@ import asyncio
 import datetime
 import logging
 
-from aiohomekit.controller.ip import IpPairing
 from aiohomekit.exceptions import (
     AccessoryDisconnectedError,
     AccessoryNotFoundError,
@@ -15,7 +14,7 @@ from aiohomekit.model.services import ServicesTypes
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN, ENTITY_MAP, HOMEKIT_ACCESSORY_DISPATCH
+from .const import CONTROLLER, DOMAIN, ENTITY_MAP, HOMEKIT_ACCESSORY_DISPATCH
 
 DEFAULT_SCAN_INTERVAL = datetime.timedelta(seconds=60)
 RETRY_INTERVAL = 60  # seconds
@@ -66,7 +65,9 @@ class HKDevice:
         # don't want to mutate a dict owned by a config entry.
         self.pairing_data = pairing_data.copy()
 
-        self.pairing = IpPairing(self.pairing_data)
+        self.pairing = hass.data[CONTROLLER].load_pairing(
+            self.pairing_data["AccessoryPairingID"], self.pairing_data
+        )
 
         self.accessories = {}
         self.config_num = 0

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.11"],
+  "requirements": ["aiohomekit[IP]==0.2.15"],
   "dependencies": [],
   "zeroconf": ["_hap._tcp.local."],
   "codeowners": ["@Jc2k"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -163,7 +163,7 @@ aioftp==0.12.0
 aioharmony==0.1.13
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.11
+aiohomekit[IP]==0.2.15
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,7 +62,7 @@ aiobotocore==0.11.1
 aioesphomeapi==2.6.1
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.11
+aiohomekit[IP]==0.2.15
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -98,11 +98,8 @@ async def setup_test_accessories(hass, accessories):
     )
     config_entry.add_to_hass(hass)
 
-    pairing_cls_loc = "homeassistant.components.homekit_controller.connection.IpPairing"
-    with mock.patch(pairing_cls_loc) as pairing_cls:
-        pairing_cls.return_value = pairing
-        await config_entry.async_setup(hass)
-        await hass.async_block_till_done()
+    await config_entry.async_setup(hass)
+    await hass.async_block_till_done()
 
     return config_entry, pairing
 

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -149,14 +149,8 @@ async def test_ecobee3_setup_connection_failure(hass):
     # a successful setup.
 
     # We just advance time by 5 minutes so that the retry happens, rather
-    # than manually invoking async_setup_entry - this means we need to
-    # make sure the IpPairing mock is in place or we'll try to connect to
-    # a real device. Normally this mocking is done by the helper in
-    # setup_test_accessories.
-    pairing_cls_loc = "homeassistant.components.homekit_controller.connection.IpPairing"
-    with mock.patch(pairing_cls_loc) as pairing_cls:
-        pairing_cls.return_value = pairing
-        await time_changed(hass, 5 * 60)
+    # than manually invoking async_setup_entry.
+    await time_changed(hass, 5 * 60)
 
     climate = entity_registry.async_get("climate.homew")
     assert climate.unique_id == "homekit-123456789012-16"


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is just another small test cleanup before converting homekit_controller to be a local push integration. Now that we are using the test helpers from upstream we don't need to patch `IpPairing` away ourselves (as long as we use `Controller.load_data` when initialising an accessory rather than manually creating the pairing object).

This bumps `aiohomekit` for the test helper improvements.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
