### PR TITLE
Remove ZHA attribute listening channel

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -103,9 +103,9 @@ class BinarySensor(ZhaEntity, BinarySensorDevice):
         return self._device_class
 
     @callback
-    def async_set_state(self, state):
+    def async_set_state(self, attr_id, attr_name, value):
         """Set the state."""
-        self._state = bool(state)
+        self._state = bool(value)
         self.async_schedule_update_ha_state()
 
     async def async_update(self):

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -235,7 +235,7 @@ class ChannelPool:
         """Create and add channels for all input clusters."""
         for cluster_id, cluster in self.endpoint.in_clusters.items():
             channel_class = zha_regs.ZIGBEE_CHANNEL_REGISTRY.get(
-                cluster_id, base.AttributeListeningChannel
+                cluster_id, base.ZigbeeChannel
             )
             # really ugly hack to deal with xiaomi using the door lock cluster
             # incorrectly.
@@ -243,7 +243,7 @@ class ChannelPool:
                 hasattr(cluster, "ep_attribute")
                 and cluster.ep_attribute == "multistate_input"
             ):
-                channel_class = base.AttributeListeningChannel
+                channel_class = base.ZigbeeChannel
             # end of ugly hack
             channel = channel_class(cluster, self)
             if channel.name == const.CHANNEL_POWER_CONFIGURATION:

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -4,7 +4,6 @@ import asyncio
 from enum import Enum
 from functools import wraps
 import logging
-from random import uniform
 from typing import Any, Union
 
 import zigpy.exceptions
@@ -205,7 +204,6 @@ class ZigbeeChannel(LogMixin):
                     await self.configure_reporting(
                         report_config["attr"], report_config["config"]
                     )
-                    await asyncio.sleep(uniform(0.1, 0.5))
             self.debug("finished channel configuration")
         else:
             self.debug("skipping channel configuration")
@@ -216,7 +214,6 @@ class ZigbeeChannel(LogMixin):
         self.debug("initializing channel: from_cache: %s", from_cache)
         for report_config in self._report_config:
             await self.get_attribute_value(report_config["attr"], from_cache=from_cache)
-            await asyncio.sleep(uniform(0.1, 0.5))
         self._status = ChannelStatus.INITIALIZED
 
     @callback

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -23,7 +23,9 @@ class DoorLockChannel(ZigbeeChannel):
         """Retrieve latest state."""
         result = await self.get_attribute_value("lock_state", from_cache=True)
 
-        self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", result)
+        self.async_send_signal(
+            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0, "lock_state", result
+        )
 
     @callback
     def attribute_updated(self, attrid, value):
@@ -33,7 +35,9 @@ class DoorLockChannel(ZigbeeChannel):
             "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
         )
         if attrid == self._value_attribute:
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, attr_name, value
+            )
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""
@@ -63,8 +67,12 @@ class WindowCovering(ZigbeeChannel):
             "current_position_lift_percentage", from_cache=False
         )
         self.debug("read current position: %s", result)
-
-        self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", result)
+        self.async_send_signal(
+            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+            8,
+            "current_position_lift_percentage",
+            result,
+        )
 
     @callback
     def attribute_updated(self, attrid, value):
@@ -74,7 +82,9 @@ class WindowCovering(ZigbeeChannel):
             "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
         )
         if attrid == self._value_attribute:
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, attr_name, value
+            )
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -18,7 +18,7 @@ from ..const import (
     SIGNAL_STATE_ATTR,
 )
 from ..helpers import get_attr_id_by_name
-from .base import AttributeListeningChannel, ZigbeeChannel, parse_and_log_command
+from .base import ZigbeeChannel, parse_and_log_command
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,21 +31,21 @@ class Alarms(ZigbeeChannel):
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.AnalogInput.cluster_id)
-class AnalogInput(AttributeListeningChannel):
+class AnalogInput(ZigbeeChannel):
     """Analog Input channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.AnalogOutput.cluster_id)
-class AnalogOutput(AttributeListeningChannel):
+class AnalogOutput(ZigbeeChannel):
     """Analog Output channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.AnalogValue.cluster_id)
-class AnalogValue(AttributeListeningChannel):
+class AnalogValue(ZigbeeChannel):
     """Analog Value channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
@@ -77,7 +77,7 @@ class BasicChannel(ZigbeeChannel):
     }
 
     def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType,
+        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType
     ) -> None:
         """Initialize BasicChannel."""
         super().__init__(cluster, ch_pool)
@@ -101,21 +101,21 @@ class BasicChannel(ZigbeeChannel):
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryInput.cluster_id)
-class BinaryInput(AttributeListeningChannel):
+class BinaryInput(ZigbeeChannel):
     """Binary Input channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryOutput.cluster_id)
-class BinaryOutput(AttributeListeningChannel):
+class BinaryOutput(ZigbeeChannel):
     """Binary Output channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryValue.cluster_id)
-class BinaryValue(AttributeListeningChannel):
+class BinaryValue(ZigbeeChannel):
     """Binary Value channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
@@ -209,21 +209,21 @@ class LevelControlChannel(ZigbeeChannel):
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateInput.cluster_id)
-class MultistateInput(AttributeListeningChannel):
+class MultistateInput(ZigbeeChannel):
     """Multistate Input channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateOutput.cluster_id)
-class MultistateOutput(AttributeListeningChannel):
+class MultistateOutput(ZigbeeChannel):
     """Multistate Output channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateValue.cluster_id)
-class MultistateValue(AttributeListeningChannel):
+class MultistateValue(ZigbeeChannel):
     """Multistate Value channel."""
 
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
@@ -242,7 +242,7 @@ class OnOffChannel(ZigbeeChannel):
     REPORT_CONFIG = ({"attr": "on_off", "config": REPORT_CONFIG_IMMEDIATE},)
 
     def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType,
+        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType
     ) -> None:
         """Initialize OnOffChannel."""
         super().__init__(cluster, ch_pool)
@@ -286,7 +286,9 @@ class OnOffChannel(ZigbeeChannel):
     def attribute_updated(self, attrid, value):
         """Handle attribute updates on this cluster."""
         if attrid == self.ON_OFF:
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, "on_off", value
+            )
             self._state = bool(value)
 
     async def async_initialize(self, from_cache):
@@ -354,7 +356,12 @@ class PowerConfigurationChannel(ZigbeeChannel):
         else:
             attr_id = attr
         if attrid == attr_id:
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                attrid,
+                self.cluster.attributes.get(attrid, [attrid])[0],
+                value,
+            )
             return
         attr_name = self.cluster.attributes.get(attrid, [attrid])[0]
         self.async_send_signal(

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -10,7 +10,7 @@ from ..const import (
     REPORT_CONFIG_DEFAULT,
     SIGNAL_ATTR_UPDATED,
 )
-from .base import AttributeListeningChannel, ZigbeeChannel
+from .base import ZigbeeChannel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class Diagnostic(ZigbeeChannel):
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
     homeautomation.ElectricalMeasurement.cluster_id
 )
-class ElectricalMeasurementChannel(AttributeListeningChannel):
+class ElectricalMeasurementChannel(ZigbeeChannel):
     """Channel that polls active power level."""
 
     CHANNEL_NAME = CHANNEL_ELECTRICAL_MEASUREMENT
@@ -60,7 +60,7 @@ class ElectricalMeasurementChannel(AttributeListeningChannel):
     REPORT_CONFIG = ({"attr": "active_power", "config": REPORT_CONFIG_DEFAULT},)
 
     def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType,
+        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType
     ) -> None:
         """Initialize Metering."""
         super().__init__(cluster, ch_pool)
@@ -73,7 +73,9 @@ class ElectricalMeasurementChannel(AttributeListeningChannel):
 
         # This is a polling channel. Don't allow cache.
         result = await self.get_attribute_value("active_power", from_cache=False)
-        self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", result)
+        self.async_send_signal(
+            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0x050B, "active_power", result
+        )
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -40,8 +40,9 @@ class FanChannel(ZigbeeChannel):
     async def async_update(self):
         """Retrieve latest state."""
         result = await self.get_attribute_value("fan_mode", from_cache=True)
-
-        self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", result)
+        self.async_send_signal(
+            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0, "fan_mode", result
+        )
 
     @callback
     def attribute_updated(self, attrid, value):
@@ -51,7 +52,9 @@ class FanChannel(ZigbeeChannel):
             "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
         )
         if attrid == self._value_attribute:
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, attr_name, value
+            )
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -14,13 +14,13 @@ from ..const import (
     SIGNAL_ATTR_UPDATED,
     UNKNOWN,
 )
-from .base import AttributeListeningChannel, ZigbeeChannel
+from .base import ZigbeeChannel
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(registries.SMARTTHINGS_HUMIDITY_CLUSTER)
-class SmartThingsHumidity(AttributeListeningChannel):
+class SmartThingsHumidity(ZigbeeChannel):
     """Smart Things Humidity channel."""
 
     REPORT_CONFIG = [
@@ -50,7 +50,7 @@ class OppleRemote(ZigbeeChannel):
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
     registries.SMARTTHINGS_ACCELERATION_CLUSTER
 )
-class SmartThingsAcceleration(AttributeListeningChannel):
+class SmartThingsAcceleration(ZigbeeChannel):
     """Smart Things Acceleration channel."""
 
     REPORT_CONFIG = [
@@ -64,7 +64,12 @@ class SmartThingsAcceleration(AttributeListeningChannel):
     def attribute_updated(self, attrid, value):
         """Handle attribute updates on this cluster."""
         if attrid == self.value_attribute:
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                attrid,
+                self._cluster.attributes.get(attrid, [UNKNOWN])[0],
+                value,
+            )
             return
 
         self.zha_send_event(

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -10,13 +10,13 @@ from ..const import (
     REPORT_CONFIG_MAX_INT,
     REPORT_CONFIG_MIN_INT,
 )
-from .base import AttributeListeningChannel
+from .base import ZigbeeChannel
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.FlowMeasurement.cluster_id)
-class FlowMeasurement(AttributeListeningChannel):
+class FlowMeasurement(ZigbeeChannel):
     """Flow Measurement channel."""
 
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
@@ -25,7 +25,7 @@ class FlowMeasurement(AttributeListeningChannel):
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
     measurement.IlluminanceLevelSensing.cluster_id
 )
-class IlluminanceLevelSensing(AttributeListeningChannel):
+class IlluminanceLevelSensing(ZigbeeChannel):
     """Illuminance Level Sensing channel."""
 
     REPORT_CONFIG = [{"attr": "level_status", "config": REPORT_CONFIG_DEFAULT}]
@@ -34,7 +34,7 @@ class IlluminanceLevelSensing(AttributeListeningChannel):
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
     measurement.IlluminanceMeasurement.cluster_id
 )
-class IlluminanceMeasurement(AttributeListeningChannel):
+class IlluminanceMeasurement(ZigbeeChannel):
     """Illuminance Measurement channel."""
 
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
@@ -42,21 +42,21 @@ class IlluminanceMeasurement(AttributeListeningChannel):
 
 @registries.BINARY_SENSOR_CLUSTERS.register(measurement.OccupancySensing.cluster_id)
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.OccupancySensing.cluster_id)
-class OccupancySensing(AttributeListeningChannel):
+class OccupancySensing(ZigbeeChannel):
     """Occupancy Sensing channel."""
 
     REPORT_CONFIG = [{"attr": "occupancy", "config": REPORT_CONFIG_IMMEDIATE}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.PressureMeasurement.cluster_id)
-class PressureMeasurement(AttributeListeningChannel):
+class PressureMeasurement(ZigbeeChannel):
     """Pressure measurement channel."""
 
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(measurement.RelativeHumidity.cluster_id)
-class RelativeHumidity(AttributeListeningChannel):
+class RelativeHumidity(ZigbeeChannel):
     """Relative Humidity measurement channel."""
 
     REPORT_CONFIG = [
@@ -70,7 +70,7 @@ class RelativeHumidity(AttributeListeningChannel):
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(
     measurement.TemperatureMeasurement.cluster_id
 )
-class TemperatureMeasurement(AttributeListeningChannel):
+class TemperatureMeasurement(ZigbeeChannel):
     """Temperature measurement channel."""
 
     REPORT_CONFIG = [

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -124,7 +124,9 @@ class IASZoneChannel(ZigbeeChannel):
         """Handle commands received to this cluster."""
         if command_id == 0:
             state = args[0] & 3
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", state)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 2, "zone_status", state
+            )
             self.debug("Updated alarm state: %s", state)
         elif command_id == 1:
             self.debug("Enroll requested")
@@ -165,7 +167,12 @@ class IASZoneChannel(ZigbeeChannel):
         """Handle attribute updates on this cluster."""
         if attrid == 2:
             value = value & 3
-            self.async_send_signal(f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value)
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                attrid,
+                self.cluster.attributes.get(attrid, [attrid])[0],
+                value,
+            )
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -8,7 +8,7 @@ from homeassistant.core import callback
 
 from .. import registries, typing as zha_typing
 from ..const import REPORT_CONFIG_DEFAULT
-from .base import AttributeListeningChannel, ZigbeeChannel
+from .base import ZigbeeChannel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class Messaging(ZigbeeChannel):
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Metering.cluster_id)
-class Metering(AttributeListeningChannel):
+class Metering(ZigbeeChannel):
     """Metering channel."""
 
     REPORT_CONFIG = [{"attr": "instantaneous_demand", "config": REPORT_CONFIG_DEFAULT}]
@@ -92,7 +92,7 @@ class Metering(AttributeListeningChannel):
     }
 
     def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType,
+        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType
     ) -> None:
         """Initialize Metering."""
         super().__init__(cluster, ch_pool)

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -134,7 +134,7 @@ class ProbeEndpoint:
                 continue
 
             channel_class = zha_regs.ZIGBEE_CHANNEL_REGISTRY.get(
-                cluster_id, base.AttributeListeningChannel
+                cluster_id, base.ZigbeeChannel
             )
             channel = channel_class(cluster, ep_channels)
             self.probe_single_cluster(component, channel, ep_channels)

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -91,10 +91,10 @@ class ZhaCover(ZhaEntity, CoverDevice):
         return self._current_position
 
     @callback
-    def async_set_position(self, pos):
+    def async_set_position(self, attr_id, attr_name, value):
         """Handle position update from channel."""
-        _LOGGER.debug("setting position: %s", pos)
-        self._current_position = 100 - pos
+        _LOGGER.debug("setting position: %s", value)
+        self._current_position = 100 - value
         if self._current_position == 0:
             self._state = STATE_CLOSED
         elif self._current_position == 100:

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -102,7 +102,7 @@ class ZhaCover(ZhaEntity, CoverDevice):
         self.async_schedule_update_ha_state()
 
     @callback
-    def async_set_state(self, state):
+    def async_update_state(self, state):
         """Handle state update from channel."""
         _LOGGER.debug("state=%s", state)
         self._state = state
@@ -112,20 +112,20 @@ class ZhaCover(ZhaEntity, CoverDevice):
         """Open the window cover."""
         res = await self._cover_channel.up_open()
         if isinstance(res, list) and res[1] is Status.SUCCESS:
-            self.async_set_state(STATE_OPENING)
+            self.async_update_state(STATE_OPENING)
 
     async def async_close_cover(self, **kwargs):
         """Close the window cover."""
         res = await self._cover_channel.down_close()
         if isinstance(res, list) and res[1] is Status.SUCCESS:
-            self.async_set_state(STATE_CLOSING)
+            self.async_update_state(STATE_CLOSING)
 
     async def async_set_cover_position(self, **kwargs):
         """Move the roller shutter to a specific position."""
         new_pos = kwargs[ATTR_POSITION]
         res = await self._cover_channel.go_to_lift_percentage(100 - new_pos)
         if isinstance(res, list) and res[1] is Status.SUCCESS:
-            self.async_set_state(
+            self.async_update_state(
                 STATE_CLOSING if new_pos < self._current_position else STATE_OPENING
             )
 

--- a/homeassistant/components/zha/device_tracker.py
+++ b/homeassistant/components/zha/device_tracker.py
@@ -83,8 +83,10 @@ class ZHADeviceScannerEntity(ScannerEntity, ZhaEntity):
         return SOURCE_TYPE_ROUTER
 
     @callback
-    def async_battery_percentage_remaining_updated(self, value):
+    def async_battery_percentage_remaining_updated(self, attr_id, attr_name, value):
         """Handle tracking."""
+        if not attr_name == "battery_percentage_remaining":
+            return
         self.debug("battery_percentage_remaining updated: %s", value)
         self._connected = True
         self._battery_level = Battery.formatter(value)

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -111,7 +111,7 @@ class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
         self.async_schedule_update_ha_state()
 
     @callback
-    def async_set_state(self, state):
+    def async_set_state(self, attr_id, attr_name, value):
         """Set the entity state."""
         pass
 

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -114,9 +114,9 @@ class ZhaFan(ZhaEntity, FanEntity):
         return self.state_attributes
 
     @callback
-    def async_set_state(self, state):
+    def async_set_state(self, attr_id, attr_name, value):
         """Handle state update from channel."""
-        self._state = VALUE_TO_SPEED.get(state, self._state)
+        self._state = VALUE_TO_SPEED.get(value, self._state)
         self.async_schedule_update_ha_state()
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:
@@ -133,7 +133,7 @@ class ZhaFan(ZhaEntity, FanEntity):
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         await self._fan_channel.async_set_speed(SPEED_TO_VALUE[speed])
-        self.async_set_state(speed)
+        self.async_set_state(0, "fan_mode", speed)
 
     async def async_update(self):
         """Attempt to retrieve on off state from the fan."""

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -155,10 +155,10 @@ class Light(ZhaEntity, light.Light):
         return self._supported_features
 
     @callback
-    def async_set_state(self, state):
+    def async_set_state(self, attr_id, attr_name, value):
         """Set the state."""
-        self._state = bool(state)
-        if state:
+        self._state = bool(value)
+        if value:
             self._off_brightness = None
         self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/zha/lock.py
+++ b/homeassistant/components/zha/lock.py
@@ -103,9 +103,9 @@ class ZhaDoorLock(ZhaEntity, LockDevice):
         await self.async_get_state()
 
     @callback
-    def async_set_state(self, state):
+    def async_set_state(self, attr_id, attr_name, value):
         """Handle state update from channel."""
-        self._state = VALUE_TO_STATE.get(state, self._state)
+        self._state = VALUE_TO_STATE.get(value, self._state)
         self.async_schedule_update_ha_state()
 
     async def async_get_state(self, from_cache=True):

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -124,11 +124,11 @@ class Sensor(ZhaEntity):
         return self._state
 
     @callback
-    def async_set_state(self, state):
+    def async_set_state(self, attr_id, attr_name, value):
         """Handle state update from channel."""
-        if state is not None:
-            state = self.formatter(state)
-        self._state = state
+        if value is not None:
+            value = self.formatter(value)
+        self._state = value
         self.async_schedule_update_ha_state()
 
     @callback

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -71,9 +71,9 @@ class Switch(ZhaEntity, SwitchDevice):
         self.async_schedule_update_ha_state()
 
     @callback
-    def async_set_state(self, state):
+    def async_set_state(self, attr_id, attr_name, value):
         """Handle state update from channel."""
-        self._state = bool(state)
+        self._state = bool(value)
         self.async_schedule_update_ha_state()
 
     @property

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -98,7 +98,7 @@ async def test_in_channel_config(
 
     cluster = zigpy_dev.endpoints[1].in_clusters[cluster_id]
     channel_class = registries.ZIGBEE_CHANNEL_REGISTRY.get(
-        cluster_id, base_channels.AttributeListeningChannel
+        cluster_id, base_channels.ZigbeeChannel
     )
     channel = channel_class(cluster, channel_pool)
 
@@ -156,7 +156,7 @@ async def test_out_channel_config(
     cluster = zigpy_dev.endpoints[1].out_clusters[cluster_id]
     cluster.bind_only = True
     channel_class = registries.ZIGBEE_CHANNEL_REGISTRY.get(
-        cluster_id, base_channels.AttributeListeningChannel
+        cluster_id, base_channels.ZigbeeChannel
     )
     channel = channel_class(cluster, channel_pool)
 


### PR DESCRIPTION
## Proposed change
This is another cleanup PR for ZHA. We are removing the AttributeListeningChannel and moving that functionality to the base ZigbeeChannel. Subsequent PR's will expand on this to allow us to read multiple attributes in a single call. This will allow us to implement things like thermostats much easier. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
