### PR TITLE
ZHA: Successful pairing feedback

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -251,3 +251,9 @@ ZHA_GW_MSG_LOG_OUTPUT = "log_output"
 ZHA_GW_MSG_RAW_INIT = "raw_device_initialized"
 ZHA_GW_RADIO = "radio"
 ZHA_GW_RADIO_DESCRIPTION = "radio_description"
+
+EFFECT_BLINK = 0x00
+EFFECT_BREATHE = 0x01
+EFFECT_OKAY = 0x02
+
+EFFECT_DEFAULT_VARIANT = 0x00

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -48,6 +48,8 @@ from .const import (
     CLUSTER_COMMANDS_SERVER,
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
+    EFFECT_DEFAULT_VARIANT,
+    EFFECT_OKAY,
     POWER_BATTERY_OR_UNKNOWN,
     POWER_MAINS_POWERED,
     SIGNAL_AVAILABLE,
@@ -341,6 +343,11 @@ class ZHADevice(LogMixin):
         self.debug("completed configuration")
         entry = self.gateway.zha_storage.async_create_or_update(self)
         self.debug("stored in registry: %s", entry)
+
+        if self._channels.identify_ch is not None:
+            await self._channels.identify_ch.trigger_effect(
+                EFFECT_OKAY, EFFECT_DEFAULT_VARIANT
+            )
 
     async def async_initialize(self, from_cache=False):
         """Initialize channels."""

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -19,6 +19,9 @@ from .core.const import (
     CHANNEL_ON_OFF,
     DATA_ZHA,
     DATA_ZHA_DISPATCHERS,
+    EFFECT_BLINK,
+    EFFECT_BREATHE,
+    EFFECT_DEFAULT_VARIANT,
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
     SIGNAL_SET_LEVEL,
@@ -38,7 +41,7 @@ UPDATE_COLORLOOP_DIRECTION = 0x2
 UPDATE_COLORLOOP_TIME = 0x4
 UPDATE_COLORLOOP_HUE = 0x8
 
-FLASH_EFFECTS = {light.FLASH_SHORT: 0x00, light.FLASH_LONG: 0x01}
+FLASH_EFFECTS = {light.FLASH_SHORT: EFFECT_BLINK, light.FLASH_LONG: EFFECT_BREATHE}
 
 UNSUPPORTED_ATTRIBUTE = 0x86
 SCAN_INTERVAL = timedelta(minutes=60)
@@ -287,7 +290,7 @@ class Light(ZhaEntity, light.Light):
 
         if flash is not None and self._supported_features & light.SUPPORT_FLASH:
             result = await self._identify_channel.trigger_effect(
-                FLASH_EFFECTS[flash], 0  # effect identifier, effect variant
+                FLASH_EFFECTS[flash], EFFECT_DEFAULT_VARIANT
             )
             t_log["trigger_effect"] = result
 

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -29,6 +29,7 @@ class FakeEndpoint:
         self.model = model
         self.profile_id = zigpy.profiles.zha.PROFILE_ID
         self.device_type = None
+        self.request = CoroutineMock()
 
     def add_input_cluster(self, cluster_id):
         """Add an input cluster."""

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -166,7 +166,9 @@ def zha_device_restored(hass, zigpy_app_controller, setup_zha):
 @pytest.fixture(params=["zha_device_joined", "zha_device_restored"])
 def zha_device_joined_restored(request):
     """Join or restore ZHA device."""
-    return request.getfixturevalue(request.param)
+    named_method = request.getfixturevalue(request.param)
+    named_method.name = request.param
+    return named_method
 
 
 @pytest.fixture

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -3,11 +3,14 @@
 import re
 from unittest import mock
 
+import asynctest
 import pytest
 import zigpy.quirks
+import zigpy.types
 import zigpy.zcl.clusters.closures
 import zigpy.zcl.clusters.general
 import zigpy.zcl.clusters.security
+import zigpy.zcl.foundation as zcl_f
 
 import homeassistant.components.zha.binary_sensor
 import homeassistant.components.zha.core.channels as zha_channels
@@ -48,6 +51,12 @@ def channels_mock(zha_device_mock):
     return _mock
 
 
+@asynctest.patch(
+    "zigpy.zcl.clusters.general.Identify.request",
+    new=asynctest.CoroutineMock(
+        return_value=[mock.sentinel.data, zcl_f.Status.SUCCESS]
+    ),
+)
 @pytest.mark.parametrize("device", DEVICES)
 async def test_devices(
     device, hass, zigpy_device_mock, monkeypatch, zha_device_joined_restored
@@ -66,6 +75,10 @@ async def test_devices(
         node_descriptor=device["node_descriptor"],
     )
 
+    cluster_identify = _get_first_identify_cluster(zigpy_device)
+    if cluster_identify:
+        cluster_identify.request.reset_mock()
+
     orig_new_entity = zha_channels.ChannelPool.async_new_entity
     _dispatch = mock.MagicMock(wraps=orig_new_entity)
     try:
@@ -80,6 +93,21 @@ async def test_devices(
     zha_entity_ids = {
         ent for ent in entity_ids if ent.split(".")[0] in zha_const.COMPONENTS
     }
+
+    if cluster_identify:
+        called = int(zha_device_joined_restored.name == "zha_device_joined")
+        assert cluster_identify.request.call_count == called
+        assert cluster_identify.request.await_count == called
+        if called:
+            assert cluster_identify.request.call_args == mock.call(
+                False,
+                64,
+                (zigpy.types.uint8_t, zigpy.types.uint8_t),
+                2,
+                0,
+                expect_reply=True,
+                manufacturer=None,
+            )
 
     event_channels = {
         ch.id for pool in zha_dev.channels.pools for ch in pool.relay_channels.values()
@@ -106,6 +134,12 @@ async def test_devices(
         assert entity_id.startswith(no_tail_id)
         assert set([ch.name for ch in channels]) == set(entity_map[key]["channels"])
         assert entity_cls.__name__ == entity_map[key]["entity_class"]
+
+
+def _get_first_identify_cluster(zigpy_device):
+    for endpoint in list(zigpy_device.endpoints.values())[1:]:
+        if hasattr(endpoint, "identify"):
+            return endpoint.identify
 
 
 @mock.patch(


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Visual confirmation of successful device pairing. See https://github.com/zigpy/zigpy/issues/310

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zigpy/zigpy/issues/310
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
