### PR TITLE
Fix DSMR 5

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -96,7 +96,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Protocol version specific obis
     if dsmr_version in ("4", "5"):
         gas_obis = obis_ref.HOURLY_GAS_METER_READING
-    elif dsmr_version in ("5B"):
+    elif dsmr_version in ("5B",):
         gas_obis = obis_ref.BELGIUM_HOURLY_GAS_METER_READING
     else:
         gas_obis = obis_ref.GAS_METER_READING
@@ -243,7 +243,7 @@ class DSMREntity(Entity):
         """Convert 2/1 to normal/low depending on DSMR version."""
         # DSMR V5B: Note: In Belgium values are swapped:
         # Rate code 2 is used for low rate and rate code 1 is used for normal rate.
-        if dsmr_version in ("5B"):
+        if dsmr_version in ("5B",):
             if value == "0001":
                 value = "0002"
             elif value == "0002":

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -188,6 +188,50 @@ async def test_v4_meter(hass, mock_connection_factory):
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
 
 
+async def test_v5_meter(hass, mock_connection_factory):
+    """Test if v5 meter is correctly parsed."""
+    (connection_factory, transport, protocol) = mock_connection_factory
+
+    from dsmr_parser.obis_references import (
+        HOURLY_GAS_METER_READING,
+        ELECTRICITY_ACTIVE_TARIFF,
+    )
+    from dsmr_parser.objects import CosemObject, MBusObject
+
+    config = {"platform": "dsmr", "dsmr_version": "5"}
+
+    telegram = {
+        HOURLY_GAS_METER_READING: MBusObject(
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": VOLUME_CUBIC_METERS},
+            ]
+        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
+    }
+
+    with assert_setup_component(1):
+        await async_setup_component(hass, "sensor", {"sensor": config})
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to update
+    await asyncio.sleep(0)
+
+    # tariff should be translated in human readable and have no unit
+    power_tariff = hass.states.get("sensor.power_tariff")
+    assert power_tariff.state == "low"
+    assert power_tariff.attributes.get("unit_of_measurement") == ""
+
+    # check if gas consumption is parsed correctly
+    gas_consumption = hass.states.get("sensor.gas_consumption")
+    assert gas_consumption.state == "745.695"
+    assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
+
+
 async def test_belgian_meter(hass, mock_connection_factory):
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = mock_connection_factory


### PR DESCRIPTION
DSMR 5 was broken because some wrong if.
if dsmr_version in ("5B"):
-> this checks dsmr_version against 5 and B. Not if its 5B.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
- This PR fixes or closes issue: fixes #32225

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works
