### PR TITLE
Added Templating to SQL Query, Changed Methods to Async, Allow for Stored Procedures

### DIFF
--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -208,4 +208,3 @@ class SQLSensor(Entity):
             )
         else:
             self._state = data
-            

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -31,10 +31,10 @@ CONF_QUERIES = "queries"
 CONF_QUERY = "query"
 CONF_QUERY_TEMPLATE = "query_template"
 
-def validate_sql_select(value):
+def validate_sql(value):
     """Validate that value is a SQL SELECT query."""
     if not value.lstrip().lower().startswith("select") and not value.lstrip().lower().startswith("exec"):
-         raise vol.Invalid("Only SELECT or EXEC queries allowed")
+        raise Exception("Only SELECT or EXEC queries allowed")
     return value
 
 _QUERY_SCHEME = vol.Schema(
@@ -176,10 +176,10 @@ class SQLSensor(Entity):
                 else:
                     self._state = None
                     _LOGGER.error("Could not render template %s: %s", self._name, ex)
-
-        try:            
+        try:     
+            validated_sql_command = validate_sql(sql_command)    
             sess = self.sessionmaker()
-            result = sess.execute(sql_command)
+            result = sess.execute(validated_sql_command)
             self._attributes = {}
 
             if not result.returns_rows or result.rowcount == 0:

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -7,9 +7,20 @@ import sqlalchemy
 from sqlalchemy.orm import scoped_session, sessionmaker
 import voluptuous as vol
 
-from homeassistant.components.recorder import CONF_DB_URL, DEFAULT_DB_FILE, DEFAULT_URL
+from homeassistant.components.recorder import (
+    CONF_DB_URL, 
+    DEFAULT_DB_FILE, 
+    DEFAULT_URL
+)
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE
+
+from homeassistant.const import (
+    CONF_NAME, 
+    CONF_UNIT_OF_MEASUREMENT, 
+    CONF_VALUE_TEMPLATE,
+)
+
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
@@ -18,22 +29,22 @@ _LOGGER = logging.getLogger(__name__)
 CONF_COLUMN_NAME = "column"
 CONF_QUERIES = "queries"
 CONF_QUERY = "query"
-
+CONF_QUERY_TEMPLATE = "query_template"
 
 def validate_sql_select(value):
     """Validate that value is a SQL SELECT query."""
-    if not value.lstrip().lower().startswith("select"):
-        raise vol.Invalid("Only SELECT queries allowed")
+    if not value.lstrip().lower().startswith("select") and not value.lstrip().lower().startswith("exec"):
+         raise vol.Invalid("Only SELECT or EXEC queries allowed")
     return value
-
 
 _QUERY_SCHEME = vol.Schema(
     {
         vol.Required(CONF_COLUMN_NAME): cv.string,
         vol.Required(CONF_NAME): cv.string,
-        vol.Required(CONF_QUERY): vol.All(cv.string, validate_sql_select),
+        vol.Optional(CONF_QUERY): cv.string,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_QUERY_TEMPLATE): cv.template,
     }
 )
 
@@ -41,10 +52,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_QUERIES): [_QUERY_SCHEME], vol.Optional(CONF_DB_URL): cv.string}
 )
 
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the SQL sensor platform."""
     db_url = config.get(CONF_DB_URL, None)
+
     if not db_url:
         db_url = DEFAULT_URL.format(hass_config_path=hass.config.path(DEFAULT_DB_FILE))
 
@@ -70,34 +81,60 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         unit = query.get(CONF_UNIT_OF_MEASUREMENT)
         value_template = query.get(CONF_VALUE_TEMPLATE)
         column_name = query.get(CONF_COLUMN_NAME)
+        query_template = query.get(CONF_QUERY_TEMPLATE)
 
+        if query_str and query_template:
+            raise Exception("Both query and query_template are defined. Choose one.")
+ 
         if value_template is not None:
             value_template.hass = hass
 
+        if query_template is not None:
+            query_template.hass = hass
+
         sensor = SQLSensor(
-            name, sessmaker, query_str, column_name, unit, value_template
+            hass, name, sessmaker, query_str, column_name, unit, value_template, query_template
         )
         queries.append(sensor)
 
-    add_entities(queries, True)
+    async_add_entities(queries)
 
+    return True
 
 class SQLSensor(Entity):
     """Representation of an SQL sensor."""
 
-    def __init__(self, name, sessmaker, query, column, unit, value_template):
+    def __init__(
+        self,
+        hass, 
+        name, 
+        sessmaker, 
+        query, 
+        column, 
+        unit, 
+        value_template, 
+        query_template
+    ):
+
         """Initialize the SQL sensor."""
+        self.hass = hass
         self._name = name
-        if "LIMIT" in query:
-            self._query = query
+        self._query_template = query_template
+
+        if query is not None:
+            if "LIMIT" in query:
+                self._query = query
+            else:
+                self._query = query.replace(";", " LIMIT 1;")
         else:
-            self._query = query.replace(";", " LIMIT 1;")
+            self._query = None
+
         self._unit_of_measurement = unit
         self._template = value_template
         self._column_name = column
         self.sessionmaker = sessmaker
         self._state = None
-        self._attributes = None
+        self._attributes = {}
 
     @property
     def name(self):
@@ -119,12 +156,30 @@ class SQLSensor(Entity):
         """Return the state attributes."""
         return self._attributes
 
-    def update(self):
+    async def async_update(self):
         """Retrieve sensor data from the query."""
+        
+        if self._query is not None:
+            sql_command = self._query
 
-        try:
+        if self._query_template is not None:
+            try:
+                sql_command = self._query_template.async_render()
+            except TemplateError as ex:
+                if ex.args and ex.args[0].startswith(
+                    "UndefinedError: 'None' has no attribute"
+                ):
+                    # Common during HA startup - so just a warning
+                    _LOGGER.warning(
+                        "Could not render template %s, the state is unknown.", self._name
+                    )
+                else:
+                    self._state = None
+                    _LOGGER.error("Could not render template %s: %s", self._name, ex)
+
+        try:            
             sess = self.sessionmaker()
-            result = sess.execute(self._query)
+            result = sess.execute(sql_command)
             self._attributes = {}
 
             if not result.returns_rows or result.rowcount == 0:

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -208,3 +208,4 @@ class SQLSensor(Entity):
             )
         else:
             self._state = data
+            


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Added several features to the SQL component:

- Converted methods to async
- Added "query_template" property to the query configuration to enable templating of the query
- Added the ability to execute stored procedures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

An example:  

```
- platform: sql
  db_url: !secret homedata_sql_connect_url
  queries:
    - name: Gallons Left
      query_template: "EXEC [dbo].[GetGallonsBurned] @lastFillDate = '{{ states.input_datetime.last_oil_refill.state | string }}'"
      column: 'Gallons'
```
This will execute the stored procedure while providing the state value to the @lastFillDate parameter.


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
