### PR TITLE
Add vicare burner attributes

### DIFF
--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -165,7 +165,11 @@ class ViCareClimate(ClimateDevice):
                 
                 self._attributes["burner_hours"] = self._api.getBurnerHours()
                 self._attributes["burner_starts"] = self._api.getBurnerStarts()
-
+                self._attributes["burner_power"] = self._api.getCurrentPower()
+                
+                self._attributes["heating_gas_consumption_today"] = self._api.getGasConsumptionHeatingToday()                           
+                self._attributes["hotwater_gas_consumption_today"] = self._api.getGasConsumptionDomesticHotWaterToday()
+                
             elif self._heating_type == HeatingType.heatpump:
                 self._current_action = self._api.getCompressorActive()
 

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -172,6 +172,9 @@ class ViCareClimate(ClimateDevice):
                 self._attributes[
                     "return_temperature"
                 ] = self._api.getReturnTemperature()
+                
+                self._attributes["heatpump_supply_temperature"] = self._api.getSupplyTemperaturePrimaryCircuit()
+                self._attributes["heatpump_return_temperature"] = self._api.getReturnTemperaturePrimaryCircuit()
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from ViCare server")
         except ValueError:

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -162,6 +162,9 @@ class ViCareClimate(ClimateDevice):
                 self._attributes[
                     "boiler_temperature"
                 ] = self._api.getBoilerTemperature()
+                
+                self._attributes["burner_hours"] = self._api.getBurnerHours()
+                self._attributes["burner_starts"] = self._api.getBurnerStarts()
 
             elif self._heating_type == HeatingType.heatpump:
                 self._current_action = self._api.getCompressorActive()


### PR DESCRIPTION
ViCare API delivers information about statistics like burner starts (times the burner has been startet since commissioning) and burner hours (hours the burner has been in operation since commissioning). Please add these two more information in the vicare-integration as suggested. PyViCare-changes are already suggested (follow link https://github.com/stefanwi87/PyViCare/tree/patch-1)

Upstream PR: https://github.com/somm15/PyViCare/pull/25

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
ViCare API delivers information about statistics like burner starts (times the burner has been startet since commissioning) and burner hours (hours the burner has been in operation since commissioning). Please add these two more information in the vicare-integration as suggested. PyViCare-changes are already suggested (follow link https://github.com/stefanwi87/PyViCare/tree/patch-1)
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
sensor:
  - platform: template
    # ViCare
    sensors:
      burner_starts:
        friendly_name: "Brennerstarts ViCare"
        unit_of_measurement: 'times'
        value_template: "{{ state_attr('climate.vicare_heating', 'burner_starts')}}"
      burner_hours:
        friendly_name: "Brennerstunden ViCare"
        unit_of_measurement: 'times'
        value_template: "{{ state_attr('climate.vicare_heating', 'burner_hours')}}"
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
