### PR TITLE
Fix zha device pings

### DIFF
--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -87,7 +87,7 @@ class ZHADevice(LogMixin):
         self._available_signal = "{}_{}_{}".format(
             self.name, self.ieee, SIGNAL_AVAILABLE
         )
-        self._checkins_missed_count = 2
+        self._checkins_missed_count = 0
         self._unsub = async_dispatcher_connect(
             self.hass, self._available_signal, self.async_initialize
         )
@@ -284,8 +284,12 @@ class ZHADevice(LogMixin):
                         )
                         if not self._channels.pools:
                             return
-                        pool = self._channels.pools[0]
-                        basic_ch = pool.all_channels[f"{pool.id}:0"]
+                        try:
+                            pool = self._channels.pools[0]
+                            basic_ch = pool.all_channels[f"{pool.id}:0x0000"]
+                        except KeyError:
+                            self.debug("%s %s does not have a mandatory basic cluster")
+                            return
                         self.hass.async_create_task(
                             basic_ch.get_attribute_value(
                                 ATTR_MANUFACTURER, from_cache=False

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -1,0 +1,146 @@
+"""Test zha device switch."""
+from datetime import timedelta
+import time
+from unittest import mock
+
+import asynctest
+import pytest
+import zigpy.zcl.clusters.general as general
+
+import homeassistant.components.zha.core.device as zha_core_device
+import homeassistant.core as ha
+import homeassistant.util.dt as dt_util
+
+from .common import async_enable_traffic
+
+
+@pytest.fixture
+def zigpy_device(zigpy_device_mock):
+    """Device tracker zigpy device."""
+
+    def _dev(with_basic_channel: bool = True):
+        in_clusters = [general.OnOff.cluster_id]
+        if with_basic_channel:
+            in_clusters.append(general.Basic.cluster_id)
+
+        endpoints = {
+            3: {"in_clusters": in_clusters, "out_clusters": [], "device_type": 0}
+        }
+        return zigpy_device_mock(endpoints)
+
+    return _dev
+
+
+@pytest.fixture
+def device_with_basic_channel(zigpy_device):
+    """Return a zha device with a basic channel present."""
+    return zigpy_device(with_basic_channel=True)
+
+
+@pytest.fixture
+def device_without_basic_channel(zigpy_device):
+    """Return a zha device with a basic channel present."""
+    return zigpy_device(with_basic_channel=False)
+
+
+def _send_time_changed(hass, seconds):
+    """Send a time changed event."""
+    now = dt_util.utcnow() + timedelta(seconds)
+    hass.bus.async_fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})
+
+
+@asynctest.patch(
+    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
+    new=mock.MagicMock(),
+)
+async def test_check_available_success(
+    hass, device_with_basic_channel, zha_device_restored
+):
+    """Check device availability success on 1st try."""
+
+    # pylint: disable=protected-access
+    zha_device = await zha_device_restored(device_with_basic_channel)
+    await async_enable_traffic(hass, [zha_device])
+    basic_ch = device_with_basic_channel.endpoints[3].basic
+
+    basic_ch.read_attributes.reset_mock()
+    device_with_basic_channel.last_seen = None
+    assert zha_device.available is True
+    _send_time_changed(hass, 61)
+    await hass.async_block_till_done()
+    assert zha_device.available is False
+    assert basic_ch.read_attributes.await_count == 0
+
+    device_with_basic_channel.last_seen = (
+        time.time() - zha_core_device._KEEP_ALIVE_INTERVAL - 2
+    )
+    _seens = [time.time(), device_with_basic_channel.last_seen]
+
+    def _update_last_seen(*args, **kwargs):
+        device_with_basic_channel.last_seen = _seens.pop()
+
+    basic_ch.read_attributes.side_effect = _update_last_seen
+
+    # successfully ping zigpy device, but zha_device is not yet available
+    _send_time_changed(hass, 61)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 1
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is False
+
+    # There was traffic from the device: pings, but not yet available
+    _send_time_changed(hass, 61)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is False
+
+    # There was traffic from the device: don't try to ping, marked as available
+    _send_time_changed(hass, 61)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is True
+
+
+@asynctest.patch(
+    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
+    new=mock.MagicMock(),
+)
+async def test_check_available_unsuccessful(
+    hass, device_with_basic_channel, zha_device_restored
+):
+    """Check device availability all tries fail."""
+
+    # pylint: disable=protected-access
+    zha_device = await zha_device_restored(device_with_basic_channel)
+    await async_enable_traffic(hass, [zha_device])
+    basic_ch = device_with_basic_channel.endpoints[3].basic
+
+    assert zha_device.available is True
+    assert basic_ch.read_attributes.await_count == 0
+
+    device_with_basic_channel.last_seen = (
+        time.time() - zha_core_device._KEEP_ALIVE_INTERVAL - 2
+    )
+
+    # unsuccessfuly ping zigpy device, but zha_device is still available
+    _send_time_changed(hass, 61)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 1
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is True
+
+    # still no traffic, but zha_device is still available
+    _send_time_changed(hass, 61)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is True
+
+    # not even trying to update, device is unavailble
+    _send_time_changed(hass, 61)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When there's no traffic from a zigpy device for two hours, ZHA tries to ping the device by reading the manufacturer attribute of a the "basic" cluster. Use correct channel ID when checking for the presence of the basic channel.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32365, #32266
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
