### PR TITLE
Add support for Minecraft SRV records

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -431,6 +431,7 @@ omit =
     homeassistant/components/minecraft_server/__init__.py
     homeassistant/components/minecraft_server/binary_sensor.py
     homeassistant/components/minecraft_server/const.py
+    homeassistant/components/minecraft_server/helpers.py
     homeassistant/components/minecraft_server/sensor.py
     homeassistant/components/minio/*
     homeassistant/components/mitemp_bt/sensor.py

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -38,10 +38,9 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry) 
     # Create and store server instance.
     unique_id = config_entry.unique_id
     _LOGGER.debug(
-        "Creating server instance for '%s' (host='%s', port=%s)",
+        "Creating server instance for '%s' (%s)",
         config_entry.data[CONF_NAME],
         config_entry.data[CONF_HOST],
-        config_entry.data[CONF_PORT],
     )
     server = MinecraftServer(hass, unique_id, config_entry.data)
     domain_data[unique_id] = server
@@ -83,7 +82,6 @@ class MinecraftServer:
     """Representation of a Minecraft server."""
 
     # Private constants
-    _MAX_RETRIES_PING = 3
     _MAX_RETRIES_STATUS = 3
 
     def __init__(
@@ -129,14 +127,14 @@ class MinecraftServer:
         self._stop_periodic_update()
 
     async def async_check_connection(self) -> None:
-        """Check server connection using a 'ping' request and store result."""
+        """Check server connection using a 'status' request and store connection status."""
         # Check if host is a valid SRV record, if not already done.
         if not self.srv_record_checked:
             self.srv_record_checked = True
             srv_record = await helpers.async_check_srv_record(self._hass, self.host)
             if srv_record is not None:
                 _LOGGER.debug(
-                    "'%s' is a valid Minecraft SRV record (host=%s, port=%s)",
+                    "'%s' is a valid Minecraft SRV record ('%s:%s')",
                     self.host,
                     srv_record[CONF_HOST],
                     srv_record[CONF_PORT],
@@ -147,15 +145,18 @@ class MinecraftServer:
                 self.port = srv_record[CONF_PORT]
                 self._mc_status = MCStatus(self.host, self.port)
 
-        # Ping the server.
+        # Ping the server with a status request.
         try:
             await self._hass.async_add_executor_job(
-                self._mc_status.ping, self._MAX_RETRIES_PING
+                self._mc_status.status, self._MAX_RETRIES_STATUS
             )
             self.online = True
         except OSError as error:
             _LOGGER.debug(
-                "Error occurred while trying to ping the server - OSError: %s", error
+                "Error occurred while trying to check the connection to '%s:%s' - OSError: %s",
+                self.host,
+                self.port,
+                error,
             )
             self.online = False
 
@@ -168,9 +169,9 @@ class MinecraftServer:
 
         # Inform user once about connection state changes if necessary.
         if server_online_old and not server_online:
-            _LOGGER.warning("Connection to server lost")
+            _LOGGER.warning("Connection to '%s:%s' lost", self.host, self.port)
         elif not server_online_old and server_online:
-            _LOGGER.info("Connection to server (re-)established")
+            _LOGGER.info("Connection to '%s:%s' (re-)established", self.host, self.port)
 
         # Update the server properties if server is online.
         if server_online:
@@ -199,7 +200,11 @@ class MinecraftServer:
 
             # Inform user once about successful update if necessary.
             if self._last_status_request_failed:
-                _LOGGER.info("Updating the server properties succeeded again")
+                _LOGGER.info(
+                    "Updating the properties of '%s:%s' succeeded again",
+                    self.host,
+                    self.port,
+                )
             self._last_status_request_failed = False
         except OSError as error:
             # No answer to request, set all properties to unknown.
@@ -213,7 +218,10 @@ class MinecraftServer:
             # Inform user once about failed update if necessary.
             if not self._last_status_request_failed:
                 _LOGGER.warning(
-                    "Updating the server properties failed - OSError: %s", error,
+                    "Updating the properties of '%s:%s' failed - OSError: %s",
+                    self.host,
+                    self.port,
+                    error,
                 )
             self._last_status_request_failed = True
 

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -29,11 +29,24 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            # User inputs.
-            host = user_input[CONF_HOST]
-            port = user_input[CONF_PORT]
+            host = None
+            port = DEFAULT_PORT
+            # Split address at last occurrence of ':'.
+            address_left, separator, address_right = user_input[CONF_HOST].rpartition(
+                ":"
+            )
+            # If no separator is found, 'rpartition' return ('', '', original_string).
+            if separator == "":
+                host = address_right
+            else:
+                host = address_left
+                try:
+                    port = int(address_right)
+                except ValueError:
+                    pass  # 'port' is already set to default value.
 
-            unique_id = ""
+            # Remove '[' and ']' in case of an IPv6 address.
+            host = host.strip("[]")
 
             # Check if 'host' is a valid IP address and if so, get the MAC address.
             ip_address = None
@@ -62,40 +75,50 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
             # Validate port configuration (limit to user and dynamic port range).
             elif (port < 1024) or (port > 65535):
                 errors["base"] = "invalid_port"
-            # Validate host and port via ping request to server.
+            # Validate host and port by checking the server connection.
             else:
-                # Build unique_id and config entry title.
-                title = f"{host}:{port}"
-                if ip_address is not None:
-                    # Since IP addresses can change and therefore are not allowed in a
-                    # unique_id, fall back to the MAC address and port (to support
-                    # servers with same MAC address but different ports).
-                    unique_id = f"{mac_address}-{port}"
-                else:
-                    # Check if 'host' is a valid SRV record.
-                    srv_record = await helpers.async_check_srv_record(self.hass, host)
-                    if srv_record is not None:
-                        # Use only SRV host name in unique_id (does not change).
-                        unique_id = f"{host}-srv"
-                        title = host
-                    else:
-                        # Use host name and port in unique_id (to support servers with
-                        # same host name but different ports).
-                        unique_id = f"{host}-{port}"
-
-                # Abort in case the host was already configured before.
-                await self.async_set_unique_id(unique_id)
-                self._abort_if_unique_id_configured()
-
                 # Create server instance with configuration data and ping the server.
-                server = MinecraftServer(self.hass, unique_id, user_input)
+                config_data = {
+                    CONF_NAME: user_input[CONF_NAME],
+                    CONF_HOST: host,
+                    CONF_PORT: port,
+                }
+                server = MinecraftServer(self.hass, "dummy_unique_id", config_data)
                 await server.async_check_connection()
                 if not server.online:
                     # Host or port invalid or server not reachable.
                     errors["base"] = "cannot_connect"
                 else:
+                    # Build unique_id and config entry title.
+                    unique_id = ""
+                    title = f"{host}:{port}"
+                    if ip_address is not None:
+                        # Since IP addresses can change and therefore are not allowed in a
+                        # unique_id, fall back to the MAC address and port (to support
+                        # servers with same MAC address but different ports).
+                        unique_id = f"{mac_address}-{port}"
+                        if ip_address.version == 6:
+                            title = f"[{host}]:{port}"
+                    else:
+                        # Check if 'host' is a valid SRV record.
+                        srv_record = await helpers.async_check_srv_record(
+                            self.hass, host
+                        )
+                        if srv_record is not None:
+                            # Use only SRV host name in unique_id (does not change).
+                            unique_id = f"{host}-srv"
+                            title = host
+                        else:
+                            # Use host name and port in unique_id (to support servers with
+                            # same host name but different ports).
+                            unique_id = f"{host}-{port}"
+
+                    # Abort in case the host was already configured before.
+                    await self.async_set_unique_id(unique_id)
+                    self._abort_if_unique_id_configured()
+
                     # Configuration data are available and no error was detected, create configuration entry.
-                    return self.async_create_entry(title=title, data=user_input)
+                    return self.async_create_entry(title=title, data=config_data)
 
         # Show configuration form (default form in case of no user_input,
         # form filled with user_input and eventually with errors otherwise).
@@ -116,9 +139,6 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(
                         CONF_HOST, default=user_input.get(CONF_HOST, DEFAULT_HOST)
                     ): vol.All(str, vol.Lower),
-                    vol.Optional(
-                        CONF_PORT, default=user_input.get(CONF_PORT, DEFAULT_PORT)
-                    ): int,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/minecraft_server/const.py
+++ b/homeassistant/components/minecraft_server/const.py
@@ -2,7 +2,7 @@
 
 ATTR_PLAYERS_LIST = "players_list"
 
-DEFAULT_HOST = "localhost"
+DEFAULT_HOST = "localhost:25565"
 DEFAULT_NAME = "Minecraft Server"
 DEFAULT_PORT = 25565
 

--- a/homeassistant/components/minecraft_server/const.py
+++ b/homeassistant/components/minecraft_server/const.py
@@ -30,6 +30,8 @@ SCAN_INTERVAL = 60
 
 SIGNAL_NAME_PREFIX = f"signal_{DOMAIN}"
 
+SRV_RECORD_PREFIX = "_minecraft._tcp"
+
 UNIT_PLAYERS_MAX = "players"
 UNIT_PLAYERS_ONLINE = "players"
 UNIT_PROTOCOL_VERSION = None

--- a/homeassistant/components/minecraft_server/helpers.py
+++ b/homeassistant/components/minecraft_server/helpers.py
@@ -1,0 +1,43 @@
+"""Helper functions for the Minecraft Server integration."""
+
+from functools import partial
+from typing import Any, Dict
+
+import dns.resolver
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import SRV_RECORD_PREFIX
+
+
+async def async_check_srv_record(hass: HomeAssistantType, host: str) -> Dict[str, Any]:
+    """Check if the given host is a valid Minecraft SRV record."""
+    # Check if 'host' is a valid SRV record.
+    return_value = None
+    srv_records = None
+    try:
+        params = {
+            "qname": f"{SRV_RECORD_PREFIX}.{host}",
+            "rdtype": dns.rdatatype.SRV,
+        }
+        srv_records = await hass.async_add_executor_job(
+            partial(dns.resolver.query, **params)
+        )
+    except (
+        dns.exception.Timeout,
+        dns.resolver.NoAnswer,
+        dns.resolver.NoNameservers,
+        dns.resolver.NXDOMAIN,
+        dns.resolver.YXDOMAIN,
+    ):
+        # 'host' is not a SRV record.
+        pass
+    else:
+        # 'host' is a valid SRV record, extract the data.
+        return_value = {
+            CONF_HOST: str(srv_records[0].target).rstrip("."),
+            CONF_PORT: srv_records[0].port,
+        }
+
+    return return_value

--- a/homeassistant/components/minecraft_server/manifest.json
+++ b/homeassistant/components/minecraft_server/manifest.json
@@ -3,7 +3,7 @@
   "name": "Minecraft Server",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/minecraft_server",
-  "requirements": ["dnspython==1.16.0", "getmac==0.8.1", "mcstatus==2.3.0"],
+  "requirements": ["aiodns==2.0.0", "getmac==0.8.1", "mcstatus==2.3.0"],
   "dependencies": [],
   "codeowners": ["@elmurato"],
   "quality_scale": "silver"

--- a/homeassistant/components/minecraft_server/manifest.json
+++ b/homeassistant/components/minecraft_server/manifest.json
@@ -3,7 +3,7 @@
   "name": "Minecraft Server",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/minecraft_server",
-  "requirements": ["getmac==0.8.1", "mcstatus==2.3.0"],
+  "requirements": ["dnspython==1.16.0", "getmac==0.8.1", "mcstatus==2.3.0"],
   "dependencies": [],
   "codeowners": ["@elmurato"],
   "quality_scale": "silver"

--- a/homeassistant/components/minecraft_server/strings.json
+++ b/homeassistant/components/minecraft_server/strings.json
@@ -7,8 +7,7 @@
                 "description": "Set up your Minecraft Server instance to allow monitoring.",
                 "data": {
                     "name": "Name",
-                    "host": "Host",
-                    "port": "Port"
+                    "host": "Host"
                 }
             }
         },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -148,6 +148,7 @@ aioautomatic==0.6.5
 aiobotocore==0.11.1
 
 # homeassistant.components.dnsip
+# homeassistant.components.minecraft_server
 aiodns==2.0.0
 
 # homeassistant.components.esphome
@@ -449,9 +450,6 @@ distro==1.4.0
 
 # homeassistant.components.digitalloggers
 dlipower==0.7.165
-
-# homeassistant.components.minecraft_server
-dnspython==1.16.0
 
 # homeassistant.components.doorbird
 doorbirdpy==2.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -450,6 +450,9 @@ distro==1.4.0
 # homeassistant.components.digitalloggers
 dlipower==0.7.165
 
+# homeassistant.components.minecraft_server
+dnspython==1.16.0
+
 # homeassistant.components.doorbird
 doorbirdpy==2.0.8
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -58,6 +58,10 @@ aioautomatic==0.6.5
 # homeassistant.components.aws
 aiobotocore==0.11.1
 
+# homeassistant.components.dnsip
+# homeassistant.components.minecraft_server
+aiodns==2.0.0
+
 # homeassistant.components.esphome
 aioesphomeapi==2.6.1
 
@@ -166,9 +170,6 @@ directpy==0.6
 
 # homeassistant.components.updater
 distro==1.4.0
-
-# homeassistant.components.minecraft_server
-dnspython==1.16.0
 
 # homeassistant.components.dsmr
 dsmr_parser==0.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -167,6 +167,9 @@ directpy==0.6
 # homeassistant.components.updater
 distro==1.4.0
 
+# homeassistant.components.minecraft_server
+dnspython==1.16.0
+
 # homeassistant.components.dsmr
 dsmr_parser==0.18
 

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -1,8 +1,9 @@
 """Test the Minecraft Server config flow."""
 
+import asyncio
+
+import aiodns
 from asynctest import patch
-import dns.rdtypes.IN.SRV
-import dns.resolver
 from mcstatus.pinger import PingResponse
 
 from homeassistant.components.minecraft_server.const import (
@@ -21,6 +22,19 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.common import MockConfigEntry
 
+
+class QueryMock:
+    """Mock for result of aiodns.DNSResolver.query."""
+
+    def __init__(self):
+        """Set up query result mock."""
+        self.host = "mc.dummyserver.com"
+        self.port = 23456
+        self.priority = 1
+        self.weight = 1
+        self.ttl = None
+
+
 STATUS_RESPONSE_RAW = {
     "description": {"text": "Dummy Description"},
     "version": {"name": "Dummy Version", "protocol": 123},
@@ -37,50 +51,33 @@ STATUS_RESPONSE_RAW = {
 
 USER_INPUT = {
     CONF_NAME: DEFAULT_NAME,
-    CONF_HOST: "mc.dummyserver.com",
-    CONF_PORT: DEFAULT_PORT,
+    CONF_HOST: f"mc.dummyserver.com:{DEFAULT_PORT}",
 }
 
-USER_INPUT_SRV = {
-    CONF_NAME: DEFAULT_NAME,
-    CONF_HOST: "dummyserver.com",
-    CONF_PORT: DEFAULT_PORT,
-}
+USER_INPUT_SRV = {CONF_NAME: DEFAULT_NAME, CONF_HOST: "dummyserver.com"}
 
 USER_INPUT_IPV4 = {
     CONF_NAME: DEFAULT_NAME,
-    CONF_HOST: "1.1.1.1",
-    CONF_PORT: DEFAULT_PORT,
+    CONF_HOST: f"1.1.1.1:{DEFAULT_PORT}",
 }
 
 USER_INPUT_IPV6 = {
     CONF_NAME: DEFAULT_NAME,
-    CONF_HOST: "::ffff:0101:0101",
-    CONF_PORT: DEFAULT_PORT,
+    CONF_HOST: f"[::ffff:0101:0101]:{DEFAULT_PORT}",
 }
 
 USER_INPUT_PORT_TOO_SMALL = {
     CONF_NAME: DEFAULT_NAME,
-    CONF_HOST: "mc.dummyserver.com",
-    CONF_PORT: 1023,
+    CONF_HOST: f"mc.dummyserver.com:1023",
 }
 
 USER_INPUT_PORT_TOO_LARGE = {
     CONF_NAME: DEFAULT_NAME,
-    CONF_HOST: "mc.dummyserver.com",
-    CONF_PORT: 65536,
+    CONF_HOST: f"mc.dummyserver.com:65536",
 }
 
-SRV_RECORDS = [
-    dns.rdtypes.IN.SRV.SRV(
-        target="mc.dummyserver.com.",
-        port=23456,
-        weight=1,
-        priority=1,
-        rdclass=None,
-        rdtype=None,
-    )
-]
+SRV_RECORDS = asyncio.Future()
+SRV_RECORDS.set_result([QueryMock()])
 
 
 async def test_show_config_form(hass: HomeAssistantType) -> None:
@@ -107,26 +104,35 @@ async def test_invalid_ip(hass: HomeAssistantType) -> None:
 async def test_same_host(hass: HomeAssistantType) -> None:
     """Test abort in case of same host name."""
     with patch(
-        "dns.resolver.query", side_effect=dns.resolver.NoAnswer,
+        "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
     ):
-        unique_id = f"{USER_INPUT[CONF_HOST]}-{USER_INPUT[CONF_PORT]}"
-        mock_config_entry = MockConfigEntry(
-            domain=DOMAIN, unique_id=unique_id, data=USER_INPUT
-        )
-        mock_config_entry.add_to_hass(hass)
+        with patch(
+            "mcstatus.server.MinecraftServer.status",
+            return_value=PingResponse(STATUS_RESPONSE_RAW),
+        ):
+            unique_id = "mc.dummyserver.com-25565"
+            config_data = {
+                CONF_NAME: DEFAULT_NAME,
+                CONF_HOST: "mc.dummyserver.com",
+                CONF_PORT: DEFAULT_PORT,
+            }
+            mock_config_entry = MockConfigEntry(
+                domain=DOMAIN, unique_id=unique_id, data=config_data
+            )
+            mock_config_entry.add_to_hass(hass)
 
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
-        )
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+            )
 
-        assert result["type"] == RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
+            assert result["type"] == RESULT_TYPE_ABORT
+            assert result["reason"] == "already_configured"
 
 
 async def test_port_too_small(hass: HomeAssistantType) -> None:
     """Test error in case of a too small port."""
     with patch(
-        "dns.resolver.query", side_effect=dns.resolver.NoAnswer,
+        "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_PORT_TOO_SMALL
@@ -139,7 +145,7 @@ async def test_port_too_small(hass: HomeAssistantType) -> None:
 async def test_port_too_large(hass: HomeAssistantType) -> None:
     """Test error in case of a too large port."""
     with patch(
-        "dns.resolver.query", side_effect=dns.resolver.NoAnswer,
+        "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_PORT_TOO_LARGE
@@ -152,9 +158,9 @@ async def test_port_too_large(hass: HomeAssistantType) -> None:
 async def test_connection_failed(hass: HomeAssistantType) -> None:
     """Test error in case of a failed connection."""
     with patch(
-        "dns.resolver.query", side_effect=dns.resolver.NoAnswer,
+        "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
     ):
-        with patch("mcstatus.server.MinecraftServer.ping", side_effect=OSError):
+        with patch("mcstatus.server.MinecraftServer.status", side_effect=OSError):
             result = await hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
             )
@@ -166,93 +172,76 @@ async def test_connection_failed(hass: HomeAssistantType) -> None:
 async def test_connection_succeeded_with_srv_record(hass: HomeAssistantType) -> None:
     """Test config entry in case of a successful connection with a SRV record."""
     with patch(
-        "dns.resolver.query", return_value=SRV_RECORDS,
+        "aiodns.DNSResolver.query", return_value=SRV_RECORDS,
     ):
-        with patch("mcstatus.server.MinecraftServer.ping", return_value=50):
-            with patch(
-                "mcstatus.server.MinecraftServer.status",
-                return_value=PingResponse(STATUS_RESPONSE_RAW),
-            ):
-                result = await hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_SRV
-                )
+        with patch(
+            "mcstatus.server.MinecraftServer.status",
+            return_value=PingResponse(STATUS_RESPONSE_RAW),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_SRV
+            )
 
-                assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-                assert result["title"] == "dummyserver.com"
-                assert result["data"][CONF_NAME] == USER_INPUT_SRV[CONF_NAME]
-                assert result["data"][CONF_HOST] == USER_INPUT_SRV[CONF_HOST]
-                assert result["data"][CONF_PORT] == DEFAULT_PORT
+            assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == USER_INPUT_SRV[CONF_HOST]
+            assert result["data"][CONF_NAME] == USER_INPUT_SRV[CONF_NAME]
+            assert result["data"][CONF_HOST] == USER_INPUT_SRV[CONF_HOST]
 
 
 async def test_connection_succeeded_with_host(hass: HomeAssistantType) -> None:
     """Test config entry in case of a successful connection with a host name."""
     with patch(
-        "dns.resolver.query", side_effect=dns.resolver.NoAnswer,
+        "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
     ):
-        with patch("mcstatus.server.MinecraftServer.ping", return_value=50):
-            with patch(
-                "mcstatus.server.MinecraftServer.status",
-                return_value=PingResponse(STATUS_RESPONSE_RAW),
-            ):
-                result = await hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
-                )
+        with patch(
+            "mcstatus.server.MinecraftServer.status",
+            return_value=PingResponse(STATUS_RESPONSE_RAW),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+            )
 
-                assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-                assert (
-                    result["title"]
-                    == f"{USER_INPUT[CONF_HOST]}:{USER_INPUT[CONF_PORT]}"
-                )
-                assert result["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
-                assert result["data"][CONF_HOST] == USER_INPUT[CONF_HOST]
-                assert result["data"][CONF_PORT] == USER_INPUT[CONF_PORT]
+            assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == USER_INPUT[CONF_HOST]
+            assert result["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
+            assert result["data"][CONF_HOST] == "mc.dummyserver.com"
 
 
 async def test_connection_succeeded_with_ip4(hass: HomeAssistantType) -> None:
     """Test config entry in case of a successful connection with an IPv4 address."""
     with patch("getmac.get_mac_address", return_value="01:23:45:67:89:ab"):
         with patch(
-            "dns.resolver.query", side_effect=dns.resolver.NoAnswer,
+            "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
         ):
-            with patch("mcstatus.server.MinecraftServer.ping", return_value=50):
-                with patch(
-                    "mcstatus.server.MinecraftServer.status",
-                    return_value=PingResponse(STATUS_RESPONSE_RAW),
-                ):
-                    result = await hass.config_entries.flow.async_init(
-                        DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV4
-                    )
+            with patch(
+                "mcstatus.server.MinecraftServer.status",
+                return_value=PingResponse(STATUS_RESPONSE_RAW),
+            ):
+                result = await hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV4
+                )
 
-                    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-                    assert (
-                        result["title"]
-                        == f"{USER_INPUT_IPV4[CONF_HOST]}:{USER_INPUT_IPV4[CONF_PORT]}"
-                    )
-                    assert result["data"][CONF_NAME] == USER_INPUT_IPV4[CONF_NAME]
-                    assert result["data"][CONF_HOST] == USER_INPUT_IPV4[CONF_HOST]
-                    assert result["data"][CONF_PORT] == USER_INPUT_IPV4[CONF_PORT]
+                assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+                assert result["title"] == USER_INPUT_IPV4[CONF_HOST]
+                assert result["data"][CONF_NAME] == USER_INPUT_IPV4[CONF_NAME]
+                assert result["data"][CONF_HOST] == "1.1.1.1"
 
 
 async def test_connection_succeeded_with_ip6(hass: HomeAssistantType) -> None:
     """Test config entry in case of a successful connection with an IPv6 address."""
     with patch("getmac.get_mac_address", return_value="01:23:45:67:89:ab"):
         with patch(
-            "dns.resolver.query", side_effect=dns.resolver.NoAnswer,
+            "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
         ):
-            with patch("mcstatus.server.MinecraftServer.ping", return_value=50):
-                with patch(
-                    "mcstatus.server.MinecraftServer.status",
-                    return_value=PingResponse(STATUS_RESPONSE_RAW),
-                ):
-                    result = await hass.config_entries.flow.async_init(
-                        DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV6
-                    )
+            with patch(
+                "mcstatus.server.MinecraftServer.status",
+                return_value=PingResponse(STATUS_RESPONSE_RAW),
+            ):
+                result = await hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV6
+                )
 
-                    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-                    assert (
-                        result["title"]
-                        == f"{USER_INPUT_IPV6[CONF_HOST]}:{USER_INPUT_IPV6[CONF_PORT]}"
-                    )
-                    assert result["data"][CONF_NAME] == USER_INPUT_IPV6[CONF_NAME]
-                    assert result["data"][CONF_HOST] == USER_INPUT_IPV6[CONF_HOST]
-                    assert result["data"][CONF_PORT] == USER_INPUT_IPV6[CONF_PORT]
+                assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+                assert result["title"] == USER_INPUT_IPV6[CONF_HOST]
+                assert result["data"][CONF_NAME] == USER_INPUT_IPV6[CONF_NAME]
+                assert result["data"][CONF_HOST] == "::ffff:0101:0101"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minecraft supports [SRV records](https://www.noip.com/support/knowledgebase/how-to-add-a-srv-record-to-your-minecraft-server-remove-the-port-on-the-end-of-the-url/) (example: `_minecraft._tcp.examplemcserver.com`) for connecting to a server without the need to enter a port manually. The domain and port are extracted out of the SRV record.
This pull request adds support for this for the Minecraft Server integration using the library `aiodns`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32214, fixes #32405
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
