### PR TITLE
Add PollControl cluster support to ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -341,6 +341,7 @@ class PollControl(ZigbeeChannel):
     """Poll Control channel."""
 
     CHECKIN_INTERVAL = 55 * 60 * 4  # 55min
+    CHECKIN_FAST_POLL_TIMEOUT = 2 * 4  # 2s
     LONG_POLL = 6 * 4  # 6s
 
     async def async_configure(self) -> None:
@@ -367,7 +368,7 @@ class PollControl(ZigbeeChannel):
 
     async def check_in_response(self, tsn: int) -> None:
         """Respond to checkin command."""
-        await self.checkin_response(True, 8, tsn=tsn)
+        await self.checkin_response(True, self.CHECKIN_FAST_POLL_TIMEOUT, tsn=tsn)
         await self.set_long_poll_interval(self.LONG_POLL)
 
 

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -1,6 +1,9 @@
 """General channels module for Zigbee Home Automation."""
+import asyncio
 import logging
+from typing import Any, List, Optional
 
+import zigpy.exceptions
 import zigpy.zcl.clusters.general as general
 
 from homeassistant.core import callback
@@ -332,11 +335,40 @@ class Partition(ZigbeeChannel):
     pass
 
 
+@registries.CHANNEL_ONLY_CLUSTERS.register(general.PollControl.cluster_id)
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.PollControl.cluster_id)
 class PollControl(ZigbeeChannel):
     """Poll Control channel."""
 
-    pass
+    CHECKIN_INTERVAL = 55 * 60 * 4  # 55min
+    LONG_POLL = 6 * 4  # 6s
+
+    async def async_configure(self) -> None:
+        """Configure channel: set check-in interval."""
+        try:
+            res = await self.cluster.write_attributes(
+                {"checkin_interval": self.CHECKIN_INTERVAL}
+            )
+            self.debug("%ss check-in interval set: %s", self.CHECKIN_INTERVAL / 4, res)
+        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
+            self.debug("Couldn't set check-in interval: %s", ex)
+        await super().async_configure()
+
+    @callback
+    def cluster_command(
+        self, tsn: int, command_id: int, args: Optional[List[Any]]
+    ) -> None:
+        """Handle commands received to this cluster."""
+        cmd_name = self.cluster.client_commands.get(command_id, [command_id])[0]
+        self.debug("Received %s tsn command '%s': %s", tsn, cmd_name, args)
+        self.zha_send_event(cmd_name, args)
+        if cmd_name == "checkin":
+            self.cluster.create_catching_task(self.check_in_response(tsn))
+
+    async def check_in_response(self, tsn: int) -> None:
+        """Respond to checkin command."""
+        await self.checkin_response(True, 8, tsn=tsn)
+        await self.set_long_poll_interval(self.LONG_POLL)
 
 
 @registries.DEVICE_TRACKER_CLUSTERS.register(general.PowerConfiguration.cluster_id)

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -127,13 +127,15 @@ async def async_enable_traffic(hass, zha_devices):
     await hass.async_block_till_done()
 
 
-def make_zcl_header(command_id: int, global_command: bool = True) -> zcl_f.ZCLHeader:
+def make_zcl_header(
+    command_id: int, global_command: bool = True, tsn: int = 1
+) -> zcl_f.ZCLHeader:
     """Cluster.handle_message() ZCL Header helper."""
     if global_command:
         frc = zcl_f.FrameControl(zcl_f.FrameType.GLOBAL_COMMAND)
     else:
         frc = zcl_f.FrameControl(zcl_f.FrameType.CLUSTER_COMMAND)
-    return zcl_f.ZCLHeader(frc, tsn=1, command_id=command_id)
+    return zcl_f.ZCLHeader(frc, tsn=tsn, command_id=command_id)
 
 
 def reset_clusters(clusters):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Poll Control cluster support to ZHA. For Zigbee devices with poll control cluster present:
- configure device to check-in every 55min
- Respond to "check-in" request and put device into fast-polling mode for 2s
- configure long poll interval to 6s

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
