### PR TITLE
Add thinkingcleaner optional host param

### DIFF
--- a/homeassistant/components/thinkingcleaner/sensor.py
+++ b/homeassistant/components/thinkingcleaner/sensor.py
@@ -1,57 +1,70 @@
 """Support for ThinkingCleaner sensors."""
-from datetime import timedelta
 import logging
-
-from pythinkingcleaner import Discovery
+from datetime import timedelta
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
 
 from homeassistant import util
 from homeassistant.const import UNIT_PERCENTAGE
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['pythinkingcleaner==0.0.3']
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
 
 SENSOR_TYPES = {
-    "battery": ["Battery", UNIT_PERCENTAGE, "mdi:battery"],
-    "state": ["State", None, None],
-    "capacity": ["Capacity", None, None],
+    'battery': ['Battery', UNIT_PERCENTAGE, 'mdi:battery'],
+    'state': ['State', None, None],
+    'capacity': ['Capacity', None, None],
 }
 
 STATES = {
-    "st_base": "On homebase: Not Charging",
-    "st_base_recon": "On homebase: Reconditioning Charging",
-    "st_base_full": "On homebase: Full Charging",
-    "st_base_trickle": "On homebase: Trickle Charging",
-    "st_base_wait": "On homebase: Waiting",
-    "st_plug": "Plugged in: Not Charging",
-    "st_plug_recon": "Plugged in: Reconditioning Charging",
-    "st_plug_full": "Plugged in: Full Charging",
-    "st_plug_trickle": "Plugged in: Trickle Charging",
-    "st_plug_wait": "Plugged in: Waiting",
-    "st_stopped": "Stopped",
-    "st_clean": "Cleaning",
-    "st_cleanstop": "Stopped with cleaning",
-    "st_clean_spot": "Spot cleaning",
-    "st_clean_max": "Max cleaning",
-    "st_delayed": "Delayed cleaning will start soon",
-    "st_dock": "Searching Homebase",
-    "st_pickup": "Roomba picked up",
-    "st_remote": "Remote control driving",
-    "st_wait": "Waiting for command",
-    "st_off": "Off",
-    "st_error": "Error",
-    "st_locate": "Find me!",
-    "st_unknown": "Unknown state",
+    'st_base': 'On homebase: Not Charging',
+    'st_base_recon': 'On homebase: Reconditioning Charging',
+    'st_base_full': 'On homebase: Full Charging',
+    'st_base_trickle': 'On homebase: Trickle Charging',
+    'st_base_wait': 'On homebase: Waiting',
+    'st_plug': 'Plugged in: Not Charging',
+    'st_plug_recon': 'Plugged in: Reconditioning Charging',
+    'st_plug_full': 'Plugged in: Full Charging',
+    'st_plug_trickle': 'Plugged in: Trickle Charging',
+    'st_plug_wait': 'Plugged in: Waiting',
+    'st_stopped': 'Stopped',
+    'st_clean': 'Cleaning',
+    'st_cleanstop': 'Stopped with cleaning',
+    'st_clean_spot': 'Spot cleaning',
+    'st_clean_max': 'Max cleaning',
+    'st_delayed': 'Delayed cleaning will start soon',
+    'st_dock': 'Searching Homebase',
+    'st_pickup': 'Roomba picked up',
+    'st_remote': 'Remote control driving',
+    'st_wait': 'Waiting for command',
+    'st_off': 'Off',
+    'st_error': 'Error',
+    'st_locate': 'Find me!',
+    'st_unknown': 'Unknown state',
 }
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST): cv.string,
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ThinkingCleaner platform."""
+    from pythinkingcleaner import ThinkingCleaner, Discovery
 
-    discovery = Discovery()
-    devices = discovery.discover()
+    if config.get(CONF_HOST) is None:
+        discovery = Discovery()
+        devices = discovery.discover()
+    else:
+        host = config.get(CONF_HOST)
+        devices = [ThinkingCleaner(host, 'unknown')]
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update_devices():
@@ -62,7 +75,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev = []
     for device in devices:
         for type_name in SENSOR_TYPES:
-            dev.append(ThinkingCleanerSensor(device, type_name, update_devices))
+            dev.append(ThinkingCleanerSensor(device, type_name,
+                                             update_devices))
 
     add_entities(dev)
 
@@ -82,7 +96,7 @@ class ThinkingCleanerSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self._tc_object.name, SENSOR_TYPES[self.type][0])
+        return '{} {}'.format(self._tc_object.name, SENSOR_TYPES[self.type][0])
 
     @property
     def icon(self):
@@ -103,9 +117,9 @@ class ThinkingCleanerSensor(Entity):
         """Update the sensor."""
         self._update_devices()
 
-        if self.type == "battery":
+        if self.type == 'battery':
             self._state = self._tc_object.battery
-        elif self.type == "state":
+        elif self.type == 'state':
             self._state = STATES[self._tc_object.status]
-        elif self.type == "capacity":
+        elif self.type == 'capacity':
             self._state = self._tc_object.capacity

--- a/homeassistant/components/thinkingcleaner/sensor.py
+++ b/homeassistant/components/thinkingcleaner/sensor.py
@@ -5,66 +5,62 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant import util
-from homeassistant.const import UNIT_PERCENTAGE
+from homeassistant.const import UNIT_PERCENTAGE, CONF_HOST
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_HOST
+
+from pythinkingcleaner import ThinkingCleaner, Discovery
 
 _LOGGER = logging.getLogger(__name__)
-
-REQUIREMENTS = ['pythinkingcleaner==0.0.3']
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
 
 SENSOR_TYPES = {
-    'battery': ['Battery', UNIT_PERCENTAGE, 'mdi:battery'],
-    'state': ['State', None, None],
-    'capacity': ['Capacity', None, None],
+    "battery": ["Battery", UNIT_PERCENTAGE, "mdi:battery"],
+    "state": ["State", None, None],
+    "capacity": ["Capacity", None, None],
 }
 
 STATES = {
-    'st_base': 'On homebase: Not Charging',
-    'st_base_recon': 'On homebase: Reconditioning Charging',
-    'st_base_full': 'On homebase: Full Charging',
-    'st_base_trickle': 'On homebase: Trickle Charging',
-    'st_base_wait': 'On homebase: Waiting',
-    'st_plug': 'Plugged in: Not Charging',
-    'st_plug_recon': 'Plugged in: Reconditioning Charging',
-    'st_plug_full': 'Plugged in: Full Charging',
-    'st_plug_trickle': 'Plugged in: Trickle Charging',
-    'st_plug_wait': 'Plugged in: Waiting',
-    'st_stopped': 'Stopped',
-    'st_clean': 'Cleaning',
-    'st_cleanstop': 'Stopped with cleaning',
-    'st_clean_spot': 'Spot cleaning',
-    'st_clean_max': 'Max cleaning',
-    'st_delayed': 'Delayed cleaning will start soon',
-    'st_dock': 'Searching Homebase',
-    'st_pickup': 'Roomba picked up',
-    'st_remote': 'Remote control driving',
-    'st_wait': 'Waiting for command',
-    'st_off': 'Off',
-    'st_error': 'Error',
-    'st_locate': 'Find me!',
-    'st_unknown': 'Unknown state',
+    "st_base": "On homebase: Not Charging",
+    "st_base_recon": "On homebase: Reconditioning Charging",
+    "st_base_full": "On homebase: Full Charging",
+    "st_base_trickle": "On homebase: Trickle Charging",
+    "st_base_wait": "On homebase: Waiting",
+    "st_plug": "Plugged in: Not Charging",
+    "st_plug_recon": "Plugged in: Reconditioning Charging",
+    "st_plug_full": "Plugged in: Full Charging",
+    "st_plug_trickle": "Plugged in: Trickle Charging",
+    "st_plug_wait": "Plugged in: Waiting",
+    "st_stopped": "Stopped",
+    "st_clean": "Cleaning",
+    "st_cleanstop": "Stopped with cleaning",
+    "st_clean_spot": "Spot cleaning",
+    "st_clean_max": "Max cleaning",
+    "st_delayed": "Delayed cleaning will start soon",
+    "st_dock": "Searching Homebase",
+    "st_pickup": "Roomba picked up",
+    "st_remote": "Remote control driving",
+    "st_wait": "Waiting for command",
+    "st_off": "Off",
+    "st_error": "Error",
+    "st_locate": "Find me!",
+    "st_unknown": "Unknown state",
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_HOST): cv.string,
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_HOST): cv.string,})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ThinkingCleaner platform."""
-    from pythinkingcleaner import ThinkingCleaner, Discovery
 
-    if config.get(CONF_HOST) is None:
+    host = config.get(CONF_HOST)
+    if host:
+        devices = [ThinkingCleaner(host, "unknown")]
+    else:
         discovery = Discovery()
         devices = discovery.discover()
-    else:
-        host = config.get(CONF_HOST)
-        devices = [ThinkingCleaner(host, 'unknown')]
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update_devices():
@@ -75,8 +71,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev = []
     for device in devices:
         for type_name in SENSOR_TYPES:
-            dev.append(ThinkingCleanerSensor(device, type_name,
-                                             update_devices))
+            dev.append(ThinkingCleanerSensor(device, type_name, update_devices))
 
     add_entities(dev)
 
@@ -96,7 +91,7 @@ class ThinkingCleanerSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return '{} {}'.format(self._tc_object.name, SENSOR_TYPES[self.type][0])
+        return "{} {}".format(self._tc_object.name, SENSOR_TYPES[self.type][0])
 
     @property
     def icon(self):
@@ -117,9 +112,9 @@ class ThinkingCleanerSensor(Entity):
         """Update the sensor."""
         self._update_devices()
 
-        if self.type == 'battery':
+        if self.type == "battery":
             self._state = self._tc_object.battery
-        elif self.type == 'state':
+        elif self.type == "state":
             self._state = STATES[self._tc_object.status]
-        elif self.type == 'capacity':
+        elif self.type == "capacity":
             self._state = self._tc_object.capacity

--- a/homeassistant/components/thinkingcleaner/sensor.py
+++ b/homeassistant/components/thinkingcleaner/sensor.py
@@ -49,7 +49,7 @@ STATES = {
     "st_unknown": "Unknown state",
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_HOST): cv.string,})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_HOST): cv.string})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/thinkingcleaner/sensor.py
+++ b/homeassistant/components/thinkingcleaner/sensor.py
@@ -1,15 +1,15 @@
 """Support for ThinkingCleaner sensors."""
-import logging
 from datetime import timedelta
+import logging
+
+from pythinkingcleaner import Discovery, ThinkingCleaner
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
 
 from homeassistant import util
-from homeassistant.const import UNIT_PERCENTAGE, CONF_HOST
-from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-
-from pythinkingcleaner import ThinkingCleaner, Discovery
+from homeassistant.const import CONF_HOST, UNIT_PERCENTAGE
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/thinkingcleaner/switch.py
+++ b/homeassistant/components/thinkingcleaner/switch.py
@@ -6,14 +6,13 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant import util
-from homeassistant.const import (STATE_ON, STATE_OFF)
+from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST
+from pythinkingcleaner import ThinkingCleaner, Discovery
 
 _LOGGER = logging.getLogger(__name__)
-
-REQUIREMENTS = ['pythinkingcleaner==0.0.3']
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
@@ -22,26 +21,22 @@ MIN_TIME_TO_WAIT = timedelta(seconds=5)
 MIN_TIME_TO_LOCK_UPDATE = 5
 
 SWITCH_TYPES = {
-    'clean': ['Clean', None, None],
-    'dock': ['Dock', None, None],
-    'find': ['Find', None, None],
+    "clean": ["Clean", None, None],
+    "dock": ["Dock", None, None],
+    "find": ["Find", None, None],
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_HOST): cv.string,
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_HOST): cv.string,})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ThinkingCleaner platform."""
-    from pythinkingcleaner import ThinkingCleaner, Discovery
-
-    if config.get(CONF_HOST) is None:
+    host = config.get(CONF_HOST)
+    if host:
+        devices = [ThinkingCleaner(host, "unknown")]
+    else:
         discovery = Discovery()
         devices = discovery.discover()
-    else:
-        host = config.get(CONF_HOST)
-        devices = [ThinkingCleaner(host, 'unknown')]
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update_devices():
@@ -52,8 +47,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev = []
     for device in devices:
         for type_name in SWITCH_TYPES:
-            dev.append(ThinkingCleanerSwitch(
-                device, type_name, update_devices))
+            dev.append(ThinkingCleanerSwitch(device, type_name, update_devices))
 
     add_entities(dev)
 
@@ -67,8 +61,7 @@ class ThinkingCleanerSwitch(ToggleEntity):
 
         self._update_devices = update_devices
         self._tc_object = tc_object
-        self._state = \
-            self._tc_object.is_cleaning if switch_type == 'clean' else False
+        self._state = self._tc_object.is_cleaning if switch_type == "clean" else False
         self.lock = False
         self.last_lock_time = None
         self.graceful_state = False
@@ -105,36 +98,38 @@ class ThinkingCleanerSwitch(ToggleEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._tc_object.name + ' ' + SWITCH_TYPES[self.type][0]
+        return self._tc_object.name + " " + SWITCH_TYPES[self.type][0]
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        if self.type == 'clean':
-            return self.graceful_state \
-                if self.is_update_locked() else self._tc_object.is_cleaning
+        if self.type == "clean":
+            return (
+                self.graceful_state
+                if self.is_update_locked()
+                else self._tc_object.is_cleaning
+            )
 
         return False
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        if self.type == 'clean':
+        if self.type == "clean":
             self.set_graceful_lock(True)
             self._tc_object.start_cleaning()
-        elif self.type == 'dock':
+        elif self.type == "dock":
             self._tc_object.dock()
-        elif self.type == 'find':
+        elif self.type == "find":
             self._tc_object.find_me()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        if self.type == 'clean':
+        if self.type == "clean":
             self.set_graceful_lock(False)
             self._tc_object.stop_cleaning()
 
     def update(self):
         """Update the switch state (Only for clean)."""
-        if self.type == 'clean' and not self.is_update_locked():
+        if self.type == "clean" and not self.is_update_locked():
             self._tc_object.update()
-            self._state = STATE_ON \
-                if self._tc_object.is_cleaning else STATE_OFF
+            self._state = STATE_ON if self._tc_object.is_cleaning else STATE_OFF

--- a/homeassistant/components/thinkingcleaner/switch.py
+++ b/homeassistant/components/thinkingcleaner/switch.py
@@ -26,7 +26,7 @@ SWITCH_TYPES = {
     "find": ["Find", None, None],
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_HOST): cv.string,})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_HOST): cv.string})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/thinkingcleaner/switch.py
+++ b/homeassistant/components/thinkingcleaner/switch.py
@@ -1,15 +1,19 @@
 """Support for ThinkingCleaner switches."""
-from datetime import timedelta
-import logging
 import time
-
-from pythinkingcleaner import Discovery
+import logging
+from datetime import timedelta
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
 
 from homeassistant import util
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import (STATE_ON, STATE_OFF)
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.const import CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['pythinkingcleaner==0.0.3']
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
@@ -18,17 +22,26 @@ MIN_TIME_TO_WAIT = timedelta(seconds=5)
 MIN_TIME_TO_LOCK_UPDATE = 5
 
 SWITCH_TYPES = {
-    "clean": ["Clean", None, None],
-    "dock": ["Dock", None, None],
-    "find": ["Find", None, None],
+    'clean': ['Clean', None, None],
+    'dock': ['Dock', None, None],
+    'find': ['Find', None, None],
 }
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST): cv.string,
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ThinkingCleaner platform."""
+    from pythinkingcleaner import ThinkingCleaner, Discovery
 
-    discovery = Discovery()
-    devices = discovery.discover()
+    if config.get(CONF_HOST) is None:
+        discovery = Discovery()
+        devices = discovery.discover()
+    else:
+        host = config.get(CONF_HOST)
+        devices = [ThinkingCleaner(host, 'unknown')]
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update_devices():
@@ -39,7 +52,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev = []
     for device in devices:
         for type_name in SWITCH_TYPES:
-            dev.append(ThinkingCleanerSwitch(device, type_name, update_devices))
+            dev.append(ThinkingCleanerSwitch(
+                device, type_name, update_devices))
 
     add_entities(dev)
 
@@ -53,7 +67,8 @@ class ThinkingCleanerSwitch(ToggleEntity):
 
         self._update_devices = update_devices
         self._tc_object = tc_object
-        self._state = self._tc_object.is_cleaning if switch_type == "clean" else False
+        self._state = \
+            self._tc_object.is_cleaning if switch_type == 'clean' else False
         self.lock = False
         self.last_lock_time = None
         self.graceful_state = False
@@ -90,38 +105,36 @@ class ThinkingCleanerSwitch(ToggleEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._tc_object.name + " " + SWITCH_TYPES[self.type][0]
+        return self._tc_object.name + ' ' + SWITCH_TYPES[self.type][0]
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        if self.type == "clean":
-            return (
-                self.graceful_state
-                if self.is_update_locked()
-                else self._tc_object.is_cleaning
-            )
+        if self.type == 'clean':
+            return self.graceful_state \
+                if self.is_update_locked() else self._tc_object.is_cleaning
 
         return False
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        if self.type == "clean":
+        if self.type == 'clean':
             self.set_graceful_lock(True)
             self._tc_object.start_cleaning()
-        elif self.type == "dock":
+        elif self.type == 'dock':
             self._tc_object.dock()
-        elif self.type == "find":
+        elif self.type == 'find':
             self._tc_object.find_me()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        if self.type == "clean":
+        if self.type == 'clean':
             self.set_graceful_lock(False)
             self._tc_object.stop_cleaning()
 
     def update(self):
         """Update the switch state (Only for clean)."""
-        if self.type == "clean" and not self.is_update_locked():
+        if self.type == 'clean' and not self.is_update_locked():
             self._tc_object.update()
-            self._state = STATE_ON if self._tc_object.is_cleaning else STATE_OFF
+            self._state = STATE_ON \
+                if self._tc_object.is_cleaning else STATE_OFF

--- a/homeassistant/components/thinkingcleaner/switch.py
+++ b/homeassistant/components/thinkingcleaner/switch.py
@@ -1,16 +1,16 @@
 """Support for ThinkingCleaner switches."""
-import time
-import logging
 from datetime import timedelta
+import logging
+import time
+
+from pythinkingcleaner import Discovery, ThinkingCleaner
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
 
 from homeassistant import util
-from homeassistant.const import STATE_ON, STATE_OFF
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.components.switch import PLATFORM_SCHEMA
-from homeassistant.const import CONF_HOST
-from pythinkingcleaner import ThinkingCleaner, Discovery
+from homeassistant.const import CONF_HOST, STATE_OFF, STATE_ON
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
… broken discovery function

## Proposed change
backend of thinking cleaner is again having issues. 
This changes adds a host variable to this sensor and switch so we don't have to rely on that external service.

its https://github.com/home-assistant/core/pull/22003 but optional


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
switch:
  - platform: thinkingcleaner
    host: 10.0.0.65
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
 will do after merge request is accepted otherwise docs arent accurate

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
