### PR TITLE
Update deconz/cover.py to adapt rest-api changes

### DIFF
--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -61,7 +61,7 @@ class DeconzCover(DeconzDevice, CoverDevice):
     @property
     def current_cover_position(self):
         """Return the current position of the cover."""
-        return 100 - int(self._device.brightness / 255 * 100)
+        return 100 - int(self._device.brightness / 254 * 100)
 
     @property
     def is_closed(self):
@@ -88,7 +88,7 @@ class DeconzCover(DeconzDevice, CoverDevice):
 
         if position < 100:
             data["on"] = True
-            data["bri"] = 255 - int(position / 100 * 255)
+            data["bri"] = 254 - int(position / 100 * 254)
 
         await self._device.async_set_state(data)
 

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -33,6 +33,14 @@ COVERS = {
         "state": {"reachable": True},
         "uniqueid": "00:00:00:00:00:00:00:02-00",
     },
+    "4": {
+        "id": "deconz old brightness cover id",
+        "name": "deconz old brightness cover",
+        "type": "Level controllable output",
+        "state": {"bri": 255, "on": False, "reachable": True},
+        "modelid": "Not zigbee spec",
+        "uniqueid": "00:00:00:00:00:00:00:03-00",
+    },
 }
 
 
@@ -62,7 +70,8 @@ async def test_cover(hass):
     assert "cover.level_controllable_cover" in gateway.deconz_ids
     assert "cover.window_covering_device" in gateway.deconz_ids
     assert "cover.unsupported_cover" not in gateway.deconz_ids
-    assert len(hass.states.async_all()) == 3
+    assert "cover.deconz_old_brightness_cover" in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 4
 
     level_controllable_cover = hass.states.get("cover.level_controllable_cover")
     assert level_controllable_cover.state == "open"
@@ -119,6 +128,23 @@ async def test_cover(hass):
         )
         await hass.async_block_till_done()
         set_callback.assert_called_with("put", "/lights/1/state", json={"bri_inc": 0})
+
+    """Test that a reported cover position of 255 (deconz-rest-api < 2.05.73) is interpreted correctly."""
+    deconz_old_brightness_cover = hass.states.get("cover.deconz_old_brightness_cover")
+    assert deconz_old_brightness_cover.state == "open"
+
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "lights",
+        "id": "4",
+        "state": {"on": True},
+    }
+    gateway.api.event_handler(state_changed_event)
+    await hass.async_block_till_done()
+
+    deconz_old_brightness_cover = hass.states.get("cover.deconz_old_brightness_cover")
+    assert deconz_old_brightness_cover.attributes["current_position"] == 0
 
     await gateway.async_reset()
 

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -14,7 +14,7 @@ COVERS = {
         "id": "Level controllable cover id",
         "name": "Level controllable cover",
         "type": "Level controllable output",
-        "state": {"bri": 255, "on": False, "reachable": True},
+        "state": {"bri": 254, "on": False, "reachable": True},
         "modelid": "Not zigbee spec",
         "uniqueid": "00:00:00:00:00:00:00:00-00",
     },
@@ -22,7 +22,7 @@ COVERS = {
         "id": "Window covering device id",
         "name": "Window covering device",
         "type": "Window covering device",
-        "state": {"bri": 255, "on": True, "reachable": True},
+        "state": {"bri": 254, "on": True, "reachable": True},
         "modelid": "lumi.curtain",
         "uniqueid": "00:00:00:00:00:00:00:01-00",
     },
@@ -105,7 +105,7 @@ async def test_cover(hass):
         )
         await hass.async_block_till_done()
         set_callback.assert_called_with(
-            "put", "/lights/1/state", json={"on": True, "bri": 255}
+            "put", "/lights/1/state", json={"on": True, "bri": 254}
         )
 
     with patch.object(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
none

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Recent releases of the deconz rest-api (2.05.73+) changed the reported value of open covers to `states.bri: 254`: [#2257 deconz-rest-plugin](https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2257)

This should be adopted in home assistant to improve position accuracy.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
