### PR TITLE
Add white value in light template platform

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -194,6 +194,7 @@ class LightTemplate(Light):
         if color_action is not None:
             self._color_script = Script(hass, color_action)
         self._color_template = color_template
+        self._white_value_script = None
         if white_value_action is not None:
             self._white_value_script = Script(hass, white_value_action)
         self._white_value_template = white_value_template
@@ -220,7 +221,7 @@ class LightTemplate(Light):
 
     @property
     def white_value(self):
-        """Return the CT color value in mireds."""
+        """Return the white value."""
         return self._white_value
 
     @property
@@ -439,7 +440,7 @@ class LightTemplate(Light):
                 self._white_value = int(white_value)
             else:
                 _LOGGER.error(
-                    "Received invalid white value : %s. Expected: 0-255", white_value
+                    "Received invalid white value: %s. Expected: 0-255", white_value
                 )
                 self._white_value = None
         except TemplateError as ex:

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -7,10 +7,12 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
+    ATTR_WHITE_VALUE,
     ENTITY_ID_FORMAT,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
+    SUPPORT_WHITE_VALUE,
     Light,
 )
 from homeassistant.const import (
@@ -46,6 +48,8 @@ CONF_TEMPERATURE_TEMPLATE = "temperature_template"
 CONF_TEMPERATURE_ACTION = "set_temperature"
 CONF_COLOR_TEMPLATE = "color_template"
 CONF_COLOR_ACTION = "set_color"
+CONF_WHITE_VALUE_TEMPLATE = "white_value_template"
+CONF_WHITE_VALUE_ACTION = "set_white_value"
 
 LIGHT_SCHEMA = vol.Schema(
     {
@@ -63,6 +67,8 @@ LIGHT_SCHEMA = vol.Schema(
         vol.Optional(CONF_TEMPERATURE_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_COLOR_TEMPLATE): cv.template,
         vol.Optional(CONF_COLOR_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_WHITE_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_WHITE_VALUE_ACTION): cv.SCRIPT_SCHEMA,
     }
 )
 
@@ -95,6 +101,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         color_action = device_config.get(CONF_COLOR_ACTION)
         color_template = device_config.get(CONF_COLOR_TEMPLATE)
 
+        white_value_action = device_config.get(CONF_WHITE_VALUE_ACTION)
+        white_value_template = device_config.get(CONF_WHITE_VALUE_TEMPLATE)
+
         templates = {
             CONF_VALUE_TEMPLATE: state_template,
             CONF_ICON_TEMPLATE: icon_template,
@@ -103,6 +112,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             CONF_LEVEL_TEMPLATE: level_template,
             CONF_TEMPERATURE_TEMPLATE: temperature_template,
             CONF_COLOR_TEMPLATE: color_template,
+            CONF_WHITE_VALUE_TEMPLATE: white_value_template,
         }
 
         initialise_templates(hass, templates)
@@ -128,6 +138,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 temperature_template,
                 color_action,
                 color_template,
+                white_value_action,
+                white_value_template,
             )
         )
 
@@ -155,6 +167,8 @@ class LightTemplate(Light):
         temperature_template,
         color_action,
         color_template,
+        white_value_action,
+        white_value_template,
     ):
         """Initialize the light."""
         self.hass = hass
@@ -180,6 +194,9 @@ class LightTemplate(Light):
         if color_action is not None:
             self._color_script = Script(hass, color_action)
         self._color_template = color_template
+        if white_value_action is not None:
+            self._white_value_script = Script(hass, white_value_action)
+        self._white_value_template = white_value_template
 
         self._state = False
         self._icon = None
@@ -187,6 +204,7 @@ class LightTemplate(Light):
         self._brightness = None
         self._temperature = None
         self._color = None
+        self._white_value = None
         self._entities = entity_ids
         self._available = True
 
@@ -199,6 +217,11 @@ class LightTemplate(Light):
     def color_temp(self):
         """Return the CT color value in mireds."""
         return self._temperature
+
+    @property
+    def white_value(self):
+        """Return the CT color value in mireds."""
+        return self._white_value
 
     @property
     def hs_color(self):
@@ -220,6 +243,8 @@ class LightTemplate(Light):
             supported_features |= SUPPORT_COLOR_TEMP
         if self._color_script is not None:
             supported_features |= SUPPORT_COLOR
+        if self._white_value_script is not None:
+            supported_features |= SUPPORT_WHITE_VALUE
         return supported_features
 
     @property
@@ -263,6 +288,7 @@ class LightTemplate(Light):
                 or self._level_template is not None
                 or self._temperature_template is not None
                 or self._color_template is not None
+                or self._white_value_template is not None
                 or self._availability_template is not None
             ):
                 async_track_state_change(
@@ -290,6 +316,13 @@ class LightTemplate(Light):
             self._brightness = kwargs[ATTR_BRIGHTNESS]
             optimistic_set = True
 
+        if self._white_value_template is None and ATTR_WHITE_VALUE in kwargs:
+            _LOGGER.info(
+                "Optimistically setting white value to %s", kwargs[ATTR_WHITE_VALUE]
+            )
+            self._white_value = kwargs[ATTR_WHITE_VALUE]
+            optimistic_set = True
+
         if self._temperature_template is None and ATTR_COLOR_TEMP in kwargs:
             _LOGGER.info(
                 "Optimistically setting color temperature to %s",
@@ -305,6 +338,10 @@ class LightTemplate(Light):
         elif ATTR_COLOR_TEMP in kwargs and self._temperature_script:
             await self._temperature_script.async_run(
                 {"color_temp": kwargs[ATTR_COLOR_TEMP]}, context=self._context
+            )
+        elif ATTR_WHITE_VALUE in kwargs and self._white_value_script:
+            await self._white_value_script.async_run(
+                {"white_value": kwargs[ATTR_WHITE_VALUE]}, context=self._context
             )
         elif ATTR_HS_COLOR in kwargs and self._color_script:
             hs_value = kwargs[ATTR_HS_COLOR]
@@ -334,6 +371,8 @@ class LightTemplate(Light):
         self.update_temperature()
 
         self.update_color()
+
+        self.update_white_value()
 
         for property_name, template in (
             ("_icon", self._icon_template),
@@ -385,6 +424,24 @@ class LightTemplate(Light):
                     "Received invalid brightness : %s. Expected: 0-255", brightness
                 )
                 self._brightness = None
+        except TemplateError as ex:
+            _LOGGER.error(ex)
+            self._state = None
+
+    @callback
+    def update_white_value(self):
+        """Update the white value from the template."""
+        if self._white_value_template is None:
+            return
+        try:
+            white_value = self._white_value_template.async_render()
+            if 0 <= int(white_value) <= 255:
+                self._white_value = int(white_value)
+            else:
+                _LOGGER.error(
+                    "Received invalid white value : %s. Expected: 0-255", white_value
+                )
+                self._white_value = None
         except TemplateError as ex:
             _LOGGER.error(ex)
             self._state = None

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -436,6 +436,9 @@ class LightTemplate(Light):
             return
         try:
             white_value = self._white_value_template.async_render()
+            if white_value in ("None", ""):
+                self._white_value = None
+                return
             if 0 <= int(white_value) <= 255:
                 self._white_value = int(white_value)
             else:
@@ -443,6 +446,12 @@ class LightTemplate(Light):
                     "Received invalid white value: %s. Expected: 0-255", white_value
                 )
                 self._white_value = None
+        except ValueError:
+            _LOGGER.error(
+                "Template must supply an integer white_value from 0-255, or 'None'",
+                exc_info=True,
+            )
+            self._white_value = None
         except TemplateError as ex:
             _LOGGER.error(ex)
             self._state = None

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -8,6 +8,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
+    ATTR_WHITE_VALUE,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import callback
@@ -35,7 +36,7 @@ class TestTemplateLight:
 
         @callback
         def record_call(service):
-            """Track function calls.."""
+            """Track function calls."""
             self.calls.append(service)
 
         self.hass.services.register("test", "automation", record_call)
@@ -494,6 +495,99 @@ class TestTemplateLight:
         state = self.hass.states.get("light.test_template_light")
         assert state.state == STATE_OFF
 
+    def test_white_value_action_no_template(self):
+        """Test setting white value with optimistic template."""
+        assert setup.setup_component(
+            self.hass,
+            "light",
+            {
+                "light": {
+                    "platform": "template",
+                    "lights": {
+                        "test_template_light": {
+                            "value_template": "{{1 == 1}}",
+                            "turn_on": {
+                                "service": "light.turn_on",
+                                "entity_id": "light.test_state",
+                            },
+                            "turn_off": {
+                                "service": "light.turn_off",
+                                "entity_id": "light.test_state",
+                            },
+                            "set_white_value": {
+                                "service": "test.automation",
+                                "data_template": {
+                                    "entity_id": "test.test_state",
+                                    "white_value": "{{white_value}}",
+                                },
+                            },
+                        }
+                    },
+                }
+            },
+        )
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("light.test_template_light")
+        assert state.attributes.get("white_value") is None
+
+        common.turn_on(
+            self.hass, "light.test_template_light", **{ATTR_WHITE_VALUE: 124}
+        )
+        self.hass.block_till_done()
+        assert len(self.calls) == 1
+        assert self.calls[0].data["white_value"] == "124"
+
+        state = self.hass.states.get("light.test_template_light")
+        _LOGGER.info(str(state.attributes))
+        assert state is not None
+        assert state.attributes.get("white_value") == 124
+
+    @pytest.mark.parametrize(
+        "expected_white_value,template", [(255, "{{255}}"), (None, "{{x - 12}}")],
+    )
+    def test_white_value_template(self, expected_white_value, template):
+        """Test the template for the white value."""
+        with assert_setup_component(1, "light"):
+            assert setup.setup_component(
+                self.hass,
+                "light",
+                {
+                    "light": {
+                        "platform": "template",
+                        "lights": {
+                            "test_template_light": {
+                                "value_template": "{{ 1 == 1 }}",
+                                "turn_on": {
+                                    "service": "light.turn_on",
+                                    "entity_id": "light.test_state",
+                                },
+                                "turn_off": {
+                                    "service": "light.turn_off",
+                                    "entity_id": "light.test_state",
+                                },
+                                "set_white_value": {
+                                    "service": "light.turn_on",
+                                    "data_template": {
+                                        "entity_id": "light.test_state",
+                                        "white_value": "{{white_value}}",
+                                    },
+                                },
+                                "white_value_template": template,
+                            }
+                        },
+                    }
+                },
+            )
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("light.test_template_light")
+        assert state is not None
+        assert state.attributes.get("white_value") == expected_white_value
+
     def test_level_action_no_template(self):
         """Test setting brightness with optimistic template."""
         assert setup.setup_component(
@@ -940,7 +1034,6 @@ class TestTemplateLight:
 
 async def test_available_template_with_entities(hass):
     """Test availability templates with values from other entities."""
-
     await setup.async_setup_component(
         hass,
         "light",

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -540,7 +540,6 @@ class TestTemplateLight:
         assert self.calls[0].data["white_value"] == "124"
 
         state = self.hass.states.get("light.test_template_light")
-        _LOGGER.info(str(state.attributes))
         assert state is not None
         assert state.attributes.get("white_value") == 124
 

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -544,7 +544,14 @@ class TestTemplateLight:
         assert state.attributes.get("white_value") == 124
 
     @pytest.mark.parametrize(
-        "expected_white_value,template", [(255, "{{255}}"), (None, "{{x - 12}}")],
+        "expected_white_value,template",
+        [
+            (255, "{{255}}"),
+            (None, "{{256}}"),
+            (None, "{{x - 12}}"),
+            (None, "{{ none }}"),
+            (None, ""),
+        ],
     )
     def test_white_value_template(self, expected_white_value, template):
         """Test the template for the white value."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This change adds support for "white value" in the Template Light integration. White value is defined in the top level Light integration and is typically used by RGBW devices. These devices allow for independent dimming of the white and RGBW channels. This change allows template lights to take on their own while value and control the while value of other lights in accordance with the HA standard.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
light:
  - platform: template
    lights:
      theater_lights:
        friendly_name: "Theater Lights"
        level_template: "{{ state_attr('sensor.theater_brightness', 'lux')|int }}"
        white_value_template: "{{ state_attr('sensor.theater_white_value, 'value')|int }}"
        value_template: "{{ state_attr('sensor.theater_brightness', 'lux')|int > 0 }}"
        temperature_template: "{{states('input_number.temperature_input') | int}}"
        color_template: "({{states('input_number.h_input') | int}}, {{states('input_number.s_input') | int}})"
        turn_on:
          service: script.theater_lights_on
        turn_off:
          service: script.theater_lights_off
        set_level:
          service: script.theater_lights_level
          data_template:
            brightness: "{{ brightness }}"
        set_white_value:
          service: script.theater_lights_white_value
          data_template:
            white_value: "{{ white_value }}"
        set_temperature:
          service: input_number.set_value
          data_template:
            value: "{{ color_temp }}"
            entity_id: input_number.temperature_input
        set_color:
          - service: input_number.set_value
            data_template:
              value: "{{ h }}"
              entity_id: input_number.h_input
          - service: input_number.set_value
            data_template:
              value: "{{ s }}"
              entity_id: input_number.s_input
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is not tied to an open issue.
- Link to documentation pull request: home-assistant/home-assistant.io#12508

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
