### PR TITLE
Fix filter sensor processing states that aren't numbers

### DIFF
--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -423,6 +423,9 @@ class RangeFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the range filter."""
+        if not isinstance(new_state.state, Number):
+            raise ValueError
+
         if self._upper_bound is not None and new_state.state > self._upper_bound:
 
             self._stats_internal["erasures_up"] += 1
@@ -469,6 +472,9 @@ class OutlierFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the outlier filter."""
+        if not isinstance(new_state.state, Number):
+            raise ValueError
+
         median = statistics.median([s.state for s in self.states]) if self.states else 0
         if (
             len(self.states) == self.states.maxlen
@@ -498,6 +504,9 @@ class LowPassFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the low pass filter."""
+        if not isinstance(new_state.state, Number):
+            raise ValueError
+
         if not self.states:
             return new_state
 
@@ -539,6 +548,9 @@ class TimeSMAFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the Simple Moving Average filter."""
+        if not isinstance(new_state.state, Number):
+            raise ValueError
+
         self._leak(new_state.timestamp)
         self.queue.append(copy(new_state))
 

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -104,6 +104,7 @@ class TestFilterSensor(unittest.TestCase):
         t_0 = dt_util.utcnow() - timedelta(minutes=1)
         t_1 = dt_util.utcnow() - timedelta(minutes=2)
         t_2 = dt_util.utcnow() - timedelta(minutes=3)
+        t_3 = dt_util.utcnow() - timedelta(minutes=4)
 
         if missing:
             fake_states = {}
@@ -111,8 +112,9 @@ class TestFilterSensor(unittest.TestCase):
             fake_states = {
                 "sensor.test_monitored": [
                     ha.State("sensor.test_monitored", 18.0, last_changed=t_0),
-                    ha.State("sensor.test_monitored", 19.0, last_changed=t_1),
-                    ha.State("sensor.test_monitored", 18.2, last_changed=t_2),
+                    ha.State("sensor.test_monitored", "unknown", last_changed=t_1),
+                    ha.State("sensor.test_monitored", 19.0, last_changed=t_2),
+                    ha.State("sensor.test_monitored", 18.2, last_changed=t_3),
                 ]
             }
 
@@ -208,6 +210,17 @@ class TestFilterSensor(unittest.TestCase):
             filtered = filt.filter_state(state)
         assert 21 == filtered.state
 
+    def test_unknown_state_outlier(self):
+        """Test issue #32395."""
+        filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)
+        out = ha.State("sensor.test_monitored", "unknown")
+        for state in [out] + self.values + [out]:
+            try:
+                filtered = filt.filter_state(state)
+            except ValueError:
+                assert state.state == "unknown"
+        assert 21 == filtered.state
+
     def test_precision_zero(self):
         """Test if precision of zero returns an integer."""
         filt = LowPassFilter(window_size=10, precision=0, entity=None, time_constant=10)
@@ -218,8 +231,12 @@ class TestFilterSensor(unittest.TestCase):
     def test_lowpass(self):
         """Test if lowpass filter works."""
         filt = LowPassFilter(window_size=10, precision=2, entity=None, time_constant=10)
-        for state in self.values:
-            filtered = filt.filter_state(state)
+        out = ha.State("sensor.test_monitored", "unknown")
+        for state in [out] + self.values + [out]:
+            try:
+                filtered = filt.filter_state(state)
+            except ValueError:
+                assert state.state == "unknown"
         assert 18.05 == filtered.state
 
     def test_range(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't process states that aren't numbers

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
- platform: filter
  name: "Luftdaten PM10"
  entity_id: sensor.luftdaten_pm10_raw
  filters:
    - filter: outlier
      window_size: 3
      radius: 10.0
    - filter: time_simple_moving_average
      window_size: 00:20
      precision: 2
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32395 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
