### PR TITLE
Add availability to opentherm_gw entities

### DIFF
--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -61,6 +61,11 @@ class OpenThermBinarySensor(BinarySensorDevice):
         self._unsub_updates()
 
     @property
+    def available(self):
+        """Return availability of the sensor."""
+        return self._state is not None
+
+    @property
     def entity_registry_enabled_default(self):
         """Disable binary_sensors by default."""
         return False
@@ -68,7 +73,8 @@ class OpenThermBinarySensor(BinarySensorDevice):
     @callback
     def receive_report(self, status):
         """Handle status updates from the component."""
-        self._state = bool(status.get(self._var))
+        state = status.get(self._var)
+        self._state = None if state is None else bool(state)
         self.async_write_ha_state()
 
     @property

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -63,6 +63,7 @@ class OpenThermClimate(ClimateDevice):
         self.friendly_name = gw_dev.name
         self.floor_temp = options.get(CONF_FLOOR_TEMP, DEFAULT_FLOOR_TEMP)
         self.temp_precision = options.get(CONF_PRECISION, DEFAULT_PRECISION)
+        self._available = False
         self._current_operation = None
         self._current_temperature = None
         self._hvac_mode = HVAC_MODE_HEAT
@@ -101,6 +102,7 @@ class OpenThermClimate(ClimateDevice):
     @callback
     def receive_report(self, status):
         """Receive and handle a new report from the Gateway."""
+        self._available = status != {}
         ch_active = status.get(gw_vars.DATA_SLAVE_CH_ACTIVE)
         flame_on = status.get(gw_vars.DATA_SLAVE_FLAME_ON)
         cooling_active = status.get(gw_vars.DATA_SLAVE_COOLING_ACTIVE)
@@ -145,6 +147,11 @@ class OpenThermClimate(ClimateDevice):
                 status.get(gw_vars.OTGW_GPIO_B_STATE) == self._away_mode_b
             )
         self.async_write_ha_state()
+
+    @property
+    def available(self):
+        """Return availability of the sensor."""
+        return self._available
 
     @property
     def name(self):

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -102,7 +102,7 @@ class OpenThermClimate(ClimateDevice):
     @callback
     def receive_report(self, status):
         """Receive and handle a new report from the Gateway."""
-        self._available = status != {}
+        self._available = bool(status)
         ch_active = status.get(gw_vars.DATA_SLAVE_CH_ACTIVE)
         flame_on = status.get(gw_vars.DATA_SLAVE_FLAME_ON)
         cooling_active = status.get(gw_vars.DATA_SLAVE_COOLING_ACTIVE)

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -62,6 +62,11 @@ class OpenThermSensor(Entity):
         self._unsub_updates()
 
     @property
+    def available(self):
+        """Return availability of the sensor."""
+        return self._value is not None
+
+    @property
     def entity_registry_enabled_default(self):
         """Disable sensors by default."""
         return False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This PR adds support for detecting availability of the gateway and/or sensor data.
So far only `sensor` and `binary_sensor` entities will report whether or not their data is included in the status report. The `climate` entity is now prepared for support as well, but it will require an update of the `pyotgw` library before it starts working. This update will be provided in a separate PR.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- N/A Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
