### PR TITLE
Guard against invalid trigger and action scenarios in ZHA

### DIFF
--- a/homeassistant/components/zha/device_action.py
+++ b/homeassistant/components/zha/device_action.py
@@ -56,7 +56,10 @@ async def async_call_action_from_config(
 
 async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
     """List device actions."""
-    zha_device = await async_get_zha_device(hass, device_id)
+    try:
+        zha_device = await async_get_zha_device(hass, device_id)
+    except (KeyError, AttributeError):
+        return []
     cluster_channels = [
         ch.name
         for pool in zha_device.channels.pools
@@ -81,7 +84,10 @@ async def _execute_service_based_action(
 ) -> None:
     action_type = config[CONF_TYPE]
     service_name = SERVICE_NAMES[action_type]
-    zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+    try:
+        zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+    except (KeyError, AttributeError):
+        return
 
     service_data = {ATTR_IEEE: str(zha_device.ieee)}
 

--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -27,7 +27,10 @@ async def async_validate_trigger_config(hass, config):
 
     if "zha" in hass.config.components:
         trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
-        zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+        try:
+            zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+        except (KeyError, AttributeError):
+            raise InvalidDeviceAutomationConfig
         if (
             zha_device.device_automation_triggers is None
             or trigger not in zha_device.device_automation_triggers
@@ -40,8 +43,10 @@ async def async_validate_trigger_config(hass, config):
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
-    zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
-
+    try:
+        zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
+    except (KeyError, AttributeError):
+        return None
     trigger = zha_device.device_automation_triggers[trigger]
 
     event_config = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds guards to ZHA device triggers and actions to prevent hard crashes when someone unplugs the USB Zigbee stick or when someone removes a device w/o cleaning up it's connected stuff. 

![image](https://user-images.githubusercontent.com/1335687/76021750-d281b080-5ef3-11ea-8ea1-87e7aff3d236.png)

Thanks Bram!!


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
