### PR TITLE
Improve homekit_controller compatibility with some LG TV models

### DIFF
--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.21"],
+  "requirements": ["aiohomekit[IP]==0.2.24"],
   "dependencies": [],
   "zeroconf": ["_hap._tcp.local."],
   "codeowners": ["@Jc2k"]

--- a/homeassistant/components/homekit_controller/media_player.py
+++ b/homeassistant/components/homekit_controller/media_player.py
@@ -17,7 +17,13 @@ from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
 )
-from homeassistant.const import STATE_IDLE, STATE_PAUSED, STATE_PLAYING
+from homeassistant.const import (
+    STATE_IDLE,
+    STATE_OK,
+    STATE_PAUSED,
+    STATE_PLAYING,
+    STATE_PROBLEM,
+)
 from homeassistant.core import callback
 
 from . import KNOWN_DEVICES, HomeKitEntity
@@ -62,6 +68,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerDevice):
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
         return [
+            CharacteristicsTypes.ACTIVE,
             CharacteristicsTypes.CURRENT_MEDIA_STATE,
             CharacteristicsTypes.TARGET_MEDIA_STATE,
             CharacteristicsTypes.REMOTE_KEY,
@@ -143,10 +150,15 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerDevice):
     @property
     def state(self):
         """State of the tv."""
+        active = self.get_hk_char_value(CharacteristicsTypes.ACTIVE)
+        if not active:
+            return STATE_PROBLEM
+
         homekit_state = self.get_hk_char_value(CharacteristicsTypes.CURRENT_MEDIA_STATE)
-        if homekit_state is None:
-            return None
-        return HK_TO_HA_STATE[homekit_state]
+        if homekit_state is not None:
+            return HK_TO_HA_STATE[homekit_state]
+
+        return STATE_OK
 
     async def async_media_play(self):
         """Send play command."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -163,7 +163,7 @@ aioftp==0.12.0
 aioharmony==0.1.13
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.21
+aiohomekit[IP]==0.2.24
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,7 +62,7 @@ aiobotocore==0.11.1
 aioesphomeapi==2.6.1
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.21
+aiohomekit[IP]==0.2.24
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/specific_devices/test_lg_tv.py
+++ b/tests/components/homekit_controller/specific_devices/test_lg_tv.py
@@ -50,6 +50,10 @@ async def test_lg_tv(hass):
         SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SELECT_SOURCE
     )
 
+    # The LG TV doesn't (at least at this patch level) report its media state via
+    # CURRENT_MEDIA_STATE. Therefore "ok" is the best we can say.
+    assert state.state == "ok"
+
     device_registry = await hass.helpers.device_registry.async_get_registry()
 
     device = device_registry.async_get(entry.device_id)


### PR DESCRIPTION
## Proposed change
We found a few issues around reconnecting and shutdown that are fixed in the latest aiohomekit. We also found that not all TV's support the CURRENT_MEDIA_STATE characteristic which meant they were permanently reporting an unknown state. This branch should fix this.

This also gets the TV code to 100% coverage again.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
