### PR TITLE
0.106.2

### DIFF
--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20200220.4"
+    "home-assistant-frontend==20200220.5"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -104,6 +104,9 @@ class LovelaceStorage:
 
     async def async_save(self, config):
         """Save config."""
+        if self._hass.config.safe_mode:
+            raise HomeAssistantError("Deleting not supported in safe mode")
+
         if self._data is None:
             await self._load()
         self._data["config"] = config
@@ -112,6 +115,9 @@ class LovelaceStorage:
 
     async def async_delete(self):
         """Delete config."""
+        if self._hass.config.safe_mode:
+            raise HomeAssistantError("Deleting not supported in safe mode")
+
         await self.async_save(None)
 
     async def _load(self):

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -202,17 +202,19 @@ class RestSensor(Entity):
         self.rest.update()
         value = self.rest.data
         _LOGGER.debug("Data fetched from resource: %s", value)
-        content_type = self.rest.headers.get("content-type")
+        if self.rest.headers is not None:
+            # If the http request failed, headers will be None
+            content_type = self.rest.headers.get("content-type")
 
-        if content_type and content_type.startswith("text/xml"):
-            try:
-                value = json.dumps(xmltodict.parse(value))
-                _LOGGER.debug("JSON converted from XML: %s", value)
-            except ExpatError:
-                _LOGGER.warning(
-                    "REST xml result could not be parsed and converted to JSON."
-                )
-                _LOGGER.debug("Erroneous XML: %s", value)
+            if content_type and content_type.startswith("text/xml"):
+                try:
+                    value = json.dumps(xmltodict.parse(value))
+                    _LOGGER.debug("JSON converted from XML: %s", value)
+                except ExpatError:
+                    _LOGGER.warning(
+                        "REST xml result could not be parsed and converted to JSON."
+                    )
+                    _LOGGER.debug("Erroneous XML: %s", value)
 
         if self._json_attrs:
             self._attributes = {}

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -338,4 +338,4 @@ class UniFiDeviceTracker(ScannerEntity):
     @property
     def should_poll(self):
         """No polling needed."""
-        return False
+        return True

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -62,4 +62,4 @@ class UniFiClient(Entity):
     @property
     def should_poll(self) -> bool:
         """No polling needed."""
-        return False
+        return True

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 106
-PATCH_VERSION = "1"
+PATCH_VERSION = "2"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,7 +11,7 @@ cryptography==2.8
 defusedxml==0.6.0
 distro==1.4.0
 hass-nabucasa==0.31
-home-assistant-frontend==20200220.4
+home-assistant-frontend==20200220.5
 importlib-metadata==1.5.0
 jinja2>=2.10.3
 netdisco==2.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -683,7 +683,7 @@ hole==0.5.0
 holidays==0.10.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20200220.4
+home-assistant-frontend==20200220.5
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -254,7 +254,7 @@ hole==0.5.0
 holidays==0.10.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20200220.4
+home-assistant-frontend==20200220.5
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.8

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -45,6 +45,16 @@ async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):
     assert not response["success"]
     assert response["error"]["code"] == "config_not_found"
 
+    await client.send_json(
+        {"id": 9, "type": "lovelace/config/save", "config": {"yo": "hello"}}
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+
+    await client.send_json({"id": 10, "type": "lovelace/config/delete"})
+    response = await client.receive_json()
+    assert not response["success"]
+
 
 async def test_lovelace_from_storage_save_before_load(
     hass, hass_ws_client, hass_storage

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -589,6 +589,35 @@ class TestRestSensor(unittest.TestCase):
         assert mock_logger.warning.called
         assert mock_logger.debug.called
 
+    @patch("homeassistant.components.rest.sensor._LOGGER")
+    def test_update_with_failed_get(self, mock_logger):
+        """Test attributes get extracted from a XML result with bad xml."""
+        value_template = template("{{ value_json.toplevel.master_value }}")
+        value_template.hass = self.hass
+
+        self.rest.update = Mock(
+            "rest.RestData.update", side_effect=self.update_side_effect(None, None),
+        )
+        self.sensor = rest.RestSensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            value_template,
+            ["key"],
+            self.force_update,
+            self.resource_template,
+            self.json_attrs_path,
+        )
+
+        self.sensor.update()
+        assert {} == self.sensor.device_state_attributes
+        assert mock_logger.warning.called
+        assert mock_logger.debug.called
+        assert self.sensor.state is None
+        assert self.sensor.available is False
+
 
 class TestRestData(unittest.TestCase):
     """Tests for RestData."""


### PR DESCRIPTION
- Updated frontend to 20200220.5 ([@bramkragten] - [#32312]) ([frontend docs])
- revent saving/deleting Lovelace config in safe mode ([@balloob] - [#32319]) ([lovelace docs])
- UniFi - Temporary workaround to get device tracker to mark cli… ([@Kane610] - [#32321]) ([unifi docs])
- Ensure rest sensors are marked unavailable when http requests… ([@bdraco] - [#32309]) ([rest docs])

[#32309]: https://github.com/home-assistant/home-assistant/pull/32309
[#32312]: https://github.com/home-assistant/home-assistant/pull/32312
[#32319]: https://github.com/home-assistant/home-assistant/pull/32319
[#32321]: https://github.com/home-assistant/home-assistant/pull/32321
[@Kane610]: https://github.com/Kane610
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[lovelace docs]: https://www.home-assistant.io/integrations/lovelace/
[rest docs]: https://www.home-assistant.io/integrations/rest/
[unifi docs]: https://www.home-assistant.io/integrations/unifi/