### PR TITLE
Make homekit_controller a local push integration

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -46,10 +46,12 @@ class HomeKitEntity(Entity):
         )
 
         self._accessory.add_pollable_characteristics(self.pollable_characteristics)
+        self._accessory.add_watchable_characteristics(self.watchable_characteristics)
 
     async def async_will_remove_from_hass(self):
         """Prepare to be removed from hass."""
         self._accessory.remove_pollable_characteristics(self._aid)
+        self._accessory.remove_watchable_characteristics(self._aid)
 
         for signal_remove in self._signals:
             signal_remove()
@@ -71,6 +73,7 @@ class HomeKitEntity(Entity):
         characteristic_types = [get_uuid(c) for c in self.get_characteristic_types()]
 
         self.pollable_characteristics = []
+        self.watchable_characteristics = []
         self._chars = {}
         self._char_names = {}
 
@@ -97,6 +100,10 @@ class HomeKitEntity(Entity):
         # Build up a list of (aid, iid) tuples to poll on update()
         if "pr" in char["perms"]:
             self.pollable_characteristics.append((self._aid, char["iid"]))
+
+        # Build up a list of (aid, iid) tuples to subscribe to
+        if "ev" in char["perms"]:
+            self.watchable_characteristics.append((self._aid, char["iid"]))
 
         # Build a map of ctype -> iid
         short_name = CharacteristicsTypes.get_short(char["type"])

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -81,7 +81,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
     """Handle a HomeKit config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     def __init__(self):
         """Initialize the homekit_controller flow."""

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -40,6 +40,11 @@ class Helper:
                 char_name = CharacteristicsTypes.get_short(char.type)
                 self.characteristics[(service_name, char_name)] = char
 
+    async def update_named_service(self, service, characteristics):
+        """Update a service."""
+        self.pairing.testing.update_named_service(service, characteristics)
+        await self.hass.async_block_till_done()
+
     async def poll_and_get_state(self):
         """Trigger a time based poll and return the current entity state."""
         await time_changed(self.hass, 60)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Now that we are using aiohomekit for homekit_controller this PR enables events. This means that accessories can now push their state changes to Home Assistant over an open HomeKit secure session as they happen. In my testing with a Phillips Hue this is near instantaneous.

We added the framework for injecting state changes from events many cycles ago (`HKDevice.process_new_events`) so this ends up being quite a modest change now we aren't restrained by a blocking client.

Polling still occurs (for now) as not all characteristics support events and it seemed like a good idea to make sure we didn't "miss" any events. There are also edge cases where e.g. a device is unavailable and then becomes available - these might not trigger events. Hybrid push/poll  minimizes the impact of these sorts of issues.

~NOTE: This is currently behind #32212 in my patch queue. The intention is that it can be reviewed seperately to 5d31f95. I will rebase it and remove the WIP tags after that is merged.~
  
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
