### PR TITLE
Make it possible to fetch proxy media player album art

### DIFF
--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -1,6 +1,7 @@
 """Test the base functions of the media player."""
 import base64
-from unittest.mock import patch
+
+from asynctest import patch
 
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.setup import async_setup_component
@@ -8,7 +9,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import mock_coro
 
 
-async def test_get_image(hass, hass_ws_client):
+async def test_get_image(hass, hass_ws_client, caplog):
     """Test get image via WS command."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
@@ -37,43 +38,53 @@ async def test_get_image(hass, hass_ws_client):
     assert msg["result"]["content_type"] == "image/jpeg"
     assert msg["result"]["content"] == base64.b64encode(b"image").decode("utf-8")
 
+    assert "media_player_thumbnail is deprecated" in caplog.text
 
-async def test_get_image_http(hass, hass_client):
+
+async def test_get_image_http(hass, aiohttp_client):
     """Test get image via http command."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
     )
 
-    client = await hass_client()
+    state = hass.states.get("media_player.bedroom")
+    assert "entity_picture_local" not in state.attributes
+
+    client = await aiohttp_client(hass.http.app)
 
     with patch(
         "homeassistant.components.media_player.MediaPlayerDevice."
         "async_get_media_image",
-        return_value=mock_coro((b"image", "image/jpeg")),
+        return_value=(b"image", "image/jpeg"),
     ):
-        resp = await client.get("/api/media_player_proxy/media_player.bedroom")
+        resp = await client.get(state.attributes["entity_picture"])
         content = await resp.read()
 
     assert content == b"image"
 
 
-async def test_get_image_http_url(hass, hass_client):
+async def test_get_image_http_remote(hass, aiohttp_client):
     """Test get image url via http command."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
-
-    client = await hass_client()
-
     with patch(
         "homeassistant.components.media_player.MediaPlayerDevice."
         "media_image_remotely_accessible",
         return_value=True,
     ):
-        resp = await client.get(
-            "/api/media_player_proxy/media_player.bedroom", allow_redirects=False
+        await async_setup_component(
+            hass, "media_player", {"media_player": {"platform": "demo"}}
         )
-        assert (
-            resp.headers["Location"]
-            == "https://img.youtube.com/vi/kxopViU98Xo/hqdefault.jpg"
-        )
+
+        state = hass.states.get("media_player.bedroom")
+        assert "entity_picture_local" in state.attributes
+
+        client = await aiohttp_client(hass.http.app)
+
+        with patch(
+            "homeassistant.components.media_player.MediaPlayerDevice."
+            "async_get_media_image",
+            return_value=(b"image", "image/jpeg"),
+        ):
+            resp = await client.get(state.attributes["entity_picture_local"])
+            content = await resp.read()
+
+        assert content == b"image"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR makes it possible to proxy the media player image via the backend, even if the resource is accessible remotely. This is necessary in the case that the frontend wants to process the image as in our upcoming image card (https://github.com/home-assistant/frontend/pull/5044).

This also deprecates the websocket thumbnail API for media player. We should not sent megabytes of data via the websocket.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
