### PR TITLE
Allow freebox connection to fail

### DIFF
--- a/homeassistant/components/freebox/device_tracker.py
+++ b/homeassistant/components/freebox/device_tracker.py
@@ -62,7 +62,7 @@ class FreeboxDeviceScanner(DeviceScanner):
         try:
             hosts = await self.connection.lan.get_hosts_list()
         except ClientConnectorError as err:
-            _LOGGER.error("Error getting freebox devices infos: %s", str(err))
+            _LOGGER.error("Error getting info from devices: %s", err)
             hosts = []
 
         last_results = [_build_device(device) for device in hosts if device["active"]]

--- a/homeassistant/components/freebox/device_tracker.py
+++ b/homeassistant/components/freebox/device_tracker.py
@@ -12,8 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_get_scanner(hass, config):
     """Validate the configuration and return a Freebox scanner."""
     scanner = FreeboxDeviceScanner(hass.data[DATA_FREEBOX])
-    await scanner.async_connect()
-    return scanner if scanner.success_init else None
+    return scanner
 
 
 Device = namedtuple("Device", ["id", "name", "ip"])
@@ -33,7 +32,7 @@ class FreeboxDeviceScanner(DeviceScanner):
     def __init__(self, fbx):
         """Initialize the scanner."""
         self.last_results = {}
-        self.success_init = False
+        self.success_init = True
         self.connection = fbx
 
     async def async_connect(self):
@@ -58,7 +57,11 @@ class FreeboxDeviceScanner(DeviceScanner):
         """Ensure the information from the Freebox router is up to date."""
         _LOGGER.debug("Checking Devices")
 
-        hosts = await self.connection.lan.get_hosts_list()
+        try:
+            hosts = await self.connection.lan.get_hosts_list()
+        except Exception as e:
+            _LOGGER.error("Error getting freebox devices infos: " + str(e))
+            hosts = []
 
         last_results = [_build_device(device) for device in hosts if device["active"]]
 

--- a/homeassistant/components/freebox/device_tracker.py
+++ b/homeassistant/components/freebox/device_tracker.py
@@ -62,7 +62,7 @@ class FreeboxDeviceScanner(DeviceScanner):
         try:
             hosts = await self.connection.lan.get_hosts_list()
         except ClientConnectorError as err:
-            _LOGGER.error("Error getting freebox devices infos: %s" % str(err))
+            _LOGGER.error("Error getting freebox devices infos: %s", str(err))
             hosts = []
 
         last_results = [_build_device(device) for device in hosts if device["active"]]

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -55,7 +55,7 @@ class FbxSensor(Entity):
         try:
             self._datas = await self._fbx.connection.get_status()
         except ClientConnectorError as err:
-            _LOGGER.error("Error while getting Freebox data: %s", str(err))
+            _LOGGER.error("Error while getting sensor data: %s", err)
             return
 
 

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -55,7 +55,7 @@ class FbxSensor(Entity):
         try:
             self._datas = await self._fbx.connection.get_status()
         except ClientConnectorError as err:
-            _LOGGER.error("Error while getting Freebox data: %s" % str(err))
+            _LOGGER.error("Error while getting Freebox data: %s", str(err))
             return
 
 

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -50,7 +50,11 @@ class FbxSensor(Entity):
 
     async def async_update(self):
         """Fetch status from freebox."""
-        self._datas = await self._fbx.connection.get_status()
+        try:
+            self._datas = await self._fbx.connection.get_status()
+        except Exception as e:
+            _LOGGER.error("Error while getting Freebox data: " + str(e))
+            return
 
 
 class FbxRXSensor(FbxSensor):

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -1,6 +1,8 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 import logging
 
+from aiohttp.client_exceptions import ClientConnectorError
+
 from homeassistant.const import DATA_RATE_KILOBYTES_PER_SECOND
 from homeassistant.helpers.entity import Entity
 
@@ -50,7 +52,11 @@ class FbxSensor(Entity):
 
     async def async_update(self):
         """Fetch status from freebox."""
-        self._datas = await self._fbx.connection.get_status()
+        try:
+            self._datas = await self._fbx.connection.get_status()
+        except ClientConnectorError as err:
+            _LOGGER.error("Error while getting Freebox data: %s" % str(err))
+            return
 
 
 class FbxRXSensor(FbxSensor):

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,6 +1,8 @@
 """Support for Freebox Delta, Revolution and Mini 4K."""
 import logging
 
+from aiohttp.client_exceptions import ClientConnectorError
+
 from homeassistant.components.switch import SwitchDevice
 
 from . import DATA_FREEBOX
@@ -57,6 +59,10 @@ class FbxWifiSwitch(SwitchDevice):
 
     async def async_update(self):
         """Get the state and update it."""
-        datas = await self._fbx.wifi.get_global_config()
+        try:
+            datas = await self._fbx.wifi.get_global_config()
+        except ClientConnectorError as err:
+            _LOGGER.error("Error getting Freebox switch info: %s" % str(err))
+            return
         active = datas["enabled"]
         self._state = bool(active)

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -57,6 +57,10 @@ class FbxWifiSwitch(SwitchDevice):
 
     async def async_update(self):
         """Get the state and update it."""
-        datas = await self._fbx.wifi.get_global_config()
+        try:
+            datas = await self._fbx.wifi.get_global_config()
+        except Exception as e:
+            _LOGGER.error("Error getting Freebox switch info: " + str(e))
+            return
         active = datas["enabled"]
         self._state = bool(active)

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -62,7 +62,7 @@ class FbxWifiSwitch(SwitchDevice):
         try:
             datas = await self._fbx.wifi.get_global_config()
         except ClientConnectorError as err:
-            _LOGGER.error("Error getting Freebox switch info: %s" % str(err))
+            _LOGGER.error("Error getting Freebox switch info: %s", str(err))
             return
         active = datas["enabled"]
         self._state = bool(active)

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -62,7 +62,7 @@ class FbxWifiSwitch(SwitchDevice):
         try:
             datas = await self._fbx.wifi.get_global_config()
         except ClientConnectorError as err:
-            _LOGGER.error("Error getting Freebox switch info: %s", str(err))
+            _LOGGER.error("Error getting switch info: %s", err)
             return
         active = datas["enabled"]
         self._state = bool(active)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In case freebox is disconnected, when HA starts, it tests if Freebox is accessible. If not, this is never retried even when Freebox reconnects.
This PR writes error logs instead of stacktrace, and moreover, it created the FreeboxDeviceScanner object without testing Freebox presence. Error handling is done in `async_update_info` method which returns an empty list if Freebox is not there

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32263
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
