### PR TITLE
Alexa: Support vacuums without turn_on/turn_off feature

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -364,6 +364,8 @@ class AlexaPowerController(AlexaCapability):
 
         if self.entity.domain == climate.DOMAIN:
             is_on = self.entity.state != climate.HVAC_MODE_OFF
+        elif self.entity.domain == vacuum.DOMAIN:
+            is_on = self.entity.state == vacuum.STATE_CLEANING
 
         else:
             is_on = self.entity.state != STATE_OFF

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -738,8 +738,11 @@ class VacuumCapabilities(AlexaEntity):
     def interfaces(self):
         """Yield the supported interfaces."""
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        if (supported & vacuum.SUPPORT_TURN_ON) and (
-            supported & vacuum.SUPPORT_TURN_OFF
+        if (
+            (supported & vacuum.SUPPORT_TURN_ON)
+            and (supported & vacuum.SUPPORT_TURN_OFF)
+            or (supported & vacuum.SUPPORT_START)
+            and (supported & vacuum.SUPPORT_STOP)
         ):
             yield AlexaPowerController(self.entity)
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -739,10 +739,10 @@ class VacuumCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if (
-            (supported & vacuum.SUPPORT_TURN_ON)
-            and (supported & vacuum.SUPPORT_TURN_OFF)
-            or (supported & vacuum.SUPPORT_START)
-            and (supported & vacuum.SUPPORT_STOP)
+            (supported & vacuum.SUPPORT_TURN_ON) or (supported & vacuum.SUPPORT_START)
+        ) and (
+            (supported & vacuum.SUPPORT_TURN_OFF)
+            or (supported & vacuum.SUPPORT_RETURN_HOME)
         ):
             yield AlexaPowerController(self.entity)
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -121,6 +121,11 @@ async def async_api_turn_on(hass, config, directive, context):
     service = SERVICE_TURN_ON
     if domain == cover.DOMAIN:
         service = cover.SERVICE_OPEN_COVER
+    elif domain == vacuum.DOMAIN:
+        supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        power_features = vacuum.SUPPORT_TURN_ON | vacuum.SUPPORT_TURN_OFF
+        if not supported & power_features:
+            service = vacuum.SERVICE_START
     elif domain == media_player.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         power_features = media_player.SUPPORT_TURN_ON | media_player.SUPPORT_TURN_OFF
@@ -149,6 +154,11 @@ async def async_api_turn_off(hass, config, directive, context):
     service = SERVICE_TURN_OFF
     if entity.domain == cover.DOMAIN:
         service = cover.SERVICE_CLOSE_COVER
+    elif domain == vacuum.DOMAIN:
+        supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        power_features = vacuum.SUPPORT_TURN_ON | vacuum.SUPPORT_TURN_OFF
+        if not supported & power_features:
+            service = vacuum.SERVICE_RETURN_TO_BASE
     elif domain == media_player.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         power_features = media_player.SUPPORT_TURN_ON | media_player.SUPPORT_TURN_OFF

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -123,8 +123,7 @@ async def async_api_turn_on(hass, config, directive, context):
         service = cover.SERVICE_OPEN_COVER
     elif domain == vacuum.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        power_features = vacuum.SUPPORT_TURN_ON | vacuum.SUPPORT_TURN_OFF
-        if not supported & power_features:
+        if not supported & vacuum.SUPPORT_TURN_ON and supported & vacuum.SUPPORT_START:
             service = vacuum.SERVICE_START
     elif domain == media_player.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
@@ -156,8 +155,10 @@ async def async_api_turn_off(hass, config, directive, context):
         service = cover.SERVICE_CLOSE_COVER
     elif domain == vacuum.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        power_features = vacuum.SUPPORT_TURN_ON | vacuum.SUPPORT_TURN_OFF
-        if not supported & power_features:
+        if (
+            not supported & vacuum.SUPPORT_TURN_OFF
+            and supported & vacuum.SUPPORT_RETURN_HOME
+        ):
             service = vacuum.SERVICE_RETURN_TO_BASE
     elif domain == media_player.DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -3411,6 +3411,17 @@ async def test_vacuum_discovery(hass):
         "Alexa",
     )
 
+    properties = await reported_properties(hass, "vacuum#test_1")
+    properties.assert_equal("Alexa.PowerController", "powerState", "OFF")
+
+    await assert_request_calls_service(
+        "Alexa.PowerController", "TurnOn", "vacuum#test_1", "vacuum.turn_on", hass,
+    )
+
+    await assert_request_calls_service(
+        "Alexa.PowerController", "TurnOff", "vacuum#test_1", "vacuum.turn_off", hass,
+    )
+
 
 async def test_vacuum_fan_speed(hass):
     """Test vacuum fan speed with rangeController."""
@@ -3603,5 +3614,43 @@ async def test_vacuum_resume(hass):
         "Resume",
         "vacuum#test_4",
         "vacuum.start_pause",
+        hass,
+    )
+
+
+async def test_vacuum_discovery_state(hass):
+    """Test vacuum discovery for state vacuums."""
+    device = (
+        "vacuum.test_5",
+        "cleaning",
+        {
+            "friendly_name": "Test vacuum 5",
+            "supported_features": vacuum.SUPPORT_START
+            | vacuum.SUPPORT_STOP
+            | vacuum.SUPPORT_PAUSE,
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.TimeHoldController",
+        "Alexa.EndpointHealth",
+        "Alexa",
+    )
+
+    properties = await reported_properties(hass, "vacuum#test_5")
+    properties.assert_equal("Alexa.PowerController", "powerState", "ON")
+
+    await assert_request_calls_service(
+        "Alexa.PowerController", "TurnOn", "vacuum#test_5", "vacuum.start", hass,
+    )
+
+    await assert_request_calls_service(
+        "Alexa.PowerController",
+        "TurnOff",
+        "vacuum#test_5",
+        "vacuum.return_to_base",
         hass,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix Alexa integration with vacuums that do not have support for `TURN_ON` or `TURN_OFF`.

#23171 introduced a `StateVacuumDevice` for MQTT vacuums. It is meant to deprecate the existing `VacuumDevice` at some point in time. As per the [documentation](https://www.home-assistant.io/integrations/vacuum.mqtt/), the latter supports `TURN_ON` and `TURN_OFF` services, while the former does only support `START` and `RETURN_TO_BASE` services.

Up until now, the Alexa integration would only work with (legacy) vacuums. This PR adds support for the newer state vacuums, i.e. it calls the `START` service when powering on, and the `RETURN_TO_BASE` service when powering off.

Additionally, this PR fixes the power state reported to Alexa for both types.

Tested successfully with a Roborock S502 running Valetudo 0.4.0 (with MQTT auto-configuration).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #23171

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
