### PR TITLE
Move apps configuration to options flow for vizio integration

### DIFF
--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -19,17 +19,13 @@
                     "pin": "PIN"
                 }
             },
+            "pairing_complete": {
+                "title": "Pairing Complete",
+                "description": "Your Vizio SmartCast device is now connected to Home Assistant."
+            },
             "pairing_complete_import": {
                 "title": "Pairing Complete",
                 "description": "Your Vizio SmartCast TV is now connected to Home Assistant.\n\nYour Access Token is '**{access_token}**'."
-            },
-            "tv_apps": {
-                "title": "Configure Apps for Smart TV",
-                "description": "If you have a Smart TV, you can optionally filter your source list by choosing which apps to include or exclude in your source list. You can skip this step for TVs that don't support apps.",
-                "data": {
-                    "include_or_exclude": "Include or Exclude Apps?",
-                    "apps_to_include_or_exclude": "Apps to Include or Exclude"
-                }
             }
         },
         "error": {
@@ -48,8 +44,11 @@
         "step": {
             "init": {
                 "title": "Update Vizo SmartCast Options",
+                "description": "If you have a Smart TV, you can optionally filter your source list by choosing which apps to include or exclude in your source list.",
                 "data": {
-                    "volume_step": "Volume Step Size"
+                    "volume_step": "Volume Step Size",
+                    "include_or_exclude": "Include or Exclude Apps?",
+                    "apps_to_include_or_exclude": "Apps to Include or Exclude"
                 }
             }
         }

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -121,6 +121,7 @@ async def test_speaker_options_flow(hass: HomeAssistantType) -> None:
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
+    assert CONF_APPS not in result["data"]
 
 
 async def test_tv_options_flow_no_apps(hass: HomeAssistantType) -> None:

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -441,10 +441,8 @@ async def test_import_flow_update_options(
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "updated_entry"
-    assert (
-        hass.config_entries.async_get_entry(entry_id).options[CONF_VOLUME_STEP]
-        == VOLUME_STEP + 1
-    )
+    config_entry = hass.config_entries.async_get_entry(entry_id)
+    assert config_entry.options[CONF_VOLUME_STEP] == VOLUME_STEP + 1
 
 
 async def test_import_flow_update_name_and_apps(
@@ -475,13 +473,10 @@ async def test_import_flow_update_name_and_apps(
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "updated_entry"
-    assert hass.config_entries.async_get_entry(entry_id).data[CONF_NAME] == NAME2
-    assert hass.config_entries.async_get_entry(entry_id).data[CONF_APPS] == {
-        CONF_INCLUDE: [CURRENT_APP]
-    }
-    assert hass.config_entries.async_get_entry(entry_id).options[CONF_APPS] == {
-        CONF_INCLUDE: [CURRENT_APP]
-    }
+    config_entry = hass.config_entries.async_get_entry(entry_id)
+    assert config_entry.data[CONF_NAME] == NAME2
+    assert config_entry.data[CONF_APPS] == {CONF_INCLUDE: [CURRENT_APP]}
+    assert config_entry.options[CONF_APPS] == {CONF_INCLUDE: [CURRENT_APP]}
 
 
 async def test_import_flow_update_remove_apps(
@@ -499,9 +494,9 @@ async def test_import_flow_update_remove_apps(
 
     assert result["result"].data[CONF_NAME] == NAME
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    entry_id = result["result"].entry_id
-    assert CONF_APPS in hass.config_entries.async_get_entry(entry_id).data
-    assert CONF_APPS in hass.config_entries.async_get_entry(entry_id).options
+    config_entry = hass.config_entries.async_get_entry(result["result"].entry_id)
+    assert CONF_APPS in config_entry.data
+    assert CONF_APPS in config_entry.options
 
     updated_config = MOCK_TV_WITH_EXCLUDE_CONFIG.copy()
     updated_config.pop(CONF_APPS)
@@ -513,8 +508,8 @@ async def test_import_flow_update_remove_apps(
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "updated_entry"
-    assert CONF_APPS not in hass.config_entries.async_get_entry(entry_id).data
-    assert CONF_APPS not in hass.config_entries.async_get_entry(entry_id).options
+    assert CONF_APPS not in config_entry.data
+    assert CONF_APPS not in config_entry.options
 
 
 async def test_import_needs_pairing(
@@ -612,9 +607,9 @@ async def test_import_flow_additional_configs(
 
     assert result["result"].data[CONF_NAME] == NAME
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    entry_id = result["result"].entry_id
-    assert CONF_APPS in hass.config_entries.async_get_entry(entry_id).data
-    assert CONF_APPS not in hass.config_entries.async_get_entry(entry_id).options
+    config_entry = hass.config_entries.async_get_entry(result["result"].entry_id)
+    assert CONF_APPS in config_entry.data
+    assert CONF_APPS not in config_entry.options
 
 
 async def test_import_error(


### PR DESCRIPTION
## Proposed change
As part of #support , a new configuration step was added to config flow for vizio TVs to allow users to filter the apps list. @MartinHjelmare suggested this should be part of the options flow instead here: https://github.com/home-assistant/core/pull/32432#discussion_r388943140 

This change moves the apps configuration to the options flow. Updated tests and added some new ones to check different conditions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
