### PR TITLE
ZHA: Support light flashing

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -39,6 +39,7 @@ class Channels:
         """Initialize instance."""
         self._pools: List[zha_typing.ChannelPoolType] = []
         self._power_config = None
+        self._identify = None
         self._semaphore = asyncio.Semaphore(3)
         self._unique_id = str(zha_device.ieee)
         self._zdo_channel = base.ZDOChannel(zha_device.device.endpoints[0], zha_device)
@@ -59,6 +60,17 @@ class Channels:
         """Power configuration channel setter."""
         if self._power_config is None:
             self._power_config = channel
+
+    @property
+    def identify_ch(self) -> zha_typing.ChannelType:
+        """Return power configuration channel."""
+        return self._identify
+
+    @identify_ch.setter
+    def identify_ch(self, channel: zha_typing.ChannelType) -> None:
+        """Power configuration channel setter."""
+        if self._identify is None:
+            self._identify = channel
 
     @property
     def semaphore(self) -> asyncio.Semaphore:
@@ -242,6 +254,8 @@ class ChannelPool:
                     # on power configuration channel per device
                     continue
                 self._channels.power_configuration_ch = channel
+            elif channel.name == const.CHANNEL_IDENTIFY:
+                self._channels.identify_ch = channel
 
             self.all_channels[channel.id] = channel
 

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -153,7 +153,13 @@ class Groups(ZigbeeChannel):
 class Identify(ZigbeeChannel):
     """Identify channel."""
 
-    pass
+    @callback
+    def cluster_command(self, tsn, command_id, args):
+        """Handle commands received to this cluster."""
+        cmd = parse_and_log_command(self, tsn, command_id, args)
+
+        if cmd == "trigger_effect":
+            self.async_send_signal(f"{self.unique_id}_{cmd}", args[0])
 
 
 @registries.BINDABLE_CLUSTERS.register(general.LevelControl.cluster_id)

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -62,6 +62,7 @@ CHANNEL_EVENT_RELAY = "event_relay"
 CHANNEL_FAN = "fan"
 CHANNEL_HUMIDITY = "humidity"
 CHANNEL_IAS_WD = "ias_wd"
+CHANNEL_IDENTIFY = "identify"
 CHANNEL_ILLUMINANCE = "illuminance"
 CHANNEL_LEVEL = ATTR_LEVEL
 CHANNEL_MULTISTATE_INPUT = "multistate_input"

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -24,6 +24,7 @@ from .core.const import (
     SIGNAL_SET_LEVEL,
 )
 from .core.registries import ZHA_ENTITIES
+from .core.typing import ZhaDeviceType
 from .entity import ZhaEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,6 +37,8 @@ UPDATE_COLORLOOP_ACTION = 0x1
 UPDATE_COLORLOOP_DIRECTION = 0x2
 UPDATE_COLORLOOP_TIME = 0x4
 UPDATE_COLORLOOP_HUE = 0x8
+
+FLASH_EFFECTS = {light.FLASH_SHORT: 0x00, light.FLASH_LONG: 0x01}
 
 UNSUPPORTED_ATTRIBUTE = 0x86
 SCAN_INTERVAL = timedelta(minutes=60)
@@ -61,7 +64,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class Light(ZhaEntity, light.Light):
     """Representation of a ZHA or ZLL light."""
 
-    def __init__(self, unique_id, zha_device, channels, **kwargs):
+    def __init__(self, unique_id, zha_device: ZhaDeviceType, channels, **kwargs):
         """Initialize the ZHA light."""
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._supported_features = 0
@@ -74,6 +77,7 @@ class Light(ZhaEntity, light.Light):
         self._on_off_channel = self.cluster_channels.get(CHANNEL_ON_OFF)
         self._level_channel = self.cluster_channels.get(CHANNEL_LEVEL)
         self._color_channel = self.cluster_channels.get(CHANNEL_COLOR)
+        self._identify_channel = self.zha_device.channels.identify_ch
 
         if self._level_channel:
             self._supported_features |= light.SUPPORT_BRIGHTNESS
@@ -92,6 +96,9 @@ class Light(ZhaEntity, light.Light):
             if color_capabilities & CAPABILITIES_COLOR_LOOP:
                 self._supported_features |= light.SUPPORT_EFFECT
                 self._effect_list.append(light.EFFECT_COLORLOOP)
+
+        if self._identify_channel:
+            self._supported_features |= light.SUPPORT_FLASH
 
     @property
     def is_on(self) -> bool:
@@ -188,6 +195,7 @@ class Light(ZhaEntity, light.Light):
         duration = transition * 10 if transition else 0
         brightness = kwargs.get(light.ATTR_BRIGHTNESS)
         effect = kwargs.get(light.ATTR_EFFECT)
+        flash = kwargs.get(light.ATTR_FLASH)
 
         if brightness is None and self._off_brightness is not None:
             brightness = self._off_brightness
@@ -276,6 +284,12 @@ class Light(ZhaEntity, light.Light):
             )
             t_log["color_loop_set"] = result
             self._effect = None
+
+        if flash is not None and self._supported_features & light.SUPPORT_FLASH:
+            result = await self._identify_channel.trigger_effect(
+                FLASH_EFFECTS[flash], 0  # effect identifier, effect variant
+            )
+            t_log["trigger_effect"] = result
 
         self._off_brightness = None
         self.debug("turned on: %s", t_log)

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -9,7 +9,8 @@ import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.lighting as lighting
 import zigpy.zcl.foundation as zcl_f
 
-from homeassistant.components.light import DOMAIN
+from homeassistant.components.light import DOMAIN, FLASH_LONG, FLASH_SHORT
+from homeassistant.components.zha.light import FLASH_EFFECTS
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
 from .common import (
@@ -26,7 +27,11 @@ OFF = 0
 LIGHT_ON_OFF = {
     1: {
         "device_type": zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT,
-        "in_clusters": [general.Basic.cluster_id, general.OnOff.cluster_id],
+        "in_clusters": [
+            general.Basic.cluster_id,
+            general.Identify.cluster_id,
+            general.OnOff.cluster_id,
+        ],
         "out_clusters": [general.Ota.cluster_id],
     }
 }
@@ -48,6 +53,7 @@ LIGHT_COLOR = {
         "device_type": zigpy.profiles.zha.DeviceType.COLOR_DIMMABLE_LIGHT,
         "in_clusters": [
             general.Basic.cluster_id,
+            general.Identify.cluster_id,
             general.LevelControl.cluster_id,
             general.OnOff.cluster_id,
             lighting.Color.cluster_id,
@@ -59,6 +65,10 @@ LIGHT_COLOR = {
 
 @asynctest.patch(
     "zigpy.zcl.clusters.lighting.Color.request",
+    new=asynctest.CoroutineMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+@asynctest.patch(
+    "zigpy.zcl.clusters.general.Identify.request",
     new=asynctest.CoroutineMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
 @asynctest.patch(
@@ -88,6 +98,7 @@ async def test_light(
     cluster_on_off = zigpy_device.endpoints[1].on_off
     cluster_level = getattr(zigpy_device.endpoints[1], "level", None)
     cluster_color = getattr(zigpy_device.endpoints[1], "light_color", None)
+    cluster_identify = getattr(zigpy_device.endpoints[1], "identify", None)
 
     # test that the lights were created and that they are unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
@@ -104,6 +115,11 @@ async def test_light(
     # test turning the lights on and off from the HA
     await async_test_on_off_from_hass(hass, cluster_on_off, entity_id)
 
+    # test short flashing the lights from the HA
+    if cluster_identify:
+        await async_test_flash_from_hass(hass, cluster_identify, entity_id, FLASH_SHORT)
+
+    # test turning the lights on and off from the HA
     if cluster_level:
         await async_test_level_on_off_from_hass(
             hass, cluster_on_off, cluster_level, entity_id
@@ -123,6 +139,10 @@ async def test_light(
     if cluster_color:
         clusters.append(cluster_color)
     await async_test_rejoin(hass, zigpy_device, clusters, reporting)
+
+    # test long flashing the lights from the HA
+    if cluster_identify:
+        await async_test_flash_from_hass(hass, cluster_identify, entity_id, FLASH_LONG)
 
 
 async def async_test_on_off_from_light(hass, cluster, entity_id):
@@ -197,7 +217,7 @@ async def async_test_level_on_off_from_hass(
     assert level_cluster.request.call_count == 0
     assert level_cluster.request.await_count == 0
     assert on_off_cluster.request.call_args == call(
-        False, 1, (), expect_reply=True, manufacturer=None
+        False, ON, (), expect_reply=True, manufacturer=None
     )
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
@@ -210,7 +230,7 @@ async def async_test_level_on_off_from_hass(
     assert level_cluster.request.call_count == 1
     assert level_cluster.request.await_count == 1
     assert on_off_cluster.request.call_args == call(
-        False, 1, (), expect_reply=True, manufacturer=None
+        False, ON, (), expect_reply=True, manufacturer=None
     )
     assert level_cluster.request.call_args == call(
         False,
@@ -232,7 +252,7 @@ async def async_test_level_on_off_from_hass(
     assert level_cluster.request.call_count == 1
     assert level_cluster.request.await_count == 1
     assert on_off_cluster.request.call_args == call(
-        False, 1, (), expect_reply=True, manufacturer=None
+        False, ON, (), expect_reply=True, manufacturer=None
     )
     assert level_cluster.request.call_args == call(
         False,
@@ -260,3 +280,23 @@ async def async_test_dimmer_from_light(hass, cluster, entity_id, level, expected
     if level == 0:
         level = None
     assert hass.states.get(entity_id).attributes.get("brightness") == level
+
+
+async def async_test_flash_from_hass(hass, cluster, entity_id, flash):
+    """Test flash functionality from hass."""
+    # turn on via UI
+    cluster.request.reset_mock()
+    await hass.services.async_call(
+        DOMAIN, "turn_on", {"entity_id": entity_id, "flash": flash}, blocking=True
+    )
+    assert cluster.request.call_count == 1
+    assert cluster.request.await_count == 1
+    assert cluster.request.call_args == call(
+        False,
+        64,
+        (zigpy.types.uint8_t, zigpy.types.uint8_t),
+        FLASH_EFFECTS[flash],
+        0,
+        expect_reply=True,
+        manufacturer=None,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow flashing the lights with ZHA. This is continuation of https://github.com/zigpy/zigpy/pull/298.
Currently it needs `dev` branch of https://github.com/zigpy/zigpy @Adminiuga can you release next version with https://github.com/zigpy/zigpy/pull/298?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example automation
action:
  service: light.turn_on
  entity_id: >-
    light.ikea_of_sweden_tradfri_bulb_e14_ws_opal_400lm_xxxxxxxx_level_light_color_on_off
  flash: short
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
