### PR TITLE
Add support for simultaneous runs of Script helper - Part 2

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1218,16 +1218,12 @@ class ServiceRegistry:
             self._hass.async_create_task(self._safe_execute(handler, service_call))
             return None
 
-        task = self._hass.loop.create_task(self._execute_service(handler, service_call))
         try:
             async with timeout(limit):
-                await asyncio.shield(task)
+                await asyncio.shield(self._execute_service(handler, service_call))
             return True
         except asyncio.TimeoutError:
             return False
-        except asyncio.CancelledError:
-            task.cancel()
-            raise
 
     async def _safe_execute(self, handler: Service, service_call: ServiceCall) -> None:
         """Execute a service and catch exceptions."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -52,27 +52,19 @@ from homeassistant.util.dt import utcnow
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 
-IF_RUNNING_ERROR = "error"
-IF_RUNNING_IGNORE = "ignore"
-IF_RUNNING_PARALLEL = "parallel"
-IF_RUNNING_RESTART = "restart"
-# First choice is default
-IF_RUNNING_CHOICES = [
-    IF_RUNNING_PARALLEL,
-    IF_RUNNING_ERROR,
-    IF_RUNNING_IGNORE,
-    IF_RUNNING_RESTART,
+SCRIPT_MODE_ERROR = "error"
+SCRIPT_MODE_IGNORE = "ignore"
+SCRIPT_MODE_LEGACY = "legacy"
+SCRIPT_MODE_PARALLEL = "parallel"
+SCRIPT_MODE_RESTART = "restart"
+SCRIPT_MODE_CHOICES = [
+    SCRIPT_MODE_ERROR,
+    SCRIPT_MODE_IGNORE,
+    SCRIPT_MODE_LEGACY,
+    SCRIPT_MODE_PARALLEL,
+    SCRIPT_MODE_RESTART,
 ]
-
-RUN_MODE_BACKGROUND = "background"
-RUN_MODE_BLOCKING = "blocking"
-RUN_MODE_LEGACY = "legacy"
-# First choice is default
-RUN_MODE_CHOICES = [
-    RUN_MODE_BLOCKING,
-    RUN_MODE_BACKGROUND,
-    RUN_MODE_LEGACY,
-]
+DEFAULT_SCRIPT_MODE = SCRIPT_MODE_LEGACY
 
 _LOG_EXCEPTION = logging.ERROR + 1
 _TIMEOUT_MSG = "Timeout reached, abort script."
@@ -333,19 +325,24 @@ class _ScriptRun(_ScriptRunBase):
         if not self._stop.is_set():
             super()._changed()
 
-    async def _async_run(self, propagate_exceptions=True):
+    async def async_run(self) -> None:
+        """Run script."""
+        try:
+            await asyncio.shield(self._async_run())
+        except asyncio.CancelledError:
+            await self.async_stop()
+            raise
+
+    async def _async_run(self):
         self._changed()
         self._log("Running script")
         try:
             for self._step, self._action in enumerate(self._script.sequence):
                 if self._stop.is_set():
                     break
-                await self._async_step(log_exceptions=not propagate_exceptions)
+                await self._async_step(log_exceptions=False)
         except _StopScript:
             pass
-        except Exception:  # pylint: disable=broad-except
-            if propagate_exceptions:
-                raise
         finally:
             self._script._runs.remove(self)  # pylint: disable=protected-access
             if not self._script.is_running:
@@ -400,26 +397,6 @@ class _ScriptRun(_ScriptRunBase):
                 raise _StopScript
         finally:
             unsub()
-
-
-class _BackgroundScriptRun(_ScriptRun):
-    """Manage background Script sequence run."""
-
-    async def async_run(self) -> None:
-        """Run script."""
-        self._hass.async_create_task(self._async_run(False))
-
-
-class _BlockingScriptRun(_ScriptRun):
-    """Manage blocking Script sequence run."""
-
-    async def async_run(self) -> None:
-        """Run script."""
-        try:
-            await asyncio.shield(self._async_run())
-        except asyncio.CancelledError:
-            await self.async_stop()
-            raise
 
 
 class _LegacyScriptRun(_ScriptRunBase):
@@ -572,8 +549,7 @@ class Script:
         sequence: Sequence[Dict[str, Any]],
         name: Optional[str] = None,
         change_listener: Optional[Callable[..., Any]] = None,
-        if_running: Optional[str] = None,
-        run_mode: Optional[str] = None,
+        script_mode: str = DEFAULT_SCRIPT_MODE,
         logger: Optional[logging.Logger] = None,
         log_exceptions: bool = True,
     ) -> None:
@@ -583,6 +559,7 @@ class Script:
         template.attach(hass, self.sequence)
         self.name = name
         self._change_listener = change_listener
+        self._script_mode = script_mode
         if logger:
             self._logger = logger
         else:
@@ -594,20 +571,11 @@ class Script:
 
         self.last_action = None
         self.last_triggered: Optional[datetime] = None
-        if not if_running and not run_mode:
-            self._if_running = IF_RUNNING_PARALLEL
-            self._run_mode = RUN_MODE_LEGACY
-        elif if_running and run_mode == RUN_MODE_LEGACY:
-            raise exceptions.HomeAssistantError(
-                'Cannot use if_running if run_mode is "legacy"'
-            )
-        else:
-            self._if_running = if_running or IF_RUNNING_CHOICES[0]
-            self._run_mode = run_mode or RUN_MODE_CHOICES[0]
         self.can_cancel = not self.is_legacy or any(
             CONF_DELAY in action or CONF_WAIT_TEMPLATE in action
             for action in self.sequence
         )
+
         self._runs: List[_ScriptRunBase] = []
         self._config_cache: Dict[Set[Tuple], Callable[..., bool]] = {}
         self._referenced_entities: Optional[Set[str]] = None
@@ -628,7 +596,7 @@ class Script:
     @property
     def is_legacy(self) -> bool:
         """Return if using legacy mode."""
-        return self._run_mode == RUN_MODE_LEGACY
+        return self._script_mode == SCRIPT_MODE_LEGACY
 
     @property
     def referenced_devices(self):
@@ -697,14 +665,14 @@ class Script:
     ) -> None:
         """Run script."""
         if self.is_running:
-            if self._if_running == IF_RUNNING_IGNORE:
+            if self._script_mode == SCRIPT_MODE_IGNORE:
                 self._log("Skipping script")
                 return
 
-            if self._if_running == IF_RUNNING_ERROR:
+            if self._script_mode == SCRIPT_MODE_ERROR:
                 raise AlreadyRunning
 
-            if self._if_running == IF_RUNNING_RESTART:
+            if self._script_mode == SCRIPT_MODE_RESTART:
                 self._log("Restarting script")
                 await self.async_stop()
 
@@ -718,14 +686,7 @@ class Script:
                 self._hass, self, variables, context, self._log_exceptions, shared
             )
         else:
-            if self._run_mode == RUN_MODE_BACKGROUND:
-                run = _BackgroundScriptRun(
-                    self._hass, self, variables, context, self._log_exceptions
-                )
-            else:
-                run = _BlockingScriptRun(
-                    self._hass, self, variables, context, self._log_exceptions
-                )
+            run = _ScriptRun(self._hass, self, variables, context, self._log_exceptions)
         self._runs.append(run)
         await run.async_run()
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -804,6 +804,7 @@ class Script:
                 await asyncio.shield(run.async_run())
         except asyncio.CancelledError:
             await run.async_stop()
+            self._changed()
             raise
 
     async def async_stop(self, update_state: bool = True) -> None:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -787,7 +787,7 @@ class Script:
 
             if self._script_mode == SCRIPT_MODE_RESTART:
                 self._log("Restarting script")
-                await self.async_stop()
+                await self.async_stop(update_state=False)
             elif self._script_mode == SCRIPT_MODE_QUEUE:
                 self._log(
                     "Queueing script behind %i run%s",
@@ -815,12 +815,13 @@ class Script:
         self._runs.append(run)
         await run.async_run()
 
-    async def async_stop(self) -> None:
+    async def async_stop(self, update_state: bool = True) -> None:
         """Stop running script."""
         if not self.is_running:
             return
         await asyncio.shield(asyncio.gather(*(run.async_stop() for run in self._runs)))
-        self._changed()
+        if update_state:
+            self._changed()
 
     def _log(self, msg, *args, level=logging.INFO):
         if self.name:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -47,7 +47,7 @@ async def test_firing_event_basic(hass):
         else:
             script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-        assert not script_obj.can_cancel
+        assert script_obj.can_cancel == (not script_obj.is_legacy)
 
         await script_obj.async_run(context=context)
 
@@ -56,7 +56,7 @@ async def test_firing_event_basic(hass):
         assert len(events) == 1
         assert events[0].context is context
         assert events[0].data.get("hello") == "world"
-        assert not script_obj.can_cancel
+        assert script_obj.can_cancel == (not script_obj.is_legacy)
 
 
 async def test_firing_event_template(hass):
@@ -93,7 +93,7 @@ async def test_firing_event_template(hass):
         else:
             script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-        assert not script_obj.can_cancel
+        assert script_obj.can_cancel == (not script_obj.is_legacy)
 
         await script_obj.async_run({"is_world": "yes"}, context=context)
 
@@ -128,7 +128,7 @@ async def test_calling_service_basic(hass):
         else:
             script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-        assert not script_obj.can_cancel
+        assert script_obj.can_cancel == (not script_obj.is_legacy)
 
         await script_obj.async_run(context=context)
 
@@ -207,7 +207,7 @@ async def test_activating_scene(hass):
         else:
             script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-        assert not script_obj.can_cancel
+        assert script_obj.can_cancel == (not script_obj.is_legacy)
 
         await script_obj.async_run(context=context)
 
@@ -257,7 +257,7 @@ async def test_calling_service_template(hass):
         else:
             script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-        assert not script_obj.can_cancel
+        assert script_obj.can_cancel == (not script_obj.is_legacy)
 
         await script_obj.async_run({"is_world": "yes"}, context=context)
 
@@ -1165,7 +1165,7 @@ async def test_condition_basic(hass):
         else:
             script_obj = script.Script(hass, schema, run_mode=run_mode)
 
-        assert not script_obj.can_cancel
+        assert script_obj.can_cancel == (not script_obj.is_legacy)
 
         await script_obj.async_run()
         await hass.async_block_till_done()

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1455,12 +1455,6 @@ async def test_if_running_with_legacy_run_mode(hass, caplog):
             run_mode="legacy",
             logger=logging.getLogger("TEST"),
         )
-    assert any(
-        rec.levelname == "ERROR"
-        and rec.name == "TEST"
-        and all(text in rec.message for text in ("if_running", "legacy"))
-        for rec in caplog.records
-    )
 
 
 async def test_if_running_ignore(hass, caplog):
@@ -1584,12 +1578,6 @@ async def test_if_running_error(hass, caplog):
             await script_obj.async_run()
 
         assert script_obj.is_running
-        assert any(
-            rec.levelname == "ERROR"
-            and rec.name == "TEST"
-            and "Already running" in rec.message
-            for rec in caplog.records
-        )
     except (AssertionError, asyncio.TimeoutError):
         await script_obj.async_stop()
         raise

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,6 +1,7 @@
 """The tests for the Script component."""
 # pylint: disable=protected-access
 import asyncio
+from contextlib import contextmanager
 from datetime import timedelta
 import logging
 from unittest import mock
@@ -15,58 +16,106 @@ import homeassistant.components.scene as scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import Context, callback
 from homeassistant.helpers import config_validation as cv, script
+from homeassistant.helpers.event import async_call_later
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.common import (
+    async_capture_events,
+    async_fire_time_changed,
+    async_mock_service,
+)
 
 ENTITY_ID = "script.test"
 
 _BASIC_SCRIPT_MODES = ("legacy", "parallel")
 
 
-async def test_firing_event_basic(hass):
+@pytest.fixture
+def mock_timeout(hass, monkeypatch):
+    """Mock async_timeout.timeout."""
+
+    class MockTimeout:
+        def __init__(self, timeout):
+            self._timeout = timeout
+            self._loop = asyncio.get_event_loop()
+            self._task = None
+            self._cancelled = False
+            self._unsub = None
+
+        async def __aenter__(self):
+            if self._timeout is None:
+                return self
+            self._task = asyncio.Task.current_task()
+            if self._timeout <= 0:
+                self._loop.call_soon(self._cancel_task)
+                return self
+            # Wait for a time_changed event instead of real time passing.
+            self._unsub = async_call_later(hass, self._timeout, self._cancel_task)
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            if exc_type is asyncio.CancelledError and self._cancelled:
+                self._unsub = None
+                self._task = None
+                raise asyncio.TimeoutError
+            if self._timeout is not None and self._unsub:
+                self._unsub()
+                self._unsub = None
+            self._task = None
+            return None
+
+        @callback
+        def _cancel_task(self, now=None):
+            if self._task is not None:
+                self._task.cancel()
+                self._cancelled = True
+
+    monkeypatch.setattr(script, "timeout", MockTimeout)
+
+
+def async_watch_for_action(script_obj, message):
+    """Watch for message in last_action."""
+    flag = asyncio.Event()
+
+    @callback
+    def check_action():
+        if script_obj.last_action and message in script_obj.last_action:
+            flag.set()
+
+    script_obj.change_listener = check_action
+    return flag
+
+
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_firing_event_basic(hass, script_mode):
     """Test the firing of events."""
     event = "test_event"
     context = Context()
+    events = async_capture_events(hass, event)
 
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
+    sequence = cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    hass.bus.async_listen(event, record_event)
+    assert script_obj.is_legacy == (script_mode == "legacy")
+    assert script_obj.can_cancel == (script_mode != "legacy")
 
-    schema = cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
+    await script_obj.async_run(context=context)
+    await hass.async_block_till_done()
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-
-        assert script_obj.can_cancel == (not script_obj.is_legacy)
-
-        await script_obj.async_run(context=context)
-
-        await hass.async_block_till_done()
-
-        assert len(events) == 1
-        assert events[0].context is context
-        assert events[0].data.get("hello") == "world"
-        assert script_obj.can_cancel == (not script_obj.is_legacy)
+    assert len(events) == 1
+    assert events[0].context is context
+    assert events[0].data.get("hello") == "world"
+    assert script_obj.can_cancel == (script_mode != "legacy")
 
 
-async def test_firing_event_template(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_firing_event_template(hass, script_mode):
     """Test the firing of events."""
     event = "test_event"
     context = Context()
+    events = async_capture_events(hass, event)
 
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    schema = cv.SCRIPT_SCHEMA(
+    sequence = cv.SCRIPT_SCHEMA(
         {
             "event": event,
             "event_data_template": {
@@ -79,133 +128,47 @@ async def test_firing_event_template(hass):
             },
         }
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
+    assert script_obj.can_cancel == (script_mode != "legacy")
 
-        assert script_obj.can_cancel == (not script_obj.is_legacy)
+    await script_obj.async_run({"is_world": "yes"}, context=context)
+    await hass.async_block_till_done()
 
-        await script_obj.async_run({"is_world": "yes"}, context=context)
-
-        await hass.async_block_till_done()
-
-        assert len(events) == 1
-        assert events[0].context is context
-        assert events[0].data == {
-            "dict": {1: "yes", 2: "yesyes", 3: "yesyesyes"},
-            "list": ["yes", "yesyes"],
-        }
+    assert len(events) == 1
+    assert events[0].context is context
+    assert events[0].data == {
+        "dict": {1: "yes", 2: "yesyes", 3: "yesyesyes"},
+        "list": ["yes", "yesyes"],
+    }
 
 
-async def test_calling_service_basic(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_calling_service_basic(hass, script_mode):
     """Test the calling of a service."""
     context = Context()
+    calls = async_mock_service(hass, "test", "script")
 
-    @callback
-    def record_call(service):
-        """Add recorded event to set."""
-        calls.append(service)
+    sequence = cv.SCRIPT_SCHEMA({"service": "test.script", "data": {"hello": "world"}})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    hass.services.async_register("test", "script", record_call)
+    assert script_obj.can_cancel == (script_mode != "legacy")
 
-    schema = cv.SCRIPT_SCHEMA({"service": "test.script", "data": {"hello": "world"}})
+    await script_obj.async_run(context=context)
+    await hass.async_block_till_done()
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        calls = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-
-        assert script_obj.can_cancel == (not script_obj.is_legacy)
-
-        await script_obj.async_run(context=context)
-
-        await hass.async_block_till_done()
-
-        assert len(calls) == 1
-        assert calls[0].context is context
-        assert calls[0].data.get("hello") == "world"
+    assert len(calls) == 1
+    assert calls[0].context is context
+    assert calls[0].data.get("hello") == "world"
 
 
-async def test_cancel_no_wait(hass, caplog):
-    """Test stopping script."""
-    event = "test_event"
-
-    async def async_simulate_long_service(service):
-        """Simulate a service that takes a not insignificant time."""
-        await asyncio.sleep(0.01)
-
-    hass.services.async_register("test", "script", async_simulate_long_service)
-
-    @callback
-    def monitor_event(event):
-        """Signal event happened."""
-        event_sem.release()
-
-    hass.bus.async_listen(event, monitor_event)
-
-    schema = cv.SCRIPT_SCHEMA([{"event": event}, {"service": "test.script"}])
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        event_sem = asyncio.Semaphore(0)
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-
-        tasks = []
-        for _ in range(3):
-            hass.async_create_task(script_obj.async_run())
-            tasks.append(hass.async_create_task(event_sem.acquire()))
-        await asyncio.wait_for(asyncio.gather(*tasks), 1)
-
-        # Can't assert just yet because we haven't verified stopping works yet.
-        # If assert fails we can hang test if async_stop doesn't work.
-        script_was_runing = script_obj.is_running
-
-        await script_obj.async_stop()
-        await hass.async_block_till_done()
-
-        assert script_was_runing
-        assert not script_obj.is_running
-
-
-async def test_activating_scene(hass):
-    """Test the activation of a scene."""
-    context = Context()
-
-    @callback
-    def record_call(service):
-        """Add recorded event to set."""
-        calls.append(service)
-
-    hass.services.async_register(scene.DOMAIN, SERVICE_TURN_ON, record_call)
-
-    schema = cv.SCRIPT_SCHEMA({"scene": "scene.hello"})
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        calls = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-
-        assert script_obj.can_cancel == (not script_obj.is_legacy)
-
-        await script_obj.async_run(context=context)
-
-        await hass.async_block_till_done()
-
-        assert len(calls) == 1
-        assert calls[0].context is context
-        assert calls[0].data.get(ATTR_ENTITY_ID) == "scene.hello"
-
-
-async def test_calling_service_template(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_calling_service_template(hass, script_mode):
     """Test the calling of a service."""
     context = Context()
+    calls = async_mock_service(hass, "test", "script")
 
-    @callback
-    def record_call(service):
-        """Add recorded event to set."""
-        calls.append(service)
-
-    hass.services.async_register("test", "script", record_call)
-
-    schema = cv.SCRIPT_SCHEMA(
+    sequence = cv.SCRIPT_SCHEMA(
         {
             "service_template": """
             {% if True %}
@@ -224,28 +187,30 @@ async def test_calling_service_template(hass):
             },
         }
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        calls = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
+    assert script_obj.can_cancel == (script_mode != "legacy")
 
-        assert script_obj.can_cancel == (not script_obj.is_legacy)
+    await script_obj.async_run({"is_world": "yes"}, context=context)
+    await hass.async_block_till_done()
 
-        await script_obj.async_run({"is_world": "yes"}, context=context)
-
-        await hass.async_block_till_done()
-
-        assert len(calls) == 1
-        assert calls[0].context is context
-        assert calls[0].data.get("hello") == "world"
+    assert len(calls) == 1
+    assert calls[0].context is context
+    assert calls[0].data.get("hello") == "world"
 
 
-async def test_multiple_runs_no_wait(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_multiple_runs_no_wait(hass, script_mode):
     """Test multiple runs with no wait in script."""
     logger = logging.getLogger("TEST")
+    calls = []
+    heard_event = asyncio.Event()
 
     async def async_simulate_long_service(service):
         """Simulate a service that takes a not insignificant time."""
+        fire = service.data.get("fire")
+        listen = service.data.get("listen")
+        service_done = asyncio.Event()
 
         @callback
         def service_done_cb(event):
@@ -253,29 +218,20 @@ async def test_multiple_runs_no_wait(hass):
             service_done.set()
 
         calls.append(service)
-
-        fire = service.data.get("fire")
-        listen = service.data.get("listen")
         logger.debug("simulated service (%s:%s) started", fire, listen)
-
-        service_done = asyncio.Event()
         unsub = hass.bus.async_listen(listen, service_done_cb)
-
         hass.bus.async_fire(fire)
-
         await service_done.wait()
         unsub()
 
     hass.services.async_register("test", "script", async_simulate_long_service)
-
-    heard_event = asyncio.Event()
 
     @callback
     def heard_event_cb(event):
         logger.debug("heard: %s", event)
         heard_event.set()
 
-    schema = cv.SCRIPT_SCHEMA(
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {
                 "service": "test.script",
@@ -287,188 +243,199 @@ async def test_multiple_runs_no_wait(hass):
             },
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        calls = []
-        heard_event.clear()
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
+    # Start script twice in such a way that second run will be started while first run
+    # is in the middle of the first service call.
 
-        # Start script twice in such a way that second run will be started while first
-        # run is in the middle of the first service call.
-
-        unsub = hass.bus.async_listen("1", heard_event_cb)
-
-        logger.debug("starting 1st script")
-        hass.async_create_task(
-            script_obj.async_run(
-                {"fire1": "1", "listen1": "2", "fire2": "3", "listen2": "4"}
-            )
+    unsub = hass.bus.async_listen("1", heard_event_cb)
+    logger.debug("starting 1st script")
+    hass.async_create_task(
+        script_obj.async_run(
+            {"fire1": "1", "listen1": "2", "fire2": "3", "listen2": "4"}
         )
-        await asyncio.wait_for(heard_event.wait(), 1)
+    )
+    await asyncio.wait_for(heard_event.wait(), 1)
+    unsub()
 
-        unsub()
+    logger.debug("starting 2nd script")
+    await script_obj.async_run(
+        {"fire1": "2", "listen1": "3", "fire2": "4", "listen2": "4"}
+    )
+    await hass.async_block_till_done()
 
-        logger.debug("starting 2nd script")
-        await script_obj.async_run(
-            {"fire1": "2", "listen1": "3", "fire2": "4", "listen2": "4"}
-        )
-
-        await hass.async_block_till_done()
-
-        assert len(calls) == 4
+    assert len(calls) == 4
 
 
-async def test_delay_basic(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_activating_scene(hass, script_mode):
+    """Test the activation of a scene."""
+    context = Context()
+    calls = async_mock_service(hass, scene.DOMAIN, SERVICE_TURN_ON)
+
+    sequence = cv.SCRIPT_SCHEMA({"scene": "scene.hello"})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+
+    assert script_obj.can_cancel == (script_mode != "legacy")
+
+    await script_obj.async_run(context=context)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].context is context
+    assert calls[0].data.get(ATTR_ENTITY_ID) == "scene.hello"
+
+
+@pytest.mark.parametrize("count", [1, 3])
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_stop_no_wait(hass, caplog, script_mode, count):
+    """Test stopping script."""
+    service_started_sem = asyncio.Semaphore(0)
+    finish_service_event = asyncio.Event()
+    event = "test_event"
+    events = async_capture_events(hass, event)
+
+    async def async_simulate_long_service(service):
+        """Simulate a service that takes a not insignificant time."""
+        service_started_sem.release()
+        await finish_service_event.wait()
+
+    hass.services.async_register("test", "script", async_simulate_long_service)
+
+    sequence = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+
+    # Get script started specified number of times and wait until the test.script
+    # service has started for each run.
+    tasks = []
+    for _ in range(count):
+        hass.async_create_task(script_obj.async_run())
+        tasks.append(hass.async_create_task(service_started_sem.acquire()))
+    await asyncio.wait_for(asyncio.gather(*tasks), 1)
+
+    # Can't assert just yet because we haven't verified stopping works yet.
+    # If assert fails we can hang test if async_stop doesn't work.
+    script_was_runing = script_obj.is_running
+    were_no_events = len(events) == 0
+
+    # Begin the process of stopping the script (which should stop all runs), and then
+    # let the service calls complete.
+    hass.async_create_task(script_obj.async_stop())
+    finish_service_event.set()
+
+    await hass.async_block_till_done()
+
+    assert script_was_runing
+    assert were_no_events
+    assert not script_obj.is_running
+    assert len(events) == (count if script_mode == "legacy" else 0)
+
+
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_delay_basic(hass, mock_timeout, script_mode):
     """Test the delay."""
     delay_alias = "delay step"
-    delay_started_flag = asyncio.Event()
+    sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": 5}, "alias": delay_alias})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    delay_started_flag = async_watch_for_action(script_obj, delay_alias)
 
-    @callback
-    def delay_started_cb():
-        if script_obj.last_action and "delay" in script_obj.last_action:
-            delay_started_flag.set()
+    assert script_obj.can_cancel
 
-    delay = timedelta(milliseconds=10)
-    schema = cv.SCRIPT_SCHEMA({"delay": delay, "alias": delay_alias})
+    try:
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(delay_started_flag.wait(), 1)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        delay_started_flag.clear()
+        assert script_obj.is_running
+        assert script_obj.last_action == delay_alias
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+        await hass.async_block_till_done()
 
-        script_obj = script.Script(
-            hass, schema, change_listener=delay_started_cb, script_mode=script_mode
-        )
-
-        assert script_obj.can_cancel
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(delay_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert script_obj.last_action == delay_alias
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + delay
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            assert script_obj.last_action is None
+        assert not script_obj.is_running
+        assert script_obj.last_action is None
 
 
-async def test_multiple_runs_delay(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_multiple_runs_delay(hass, mock_timeout, script_mode):
     """Test multiple runs with delay in script."""
     event = "test_event"
-    delay_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def delay_started_cb():
-        if script_obj.last_action and "delay" in script_obj.last_action:
-            delay_started_flag.set()
-
-    delay = timedelta(milliseconds=10)
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    delay = timedelta(seconds=5)
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event, "event_data": {"value": 1}},
             {"delay": delay},
             {"event": event, "event_data": {"value": 2}},
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    delay_started_flag = async_watch_for_action(script_obj, "delay")
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        delay_started_flag.clear()
+    try:
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(delay_started_flag.wait(), 1)
 
-        script_obj = script.Script(
-            hass, schema, change_listener=delay_started_cb, script_mode=script_mode
-        )
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(delay_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert len(events) == 1
-            assert events[-1].data["value"] == 1
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            # Start second run of script while first run is in a delay.
+        assert script_obj.is_running
+        assert len(events) == 1
+        assert events[-1].data["value"] == 1
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        # Start second run of script while first run is in a delay.
+        if script_mode == "legacy":
             await script_obj.async_run()
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + delay
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            if script_mode == "legacy":
-                assert len(events) == 2
-            else:
-                assert len(events) == 4
-                assert events[-3].data["value"] == 1
-                assert events[-2].data["value"] == 2
-            assert events[-1].data["value"] == 2
-
-
-async def test_delay_template_ok(hass):
-    """Test the delay as a template."""
-    delay_started_flag = asyncio.Event()
-
-    @callback
-    def delay_started_cb():
-        if script_obj.last_action and "delay" in script_obj.last_action:
-            delay_started_flag.set()
-
-    schema = cv.SCRIPT_SCHEMA({"delay": "00:00:{{ 1 }}"})
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        delay_started_flag.clear()
-
-        script_obj = script.Script(
-            hass, schema, change_listener=delay_started_cb, script_mode=script_mode
-        )
-
-        assert script_obj.can_cancel
-
-        try:
+        else:
+            script_obj.sequence[1]["alias"] = "delay run 2"
+            delay_started_flag = async_watch_for_action(script_obj, "delay run 2")
             hass.async_create_task(script_obj.async_run())
             await asyncio.wait_for(delay_started_flag.wait(), 1)
-            assert script_obj.is_running
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
+        async_fire_time_changed(hass, dt_util.utcnow() + delay)
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        if script_mode == "legacy":
+            assert len(events) == 2
         else:
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + timedelta(seconds=1)
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
+            assert len(events) == 4
+            assert events[-3].data["value"] == 1
+            assert events[-2].data["value"] == 2
+        assert events[-1].data["value"] == 2
 
 
-async def test_delay_template_invalid(hass, caplog):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_delay_template_ok(hass, mock_timeout, script_mode):
+    """Test the delay as a template."""
+    sequence = cv.SCRIPT_SCHEMA({"delay": "00:00:{{ 5 }}"})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    delay_started_flag = async_watch_for_action(script_obj, "delay")
+
+    assert script_obj.can_cancel
+
+    try:
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(delay_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+
+
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_delay_template_invalid(hass, caplog, script_mode):
     """Test the delay as a template that fails."""
     event = "test_event"
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event},
             {"delay": "{{ invalid_delay }}"},
@@ -476,73 +443,50 @@ async def test_delay_template_invalid(hass, caplog):
             {"event": event},
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    start_idx = len(caplog.records)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-        start_idx = len(caplog.records)
+    await script_obj.async_run()
+    await hass.async_block_till_done()
 
-        await script_obj.async_run()
+    assert any(
+        rec.levelname == "ERROR" and "Error rendering" in rec.message
+        for rec in caplog.records[start_idx:]
+    )
+
+    assert not script_obj.is_running
+    assert len(events) == 1
+
+
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_delay_template_complex_ok(hass, mock_timeout, script_mode):
+    """Test the delay with a working complex template."""
+    sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": "{{ 5 }}"}})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    delay_started_flag = async_watch_for_action(script_obj, "delay")
+
+    assert script_obj.can_cancel
+
+    try:
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(delay_started_flag.wait(), 1)
+        assert script_obj.is_running
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
         await hass.async_block_till_done()
 
-        assert any(
-            rec.levelname == "ERROR" and "Error rendering" in rec.message
-            for rec in caplog.records[start_idx:]
-        )
-
         assert not script_obj.is_running
-        assert len(events) == 1
 
 
-async def test_delay_template_complex_ok(hass):
-    """Test the delay with a working complex template."""
-    delay_started_flag = asyncio.Event()
-
-    @callback
-    def delay_started_cb():
-        if script_obj.last_action and "delay" in script_obj.last_action:
-            delay_started_flag.set()
-
-    milliseconds = 10
-    schema = cv.SCRIPT_SCHEMA({"delay": {"milliseconds": "{{ milliseconds }}"}})
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        delay_started_flag.clear()
-
-        script_obj = script.Script(
-            hass, schema, change_listener=delay_started_cb, script_mode=script_mode
-        )
-
-        assert script_obj.can_cancel
-
-        try:
-            hass.async_create_task(script_obj.async_run({"milliseconds": milliseconds}))
-            await asyncio.wait_for(delay_started_flag.wait(), 1)
-            assert script_obj.is_running
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + timedelta(milliseconds=milliseconds)
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-
-
-async def test_delay_template_complex_invalid(hass, caplog):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_delay_template_complex_invalid(hass, caplog, script_mode):
     """Test the delay with a complex template that fails."""
     event = "test_event"
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event},
             {"delay": {"seconds": "{{ invalid_delay }}"}},
@@ -550,494 +494,260 @@ async def test_delay_template_complex_invalid(hass, caplog):
             {"event": event},
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    start_idx = len(caplog.records)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-        start_idx = len(caplog.records)
+    await script_obj.async_run()
+    await hass.async_block_till_done()
 
-        await script_obj.async_run()
-        await hass.async_block_till_done()
+    assert any(
+        rec.levelname == "ERROR" and "Error rendering" in rec.message
+        for rec in caplog.records[start_idx:]
+    )
 
-        assert any(
-            rec.levelname == "ERROR" and "Error rendering" in rec.message
-            for rec in caplog.records[start_idx:]
-        )
+    assert not script_obj.is_running
+    assert len(events) == 1
+
+
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_cancel_delay(hass, script_mode):
+    """Test the cancelling while the delay is present."""
+    event = "test_event"
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA([{"delay": {"seconds": 5}}, {"event": event}])
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    delay_started_flag = async_watch_for_action(script_obj, "delay")
+
+    try:
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(delay_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 0
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        await script_obj.async_stop()
 
         assert not script_obj.is_running
-        assert len(events) == 1
+
+        # Make sure the script is really stopped.
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 0
 
 
-async def test_cancel_delay(hass):
-    """Test the cancelling while the delay is present."""
-    delay_started_flag = asyncio.Event()
-    event = "test_event"
-
-    @callback
-    def delay_started_cb():
-        if script_obj.last_action and "delay" in script_obj.last_action:
-            delay_started_flag.set()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    delay = timedelta(milliseconds=10)
-    schema = cv.SCRIPT_SCHEMA([{"delay": delay}, {"event": event}])
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        delay_started_flag.clear()
-        events = []
-
-        script_obj = script.Script(
-            hass, schema, change_listener=delay_started_cb, script_mode=script_mode
-        )
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(delay_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert len(events) == 0
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            await script_obj.async_stop()
-
-            assert not script_obj.is_running
-
-            # Make sure the script is really stopped.
-
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + delay
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            assert len(events) == 0
-
-
-async def test_wait_template_basic(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_wait_template_basic(hass, script_mode):
     """Test the wait template."""
     wait_alias = "wait step"
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    schema = cv.SCRIPT_SCHEMA(
+    sequence = cv.SCRIPT_SCHEMA(
         {
             "wait_template": "{{ states.switch.test.state == 'off' }}",
             "alias": wait_alias,
         }
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    wait_started_flag = async_watch_for_action(script_obj, wait_alias)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        wait_started_flag.clear()
+    assert script_obj.can_cancel
+
+    try:
         hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-        script_obj = script.Script(
-            hass, schema, change_listener=wait_started_cb, script_mode=script_mode
-        )
+        assert script_obj.is_running
+        assert script_obj.last_action == wait_alias
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
 
-        assert script_obj.can_cancel
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert script_obj.last_action == wait_alias
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            hass.states.async_set("switch.test", "off")
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            assert script_obj.last_action is None
+        assert not script_obj.is_running
+        assert script_obj.last_action is None
 
 
-async def test_multiple_runs_wait_template(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_multiple_runs_wait_template(hass, script_mode):
     """Test multiple runs with wait_template in script."""
     event = "test_event"
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event, "event_data": {"value": 1}},
             {"wait_template": "{{ states.switch.test.state == 'off' }}"},
             {"event": event, "event_data": {"value": 2}},
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        wait_started_flag.clear()
+    try:
         hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-        script_obj = script.Script(
-            hass, schema, change_listener=wait_started_cb, script_mode=script_mode
-        )
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert len(events) == 1
-            assert events[-1].data["value"] == 1
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
+        assert script_obj.is_running
+        assert len(events) == 1
+        assert events[-1].data["value"] == 1
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        # Start second run of script while first run is in wait_template.
+        if script_mode == "legacy":
+            await script_obj.async_run()
         else:
-            # Start second run of script while first run is in wait_template.
-            if script_mode == "legacy":
-                await script_obj.async_run()
-            else:
-                hass.async_create_task(script_obj.async_run())
-            hass.states.async_set("switch.test", "off")
-            await hass.async_block_till_done()
+            hass.async_create_task(script_obj.async_run())
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
 
-            assert not script_obj.is_running
-            if script_mode == "legacy":
-                assert len(events) == 2
-            else:
-                assert len(events) == 4
-                assert events[-3].data["value"] == 1
-                assert events[-2].data["value"] == 2
-            assert events[-1].data["value"] == 2
+        assert not script_obj.is_running
+        if script_mode == "legacy":
+            assert len(events) == 2
+        else:
+            assert len(events) == 4
+            assert events[-3].data["value"] == 1
+            assert events[-2].data["value"] == 2
+        assert events[-1].data["value"] == 2
 
 
-async def test_cancel_wait_template(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_cancel_wait_template(hass, script_mode):
     """Test the cancelling while wait_template is present."""
-    wait_started_flag = asyncio.Event()
     event = "test_event"
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {"wait_template": "{{ states.switch.test.state == 'off' }}"},
             {"event": event},
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        wait_started_flag.clear()
-        events = []
+    try:
         hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-        script_obj = script.Script(
-            hass, schema, change_listener=wait_started_cb, script_mode=script_mode
-        )
+        assert script_obj.is_running
+        assert len(events) == 0
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        await script_obj.async_stop()
 
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(wait_started_flag.wait(), 1)
+        assert not script_obj.is_running
 
-            assert script_obj.is_running
-            assert len(events) == 0
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            await script_obj.async_stop()
+        # Make sure the script is really stopped.
 
-            assert not script_obj.is_running
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
 
-            # Make sure the script is really stopped.
-
-            hass.states.async_set("switch.test", "off")
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            assert len(events) == 0
+        assert not script_obj.is_running
+        assert len(events) == 0
 
 
-async def test_wait_template_not_schedule(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_wait_template_not_schedule(hass, script_mode):
     """Test the wait template with correct condition."""
     event = "test_event"
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    hass.states.async_set("switch.test", "on")
-
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event},
             {"wait_template": "{{ states.switch.test.state == 'on' }}"},
             {"event": event},
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
+    hass.states.async_set("switch.test", "on")
+    await script_obj.async_run()
+    await hass.async_block_till_done()
 
-        await script_obj.async_run()
+    assert not script_obj.is_running
+    assert len(events) == 2
+
+
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+@pytest.mark.parametrize(
+    "continue_on_timeout,n_events", [(False, 0), (True, 1), (None, 1)]
+)
+async def test_wait_template_timeout(
+    hass, mock_timeout, continue_on_timeout, n_events, script_mode
+):
+    """Test the wait template, halt on timeout."""
+    event = "test_event"
+    events = async_capture_events(hass, event)
+    sequence = [
+        {"wait_template": "{{ states.switch.test.state == 'off' }}", "timeout": 5},
+        {"event": event},
+    ]
+    if continue_on_timeout is not None:
+        sequence[0]["continue_on_timeout"] = continue_on_timeout
+    sequence = cv.SCRIPT_SCHEMA(sequence)
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
+
+    try:
+        hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 0
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
         await hass.async_block_till_done()
 
         assert not script_obj.is_running
-        assert len(events) == 2
+        assert len(events) == n_events
 
 
-async def test_wait_template_timeout_halt(hass):
-    """Test the wait template, halt on timeout."""
-    event = "test_event"
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    timeout = timedelta(milliseconds=10)
-    schema = cv.SCRIPT_SCHEMA(
-        [
-            {
-                "wait_template": "{{ states.switch.test.state == 'off' }}",
-                "continue_on_timeout": False,
-                "timeout": timeout,
-            },
-            {"event": event},
-        ]
-    )
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        wait_started_flag.clear()
-
-        script_obj = script.Script(
-            hass, schema, change_listener=wait_started_cb, script_mode=script_mode
-        )
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert len(events) == 0
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + timeout
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            assert len(events) == 0
-
-
-async def test_wait_template_timeout_continue(hass):
-    """Test the wait template with continuing the script."""
-    event = "test_event"
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    timeout = timedelta(milliseconds=10)
-    schema = cv.SCRIPT_SCHEMA(
-        [
-            {
-                "wait_template": "{{ states.switch.test.state == 'off' }}",
-                "continue_on_timeout": True,
-                "timeout": timeout,
-            },
-            {"event": event},
-        ]
-    )
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        wait_started_flag.clear()
-
-        script_obj = script.Script(
-            hass, schema, change_listener=wait_started_cb, script_mode=script_mode
-        )
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert len(events) == 0
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + timeout
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            assert len(events) == 1
-
-
-async def test_wait_template_timeout_default(hass):
-    """Test the wait template with default continue."""
-    event = "test_event"
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    timeout = timedelta(milliseconds=10)
-    schema = cv.SCRIPT_SCHEMA(
-        [
-            {
-                "wait_template": "{{ states.switch.test.state == 'off' }}",
-                "timeout": timeout,
-            },
-            {"event": event},
-        ]
-    )
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        wait_started_flag.clear()
-
-        script_obj = script.Script(
-            hass, schema, change_listener=wait_started_cb, script_mode=script_mode
-        )
-
-        try:
-            hass.async_create_task(script_obj.async_run())
-            await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-            assert len(events) == 0
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            if script_mode == "legacy":
-                future = dt_util.utcnow() + timeout
-                async_fire_time_changed(hass, future)
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
-            assert len(events) == 1
-
-
-async def test_wait_template_variables(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_wait_template_variables(hass, script_mode):
     """Test the wait template with variables."""
-    wait_started_flag = asyncio.Event()
+    sequence = cv.SCRIPT_SCHEMA({"wait_template": "{{ is_state(data, 'off') }}"})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
 
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
+    assert script_obj.can_cancel
 
-    schema = cv.SCRIPT_SCHEMA({"wait_template": "{{ is_state(data, 'off') }}"})
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        wait_started_flag.clear()
+    try:
         hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run({"data": "switch.test"}))
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
 
-        script_obj = script.Script(
-            hass, schema, change_listener=wait_started_cb, script_mode=script_mode
-        )
+        assert script_obj.is_running
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
 
-        assert script_obj.can_cancel
-
-        try:
-            hass.async_create_task(script_obj.async_run({"data": "switch.test"}))
-            await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-            assert script_obj.is_running
-        except (AssertionError, asyncio.TimeoutError):
-            await script_obj.async_stop()
-            raise
-        else:
-            hass.states.async_set("switch.test", "off")
-            await hass.async_block_till_done()
-
-            assert not script_obj.is_running
+        assert not script_obj.is_running
 
 
-async def test_condition_basic(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_condition_basic(hass, script_mode):
     """Test if we can use conditions in a script."""
     event = "test_event"
-    events = []
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event},
             {
@@ -1047,187 +757,127 @@ async def test_condition_basic(hass):
             {"event": event},
         ]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        hass.states.async_set("test.entity", "hello")
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-
-        assert script_obj.can_cancel == (not script_obj.is_legacy)
-
-        await script_obj.async_run()
-        await hass.async_block_till_done()
-
-        assert len(events) == 2
-
-        hass.states.async_set("test.entity", "goodbye")
-
-        await script_obj.async_run()
-        await hass.async_block_till_done()
-
-        assert len(events) == 3
-
-
-@asynctest.patch("homeassistant.helpers.script.condition.async_from_config")
-async def test_condition_created_once(async_from_config, hass):
-    """Test that the conditions do not get created multiple times."""
-    event = "test_event"
-    events = []
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
+    assert script_obj.can_cancel == (script_mode != "legacy")
 
     hass.states.async_set("test.entity", "hello")
+    await script_obj.async_run()
+    await hass.async_block_till_done()
 
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "condition": "template",
-                    "value_template": '{{ states.test.entity.state == "hello" }}',
-                },
-                {"event": event},
-            ]
-        ),
+    assert len(events) == 2
+
+    hass.states.async_set("test.entity", "goodbye")
+
+    await script_obj.async_run()
+    await hass.async_block_till_done()
+
+    assert len(events) == 3
+
+
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+@asynctest.patch("homeassistant.helpers.script.condition.async_from_config")
+async def test_condition_created_once(async_from_config, hass, script_mode):
+    """Test that the conditions do not get created multiple times."""
+    sequence = cv.SCRIPT_SCHEMA(
+        {
+            "condition": "template",
+            "value_template": '{{ states.test.entity.state == "hello" }}',
+        }
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
+    async_from_config.reset_mock()
+
+    hass.states.async_set("test.entity", "hello")
     await script_obj.async_run()
     await script_obj.async_run()
     await hass.async_block_till_done()
-    assert async_from_config.call_count == 1
+
+    async_from_config.assert_called_once()
     assert len(script_obj._config_cache) == 1
 
 
-async def test_condition_all_cached(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_condition_all_cached(hass, script_mode):
     """Test that multiple conditions get cached."""
-    event = "test_event"
-    events = []
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {
+                "condition": "template",
+                "value_template": '{{ states.test.entity.state == "hello" }}',
+            },
+            {
+                "condition": "template",
+                "value_template": '{{ states.test.entity.state != "hello" }}',
+            },
+        ]
+    )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
     hass.states.async_set("test.entity", "hello")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event},
-                {
-                    "condition": "template",
-                    "value_template": '{{ states.test.entity.state == "hello" }}',
-                },
-                {
-                    "condition": "template",
-                    "value_template": '{{ states.test.entity.state != "hello" }}',
-                },
-                {"event": event},
-            ]
-        ),
-    )
-
     await script_obj.async_run()
     await hass.async_block_till_done()
+
     assert len(script_obj._config_cache) == 2
 
 
-async def test_last_triggered(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_last_triggered(hass, script_mode):
     """Test the last_triggered."""
     event = "test_event"
+    sequence = cv.SCRIPT_SCHEMA({"event": event})
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    schema = cv.SCRIPT_SCHEMA({"event": event})
+    assert script_obj.last_triggered is None
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
+    time = dt_util.utcnow()
+    with mock.patch("homeassistant.helpers.script.utcnow", return_value=time):
+        await script_obj.async_run()
+        await hass.async_block_till_done()
 
-        assert script_obj.last_triggered is None
-
-        time = dt_util.utcnow()
-        with mock.patch("homeassistant.helpers.script.utcnow", return_value=time):
-            await script_obj.async_run()
-            await hass.async_block_till_done()
-
-        assert script_obj.last_triggered == time
+    assert script_obj.last_triggered == time
 
 
-async def test_propagate_error_service_not_found(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_propagate_error_service_not_found(hass, script_mode):
     """Test that a script aborts when a service is not found."""
     event = "test_event"
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    @callback
-    def record_event(event):
-        events.append(event)
+    with pytest.raises(exceptions.ServiceNotFound):
+        await script_obj.async_run()
 
-    hass.bus.async_listen(event, record_event)
-
-    schema = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
-
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
-
-        with pytest.raises(exceptions.ServiceNotFound):
-            await script_obj.async_run()
-
-        assert len(events) == 0
-        assert not script_obj.is_running
+    assert len(events) == 0
+    assert not script_obj.is_running
 
 
-async def test_propagate_error_invalid_service_data(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_propagate_error_invalid_service_data(hass, script_mode):
     """Test that a script aborts when we send invalid service data."""
     event = "test_event"
-
-    @callback
-    def record_event(event):
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def record_call(service):
-        """Add recorded event to set."""
-        calls.append(service)
-
-    hass.services.async_register(
-        "test", "script", record_call, schema=vol.Schema({"text": str})
-    )
-
-    schema = cv.SCRIPT_SCHEMA(
+    events = async_capture_events(hass, event)
+    calls = async_mock_service(hass, "test", "script", vol.Schema({"text": str}))
+    sequence = cv.SCRIPT_SCHEMA(
         [{"service": "test.script", "data": {"text": 1}}, {"event": event}]
     )
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        calls = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
+    with pytest.raises(vol.Invalid):
+        await script_obj.async_run()
 
-        with pytest.raises(vol.Invalid):
-            await script_obj.async_run()
-
-        assert len(events) == 0
-        assert len(calls) == 0
-        assert not script_obj.is_running
+    assert len(events) == 0
+    assert len(calls) == 0
+    assert not script_obj.is_running
 
 
-async def test_propagate_error_service_exception(hass):
+@pytest.mark.parametrize("script_mode", _BASIC_SCRIPT_MODES)
+async def test_propagate_error_service_exception(hass, script_mode):
     """Test that a script aborts when a service throws an exception."""
     event = "test_event"
-
-    @callback
-    def record_event(event):
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
+    events = async_capture_events(hass, event)
 
     @callback
     def record_call(service):
@@ -1236,17 +886,14 @@ async def test_propagate_error_service_exception(hass):
 
     hass.services.async_register("test", "script", record_call)
 
-    schema = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
+    sequence = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
+    script_obj = script.Script(hass, sequence, script_mode=script_mode)
 
-    for script_mode in _BASIC_SCRIPT_MODES:
-        events = []
-        script_obj = script.Script(hass, schema, script_mode=script_mode)
+    with pytest.raises(ValueError):
+        await script_obj.async_run()
 
-        with pytest.raises(ValueError):
-            await script_obj.async_run()
-
-        assert len(events) == 0
-        assert not script_obj.is_running
+    assert len(events) == 0
+    assert not script_obj.is_running
 
 
 async def test_referenced_entities():
@@ -1305,41 +952,36 @@ async def test_referenced_devices():
     assert script_obj.referenced_devices is script_obj.referenced_devices
 
 
-async def test_script_mode_ignore(hass, caplog):
+@contextmanager
+def does_not_raise():
+    """Indicate no exception is expected."""
+    yield
+
+
+@pytest.mark.parametrize(
+    "script_mode,expectation,messages",
+    [
+        ("ignore", does_not_raise(), ["Skipping"]),
+        ("error", pytest.raises(exceptions.HomeAssistantError), []),
+    ],
+)
+async def test_script_mode_1(hass, caplog, script_mode, expectation, messages):
     """Test overlapping runs with script_mode='ignore'."""
     event = "test_event"
-    events = []
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event, "event_data": {"value": 1}},
-                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
-                {"event": event, "event_data": {"value": 2}},
-            ]
-        ),
-        change_listener=wait_started_cb,
-        script_mode="ignore",
-        logger=logging.getLogger("TEST"),
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event, "event_data": {"value": 1}},
+            {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+            {"event": event, "event_data": {"value": 2}},
+        ]
     )
+    logger = logging.getLogger("TEST")
+    script_obj = script.Script(hass, sequence, script_mode=script_mode, logger=logger)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
+        hass.states.async_set("switch.test", "on")
         hass.async_create_task(script_obj.async_run())
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
@@ -1348,14 +990,19 @@ async def test_script_mode_ignore(hass, caplog):
         assert events[0].data["value"] == 1
 
         # Start second run of script while first run is suspended in wait_template.
-        # This should ignore second run.
 
-        await script_obj.async_run()
+        with expectation:
+            await script_obj.async_run()
 
         assert script_obj.is_running
-        assert any(
-            rec.levelname == "INFO" and rec.name == "TEST" and "Skipping" in rec.message
-            for rec in caplog.records
+        assert all(
+            any(
+                rec.levelname == "INFO"
+                and rec.name == "TEST"
+                and message in rec.message
+                for rec in caplog.records
+            )
+            for message in messages
         )
     except (AssertionError, asyncio.TimeoutError):
         await script_obj.async_stop()
@@ -1369,102 +1016,27 @@ async def test_script_mode_ignore(hass, caplog):
         assert events[1].data["value"] == 2
 
 
-async def test_script_mode_error(hass, caplog):
-    """Test overlapping runs with script_mode='error'."""
-    event = "test_event"
-    events = []
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event, "event_data": {"value": 1}},
-                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
-                {"event": event, "event_data": {"value": 2}},
-            ]
-        ),
-        change_listener=wait_started_cb,
-        script_mode="error",
-        logger=logging.getLogger("TEST"),
-    )
-
-    try:
-        hass.async_create_task(script_obj.async_run())
-        await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-        assert script_obj.is_running
-        assert len(events) == 1
-        assert events[0].data["value"] == 1
-
-        # Start second run of script while first run is suspended in wait_template.
-        # This should cause an error.
-
-        with pytest.raises(exceptions.HomeAssistantError):
-            await script_obj.async_run()
-
-        assert script_obj.is_running
-    except (AssertionError, asyncio.TimeoutError):
-        await script_obj.async_stop()
-        raise
-    else:
-        hass.states.async_set("switch.test", "off")
-        await hass.async_block_till_done()
-
-        assert not script_obj.is_running
-        assert len(events) == 2
-        assert events[1].data["value"] == 2
-
-
-async def test_script_mode_restart(hass, caplog):
+@pytest.mark.parametrize(
+    "script_mode,messages,last_events",
+    [("restart", ["Restarting"], [2]), ("parallel", [], [2, 2])],
+)
+async def test_script_mode_2(hass, caplog, script_mode, messages, last_events):
     """Test overlapping runs with script_mode='restart'."""
     event = "test_event"
-    events = []
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event, "event_data": {"value": 1}},
-                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
-                {"event": event, "event_data": {"value": 2}},
-            ]
-        ),
-        change_listener=wait_started_cb,
-        script_mode="restart",
-        logger=logging.getLogger("TEST"),
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event, "event_data": {"value": 1}},
+            {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+            {"event": event, "event_data": {"value": 2}},
+        ]
     )
+    logger = logging.getLogger("TEST")
+    script_obj = script.Script(hass, sequence, script_mode=script_mode, logger=logger)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
+        hass.states.async_set("switch.test", "on")
         hass.async_create_task(script_obj.async_run())
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
@@ -1482,11 +1054,14 @@ async def test_script_mode_restart(hass, caplog):
         assert script_obj.is_running
         assert len(events) == 2
         assert events[1].data["value"] == 1
-        assert any(
-            rec.levelname == "INFO"
-            and rec.name == "TEST"
-            and "Restarting" in rec.message
-            for rec in caplog.records
+        assert all(
+            any(
+                rec.levelname == "INFO"
+                and rec.name == "TEST"
+                and message in rec.message
+                for rec in caplog.records
+            )
+            for message in messages
         )
     except (AssertionError, asyncio.TimeoutError):
         await script_obj.async_stop()
@@ -1496,111 +1071,29 @@ async def test_script_mode_restart(hass, caplog):
         await hass.async_block_till_done()
 
         assert not script_obj.is_running
-        assert len(events) == 3
-        assert events[2].data["value"] == 2
-
-
-async def test_script_mode_parallel(hass):
-    """Test overlapping runs with script_mode='parallel'."""
-    event = "test_event"
-    events = []
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event, "event_data": {"value": 1}},
-                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
-                {"event": event, "event_data": {"value": 2}},
-            ]
-        ),
-        change_listener=wait_started_cb,
-        script_mode="parallel",
-        logger=logging.getLogger("TEST"),
-    )
-
-    try:
-        hass.async_create_task(script_obj.async_run())
-        await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-        assert script_obj.is_running
-        assert len(events) == 1
-        assert events[0].data["value"] == 1
-
-        # Start second run of script while first run is suspended in wait_template.
-        # This should start a new, independent run.
-
-        wait_started_flag.clear()
-        hass.async_create_task(script_obj.async_run())
-        await asyncio.wait_for(wait_started_flag.wait(), 1)
-
-        assert script_obj.is_running
-        assert len(events) == 2
-        assert events[1].data["value"] == 1
-    except (AssertionError, asyncio.TimeoutError):
-        await script_obj.async_stop()
-        raise
-    else:
-        hass.states.async_set("switch.test", "off")
-        await hass.async_block_till_done()
-
-        assert not script_obj.is_running
-        assert len(events) == 4
-        assert events[2].data["value"] == 2
-        assert events[3].data["value"] == 2
+        assert len(events) == 2 + len(last_events)
+        for idx, value in enumerate(last_events, start=2):
+            assert events[idx].data["value"] == value
 
 
 async def test_script_mode_queue(hass):
     """Test overlapping runs with script_mode='queue'."""
     event = "test_event"
-    events = []
-    wait_started_flag = asyncio.Event()
-
-    @callback
-    def record_event(event):
-        """Add recorded event to set."""
-        events.append(event)
-
-    hass.bus.async_listen(event, record_event)
-
-    @callback
-    def wait_started_cb():
-        if script_obj.last_action and "wait" in script_obj.last_action:
-            wait_started_flag.set()
-
-    hass.states.async_set("switch.test", "on")
-
-    script_obj = script.Script(
-        hass,
-        cv.SCRIPT_SCHEMA(
-            [
-                {"event": event, "event_data": {"value": 1}},
-                {"wait_template": "{{ states.switch.test.state == 'off' }}"},
-                {"event": event, "event_data": {"value": 2}},
-                {"wait_template": "{{ states.switch.test.state == 'on' }}"},
-            ]
-        ),
-        change_listener=wait_started_cb,
-        script_mode="queue",
-        logger=logging.getLogger("TEST"),
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event, "event_data": {"value": 1}},
+            {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+            {"event": event, "event_data": {"value": 2}},
+            {"wait_template": "{{ states.switch.test.state == 'on' }}"},
+        ]
     )
+    logger = logging.getLogger("TEST")
+    script_obj = script.Script(hass, sequence, script_mode="queue", logger=logger)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
+        hass.states.async_set("switch.test", "on")
         hass.async_create_task(script_obj.async_run())
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-on to #31937.

While working to use those changes in the script integration a few bugs were discovered. Also it became clear that a slight change of direction was needed regarding how to configure/handle long running scripts. Lastly a new `queue` mode was added which can be very helpful in certain scenarios (especially for automation action sequences.)

The changes were broken up into several, smaller commits to help make the review process easier.

### New Script helper option

> Replaces `if_running`.

#### script_mode
- Controls what happens if Script run (i.e., `async_run` called) while previous run has not yet completed.
- Values:
  - `error` Raise an exception
  - `ignore` Return without doing anything (previous run continues as-is)
  - `legacy` Implements previous behavior, which is to return when done, or when suspended by `delay` or `wait_template`, whichever comes first. This is the default
  - `parallel` Start run in new task
  - `queue` Start new run when previous runs have completed
  - `restart` Stop previous run before starting new run

### New script.turn_on service parameter

> Replaces `run_mode`.

Background/blocking behavior is now controlled by the `script.turn_on` service. The default (which also applies when calling a script "directly" -- `script.abc` -- or via the `script.toggle` service) is to be fully blocking. To run a script in the "background" a new `blocking` parameter to the `script.turn_on` service has been defined:

```yaml
- service: script.turn_on
  entity_id: script.abc
  data:
    blocking: false
    variables: ...
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
