### PR TITLE
Keeping adding in Github repositories after error

### DIFF
--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -61,8 +61,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 "Error setting up GitHub platform. %s",
                 "Check previous errors for details",
             )
-            return
-        sensors.append(GitHubSensor(data))
+        else:
+            sensors.append(GitHubSensor(data))
     add_entities(sensors, True)
 
 
@@ -170,7 +170,6 @@ class GitHubData:
             return
 
         self.name = repository.get(CONF_NAME, repo.name)
-
         self.available = False
         self.latest_commit_message = None
         self.latest_commit_sha = None


### PR DESCRIPTION
Fixes #31951



## Proposed change

Currently, if encounter an error in getting details for 1 Github repository, it crashes the rest after. This patch ignores the repository with an error, logs the details about it, but continues on adding the rest in the list.


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
  - platform: github
    access_token: !secret github_token
    entity_namespace: Github
    scan_interval: 3600
    repositories:
      - path: kuchel77/home-assistant
        name: "Works"
      - path: home-assistant/home-assistant
        name: "Works also "
      - path: home-assiaevstant/home-assistant
        name: "Doesn't work, log the error but keep going with the rest"
      - path: kuchel77/diskspace
        name: "This also works"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31951 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

