### PR TITLE
Remove discovery and legacy config file loading for Plex

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -37,7 +37,6 @@ SERVICE_KONNECTED = "konnected"
 SERVICE_MOBILE_APP = "hass_mobile_app"
 SERVICE_NETGEAR = "netgear_router"
 SERVICE_OCTOPRINT = "octoprint"
-SERVICE_PLEX = "plex_mediaserver"
 SERVICE_ROKU = "roku"
 SERVICE_SABNZBD = "sabnzbd"
 SERVICE_SAMSUNG_PRINTER = "samsung_printer"
@@ -51,7 +50,6 @@ CONFIG_ENTRY_HANDLERS = {
     SERVICE_DAIKIN: "daikin",
     SERVICE_TELLDUSLIVE: "tellduslive",
     SERVICE_IGD: "upnp",
-    SERVICE_PLEX: "plex",
 }
 
 SERVICE_HANDLERS = {

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -11,11 +11,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.const import CONF_SSL, CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.json import load_json
 
 from .const import (  # pylint: disable=unused-import
     AUTH_CALLBACK_NAME,
@@ -28,7 +27,6 @@ from .const import (  # pylint: disable=unused-import
     CONF_USE_EPISODE_ART,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
-    PLEX_CONFIG_FILE,
     PLEX_SERVER_CONFIG,
     SERVERS,
     X_PLEX_DEVICE_NAME,
@@ -183,29 +181,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors={},
         )
-
-    async def async_step_discovery(self, discovery_info):
-        """Set default host and port from discovery."""
-        if self._async_current_entries() or self._async_in_progress():
-            # Skip discovery if a config already exists or is in progress.
-            return self.async_abort(reason="already_configured")
-
-        json_file = self.hass.config.path(PLEX_CONFIG_FILE)
-        file_config = await self.hass.async_add_executor_job(load_json, json_file)
-
-        if file_config:
-            host_and_port, host_config = file_config.popitem()
-            prefix = "https" if host_config[CONF_SSL] else "http"
-
-            server_config = {
-                CONF_URL: f"{prefix}://{host_and_port}",
-                CONF_TOKEN: host_config[CONF_TOKEN],
-                CONF_VERIFY_SSL: host_config["verify"],
-            }
-            _LOGGER.info("Imported legacy config, file can be removed: %s", json_file)
-            return await self.async_step_server_validate(server_config)
-
-        return self.async_abort(reason="discovery_no_file")
 
     async def async_step_import(self, import_config):
         """Import from Plex configuration."""

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -15,7 +15,6 @@ PLATFORMS_COMPLETED = "platforms_completed"
 SERVERS = "servers"
 WEBSOCKETS = "websockets"
 
-PLEX_CONFIG_FILE = "plex.conf"
 PLEX_MEDIA_PLAYER_OPTIONS = "plex_mp_options"
 PLEX_SERVER_CONFIG = "server_config"
 

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -23,7 +23,6 @@
             "all_configured": "All linked servers already configured",
             "already_configured": "This Plex server is already configured",
             "already_in_progress": "Plex is being configured",
-            "discovery_no_file": "No legacy configuration file found",
             "invalid_import": "Imported configuration is invalid",
             "non-interactive": "Non-interactive import",
             "token_request_timeout": "Timed out obtaining token",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Ability to load legacy configuration files (`plex.conf`) is removed.

Discovery for new integrations is removed.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `discovery`/`netdisco` discovery method is deprecated and most Plex setups require external authentication to complete setup anyway.

Loading the legacy config file was preserved to simplify migrations of configs created before 0.100. It was a finicky format and only read during discovery.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12274

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
