### PR TITLE
Catch Eight Sleep API errors, don't round None type

### DIFF
--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -277,11 +277,11 @@ class EightUserSensor(EightSleepUserEntity):
         elif "last" in self._sensor_root:
             try:
                 state_attr[ATTR_AVG_RESP_RATE] = round(self._attr["resp_rate"], 2)
-            except:
+            except TypeError:
                 state_attr[ATTR_AVG_RESP_RATE] = None
             try:
                 state_attr[ATTR_AVG_HEART_RATE] = round(self._attr["heart_rate"], 2)
-            except:
+            except TypeError:
                 state_attr[ATTR_AVG_HEART_RATE] = None
             state_attr[ATTR_AVG_ROOM_TEMP] = room_temp
             state_attr[ATTR_AVG_BED_TEMP] = bed_temp

--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -263,14 +263,26 @@ class EightUserSensor(EightSleepUserEntity):
             bed_temp = None
 
         if "current" in self._sensor_root:
-            state_attr[ATTR_RESP_RATE] = round(self._attr["resp_rate"], 2)
-            state_attr[ATTR_HEART_RATE] = round(self._attr["heart_rate"], 2)
+            try:
+                state_attr[ATTR_RESP_RATE] = round(self._attr["resp_rate"], 2)
+            except TypeError:
+                state_attr[ATTR_RESP_RATE] = None
+            try:
+                state_attr[ATTR_HEART_RATE] = round(self._attr["heart_rate"], 2)
+            except TypeError:
+                state_attr[ATTR_HEART_RATE] = None
             state_attr[ATTR_SLEEP_STAGE] = self._attr["stage"]
             state_attr[ATTR_ROOM_TEMP] = room_temp
             state_attr[ATTR_BED_TEMP] = bed_temp
         elif "last" in self._sensor_root:
-            state_attr[ATTR_AVG_RESP_RATE] = round(self._attr["resp_rate"], 2)
-            state_attr[ATTR_AVG_HEART_RATE] = round(self._attr["heart_rate"], 2)
+            try:
+                state_attr[ATTR_AVG_RESP_RATE] = round(self._attr["resp_rate"], 2)
+            except:
+                state_attr[ATTR_AVG_RESP_RATE] = None
+            try:
+                state_attr[ATTR_AVG_HEART_RATE] = round(self._attr["heart_rate"], 2)
+            except:
+                state_attr[ATTR_AVG_HEART_RATE] = None
             state_attr[ATTR_AVG_ROOM_TEMP] = room_temp
             state_attr[ATTR_AVG_BED_TEMP] = bed_temp
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes the eight sleep api doesn't return values for heart rate or respiratory rate leading to a type error when the None value is trying to be rounded off for display as an attribute.  These changes catch those errors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
