### PR TITLE
Allow multiple attribute reads in ZHA

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -112,7 +112,9 @@ class BinarySensor(ZhaEntity, BinarySensorDevice):
         """Attempt to retrieve on off state from the binary sensor."""
         await super().async_update()
         attribute = getattr(self._channel, "value_attribute", "on_off")
-        self._state = await self._channel.get_attribute_value(attribute)
+        attr_value = await self._channel.get_attribute_value(attribute)
+        if attr_value is not None:
+            self._state = attr_value
 
 
 @STRICT_MATCH(channel_names=CHANNEL_ACCELEROMETER)

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -192,6 +192,11 @@ class ChannelPool:
         return self._channels.zha_device.nwk
 
     @property
+    def is_mains_powered(self) -> bool:
+        """Device is_mains_powered."""
+        return self._channels.zha_device.is_mains_powered
+
+    @property
     def manufacturer(self) -> Optional[str]:
         """Return device manufacturer."""
         return self._channels.zha_device.manufacturer

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -207,6 +207,11 @@ class ChannelPool:
         return self._channels.zha_device.manufacturer_code
 
     @property
+    def hass(self):
+        """Return hass."""
+        return self._channels.zha_device.hass
+
+    @property
     def model(self) -> Optional[str]:
         """Return device model."""
         return self._channels.zha_device.model

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -215,7 +215,8 @@ class ZigbeeChannel(LogMixin):
         attributes = []
         for report_config in self._report_config:
             attributes.append(report_config["attr"])
-        await self.get_attributes(attributes, from_cache=from_cache)
+        if len(attributes) > 0:
+            await self.get_attributes(attributes, from_cache=from_cache)
         self._status = ChannelStatus.INITIALIZED
 
     @callback
@@ -270,9 +271,8 @@ class ZigbeeChannel(LogMixin):
         return result.get(attribute)
 
     async def get_attributes(self, attributes, from_cache=True):
-        """Get the values for a list of attributes and call the result handler callback."""
+        """Get the values for a list of attributes."""
         manufacturer = None
-        results = {}
         manufacturer_code = self._ch_pool.manufacturer_code
         if self.cluster.cluster_id >= 0xFC00 and manufacturer_code:
             manufacturer = manufacturer_code
@@ -291,6 +291,7 @@ class ZigbeeChannel(LogMixin):
                 self.cluster.ep_attribute,
                 str(ex),
             )
+            results = {}
         return results
 
     def log(self, level, msg, *args):

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -285,7 +285,7 @@ class ZigbeeChannel(LogMixin):
             )
             results = {attribute: result.get(attribute) for attribute in attributes}
         except (asyncio.TimeoutError, zigpy.exceptions.DeliveryError) as ex:
-            self.error(
+            self.debug(
                 "failed to get attributes '%s' on '%s' cluster: %s",
                 attributes,
                 self.cluster.ep_attribute,

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -267,9 +267,7 @@ class ZigbeeChannel(LogMixin):
         )
         return result.get(attribute)
 
-    async def get_many_attribute_values(
-        self, attributes, result_handler, from_cache=True
-    ):
+    async def get_attributes(self, attributes, result_handler, from_cache=True):
         """Get the values for a list of attributes and call the result handler callback."""
         manufacturer = None
         manufacturer_code = self._ch_pool.manufacturer_code
@@ -285,7 +283,7 @@ class ZigbeeChannel(LogMixin):
             results = {attribute: result.get(attribute) for attribute in attributes}
             result_handler(results)
         except (asyncio.TimeoutError, zigpy.exceptions.DeliveryError) as ex:
-            self.debug(
+            self.error(
                 "failed to get attributes '%s' on '%s' cluster: %s",
                 attributes,
                 self.cluster.ep_attribute,

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -284,8 +284,13 @@ class ZigbeeChannel(LogMixin):
             )
             results = {attribute: result.get(attribute) for attribute in attributes}
             result_handler(results)
-        except Exception:  # pylint: disable=broad-except
-            pass
+        except (asyncio.TimeoutError, zigpy.exceptions.DeliveryError) as ex:
+            self.debug(
+                "failed to get attributes '%s' on '%s' cluster: %s",
+                attributes,
+                self.cluster.ep_attribute,
+                str(ex),
+            )
 
     def log(self, level, msg, *args):
         """Log a message."""

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -267,6 +267,26 @@ class ZigbeeChannel(LogMixin):
         )
         return result.get(attribute)
 
+    async def get_many_attribute_values(
+        self, attributes, result_handler, from_cache=True
+    ):
+        """Get the values for a list of attributes and call the result handler callback."""
+        manufacturer = None
+        manufacturer_code = self._ch_pool.manufacturer_code
+        if self.cluster.cluster_id >= 0xFC00 and manufacturer_code:
+            manufacturer = manufacturer_code
+        try:
+            result, _ = await self.cluster.read_attributes(
+                attributes,
+                allow_cache=from_cache,
+                only_cache=from_cache,
+                manufacturer=manufacturer,
+            )
+            results = {attribute: result.get(attribute) for attribute in attributes}
+            result_handler(results)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     def log(self, level, msg, *args):
         """Log a message."""
         msg = f"[%s:%s]: {msg}"

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -22,10 +22,10 @@ class DoorLockChannel(ZigbeeChannel):
     async def async_update(self):
         """Retrieve latest state."""
         result = await self.get_attribute_value("lock_state", from_cache=True)
-
-        self.async_send_signal(
-            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0, "lock_state", result
-        )
+        if result is not None:
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0, "lock_state", result
+            )
 
     @callback
     def attribute_updated(self, attrid, value):
@@ -67,12 +67,13 @@ class WindowCovering(ZigbeeChannel):
             "current_position_lift_percentage", from_cache=False
         )
         self.debug("read current position: %s", result)
-        self.async_send_signal(
-            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
-            8,
-            "current_position_lift_percentage",
-            result,
-        )
+        if result is not None:
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                8,
+                "current_position_lift_percentage",
+                result,
+            )
 
     @callback
     def attribute_updated(self, attrid, value):

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -270,7 +270,7 @@ class OnOffChannel(ZigbeeChannel):
                 self.attribute_updated(self.ON_OFF, True)
                 if on_time > 0:
                     self._off_listener = async_call_later(
-                        self.device.hass,
+                        self._ch_pool.hass,
                         (on_time / 10),  # value is in 10ths of a second
                         self.set_to_off,
                     )

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -302,9 +302,10 @@ class OnOffChannel(ZigbeeChannel):
         """Initialize channel."""
         if self.cluster.is_client:
             return
-        self.debug("attempting to update onoff state - from cache: False")
+        from_cache = not self._ch_pool.is_mains_powered
+        self.debug("attempting to update onoff state - from cache: %s", from_cache)
         self._state = bool(
-            await self.get_attribute_value(self.ON_OFF, from_cache=False)
+            await self.get_attribute_value(self.ON_OFF, from_cache=from_cache)
         )
         await super().async_update()
 

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -73,9 +73,13 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
 
         # This is a polling channel. Don't allow cache.
         result = await self.get_attribute_value("active_power", from_cache=False)
-        self.async_send_signal(
-            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0x050B, "active_power", result
-        )
+        if result is not None:
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                0x050B,
+                "active_power",
+                result,
+            )
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""
@@ -92,6 +96,8 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
             divisor = await self.get_attribute_value(
                 "power_divisor", from_cache=from_cache
             )
+            if divisor is None:
+                divisor = 1
         self._divisor = divisor
 
         mult = await self.get_attribute_value(
@@ -101,6 +107,8 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
             mult = await self.get_attribute_value(
                 "power_multiplier", from_cache=from_cache
             )
+            if mult is None:
+                mult = 1
         self._multiplier = mult
 
     @property

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -40,9 +40,10 @@ class FanChannel(ZigbeeChannel):
     async def async_update(self):
         """Retrieve latest state."""
         result = await self.get_attribute_value("fan_mode", from_cache=True)
-        self.async_send_signal(
-            f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0, "fan_mode", result
-        )
+        if result is not None:
+            self.async_send_signal(
+                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 0, "fan_mode", result
+            )
 
     @callback
     def attribute_updated(self, attrid, value):

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -34,7 +34,7 @@ class ColorChannel(ZigbeeChannel):
     )
 
     def __init__(
-        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType,
+        self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType
     ) -> None:
         """Initialize ColorChannel."""
         super().__init__(cluster, ch_pool)
@@ -52,9 +52,8 @@ class ColorChannel(ZigbeeChannel):
     async def async_initialize(self, from_cache):
         """Initialize channel."""
         await self.fetch_color_capabilities(True)
-        await self.get_attribute_value("color_temperature", from_cache=from_cache)
-        await self.get_attribute_value("current_x", from_cache=from_cache)
-        await self.get_attribute_value("current_y", from_cache=from_cache)
+        attributes = ["color_temperature", "current_x", "current_y"]
+        await self.get_attributes(attributes, from_cache=from_cache)
 
     async def fetch_color_capabilities(self, from_cache):
         """Get the color configuration."""
@@ -72,7 +71,7 @@ class ColorChannel(ZigbeeChannel):
                 "color_temperature", from_cache=from_cache
             )
 
-            if result is not self.UNSUPPORTED_ATTRIBUTE:
+            if result is not None and result is not self.UNSUPPORTED_ATTRIBUTE:
                 capabilities |= self.CAPABILITIES_COLOR_TEMP
         self._color_capabilities = capabilities
         await super().async_initialize(from_cache)

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -176,6 +176,6 @@ class IASZoneChannel(ZigbeeChannel):
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""
-        await self.get_attribute_value("zone_status", from_cache=from_cache)
-        await self.get_attribute_value("zone_state", from_cache=from_cache)
+        attributes = ["zone_status", "zone_state"]
+        await self.get_attributes(attributes, from_cache=from_cache)
         await super().async_initialize(from_cache)

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -35,18 +35,6 @@ async def safe_read(
         return {}
 
 
-def get_attr_id_by_name(cluster, attr_name):
-    """Get the attribute id for a cluster attribute by its name."""
-    return next(
-        (
-            attrid
-            for attrid, (attrname, datatype) in cluster.attributes.items()
-            if attr_name == attrname
-        ),
-        None,
-    )
-
-
 async def get_matched_clusters(source_zha_device, target_zha_device):
     """Get matched input/output cluster pairs for 2 devices."""
     source_clusters = source_zha_device.async_get_std_clusters()

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -373,7 +373,7 @@ class Light(ZhaEntity, light.Light):
             ):
                 attributes.append("color_loop_active")
 
-            await self._color_channel.get_many_attribute_values(
+            await self._color_channel.get_attributes(
                 attributes, result_handler, from_cache=from_cache
             )
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -176,10 +176,12 @@ class Battery(Sensor):
     async def async_state_attr_provider(self):
         """Return device state attrs for battery sensors."""
         state_attrs = {}
-        battery_size = await self._channel.get_attribute_value("battery_size")
+        attributes = ["battery_size", "battery_quantity"]
+        results = await self._channel.get_attributes(attributes)
+        battery_size = results.get("battery_size", None)
         if battery_size is not None:
             state_attrs["battery_size"] = BATTERY_SIZES.get(battery_size, "Unknown")
-        battery_quantity = await self._channel.get_attribute_value("battery_quantity")
+        battery_quantity = results.get("battery_quantity", None)
         if battery_quantity is not None:
             state_attrs["battery_quantity"] = battery_quantity
         return state_attrs

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -97,4 +97,6 @@ class Switch(ZhaEntity, SwitchDevice):
         """Attempt to retrieve on off state from the switch."""
         await super().async_update()
         if self._on_off_channel:
-            self._state = await self._on_off_channel.get_attribute_value("on_off")
+            state = await self._on_off_channel.get_attribute_value("on_off")
+            if state is not None:
+                self._state = state

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -52,7 +52,7 @@ def patch_cluster(cluster):
     cluster.configure_reporting = CoroutineMock(return_value=[0])
     cluster.deserialize = Mock()
     cluster.handle_cluster_request = Mock()
-    cluster.read_attributes = CoroutineMock()
+    cluster.read_attributes = CoroutineMock(return_value=[{}, {}])
     cluster.read_attributes_raw = Mock()
     cluster.unbind = CoroutineMock(return_value=[0])
     cluster.write_attributes = CoroutineMock(return_value=[0])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds multiple attribute reads to ZHA and adds guards around attribute reads that could have caused unintended state flipping when remote requests failed. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
