### PR TITLE
Add attribute 'on' and 'reachable' for hue binary sensor

### DIFF
--- a/homeassistant/components/hue/binary_sensor.py
+++ b/homeassistant/components/hue/binary_sensor.py
@@ -34,6 +34,8 @@ class HuePresence(GenericZLLSensor, BinarySensorDevice):
     def device_state_attributes(self):
         """Return the device state attributes."""
         attributes = super().device_state_attributes
+        if "on" in self.sensor.config:
+            attributes["on"] = self.sensor.config["on"]
         if "sensitivity" in self.sensor.config:
             attributes["sensitivity"] = self.sensor.config["sensitivity"]
         if "sensitivitymax" in self.sensor.config:

--- a/homeassistant/components/hue/binary_sensor.py
+++ b/homeassistant/components/hue/binary_sensor.py
@@ -36,6 +36,8 @@ class HuePresence(GenericZLLSensor, BinarySensorDevice):
         attributes = super().device_state_attributes
         if "on" in self.sensor.config:
             attributes["on"] = self.sensor.config["on"]
+        if "reachable" in self.sensor.config:
+            attributes["reachable"] = self.sensor.config["reachable"]
         if "sensitivity" in self.sensor.config:
             attributes["sensitivity"] = self.sensor.config["sensitivity"]
         if "sensitivitymax" in self.sensor.config:


### PR DESCRIPTION
which refers to the physical sensor being switched on, not the state Motion.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With this added attributes, we can easily see/check/act upon the motion sensor actually being switched on or not, and for reachability.

this is a first step to move functionality from the Custom integration Hue sensors to HA core, and relieve the Hue hub from extraneous stress.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


<img width="895" alt="Schermafbeelding 2020-03-06 om 10 22 27" src="https://user-images.githubusercontent.com/33354141/76070267-85a1e680-5f94-11ea-89e5-e0bc84f8f939.png">

<img width="876" alt="Schermafbeelding 2020-03-06 om 10 22 38" src="https://user-images.githubusercontent.com/33354141/76070290-8d618b00-5f94-11ea-95b0-9f99ada9e578.png">

<img width="863" alt="Schermafbeelding 2020-03-06 om 10 24 04" src="https://user-images.githubusercontent.com/33354141/76070337-a36f4b80-5f94-11ea-8c37-e16378651e5d.png">

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
