### PR TITLE
Allow configuration of Zigbee source routing for ZHA

### DIFF
--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -15,60 +15,36 @@
         "title": "ZHA"
       }
     },
-    "device_automation": {
-      "action_type": {
-        "squawk": "Squawk",
-        "warn": "Warn"
-      },
-      "trigger_subtype": {
-        "both_buttons": "Both buttons",
-        "button_1": "First button",
-        "button_2": "Second button",
-        "button_3": "Third button",
-        "button_4": "Fourth button",
-        "button_5": "Fifth button",
-        "button_6": "Sixth button",
-        "close": "Close",
-        "dim_down": "Dim down",
-        "dim_up": "Dim up",
-        "face_1": "with face 1 activated",
-        "face_2": "with face 2 activated",
-        "face_3": "with face 3 activated",
-        "face_4": "with face 4 activated",
-        "face_5": "with face 5 activated",
-        "face_6": "with face 6 activated",
-        "face_any": "With any/specified face(s) activated",
-        "left": "Left",
-        "open": "Open",
-        "right": "Right",
-        "turn_off": "Turn off",
-        "turn_on": "Turn on"
-      },
-      "trigger_type": {
-        "device_dropped": "Device dropped",
-        "device_flipped": "Device flipped \"{subtype}\"",
-        "device_knocked": "Device knocked \"{subtype}\"",
-        "device_rotated": "Device rotated \"{subtype}\"",
-        "device_shaken": "Device shaken",
-        "device_slid": "Device slid \"{subtype}\"",
-        "device_tilted": "Device tilted",
-        "remote_button_alt_double_press": "\"{subtype}\" button double clicked (Alternate mode)",
-        "remote_button_alt_long_press": "\"{subtype}\" button continuously pressed (Alternate mode)",
-        "remote_button_alt_long_release": "\"{subtype}\" button released after long press (Alternate mode)",
-        "remote_button_alt_quadruple_press": "\"{subtype}\" button quadruple clicked (Alternate mode)",
-        "remote_button_alt_quintuple_press": "\"{subtype}\" button quintuple clicked (Alternate mode)",
-        "remote_button_alt_short_press": "\"{subtype}\" button pressed (Alternate mode)",
-        "remote_button_alt_short_release": "\"{subtype}\" button released (Alternate mode)",
-        "remote_button_alt_triple_press": "\"{subtype}\" button triple clicked (Alternate mode)",
-        "remote_button_double_press": "\"{subtype}\" button double clicked",
-        "remote_button_long_press": "\"{subtype}\" button continuously pressed",
-        "remote_button_long_release": "\"{subtype}\" button released after long press",
-        "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
-        "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
-        "remote_button_short_press": "\"{subtype}\" button pressed",
-        "remote_button_short_release": "\"{subtype}\" button released",
-        "remote_button_triple_press": "\"{subtype}\" button triple clicked"
-      }
+    "title": "ZHA"
+  },
+  "device_automation": {
+    "action_type": {
+      "squawk": "Squawk",
+      "warn": "Warn"
+    },
+    "trigger_subtype": {
+      "both_buttons": "Both buttons",
+      "button_1": "First button",
+      "button_2": "Second button",
+      "button_3": "Third button",
+      "button_4": "Fourth button",
+      "button_5": "Fifth button",
+      "button_6": "Sixth button",
+      "close": "Close",
+      "dim_down": "Dim down",
+      "dim_up": "Dim up",
+      "face_1": "with face 1 activated",
+      "face_2": "with face 2 activated",
+      "face_3": "with face 3 activated",
+      "face_4": "with face 4 activated",
+      "face_5": "with face 5 activated",
+      "face_6": "with face 6 activated",
+      "face_any": "With any/specified face(s) activated",
+      "left": "Left",
+      "open": "Open",
+      "right": "Right",
+      "turn_off": "Turn off",
+      "turn_on": "Turn on"
     },
     "trigger_type": {
       "device_dropped": "Device dropped",

--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -1,88 +1,91 @@
 {
-    "config": {
-        "abort": {
-            "single_instance_allowed": "Only a single configuration of ZHA is allowed."
-        },
-        "error": {
-            "cannot_connect": "Unable to connect to ZHA device."
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "radio_type": "Radio Type",
-                    "usb_path": "USB Device Path"
-                },
-                "title": "ZHA"
-            }
+  "config": {
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of ZHA is allowed."
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to ZHA device."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "radio_type": "Radio Type",
+          "usb_path": "USB Device Path"
         },
         "title": "ZHA"
+      }
     },
     "device_automation": {
-        "action_type": {
-            "squawk": "Squawk",
-            "warn": "Warn"
-        },
-        "trigger_subtype": {
-            "both_buttons": "Both buttons",
-            "button_1": "First button",
-            "button_2": "Second button",
-            "button_3": "Third button",
-            "button_4": "Fourth button",
-            "button_5": "Fifth button",
-            "button_6": "Sixth button",
-            "close": "Close",
-            "dim_down": "Dim down",
-            "dim_up": "Dim up",
-            "face_1": "with face 1 activated",
-            "face_2": "with face 2 activated",
-            "face_3": "with face 3 activated",
-            "face_4": "with face 4 activated",
-            "face_5": "with face 5 activated",
-            "face_6": "with face 6 activated",
-            "face_any": "With any/specified face(s) activated",
-            "left": "Left",
-            "open": "Open",
-            "right": "Right",
-            "turn_off": "Turn off",
-            "turn_on": "Turn on"
-        },
-        "trigger_type": {
-            "device_dropped": "Device dropped",
-            "device_flipped": "Device flipped \"{subtype}\"",
-            "device_knocked": "Device knocked \"{subtype}\"",
-            "device_rotated": "Device rotated \"{subtype}\"",
-            "device_shaken": "Device shaken",
-            "device_slid": "Device slid \"{subtype}\"",
-            "device_tilted": "Device tilted",
-            "remote_button_alt_double_press": "\"{subtype}\" button double clicked (Alternate mode)",
-            "remote_button_alt_long_press": "\"{subtype}\" button continuously pressed (Alternate mode)",
-            "remote_button_alt_long_release": "\"{subtype}\" button released after long press (Alternate mode)",
-            "remote_button_alt_quadruple_press": "\"{subtype}\" button quadruple clicked (Alternate mode)",
-            "remote_button_alt_quintuple_press": "\"{subtype}\" button quintuple clicked (Alternate mode)",
-            "remote_button_alt_short_press": "\"{subtype}\" button pressed (Alternate mode)",
-            "remote_button_alt_short_release": "\"{subtype}\" button released (Alternate mode)",
-            "remote_button_alt_triple_press": "\"{subtype}\" button triple clicked (Alternate mode)",
-            "remote_button_double_press": "\"{subtype}\" button double clicked",
-            "remote_button_long_press": "\"{subtype}\" button continuously pressed",
-            "remote_button_long_release": "\"{subtype}\" button released after long press",
-            "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
-            "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
-            "remote_button_short_press": "\"{subtype}\" button pressed",
-            "remote_button_short_release": "\"{subtype}\" button released",
-            "remote_button_triple_press": "\"{subtype}\" button triple clicked"
-        }
+      "action_type": {
+        "squawk": "Squawk",
+        "warn": "Warn"
+      },
+      "trigger_subtype": {
+        "both_buttons": "Both buttons",
+        "button_1": "First button",
+        "button_2": "Second button",
+        "button_3": "Third button",
+        "button_4": "Fourth button",
+        "button_5": "Fifth button",
+        "button_6": "Sixth button",
+        "close": "Close",
+        "dim_down": "Dim down",
+        "dim_up": "Dim up",
+        "face_1": "with face 1 activated",
+        "face_2": "with face 2 activated",
+        "face_3": "with face 3 activated",
+        "face_4": "with face 4 activated",
+        "face_5": "with face 5 activated",
+        "face_6": "with face 6 activated",
+        "face_any": "With any/specified face(s) activated",
+        "left": "Left",
+        "open": "Open",
+        "right": "Right",
+        "turn_off": "Turn off",
+        "turn_on": "Turn on"
+      },
+      "trigger_type": {
+        "device_dropped": "Device dropped",
+        "device_flipped": "Device flipped \"{subtype}\"",
+        "device_knocked": "Device knocked \"{subtype}\"",
+        "device_rotated": "Device rotated \"{subtype}\"",
+        "device_shaken": "Device shaken",
+        "device_slid": "Device slid \"{subtype}\"",
+        "device_tilted": "Device tilted",
+        "remote_button_alt_double_press": "\"{subtype}\" button double clicked (Alternate mode)",
+        "remote_button_alt_long_press": "\"{subtype}\" button continuously pressed (Alternate mode)",
+        "remote_button_alt_long_release": "\"{subtype}\" button released after long press (Alternate mode)",
+        "remote_button_alt_quadruple_press": "\"{subtype}\" button quadruple clicked (Alternate mode)",
+        "remote_button_alt_quintuple_press": "\"{subtype}\" button quintuple clicked (Alternate mode)",
+        "remote_button_alt_short_press": "\"{subtype}\" button pressed (Alternate mode)",
+        "remote_button_alt_short_release": "\"{subtype}\" button released (Alternate mode)",
+        "remote_button_alt_triple_press": "\"{subtype}\" button triple clicked (Alternate mode)",
+        "remote_button_double_press": "\"{subtype}\" button double clicked",
+        "remote_button_long_press": "\"{subtype}\" button continuously pressed",
+        "remote_button_long_release": "\"{subtype}\" button released after long press",
+        "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
+        "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
+        "remote_button_short_press": "\"{subtype}\" button pressed",
+        "remote_button_short_release": "\"{subtype}\" button released",
+        "remote_button_triple_press": "\"{subtype}\" button triple clicked"
+      }
     },
-    "options": {
-        "step": {
-            "zha_network_options": {
-                "data": {
-                    "enable_quirks": "Enable Quirks",
-                    "enable_source_routing": "Enable Zigbee source routing",
-                    "radio_type": "Radio Type",
-                    "usb_path": "USB Device Path"
-                },
-                "description": "ZHA Options"
-            }
-        }
+    "trigger_type": {
+      "device_dropped": "Device dropped",
+      "device_flipped": "Device flipped \"{subtype}\"",
+      "device_knocked": "Device knocked \"{subtype}\"",
+      "device_rotated": "Device rotated \"{subtype}\"",
+      "device_shaken": "Device shaken",
+      "device_slid": "Device slid \"{subtype}\"",
+      "device_tilted": "Device tilted",
+      "remote_button_double_press": "\"{subtype}\" button double clicked",
+      "remote_button_long_press": "\"{subtype}\" button continuously pressed",
+      "remote_button_long_release": "\"{subtype}\" button released after long press",
+      "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
+      "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
+      "remote_button_short_press": "\"{subtype}\" button pressed",
+      "remote_button_short_release": "\"{subtype}\" button released",
+      "remote_button_triple_press": "\"{subtype}\" button triple clicked"
     }
+  }
 }

--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -71,5 +71,18 @@
             "remote_button_short_release": "\"{subtype}\" button released",
             "remote_button_triple_press": "\"{subtype}\" button triple clicked"
         }
+    },
+    "options": {
+        "step": {
+            "zha_network_options": {
+                "data": {
+                    "enable_quirks": "Enable Quirks",
+                    "enable_source_routing": "Enable Zigbee source routing",
+                    "radio_type": "Radio Type",
+                    "usb_path": "USB Device Path"
+                },
+                "description": "ZHA Options"
+            }
+        }
     }
 }

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -10,7 +10,6 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 
 from .core.const import (
-    CONF_ENABLE_QUIRKS,
     CONF_ENABLE_SOURCE_ROUTING,
     CONF_RADIO_TYPE,
     CONF_USB_PATH,
@@ -79,29 +78,17 @@ class ZHAOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
         """Initialize ZHA options flow."""
         self.options = copy.deepcopy(config_entry.options)
-        self.options[CONF_USB_PATH] = config_entry.options.get(
-            CONF_USB_PATH, config_entry.data.get(CONF_USB_PATH)
-        )
-        self.options[CONF_RADIO_TYPE] = config_entry.options.get(
-            CONF_RADIO_TYPE, config_entry.data.get(CONF_RADIO_TYPE)
-        )
-        self.options[CONF_ENABLE_QUIRKS] = config_entry.options.get(
-            CONF_ENABLE_QUIRKS, True
-        )
         self.options[CONF_ENABLE_SOURCE_ROUTING] = config_entry.options.get(
             CONF_ENABLE_SOURCE_ROUTING, False
         )
 
     async def async_step_init(self, user_input=None):
         """Manage the ZHA options."""
-        return await self.async_step_zha_options()
+        return await self.async_step_zha_network_options()
 
-    async def async_step_zha_options(self, user_input=None):
-        """Manage the ZHA Zigpy configuration options."""
+    async def async_step_zha_network_options(self, user_input=None):
+        """Manage the Zigpy configuration options for ZHA."""
         if user_input is not None:
-            self.options[CONF_USB_PATH] = user_input[CONF_USB_PATH]
-            self.options[CONF_RADIO_TYPE] = user_input[CONF_RADIO_TYPE]
-            self.options[CONF_ENABLE_QUIRKS] = user_input[CONF_ENABLE_QUIRKS]
             self.options[CONF_ENABLE_SOURCE_ROUTING] = user_input[
                 CONF_ENABLE_SOURCE_ROUTING
             ]
@@ -112,18 +99,9 @@ class ZHAOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_USB_PATH, default=self.options[CONF_USB_PATH]
-                    ): str,
-                    vol.Optional(
-                        CONF_RADIO_TYPE, default=self.options[CONF_RADIO_TYPE]
-                    ): vol.In(RadioType.list()),
-                    vol.Required(
-                        CONF_ENABLE_QUIRKS, default=self.options[CONF_ENABLE_QUIRKS]
-                    ): bool,
-                    vol.Required(
                         CONF_ENABLE_SOURCE_ROUTING,
                         default=self.options[CONF_ENABLE_SOURCE_ROUTING],
-                    ): bool,
+                    ): bool
                 }
             ),
         )

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -94,6 +94,7 @@ CONF_DEVICE_CONFIG = "device_config"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
+CONF_ENABLE_SOURCE_ROUTING = "enable_source_routing"
 CONTROLLER = "controller"
 
 DATA_DEVICE_CONFIG = "zha_device_config"

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -2,6 +2,8 @@
 import enum
 import logging
 
+from bellows.zigbee.application import CONF_PARAM_SRC_RTG
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.cover import DOMAIN as COVER
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
@@ -94,7 +96,9 @@ CONF_DEVICE_CONFIG = "device_config"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
-CONF_ENABLE_SOURCE_ROUTING = "enable_source_routing"
+CONF_SOURCE_ROUTE_TABLE_SIZE = "source_routing_table_size"
+CONF_ADDRESS_TABLE_SIZE = "address_table_size"
+CONF_NEIGHBOR_TABLE_SIZE = "neighbor_table_size"
 CONTROLLER = "controller"
 
 DATA_DEVICE_CONFIG = "zha_device_config"
@@ -261,6 +265,13 @@ ZHA_GW_MSG_LOG_OUTPUT = "log_output"
 ZHA_GW_MSG_RAW_INIT = "raw_device_initialized"
 ZHA_GW_RADIO = "radio"
 ZHA_GW_RADIO_DESCRIPTION = "radio_description"
+
+ZIGPY_OPTIONS = [
+    CONF_PARAM_SRC_RTG,
+    CONF_SOURCE_ROUTE_TABLE_SIZE,
+    CONF_ADDRESS_TABLE_SIZE,
+    CONF_NEIGHBOR_TABLE_SIZE,
+]
 
 EFFECT_BLINK = 0x00
 EFFECT_BREATHE = 0x01

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 
 from serial import SerialException
 import zigpy.device as zigpy_dev
-from bellows.zigbee.application import CONF_PARAM_SRC_RTG
 
 from homeassistant.components.system_log import LogEntry, _figure_out_source
 from homeassistant.core import callback
@@ -36,7 +35,6 @@ from .const import (
     ATTR_TYPE,
     CONF_BAUDRATE,
     CONF_DATABASE,
-    CONF_ENABLE_SOURCE_ROUTING,
     CONF_RADIO_TYPE,
     CONF_USB_PATH,
     CONTROLLER,
@@ -78,6 +76,7 @@ from .const import (
     ZHA_GW_MSG_RAW_INIT,
     ZHA_GW_RADIO,
     ZHA_GW_RADIO_DESCRIPTION,
+    ZIGPY_OPTIONS,
 )
 from .device import DeviceStatus, ZHADevice
 from .group import ZHAGroup
@@ -118,7 +117,6 @@ class ZHAGateway:
         self._log_relay_handler = LogRelayHandler(hass, self)
         self._config_entry = config_entry
         self._zigpy_options = {}
-        self._config_entry.add_update_listener(self.async_options_updated)
 
     async def async_initialize(self):
         """Initialize controller and connect radio."""
@@ -133,9 +131,11 @@ class ZHAGateway:
         baudrate = self._config.get(CONF_BAUDRATE, DEFAULT_BAUDRATE)
         radio_type = self._config_entry.data.get(CONF_RADIO_TYPE)
 
-        self._zigpy_options[CONF_PARAM_SRC_RTG] = self._config_entry.options.get(
-            CONF_ENABLE_SOURCE_ROUTING, False
-        )
+        self._zigpy_options = {
+            option: self._config_entry.options[option]
+            for option in ZIGPY_OPTIONS
+            if option in self._config_entry.options
+        }
 
         radio_details = RADIO_TYPES[radio_type]
         radio = radio_details[ZHA_GW_RADIO]()
@@ -223,25 +223,6 @@ class ZHAGateway:
                 if dev.is_mains_powered
             ]
         )
-
-    @staticmethod
-    async def async_options_updated(hass, config_entry):
-        """Handle the update signal from updating the config entry."""
-        gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
-        await gateway.async_update_options(config_entry)
-
-    async def async_update_options(self, config_entry):
-        """Triggered by config entry options updates."""
-        _LOGGER.debug(
-            "ZHA config entry options updated from: %s to: %s",
-            self._config_entry.options,
-            config_entry.options,
-        )
-        self._config_entry = config_entry
-        self.application_controller.use_source_routing = self._config_entry.options.get(
-            CONF_ENABLE_SOURCE_ROUTING, False
-        )
-        await self.application_controller.set_source_routing()
 
     def device_joined(self, device):
         """Handle device joined.

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -20,9 +20,12 @@
   "options": {
     "step": {
       "zha_network_options": {
-        "description": "ZHA Network Options",
+        "description": "ZHA Network Options - Home Assistant will have to be restarted after changing these options",
         "data": {
-          "enable_source_routing": "Enable Zigbee source routing"
+          "source_routing": "Enable Zigbee source routing",
+          "source_routing_table_size": "Source route table size",
+          "address_table_size": "Address table size",
+          "neighbor_table_size": "Neighbor table size"
         }
       }
     }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -20,11 +20,8 @@
   "options": {
     "step": {
       "zha_network_options": {
-        "description": "ZHA Options",
+        "description": "ZHA Network Options",
         "data": {
-          "radio_type": "Radio Type",
-          "usb_path": "USB Device Path",
-          "enable_quirks": "Enable Quirks",
           "enable_source_routing": "Enable Zigbee source routing"
         }
       }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -17,6 +17,19 @@
       "single_instance_allowed": "Only a single configuration of ZHA is allowed."
     }
   },
+  "options": {
+    "step": {
+      "zha_network_options": {
+        "description": "ZHA Options",
+        "data": {
+          "radio_type": "Radio Type",
+          "usb_path": "USB Device Path",
+          "enable_quirks": "Enable Quirks",
+          "enable_source_routing": "Enable Zigbee source routing"
+        }
+      }
+    }
+  },
   "device_automation": {
     "action_type": {
       "squawk": "Squawk",


### PR DESCRIPTION
## Proposed change
This adds a config entry options flow handler for ZHA that allows users to enable / disable Zigbee source routing. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
