### PR TITLE
Add custom data type support into Modbus climate

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
+    CONF_STRUCTURE,
     CONF_TIMEOUT,
     CONF_TYPE,
     EVENT_HOMEASSISTANT_STOP,
@@ -37,19 +38,38 @@ from .const import (
     CALL_TYPE_REGISTER_INPUT,
     CONF_BAUDRATE,
     CONF_BYTESIZE,
+    CONF_CLIMATES,
+    CONF_CURRENT_TEMP,
+    CONF_CURRENT_TEMP_REGISTER_TYPE,
+    CONF_DATA_COUNT,
+    CONF_DATA_TYPE,
     CONF_INPUT_TYPE,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
+    CONF_OFFSET,
     CONF_PARITY,
+    CONF_PRECISION,
     CONF_REGISTER,
+    CONF_SCALE,
     CONF_STATE_CLOSED,
     CONF_STATE_CLOSING,
     CONF_STATE_OPEN,
     CONF_STATE_OPENING,
     CONF_STATUS_REGISTER,
     CONF_STATUS_REGISTER_TYPE,
+    CONF_STEP,
     CONF_STOPBITS,
+    CONF_TARGET_TEMP,
+    CONF_UNIT,
+    DATA_TYPE_CUSTOM,
+    DATA_TYPE_FLOAT,
+    DATA_TYPE_INT,
+    DATA_TYPE_UINT,
     DEFAULT_HUB,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SLAVE,
+    DEFAULT_STRUCTURE_PREFIX,
+    DEFAULT_TEMP_UNIT,
     MODBUS_DOMAIN as DOMAIN,
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
@@ -58,6 +78,33 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 BASE_SCHEMA = vol.Schema({vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string})
+
+CLIMATE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CURRENT_TEMP): cv.positive_int,
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_SLAVE): cv.positive_int,
+        vol.Required(CONF_TARGET_TEMP): cv.positive_int,
+        vol.Optional(CONF_DATA_COUNT, default=2): cv.positive_int,
+        vol.Optional(
+            CONF_CURRENT_TEMP_REGISTER_TYPE, default=CALL_TYPE_REGISTER_HOLDING
+        ): vol.In([CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT]),
+        vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT): vol.In(
+            [DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT, DATA_TYPE_CUSTOM]
+        ),
+        vol.Optional(CONF_PRECISION, default=1): cv.positive_int,
+        vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+            cv.time_period, lambda value: value.total_seconds()
+        ),
+        vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
+        vol.Optional(CONF_MAX_TEMP, default=35): cv.positive_int,
+        vol.Optional(CONF_MIN_TEMP, default=5): cv.positive_int,
+        vol.Optional(CONF_STEP, default=0.5): vol.Coerce(float),
+        vol.Optional(CONF_STRUCTURE, default=DEFAULT_STRUCTURE_PREFIX): cv.string,
+        vol.Optional(CONF_UNIT, default=DEFAULT_TEMP_UNIT): cv.string,
+    }
+)
 
 COVERS_SCHEMA = vol.All(
     cv.has_at_least_one_key(CALL_TYPE_COIL, CONF_REGISTER),
@@ -94,6 +141,7 @@ SERIAL_SCHEMA = BASE_SCHEMA.extend(
         vol.Required(CONF_STOPBITS): vol.Any(1, 2),
         vol.Required(CONF_TYPE): "serial",
         vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
+        vol.Optional(CONF_CLIMATES): vol.All(cv.ensure_list, [CLIMATE_SCHEMA]),
         vol.Optional(CONF_COVERS): vol.All(cv.ensure_list, [COVERS_SCHEMA]),
     }
 )
@@ -105,6 +153,7 @@ ETHERNET_SCHEMA = BASE_SCHEMA.extend(
         vol.Required(CONF_TYPE): vol.Any("tcp", "udp", "rtuovertcp"),
         vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
         vol.Optional(CONF_DELAY, default=0): cv.positive_int,
+        vol.Optional(CONF_CLIMATES): vol.All(cv.ensure_list, [CLIMATE_SCHEMA]),
         vol.Optional(CONF_COVERS): vol.All(cv.ensure_list, [COVERS_SCHEMA]),
     }
 )
@@ -150,7 +199,10 @@ def setup(hass, config):
         hub_collect[conf_hub[CONF_NAME]] = ModbusHub(conf_hub)
 
         # load platforms
-        for component, conf_key in (("cover", CONF_COVERS),):
+        for component, conf_key in (
+            ("climate", CONF_CLIMATES),
+            ("cover", CONF_COVERS),
+        ):
             if conf_key in conf_hub:
                 load_platform(hass, component, DOMAIN, conf_hub, config)
 

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -132,6 +132,7 @@ class ModbusThermostat(ClimateEntity):
         self._max_temp = config[CONF_MAX_TEMP]
         self._min_temp = config[CONF_MIN_TEMP]
         self._temp_step = config[CONF_STEP]
+        self._hvac_mode = HVAC_MODE_AUTO
         self._available = True
 
     async def async_added_to_hass(self):
@@ -158,12 +159,16 @@ class ModbusThermostat(ClimateEntity):
     @property
     def hvac_mode(self):
         """Return the current HVAC mode."""
-        return HVAC_MODE_AUTO
+        return self._hvac_mode
 
     @property
     def hvac_modes(self):
         """Return the possible HVAC modes."""
         return [HVAC_MODE_AUTO]
+
+    def set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        self._hvac_mode = hvac_mode
 
     @property
     def name(self):

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -132,7 +132,6 @@ class ModbusThermostat(ClimateEntity):
         self._max_temp = config[CONF_MAX_TEMP]
         self._min_temp = config[CONF_MIN_TEMP]
         self._temp_step = config[CONF_STEP]
-        self._hvac_mode = HVAC_MODE_AUTO
         self._available = True
 
     async def async_added_to_hass(self):
@@ -159,7 +158,7 @@ class ModbusThermostat(ClimateEntity):
     @property
     def hvac_mode(self):
         """Return the current HVAC mode."""
-        return self._hvac_mode
+        return HVAC_MODE_AUTO
 
     @property
     def hvac_modes(self):
@@ -168,7 +167,9 @@ class ModbusThermostat(ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
-        self._hvac_mode = hvac_mode
+        # Home Assistant expects this method.
+        # We'll keep it here to avoid getting exceptions.
+        pass
 
     @property
     def name(self):

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -63,13 +63,13 @@ async def async_setup_platform(
     if discovery_info is None:
         return
 
-    climates = []
-    for climate in discovery_info[CONF_CLIMATES]:
+    entities = []
+    for entity in discovery_info[CONF_CLIMATES]:
         hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
-        count = climate[CONF_DATA_COUNT]
-        data_type = climate[CONF_DATA_TYPE]
-        name = climate[CONF_NAME]
-        structure = climate[CONF_STRUCTURE]
+        count = entity[CONF_DATA_COUNT]
+        data_type = entity[CONF_DATA_TYPE]
+        name = entity[CONF_NAME]
+        structure = entity[CONF_STRUCTURE]
 
         if data_type != DATA_TYPE_CUSTOM:
             try:
@@ -96,10 +96,10 @@ async def async_setup_platform(
             )
             continue
 
-        climate[CONF_STRUCTURE] = structure
-        climates.append(ModbusThermostat(hub, climate))
+        entity[CONF_STRUCTURE] = structure
+        entities.append(ModbusThermostat(hub, entity))
 
-    async_add_entities(climates)
+    async_add_entities(entities)
 
 
 class ModbusThermostat(ClimateEntity):

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -169,7 +169,6 @@ class ModbusThermostat(ClimateEntity):
         """Set new target hvac mode."""
         # Home Assistant expects this method.
         # We'll keep it here to avoid getting exceptions.
-        pass
 
     @property
     def name(self):

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -55,6 +55,11 @@ CONF_ADDRESS = "address"
 
 # sensor.py
 # CONF_DATA_TYPE = "data_type"
+DEFAULT_STRUCT_FORMAT = {
+    DATA_TYPE_INT: {1: "h", 2: "i", 4: "q"},
+    DATA_TYPE_UINT: {1: "H", 2: "I", 4: "Q"},
+    DATA_TYPE_FLOAT: {1: "e", 2: "f", 4: "d"},
+}
 
 # switch.py
 CONF_STATE_OFF = "state_off"
@@ -72,6 +77,8 @@ CONF_UNIT = "temperature_unit"
 CONF_MAX_TEMP = "max_temp"
 CONF_MIN_TEMP = "min_temp"
 CONF_STEP = "temp_step"
+DEFAULT_STRUCTURE_PREFIX = ">f"
+DEFAULT_TEMP_UNIT = "C"
 
 # cover.py
 CONF_STATE_OPEN = "state_open"

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -68,6 +68,7 @@ CONF_VERIFY_REGISTER = "verify_register"
 CONF_VERIFY_STATE = "verify_state"
 
 # climate.py
+CONF_CLIMATES = "climates"
 CONF_TARGET_TEMP = "target_temp_register"
 CONF_CURRENT_TEMP = "current_temp_register"
 CONF_CURRENT_TEMP_REGISTER_TYPE = "current_temp_register_type"

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -37,6 +37,7 @@ from .const import (
     DATA_TYPE_STRING,
     DATA_TYPE_UINT,
     DEFAULT_HUB,
+    DEFAULT_STRUCT_FORMAT,
     MODBUS_DOMAIN,
 )
 
@@ -99,21 +100,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus sensors."""
     sensors = []
-    data_types = {
-        DATA_TYPE_INT: {1: "h", 2: "i", 4: "q"},
-        DATA_TYPE_UINT: {1: "H", 2: "I", 4: "Q"},
-        DATA_TYPE_FLOAT: {1: "e", 2: "f", 4: "d"},
-    }
 
     for register in config[CONF_REGISTERS]:
-        structure = ">i"
         if register[CONF_DATA_TYPE] == DATA_TYPE_STRING:
             structure = str(register[CONF_COUNT] * 2) + "s"
         elif register[CONF_DATA_TYPE] != DATA_TYPE_CUSTOM:
             try:
-                structure = (
-                    f">{data_types[register[CONF_DATA_TYPE]][register[CONF_COUNT]]}"
-                )
+                structure = f">{DEFAULT_STRUCT_FORMAT[register[CONF_DATA_TYPE]][register[CONF_COUNT]]}"
             except KeyError:
                 _LOGGER.error(
                     "Unable to detect data type for %s sensor, try a custom type",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Climate configuration was moved from the platform directly into the `Modbus` integration. This change was required to meet the 
latest [architecture requirements](https://github.com/home-assistant/architecture/blob/master/adr/0007-integration-config-yaml-structure.md) for Home Assistant.

### Before
```yaml
climate:
  - platform: modbus
    name: Watlow F4T
    hub: hub1
    slave: 1
    data_type: uint
    data_count: 1
    scale: 0.1
    offset: 0
    precision: 1
    max_temp: 30
    min_temp: 15
    temp_step: 1
    target_temp_register: 2782
    current_temp_register: 27586
```

### After
```yaml
# Example configuration.yaml
modbus:
  - name: hub1
    type: tcp
    host: 127.0.0.1
    port: 5020

    climates:
      - name: Watlow F4T
        slave: 1
        data_type: uint
        data_count: 1
        scale: 0.1
        offset: 0
        precision: 1
        max_temp: 30
        min_temp: 15
        temp_step: 1
        target_temp_register: 2782
        current_temp_register: 27586
```

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This commit adds support for custom data type into Modbus climate,
and improves error handling.

Currently if a user sets `data_count` into a value other than 1, 2 or 4 bytes,
code throws an exception because it didn't support the parsing.

New behavior is to notify user that parsing was not successful,
and to inform him to specify a custom data structure to use.

This behavior will be the same as used in Modbus sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
modbus:
  - name: hub1
    type: tcp
    host: 127.0.0.1
    port: 5020

    climates:
      name: Watlow F4T
      slave: 1
      data_type: custom
      structure: ">f"
      data_count: 1
      target_temp_register: 2782
      current_temp_register: 27586
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#12250

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
