### PR TITLE
Add rflink binary_sensor allon and alloff commands

### DIFF
--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -73,11 +73,11 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorDevice):
     def _handle_event(self, event):
         """Domain specific event handler."""
         command = event["command"]
-        if command == "on":
+        if command in ["on", "allon"]:
             self._state = True
-        elif command == "off":
+        elif command in ["off", "alloff"]:
             self._state = False
-
+            
         if self._state and self._off_delay is not None:
 
             def off_delay_listener(now):

--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -76,8 +76,7 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorDevice):
         if command in ["on", "allon"]:
             self._state = True
         elif command in ["off", "alloff"]:
-            self._state = False
-            
+            self._state = False            
         if self._state and self._off_delay is not None:
 
             def off_delay_listener(now):

--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -76,7 +76,8 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorDevice):
         if command in ["on", "allon"]:
             self._state = True
         elif command in ["off", "alloff"]:
-            self._state = False            
+            self._state = False
+
         if self._state and self._off_delay is not None:
 
             def off_delay_listener(now):

--- a/tests/components/rflink/test_binary_sensor.py
+++ b/tests/components/rflink/test_binary_sensor.py
@@ -56,14 +56,26 @@ async def test_default_setup(hass, monkeypatch):
     assert config_sensor.state == STATE_OFF
     assert config_sensor.attributes["device_class"] == "door"
 
-    # test event for config sensor
+    # test on event for config sensor
     event_callback({"id": "test", "command": "on"})
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.test").state == STATE_ON
 
-    # test event for config sensor
+    # test off event for config sensor
     event_callback({"id": "test", "command": "off"})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.test").state == STATE_OFF
+
+    # test allon event for config sensor
+    event_callback({"id": "test", "command": "allon"})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.test").state == STATE_ON
+
+    # test alloff event for config sensor
+    event_callback({"id": "test", "command": "alloff"})
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.test").state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Added the rflink group command "allon" and "alloff" to the binary sensor component.
Some devices (like buttons) seems to send "allon" rather than just on and also never sends an "off".

<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
No changes to the config
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
N/A
```

## Additional information
N/A
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32399
- This PR is related to issue: https://github.com/home-assistant/core/issues/32399
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
