### PR TITLE
Add is_volume_muted property to vizio integration

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -230,7 +230,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         new_options.update(updated_options)
 
                     self.hass.config_entries.async_update_entry(
-                        entry=entry, data=new_data, options=new_options,
+                        entry=entry, data=new_data, options=new_options
                     )
                     return self.async_abort(reason="updated_entry")
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -146,6 +146,7 @@ class VizioDevice(MediaPlayerDevice):
         if not is_on:
             self._state = STATE_OFF
             self._volume_level = None
+            self._is_muted = None
             self._current_input = None
             self._available_inputs = None
             return

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -54,7 +54,7 @@ async def async_setup_entry(
 
     # If config entry options not set up, set them up, otherwise assign values managed in options
     volume_step = config_entry.options.get(
-        CONF_VOLUME_STEP, config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+        CONF_VOLUME_STEP, config_entry.data.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
     )
 
     params = {}

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -157,9 +157,7 @@ class VizioDevice(MediaPlayerDevice):
         )
         if audio_settings is not None:
             self._volume_level = float(audio_settings["volume"]) / self._max_volume
-
-            mute_val = audio_settings["mute"].lower()
-            self._is_muted = mute_val == "on"
+            self._is_muted = audio_settings["mute"].lower() == "on"
 
         input_ = await self._device.get_current_input(log_api_exception=False)
         if input_ is not None:

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -107,6 +107,7 @@ class VizioDevice(MediaPlayerDevice):
         self._state = None
         self._volume_level = None
         self._volume_step = volume_step
+        self._is_muted = None
         self._current_input = None
         self._available_inputs = None
         self._device_class = device_class
@@ -151,9 +152,14 @@ class VizioDevice(MediaPlayerDevice):
 
         self._state = STATE_ON
 
-        volume = await self._device.get_current_volume(log_api_exception=False)
-        if volume is not None:
-            self._volume_level = float(volume) / self._max_volume
+        audio_settings = await self._device.get_all_audio_settings(
+            log_api_exception=False
+        )
+        if audio_settings is not None:
+            self._volume_level = float(audio_settings["volume"]) / self._max_volume
+
+            mute_val = audio_settings["mute"].lower()
+            self._is_muted = mute_val == "on"
 
         input_ = await self._device.get_current_input(log_api_exception=False)
         if input_ is not None:
@@ -223,6 +229,11 @@ class VizioDevice(MediaPlayerDevice):
     def volume_level(self) -> float:
         """Return the volume level of the device."""
         return self._volume_level
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self._is_muted
 
     @property
     def source(self) -> str:

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -283,8 +283,10 @@ class VizioDevice(MediaPlayerDevice):
         """Mute the volume."""
         if mute:
             await self._device.mute_on()
+            self._is_muted = True
         else:
             await self._device.mute_off()
+            self._is_muted = False
 
     async def async_media_previous_track(self) -> None:
         """Send previous channel command."""

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -132,8 +132,11 @@ def vizio_update_fixture():
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect_with_auth_check",
         return_value=True,
     ), patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.get_current_volume",
-        return_value=int(MAX_VOLUME[DEVICE_CLASS_SPEAKER] / 2),
+        "homeassistant.components.vizio.media_player.VizioAsync.get_all_audio_settings",
+        return_value={
+            "volume": int(MAX_VOLUME[DEVICE_CLASS_SPEAKER] / 2),
+            "mute": "Off",
+        },
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_current_input",
         return_value=CURRENT_INPUT,

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -69,8 +69,8 @@ async def _test_setup(
         )
 
     with patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.get_current_volume",
-        return_value=int(MAX_VOLUME[vizio_device_class] / 2),
+        "homeassistant.components.vizio.media_player.VizioAsync.get_all_audio_settings",
+        return_value={"volume": int(MAX_VOLUME[vizio_device_class] / 2), "mute": "Off"},
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
         return_value=vizio_power_state,


### PR DESCRIPTION
## Proposed change
Adding the `is_volume_muted` property to the vizio integration. Since this is being pulled directly from the device, there are no tests to add, so the existing tests have just been updated to account for the change in logic


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
