### PR TITLE
Remove 'show all controls' option for Plex

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -48,12 +48,15 @@ from .const import (
 )
 from .server import PlexServer
 
-MEDIA_PLAYER_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
-        vol.Optional(CONF_SHOW_ALL_CONTROLS, default=False): cv.boolean,
-        vol.Optional(CONF_IGNORE_NEW_SHARED_USERS, default=False): cv.boolean,
-    }
+MEDIA_PLAYER_SCHEMA = vol.All(
+    cv.deprecated(CONF_SHOW_ALL_CONTROLS, invalidation_version="0.110"),
+    vol.Schema(
+        {
+            vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
+            vol.Optional(CONF_SHOW_ALL_CONTROLS): cv.boolean,
+            vol.Optional(CONF_IGNORE_NEW_SHARED_USERS, default=False): cv.boolean,
+        }
+    ),
 )
 
 SERVER_CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -25,7 +25,6 @@ from .const import (  # pylint: disable=unused-import
     CONF_MONITORED_USERS,
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
-    CONF_SHOW_ALL_CONTROLS,
     CONF_USE_EPISODE_ART,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -272,9 +271,6 @@ class PlexOptionsFlowHandler(config_entries.OptionsFlow):
             self.options[MP_DOMAIN][CONF_USE_EPISODE_ART] = user_input[
                 CONF_USE_EPISODE_ART
             ]
-            self.options[MP_DOMAIN][CONF_SHOW_ALL_CONTROLS] = user_input[
-                CONF_SHOW_ALL_CONTROLS
-            ]
             self.options[MP_DOMAIN][CONF_IGNORE_NEW_SHARED_USERS] = user_input[
                 CONF_IGNORE_NEW_SHARED_USERS
             ]
@@ -314,10 +310,6 @@ class PlexOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required(
                         CONF_USE_EPISODE_ART,
                         default=plex_server.option_use_episode_art,
-                    ): bool,
-                    vol.Required(
-                        CONF_SHOW_ALL_CONTROLS,
-                        default=plex_server.option_show_all_controls,
                     ): bool,
                     vol.Optional(
                         CONF_MONITORED_USERS, default=default_accounts

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -17,7 +17,6 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_STOP,
-    SUPPORT_TURN_OFF,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
 )
@@ -481,46 +480,6 @@ class PlexMediaPlayer(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        # force show all controls
-        if self.plex_server.option_show_all_controls:
-            return (
-                SUPPORT_PAUSE
-                | SUPPORT_PREVIOUS_TRACK
-                | SUPPORT_NEXT_TRACK
-                | SUPPORT_STOP
-                | SUPPORT_VOLUME_SET
-                | SUPPORT_PLAY
-                | SUPPORT_PLAY_MEDIA
-                | SUPPORT_TURN_OFF
-                | SUPPORT_VOLUME_MUTE
-            )
-
-        # no mute support
-        if self.make.lower() == "shield android tv":
-            _LOGGER.debug(
-                "Shield Android TV client detected, disabling mute controls: %s",
-                self.name,
-            )
-            return (
-                SUPPORT_PAUSE
-                | SUPPORT_PREVIOUS_TRACK
-                | SUPPORT_NEXT_TRACK
-                | SUPPORT_STOP
-                | SUPPORT_VOLUME_SET
-                | SUPPORT_PLAY
-                | SUPPORT_PLAY_MEDIA
-                | SUPPORT_TURN_OFF
-            )
-
-        # Only supports play,pause,stop (and off which really is stop)
-        if self.make.lower().startswith("tivo"):
-            _LOGGER.debug(
-                "Tivo client detected, only enabling pause, play, "
-                "stop, and off controls: %s",
-                self.name,
-            )
-            return SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_STOP | SUPPORT_TURN_OFF
-
         if self.device and "playback" in self._device_protocol_capabilities:
             return (
                 SUPPORT_PAUSE
@@ -530,7 +489,6 @@ class PlexMediaPlayer(MediaPlayerDevice):
                 | SUPPORT_VOLUME_SET
                 | SUPPORT_PLAY
                 | SUPPORT_PLAY_MEDIA
-                | SUPPORT_TURN_OFF
                 | SUPPORT_VOLUME_MUTE
             )
 
@@ -593,11 +551,6 @@ class PlexMediaPlayer(MediaPlayerDevice):
         if self.device and "playback" in self._device_protocol_capabilities:
             self.device.stop(self._active_media_plexapi_type)
             self.plex_server.update_platforms()
-
-    def turn_off(self):
-        """Turn the client off."""
-        # Fake it since we can't turn the client off
-        self.media_stop()
 
     def media_next_track(self):
         """Send next track command."""

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -16,7 +16,6 @@ from .const import (
     CONF_IGNORE_NEW_SHARED_USERS,
     CONF_MONITORED_USERS,
     CONF_SERVER,
-    CONF_SHOW_ALL_CONTROLS,
     CONF_USE_EPISODE_ART,
     DEFAULT_VERIFY_SSL,
     PLEX_NEW_MP_SIGNAL,
@@ -263,11 +262,6 @@ class PlexServer:
     def option_use_episode_art(self):
         """Return use_episode_art option."""
         return self.options[MP_DOMAIN][CONF_USE_EPISODE_ART]
-
-    @property
-    def option_show_all_controls(self):
-        """Return show_all_controls option."""
-        return self.options[MP_DOMAIN][CONF_SHOW_ALL_CONTROLS]
 
     @property
     def option_monitored_users(self):

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -36,7 +36,6 @@
                 "description": "Options for Plex Media Players",
                 "data": {
                     "use_episode_art": "Use episode art",
-                    "show_all_controls": "Show all controls",
                     "ignore_new_shared_users": "Ignore new managed/shared users",
                     "monitored_users": "Monitored users"
                 }

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -26,7 +26,6 @@ MOCK_FILE_CONTENTS = {
 DEFAULT_OPTIONS = {
     config_flow.MP_DOMAIN: {
         config_flow.CONF_USE_EPISODE_ART: False,
-        config_flow.CONF_SHOW_ALL_CONTROLS: False,
         config_flow.CONF_IGNORE_NEW_SHARED_USERS: False,
     }
 }
@@ -485,7 +484,6 @@ async def test_option_flow(hass):
         result["flow_id"],
         user_input={
             config_flow.CONF_USE_EPISODE_ART: True,
-            config_flow.CONF_SHOW_ALL_CONTROLS: True,
             config_flow.CONF_IGNORE_NEW_SHARED_USERS: True,
             config_flow.CONF_MONITORED_USERS: list(mock_plex_server.accounts),
         },
@@ -494,7 +492,6 @@ async def test_option_flow(hass):
     assert result["data"] == {
         config_flow.MP_DOMAIN: {
             config_flow.CONF_USE_EPISODE_ART: True,
-            config_flow.CONF_SHOW_ALL_CONTROLS: True,
             config_flow.CONF_IGNORE_NEW_SHARED_USERS: True,
             config_flow.CONF_MONITORED_USERS: {
                 user: {"enabled": True} for user in mock_plex_server.accounts
@@ -530,7 +527,6 @@ async def test_option_flow_loading_saved_users(hass):
         result["flow_id"],
         user_input={
             config_flow.CONF_USE_EPISODE_ART: True,
-            config_flow.CONF_SHOW_ALL_CONTROLS: True,
             config_flow.CONF_IGNORE_NEW_SHARED_USERS: True,
             config_flow.CONF_MONITORED_USERS: list(mock_plex_server.accounts),
         },
@@ -539,7 +535,6 @@ async def test_option_flow_loading_saved_users(hass):
     assert result["data"] == {
         config_flow.MP_DOMAIN: {
             config_flow.CONF_USE_EPISODE_ART: True,
-            config_flow.CONF_SHOW_ALL_CONTROLS: True,
             config_flow.CONF_IGNORE_NEW_SHARED_USERS: True,
             config_flow.CONF_MONITORED_USERS: {
                 user: {"enabled": True} for user in mock_plex_server.accounts
@@ -580,7 +575,6 @@ async def test_option_flow_new_users_available(hass):
         result["flow_id"],
         user_input={
             config_flow.CONF_USE_EPISODE_ART: True,
-            config_flow.CONF_SHOW_ALL_CONTROLS: True,
             config_flow.CONF_IGNORE_NEW_SHARED_USERS: True,
             config_flow.CONF_MONITORED_USERS: list(mock_plex_server.accounts),
         },
@@ -589,7 +583,6 @@ async def test_option_flow_new_users_available(hass):
     assert result["data"] == {
         config_flow.MP_DOMAIN: {
             config_flow.CONF_USE_EPISODE_ART: True,
-            config_flow.CONF_SHOW_ALL_CONTROLS: True,
             config_flow.CONF_IGNORE_NEW_SHARED_USERS: True,
             config_flow.CONF_MONITORED_USERS: {
                 user: {"enabled": True} for user in mock_plex_server.accounts


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Deprecates a YAML & options config option and removes its associated functionality. Breaking config removal scheduled for the 0.110 release.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The ‘show all controls’ option has historically caused confusion as enabling it makes it appear that uncontrollable Plex clients are controllable. Additionally, client-specific workarounds regularly cause confusion and incorrect behavior. For example, NVIDIA SHIELD clients _always_ appear controllable. Any client-specific workarounds should be pushed down into the underlying library’s domain.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
plex:
  media_player:
    show_all_controls: True  # Deprecated
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12269

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
