### PR TITLE
Add MQTT Alarm Control Panel custom bypass state

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -85,6 +85,7 @@ ABBREVIATIONS = {
     "pl_arm_away": "payload_arm_away",
     "pl_arm_home": "payload_arm_home",
     "pl_arm_nite": "payload_arm_night",
+    "pl_arm_custom_b": "payload_arm_custom_bypass",
     "pl_avail": "payload_available",
     "pl_cln_sp": "payload_clean_spot",
     "pl_cls": "payload_close",

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -17,9 +17,12 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_VALUE_TEMPLATE,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
+    STATE_ALARM_DISARMING,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
@@ -179,7 +182,10 @@ class MqttAlarm(
                 STATE_ALARM_ARMED_HOME,
                 STATE_ALARM_ARMED_AWAY,
                 STATE_ALARM_ARMED_NIGHT,
+                STATE_ALARM_ARMED_CUSTOM_BYPASS,
                 STATE_ALARM_PENDING,
+                STATE_ALARM_ARMING,
+                STATE_ALARM_DISARMING,
                 STATE_ALARM_TRIGGERED,
             ):
                 _LOGGER.warning("Received unexpected payload: %s", msg.payload)

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -335,6 +335,80 @@ async def test_arm_night_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
     )
 
 
+async def test_arm_custom_bypass_publishes_mqtt(hass, mqtt_mock):
+    """Test publishing of MQTT messages while armed."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            alarm_control_panel.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "alarm/state",
+                "command_topic": "alarm/command",
+            }
+        },
+    )
+
+    await common.async_alarm_arm_custom_bypass(hass)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "alarm/command", "ARM_CUSTOM_BYPASS", 0, False
+    )
+
+
+async def test_arm_custom_bypass_not_publishes_mqtt_with_invalid_code_when_req(
+    hass, mqtt_mock
+):
+    """Test not publishing of MQTT messages with invalid code.
+
+    When code_arm_required = True
+    """
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            alarm_control_panel.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "alarm/state",
+                "command_topic": "alarm/command",
+                "code": "1234",
+                "code_arm_required": True,
+            }
+        },
+    )
+
+    call_count = mqtt_mock.async_publish.call_count
+    await common.async_alarm_arm_custom_bypass(hass, "abcd")
+    assert mqtt_mock.async_publish.call_count == call_count
+
+
+async def test_arm_custom_bypass_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
+    """Test publishing of MQTT messages.
+
+    When code_arm_required = False
+    """
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            alarm_control_panel.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "alarm/state",
+                "command_topic": "alarm/command",
+                "code": "1234",
+                "code_arm_required": False,
+            }
+        },
+    )
+
+    await common.async_alarm_arm_custom_bypass(hass)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "alarm/command", "ARM_CUSTOM_BYPASS", 0, False
+    )
+
+
 async def test_disarm_publishes_mqtt(hass, mqtt_mock):
     """Test publishing of MQTT messages while disarmed."""
     assert await async_setup_component(

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -6,9 +6,12 @@ from homeassistant.components import alarm_control_panel, mqtt
 from homeassistant.components.mqtt.discovery import async_start
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
+    STATE_ALARM_DISARMING,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
     STATE_UNAVAILABLE,
@@ -83,7 +86,10 @@ async def test_update_state_via_state_topic(hass, mqtt_mock):
         STATE_ALARM_ARMED_HOME,
         STATE_ALARM_ARMED_AWAY,
         STATE_ALARM_ARMED_NIGHT,
+        STATE_ALARM_ARMED_CUSTOM_BYPASS,
         STATE_ALARM_PENDING,
+        STATE_ALARM_ARMING,
+        STATE_ALARM_DISARMING,
         STATE_ALARM_TRIGGERED,
     ):
         async_fire_mqtt_message(hass, "alarm/state", state)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently [Alarm Control Panel component](https://developers.home-assistant.io/docs/entity_alarm_control_panel/#states) has more states than is available in it's MQTT version.
This pull request fixes that. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12291

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
