### PR TITLE
Bump simplisafe-python to 9.0.0

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -154,6 +154,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 @callback
 def _async_save_refresh_token(hass, config_entry, token):
+    """Save a refresh token to the config entry."""
     hass.config_entries.async_update_entry(
         config_entry, data={**config_entry.data, CONF_TOKEN: token}
     )
@@ -501,12 +502,7 @@ class SimpliSafe:
                 _LOGGER.error("Unknown error while updating: %s", result)
                 return
 
-        if self._api.refresh_token_dirty:
-            # Reconnect the websocket:
-            await self._api.websocket.async_disconnect()
-            await self._api.websocket.async_connect()
-
-            # Save the new refresh token:
+        if self._api.refresh_token != self._config_entry.data[CONF_TOKEN]:
             _async_save_refresh_token(
                 self._hass, self._config_entry, self._api.refresh_token
             )

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==8.1.1"],
+  "requirements": ["simplisafe-python==9.0.0"],
   "dependencies": [],
   "codeowners": ["@bachya"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1831,7 +1831,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==8.1.1
+simplisafe-python==9.0.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -629,7 +629,7 @@ sentry-sdk==0.13.5
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==8.1.1
+simplisafe-python==9.0.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per [@pvizeli's request](https://github.com/home-assistant/home-assistant/pull/32199#pullrequestreview-364817740) in https://github.com/home-assistant/home-assistant/pull/32199, this PR bumps [`simplisafe-python`](https://github.com/bachya/simplisafe-python) to 9.0.0 (changelog: https://github.com/bachya/simplisafe-python/releases/tag/9.0.0). Tactically, this relieves HASS of the burden of re-establishing a SimpliSafe websocket connection when the access token refreshes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
       password: !secret simplisafe_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
