### PR TITLE
Require title, separate show sidebar option

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -16,10 +16,11 @@ from .const import (
     CONF_MODE,
     CONF_REQUIRE_ADMIN,
     CONF_RESOURCES,
-    CONF_SIDEBAR,
+    CONF_SHOW_IN_SIDEBAR,
     CONF_TITLE,
     CONF_URL_PATH,
     DASHBOARD_BASE_CREATE_FIELDS,
+    DEFAULT_ICON,
     DOMAIN,
     MODE_STORAGE,
     MODE_YAML,
@@ -207,8 +208,8 @@ def _register_panel(hass, url_path, mode, config, update):
         "update": update,
     }
 
-    if CONF_SIDEBAR in config:
-        kwargs["sidebar_title"] = config[CONF_SIDEBAR][CONF_TITLE]
-        kwargs["sidebar_icon"] = config[CONF_SIDEBAR][CONF_ICON]
+    if config[CONF_SHOW_IN_SIDEBAR]:
+        kwargs["sidebar_title"] = config[CONF_TITLE]
+        kwargs["sidebar_icon"] = config.get(CONF_ICON, DEFAULT_ICON)
 
     frontend.async_register_built_in_panel(hass, DOMAIN, **kwargs)

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -172,6 +172,7 @@ async def async_setup(hass, config):
 
             update = False
         else:
+            hass.data[DOMAIN]["dashboards"][url_path].config = item
             update = True
 
         try:

--- a/homeassistant/components/lovelace/const.py
+++ b/homeassistant/components/lovelace/const.py
@@ -11,6 +11,8 @@ from homeassistant.util import slugify
 DOMAIN = "lovelace"
 EVENT_LOVELACE_UPDATED = "lovelace_updated"
 
+DEFAULT_ICON = "hass:view-dashboard"
+
 CONF_MODE = "mode"
 MODE_YAML = "yaml"
 MODE_STORAGE = "storage"
@@ -39,24 +41,23 @@ RESOURCE_UPDATE_FIELDS = {
     vol.Optional(CONF_URL): cv.string,
 }
 
-CONF_SIDEBAR = "sidebar"
 CONF_TITLE = "title"
 CONF_REQUIRE_ADMIN = "require_admin"
-
-SIDEBAR_FIELDS = {
-    vol.Required(CONF_ICON): cv.icon,
-    vol.Required(CONF_TITLE): cv.string,
-}
+CONF_SHOW_IN_SIDEBAR = "show_in_sidebar"
 
 DASHBOARD_BASE_CREATE_FIELDS = {
     vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
-    vol.Optional(CONF_SIDEBAR): SIDEBAR_FIELDS,
+    vol.Optional(CONF_ICON): cv.icon,
+    vol.Required(CONF_TITLE): cv.string,
+    vol.Optional(CONF_SHOW_IN_SIDEBAR, default=True): cv.boolean,
 }
 
 
 DASHBOARD_BASE_UPDATE_FIELDS = {
     vol.Optional(CONF_REQUIRE_ADMIN): cv.boolean,
-    vol.Optional(CONF_SIDEBAR): vol.Any(None, SIDEBAR_FIELDS),
+    vol.Optional(CONF_ICON): vol.Any(cv.icon, None),
+    vol.Optional(CONF_TITLE): cv.string,
+    vol.Optional(CONF_SHOW_IN_SIDEBAR): cv.boolean,
 }
 
 
@@ -68,9 +69,7 @@ STORAGE_DASHBOARD_CREATE_FIELDS = {
     vol.Optional(CONF_MODE, default=MODE_STORAGE): MODE_STORAGE,
 }
 
-STORAGE_DASHBOARD_UPDATE_FIELDS = {
-    **DASHBOARD_BASE_UPDATE_FIELDS,
-}
+STORAGE_DASHBOARD_UPDATE_FIELDS = DASHBOARD_BASE_UPDATE_FIELDS
 
 
 def url_slug(value: Any) -> str:

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import collection, storage
 from homeassistant.util.yaml import load_yaml
 
 from .const import (
-    CONF_SIDEBAR,
+    CONF_ICON,
     CONF_URL_PATH,
     DOMAIN,
     EVENT_LOVELACE_UPDATED,
@@ -246,7 +246,7 @@ class DashboardsCollection(collection.StorageCollection):
         update_data = self.UPDATE_SCHEMA(update_data)
         updated = {**data, **update_data}
 
-        if CONF_SIDEBAR in updated and updated[CONF_SIDEBAR] is None:
-            updated.pop(CONF_SIDEBAR)
+        if CONF_ICON in updated and updated[CONF_ICON] is None:
+            updated.pop(CONF_ICON)
 
         return updated

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -323,14 +323,14 @@ async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
             "type": "lovelace/dashboards/create",
             "url_path": "created_url_path",
             "require_admin": True,
-            "title": "Updated Title",
+            "title": "New Title",
             "icon": "mdi:map",
         }
     )
     response = await client.receive_json()
     assert response["success"]
     assert response["result"]["require_admin"] is True
-    assert response["result"]["title"] == "Updated Title"
+    assert response["result"]["title"] == "New Title"
     assert response["result"]["icon"] == "mdi:map"
 
     dashboard_id = response["result"]["id"]
@@ -342,7 +342,7 @@ async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
     assert response["success"]
     assert len(response["result"]) == 1
     assert response["result"][0]["mode"] == "storage"
-    assert response["result"][0]["title"] == "Updated Title"
+    assert response["result"][0]["title"] == "New Title"
     assert response["result"][0]["icon"] == "mdi:map"
     assert response["result"][0]["show_in_sidebar"] is True
     assert response["result"][0]["require_admin"] is True
@@ -388,25 +388,39 @@ async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
             "type": "lovelace/dashboards/update",
             "dashboard_id": dashboard_id,
             "require_admin": False,
+            "icon": "mdi:updated",
             "show_in_sidebar": False,
+            "title": "Updated Title",
         }
     )
     response = await client.receive_json()
     assert response["success"]
+    assert response["result"]["title"] == "Updated Title"
+    assert response["result"]["icon"] == "mdi:updated"
     assert response["result"]["show_in_sidebar"] is False
     assert response["result"]["require_admin"] is False
-    assert "sidebar" not in response["result"]
+
+    # List dashboards again and make sure we see latest config
+    await client.send_json({"id": 12, "type": "lovelace/dashboards/list"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert len(response["result"]) == 1
+    assert response["result"][0]["mode"] == "storage"
+    assert response["result"][0]["title"] == "Updated Title"
+    assert response["result"][0]["icon"] == "mdi:updated"
+    assert response["result"][0]["show_in_sidebar"] is False
+    assert response["result"][0]["require_admin"] is False
 
     # Add dashboard with existing url path
     await client.send_json(
-        {"id": 12, "type": "lovelace/dashboards/create", "url_path": "created_url_path"}
+        {"id": 13, "type": "lovelace/dashboards/create", "url_path": "created_url_path"}
     )
     response = await client.receive_json()
     assert not response["success"]
 
     # Delete dashboards
     await client.send_json(
-        {"id": 13, "type": "lovelace/dashboards/delete", "dashboard_id": dashboard_id}
+        {"id": 14, "type": "lovelace/dashboards/delete", "dashboard_id": dashboard_id}
     )
     response = await client.receive_json()
     assert response["success"]

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -395,6 +395,8 @@ async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
     )
     response = await client.receive_json()
     assert response["success"]
+    assert response["result"]["mode"] == "storage"
+    assert response["result"]["url_path"] == "created_url_path"
     assert response["result"]["title"] == "Updated Title"
     assert response["result"]["icon"] == "mdi:updated"
     assert response["result"]["show_in_sidebar"] is False
@@ -406,6 +408,7 @@ async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
     assert response["success"]
     assert len(response["result"]) == 1
     assert response["result"][0]["mode"] == "storage"
+    assert response["result"][0]["url_path"] == "created_url_path"
     assert response["result"][0]["title"] == "Updated Title"
     assert response["result"][0]["icon"] == "mdi:updated"
     assert response["result"][0]["show_in_sidebar"] is False


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on feedback from @bramkragten  we're going to tweak the Lovelace dashboard config.

This is not a released feature. However, this will break all your Lovelace dashboards if you are currently running dev and have played with it.

Changes:
 - Required: `title`. The title of the dashboard
 - Optional: `icon`. Icon of the dashboard if shown in the sidebar
 - Optional: `show_in_sidebar`. Boolean if should be shown in sidebar, default is True
 - Removed: `sidebar` group.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
