### PR TITLE
Mark clients away if they have never been seen.

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -200,6 +200,11 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
 
         else:
             self.wired_bug = None
+
+            # A client that has never been seen cannot be connected.
+            if self.client.last_seen is None:
+                return False
+
             since_last_seen = dt_util.utcnow() - dt_util.utc_from_timestamp(
                 float(self.client.last_seen)
             )

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -54,6 +54,14 @@ CLIENT_4 = {
     "last_seen": 1562600145,
     "mac": "00:00:00:00:00:04",
 }
+CLIENT_5 = {
+    "essid": "ssid",
+    "hostname": "client_5",
+    "ip": "10.0.0.5",
+    "is_wired": True,
+    "last_seen": None,
+    "mac": "00:00:00:00:00:05",
+}
 
 DEVICE_1 = {
     "board_rev": 3,
@@ -111,11 +119,11 @@ async def test_tracked_devices(hass):
     controller = await setup_unifi_integration(
         hass,
         options={CONF_SSID_FILTER: ["ssid"]},
-        clients_response=[CLIENT_1, CLIENT_2, CLIENT_3, client_4_copy],
+        clients_response=[CLIENT_1, CLIENT_2, CLIENT_3, CLIENT_5, client_4_copy],
         devices_response=[DEVICE_1, DEVICE_2],
         known_wireless_clients=(CLIENT_4["mac"],),
     )
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 7
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -133,6 +141,11 @@ async def test_tracked_devices(hass):
     client_4 = hass.states.get("device_tracker.client_4")
     assert client_4 is not None
     assert client_4.state == "not_home"
+
+    # A client that has never been seen should be marked away.
+    client_5 = hass.states.get("device_tracker.client_5")
+    assert client_5 is not None
+    assert client_5.state == "not_home"
 
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1 is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If a UniFi client has never been seen, the connection check breaks.
This PR fixes this behavior by marking them away.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

```
2020-02-26 19:36:49 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 434, in _async_add_entity
    await entity.async_update_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 284, in async_update_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 320, in _async_write_ha_state
    state = self.state
  File "/usr/src/homeassistant/homeassistant/components/device_tracker/config_entry.py", line 131, in state
    if self.is_connected:
  File "/usr/src/homeassistant/homeassistant/components/unifi/device_tracker.py", line 204, in is_connected
    float(self.client.last_seen)
TypeError: float() argument must be a string or a number, not 'NoneType'
```

Usually UniFi creates clients when they connect. However clients can also be added manually e.g. to assign them static leases. If this is done to UniFi infrastructure devices, such as switches or access points, they will make use of that lease but will never be marked seen.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
