### PR TITLE
Add attribute 'reachable' to Hue lights

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -54,6 +54,7 @@ SUPPORT_HUE = {
 }
 
 ATTR_IS_HUE_GROUP = "is_hue_group"
+ATTR_REACHABLE = "reachable"
 GAMUT_TYPE_UNAVAILABLE = "None"
 # Minimum Hue Bridge API version to support groups
 # 1.4.0 introduced extended group info
@@ -303,6 +304,11 @@ class HueLight(Light):
         )
 
     @property
+    def reachable(self):
+        """Return true if reachable (has power)."""
+        return self.light.state["reachable"]
+    
+    @property
     def supported_features(self):
         """Flag supported features."""
         return self._supported_features
@@ -443,4 +449,5 @@ class HueLight(Light):
         attributes = {}
         if self.is_group:
             attributes[ATTR_IS_HUE_GROUP] = self.is_group
+        attributes[ATTR_REACHABLE] = self.reachable
         return attributes


### PR DESCRIPTION
to be able to distinguish between reachable: false (cut off power) and unavailable (Hue Hub can't communicate with light)
see https://github.com/home-assistant/core/issues/32438#issuecomment-595397733.

this is a further attempt in deleting as many extraneous calls to the Hue hub. reachable would otherwise have to be tested by means of a rest sensor like:
```
  - platform: rest
    name: Hue lights config
    resource: !secret hue_lights_resource
    method: GET
    value_template: >
      {{value_json|length}}
    json_attributes:
      - '10' #mobile
      - '13' #driveway
      - '16' #garden_terrace
      - '17' #garden_backyard
      - '41' #gate_outdoors
      - '42' #porch_outdoors
      - '50' #bureau_marte
      - '53' #backdoor_outdoors
    scan_interval: 300
```
causing extra Hue hub stress.

<img width="725" alt="Schermafbeelding 2020-03-06 om 17 13 00" src="https://user-images.githubusercontent.com/33354141/76101017-fe716480-5fcd-11ea-94cd-6bb6eaaade4f.png">

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
