### PR TITLE
Implement source switching for homekit_controller televisions

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -95,6 +95,16 @@ class HomeKitEntity(Entity):
                         continue
                     self._setup_characteristic(char)
 
+                accessory = self._accessory.entity_map.aid(self._aid)
+                this_service = accessory.services.iid(self._iid)
+                for child_service in accessory.services.filter(
+                    parent_service=this_service
+                ):
+                    for char in child_service.characteristics:
+                        if char.type not in characteristic_types:
+                            continue
+                        self._setup_characteristic(char.to_accessory_and_service_list())
+
     def _setup_characteristic(self, char):
         """Configure an entity based on a HomeKit characteristics metadata."""
         # Build up a list of (aid, iid) tuples to poll on update()

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.17"],
+  "requirements": ["aiohomekit[IP]==0.2.21"],
   "dependencies": [],
   "zeroconf": ["_hap._tcp.local."],
   "codeowners": ["@Jc2k"]

--- a/homeassistant/components/homekit_controller/media_player.py
+++ b/homeassistant/components/homekit_controller/media_player.py
@@ -7,12 +7,14 @@ from aiohomekit.model.characteristics import (
     RemoteKeyValues,
     TargetMediaStateValues,
 )
+from aiohomekit.model.services import ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
 
 from homeassistant.components.media_player import DEVICE_CLASS_TV, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
+    SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
 )
 from homeassistant.const import STATE_IDLE, STATE_PAUSED, STATE_PLAYING
@@ -63,7 +65,14 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerDevice):
             CharacteristicsTypes.CURRENT_MEDIA_STATE,
             CharacteristicsTypes.TARGET_MEDIA_STATE,
             CharacteristicsTypes.REMOTE_KEY,
+            CharacteristicsTypes.ACTIVE_IDENTIFIER,
+            # Characterics that are on the linked INPUT_SOURCE services
+            CharacteristicsTypes.CONFIGURED_NAME,
+            CharacteristicsTypes.IDENTIFIER,
         ]
+
+    def _setup_active_identifier(self, char):
+        self._features |= SUPPORT_SELECT_SOURCE
 
     def _setup_target_media_state(self, char):
         self._supported_target_media_state = clamp_enum_to_char(
@@ -93,6 +102,43 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerDevice):
     def supported_features(self):
         """Flag media player features that are supported."""
         return self._features
+
+    @property
+    def source_list(self):
+        """List of all input sources for this television."""
+        sources = []
+
+        this_accessory = self._accessory.entity_map.aid(self._aid)
+        this_tv = this_accessory.services.iid(self._iid)
+
+        input_sources = this_accessory.services.filter(
+            service_type=ServicesTypes.INPUT_SOURCE, parent_service=this_tv,
+        )
+
+        for input_source in input_sources:
+            char = input_source[CharacteristicsTypes.CONFIGURED_NAME]
+            sources.append(char.value)
+        return sources
+
+    @property
+    def source(self):
+        """Name of the current input source."""
+        active_identifier = self.get_hk_char_value(
+            CharacteristicsTypes.ACTIVE_IDENTIFIER
+        )
+        if not active_identifier:
+            return None
+
+        this_accessory = self._accessory.entity_map.aid(self._aid)
+        this_tv = this_accessory.services.iid(self._iid)
+
+        input_source = this_accessory.services.first(
+            service_type=ServicesTypes.INPUT_SOURCE,
+            characteristics={CharacteristicsTypes.IDENTIFIER: active_identifier},
+            parent_service=this_tv,
+        )
+        char = input_source[CharacteristicsTypes.CONFIGURED_NAME]
+        return char.value
 
     @property
     def state(self):
@@ -167,3 +213,28 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerDevice):
                 }
             ]
             await self._accessory.put_characteristics(characteristics)
+
+    async def async_select_source(self, source):
+        """Switch to a different media source."""
+        this_accessory = self._accessory.entity_map.aid(self._aid)
+        this_tv = this_accessory.services.iid(self._iid)
+
+        input_source = this_accessory.services.first(
+            service_type=ServicesTypes.INPUT_SOURCE,
+            characteristics={CharacteristicsTypes.CONFIGURED_NAME: source},
+            parent_service=this_tv,
+        )
+
+        if not input_source:
+            raise ValueError(f"Could not find source {source}")
+
+        identifier = input_source[CharacteristicsTypes.IDENTIFIER]
+
+        characteristics = [
+            {
+                "aid": self._aid,
+                "iid": self._chars["active-identifier"],
+                "value": identifier.value,
+            }
+        ]
+        await self._accessory.put_characteristics(characteristics)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -163,7 +163,7 @@ aioftp==0.12.0
 aioharmony==0.1.13
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.17
+aiohomekit[IP]==0.2.21
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,7 +62,7 @@ aiobotocore==0.11.1
 aioesphomeapi==2.6.1
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.17
+aiohomekit[IP]==0.2.21
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -67,7 +67,7 @@ async def setup_accessories_from_file(hass, path):
         load_fixture, os.path.join("homekit_controller", path)
     )
     accessories_json = json.loads(accessories_fixture)
-    accessories = Accessory.setup_accessories_from_list(accessories_json)
+    accessories = Accessories.from_list(accessories_json)
     return accessories
 
 
@@ -153,7 +153,9 @@ async def setup_test_component(hass, setup_accessory, capitalize=False, suffix=N
 
     If suffix is set, entityId will include the suffix
     """
-    accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
+    accessory = Accessory.create_with_info(
+        "TestDevice", "example.com", "Test", "0001", "0.1"
+    )
     setup_accessory(accessory)
 
     domain = None

--- a/tests/components/homekit_controller/specific_devices/test_lg_tv.py
+++ b/tests/components/homekit_controller/specific_devices/test_lg_tv.py
@@ -1,7 +1,11 @@
 """Make sure that handling real world LG HomeKit characteristics isn't broken."""
 
 
-from homeassistant.components.media_player.const import SUPPORT_PAUSE, SUPPORT_PLAY
+from homeassistant.components.media_player.const import (
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_SELECT_SOURCE,
+)
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -29,8 +33,22 @@ async def test_lg_tv(hass):
     # Assert that the friendly name is detected correctly
     assert state.attributes["friendly_name"] == "LG webOS TV AF80"
 
+    # Assert that all channels were found and that we know which is active.
+    assert state.attributes["source_list"] == [
+        "AirPlay",
+        "Live TV",
+        "HDMI 1",
+        "Sony",
+        "Apple",
+        "AV",
+        "HDMI 4",
+    ]
+    assert state.attributes["source"] == "HDMI 4"
+
     # Assert that all optional features the LS1 supports are detected
-    assert state.attributes["supported_features"] == (SUPPORT_PAUSE | SUPPORT_PLAY)
+    assert state.attributes["supported_features"] == (
+        SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SELECT_SOURCE
+    )
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -147,7 +147,7 @@ def setup_mock_accessory(controller):
     """Add a bridge accessory to a test controller."""
     bridge = Accessories()
 
-    accessory = Accessory(
+    accessory = Accessory.create_with_info(
         name="Koogeek-LS1-20833F",
         manufacturer="Koogeek",
         model="LS1",
@@ -500,7 +500,9 @@ async def test_user_no_unpaired_devices(hass, controller):
 
 async def test_parse_new_homekit_json(hass):
     """Test migrating recent .homekit/pairings.json files."""
-    accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
+    accessory = Accessory.create_with_info(
+        "TestDevice", "example.com", "Test", "0001", "0.1"
+    )
     service = accessory.add_service(ServicesTypes.LIGHTBULB)
     on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0
@@ -549,7 +551,9 @@ async def test_parse_new_homekit_json(hass):
 
 async def test_parse_old_homekit_json(hass):
     """Test migrating original .homekit/hk-00:00:00:00:00:00 files."""
-    accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
+    accessory = Accessory.create_with_info(
+        "TestDevice", "example.com", "Test", "0001", "0.1"
+    )
     service = accessory.add_service(ServicesTypes.LIGHTBULB)
     on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0
@@ -602,7 +606,9 @@ async def test_parse_old_homekit_json(hass):
 
 async def test_parse_overlapping_homekit_json(hass):
     """Test migrating .homekit/pairings.json files when hk- exists too."""
-    accessory = Accessory("TestDevice", "example.com", "Test", "0001", "0.1")
+    accessory = Accessory.create_with_info(
+        "TestDevice", "example.com", "Test", "0001", "0.1"
+    )
     service = accessory.add_service(ServicesTypes.LIGHTBULB)
     on_char = service.add_char(CharacteristicsTypes.ON)
     on_char.value = 0


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This implements `source` and `source_list` for the homekit_controller media player. If they are supported it sets `SUPPORT_SELECT_SOURCE` and it adds `async_select_source`.

Historically one HomeKit service mapped to one Home Assistant entity. But for TV's there are additional satellite services for input sources. This means that the polling and subscribing logic had to be tweaked a bit too, and to avoid some awful code in HA i've added some abstractions to aiohomekit to make it easier to work with these linked services.

This introduces an `entity_map` object on `HKDevice`. The plan is to stop using the raw JSON in `HKDevice.accesories` and `HKDevice.current_state` and to use `entity_map` instead, moving a lot of non-HA specific state management code upstream and out of HA. But that will be in a future PR.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #25960
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
