### PR TITLE
Validate WWLLN window size in config schema

### DIFF
--- a/homeassistant/components/wwlln/.translations/en.json
+++ b/homeassistant/components/wwlln/.translations/en.json
@@ -1,8 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "This location is already registered.",
-            "window_too_small": "A too-small window will cause Home Assistant to miss events."
+            "already_configured": "This location is already registered."
         },
         "step": {
             "user": {

--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -1,4 +1,6 @@
 """Support for World Wide Lightning Location Network."""
+import logging
+
 from aiowwlln import Client
 import voluptuous as vol
 
@@ -6,14 +8,9 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import (
-    CONF_WINDOW,
-    DATA_CLIENT,
-    DEFAULT_RADIUS,
-    DEFAULT_WINDOW,
-    DOMAIN,
-    LOGGER,
-)
+from .const import CONF_WINDOW, DATA_CLIENT, DEFAULT_RADIUS, DEFAULT_WINDOW, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -26,6 +23,7 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.time_period,
                     cv.positive_timedelta,
                     lambda value: value.total_seconds(),
+                    vol.Range(min=DEFAULT_WINDOW.total_seconds()),
                 ),
             }
         )
@@ -91,7 +89,7 @@ async def async_migrate_entry(hass, config_entry):
 
     default_total_seconds = DEFAULT_WINDOW.total_seconds()
 
-    LOGGER.debug("Migrating from version %s", version)
+    _LOGGER.debug("Migrating from version %s", version)
 
     # 1 -> 2: Expanding the default window to 1 hour (if needed):
     if version == 1:
@@ -99,6 +97,6 @@ async def async_migrate_entry(hass, config_entry):
             data[CONF_WINDOW] = default_total_seconds
         version = config_entry.version = 2
         hass.config_entries.async_update_entry(config_entry, data=data)
-        LOGGER.info("Migration to version %s successful", version)
+        _LOGGER.info("Migration to version %s successful", version)
 
     return True

--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -1,4 +1,5 @@
 """Support for World Wide Lightning Location Network."""
+from datetime import timedelta
 import logging
 
 from aiowwlln import Client
@@ -8,9 +9,12 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import CONF_WINDOW, DATA_CLIENT, DEFAULT_RADIUS, DEFAULT_WINDOW, DOMAIN
+from .const import CONF_WINDOW, DATA_CLIENT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_RADIUS = 25
+DEFAULT_WINDOW = timedelta(hours=1)
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -1,5 +1,4 @@
 """Support for World Wide Lightning Location Network."""
-from datetime import timedelta
 import logging
 
 from aiowwlln import Client
@@ -9,12 +8,9 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import CONF_WINDOW, DATA_CLIENT, DOMAIN
+from .const import CONF_WINDOW, DATA_CLIENT, DEFAULT_RADIUS, DEFAULT_WINDOW, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-DEFAULT_RADIUS = 25
-DEFAULT_WINDOW = timedelta(hours=1)
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -10,7 +10,6 @@ from .const import (  # pylint: disable=unused-import
     DEFAULT_RADIUS,
     DEFAULT_WINDOW,
     DOMAIN,
-    LOGGER,
 )
 
 
@@ -43,18 +42,6 @@ class WWLLNFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
-        default_window_seconds = DEFAULT_WINDOW.total_seconds()
-        if (
-            CONF_WINDOW in import_config
-            and import_config[CONF_WINDOW] < default_window_seconds
-        ):
-            LOGGER.error(
-                "Refusing to use too-small window (%s < %s)",
-                import_config[CONF_WINDOW],
-                default_window_seconds,
-            )
-            return self.async_abort(reason="window_too_small")
-
         return await self.async_step_user(import_config)
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/wwlln/const.py
+++ b/homeassistant/components/wwlln/const.py
@@ -1,6 +1,11 @@
 """Define constants for the WWLLN integration."""
+from datetime import timedelta
+
 DOMAIN = "wwlln"
 
 CONF_WINDOW = "window"
 
 DATA_CLIENT = "client"
+
+DEFAULT_RADIUS = 25
+DEFAULT_WINDOW = timedelta(hours=1)

--- a/homeassistant/components/wwlln/const.py
+++ b/homeassistant/components/wwlln/const.py
@@ -1,8 +1,5 @@
 """Define constants for the WWLLN integration."""
 from datetime import timedelta
-import logging
-
-LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "wwlln"
 

--- a/homeassistant/components/wwlln/const.py
+++ b/homeassistant/components/wwlln/const.py
@@ -1,11 +1,6 @@
 """Define constants for the WWLLN integration."""
-from datetime import timedelta
-
 DOMAIN = "wwlln"
 
 CONF_WINDOW = "window"
 
 DATA_CLIENT = "client"
-
-DEFAULT_RADIUS = 25
-DEFAULT_WINDOW = timedelta(hours=1)

--- a/homeassistant/components/wwlln/geo_location.py
+++ b/homeassistant/components/wwlln/geo_location.py
@@ -1,5 +1,6 @@
 """Support for WWLLN geo location events."""
 from datetime import timedelta
+import logging
 
 from aiowwlln.errors import WWLLNError
 
@@ -21,7 +22,9 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.dt import utc_from_timestamp
 
-from .const import CONF_WINDOW, DATA_CLIENT, DOMAIN, LOGGER
+from .const import CONF_WINDOW, DATA_CLIENT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 ATTR_EXTERNAL_ID = "external_id"
 ATTR_PUBLICATION_DATE = "publication_date"
@@ -81,7 +84,7 @@ class WWLLNEventManager:
     @callback
     def _create_events(self, ids_to_create):
         """Create new geo location events."""
-        LOGGER.debug("Going to create %s", ids_to_create)
+        _LOGGER.debug("Going to create %s", ids_to_create)
         events = []
         for strike_id in ids_to_create:
             strike = self._strikes[strike_id]
@@ -100,7 +103,7 @@ class WWLLNEventManager:
     @callback
     def _remove_events(self, ids_to_remove):
         """Remove old geo location events."""
-        LOGGER.debug("Going to remove %s", ids_to_remove)
+        _LOGGER.debug("Going to remove %s", ids_to_remove)
         for strike_id in ids_to_remove:
             async_dispatcher_send(self._hass, SIGNAL_DELETE_ENTITY.format(strike_id))
 
@@ -116,7 +119,7 @@ class WWLLNEventManager:
 
     async def async_update(self):
         """Refresh data."""
-        LOGGER.debug("Refreshing WWLLN data")
+        _LOGGER.debug("Refreshing WWLLN data")
 
         try:
             self._strikes = await self._client.within_radius(
@@ -127,7 +130,7 @@ class WWLLNEventManager:
                 window=self._window,
             )
         except WWLLNError as err:
-            LOGGER.error("Error while updating WWLLN data: %s", err)
+            _LOGGER.error("Error while updating WWLLN data: %s", err)
             return
 
         new_strike_ids = set(self._strikes)

--- a/homeassistant/components/wwlln/strings.json
+++ b/homeassistant/components/wwlln/strings.json
@@ -12,8 +12,7 @@
       }
     },
     "abort": {
-      "already_configured": "This location is already registered.",
-      "window_too_small": "A too-small window will cause Home Assistant to miss events."
+      "already_configured": "This location is already registered."
     }
   }
 }

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -62,23 +62,6 @@ async def test_step_import(hass):
     }
 
 
-async def test_step_import_too_small_window(hass):
-    """Test that the import step with a too-small window is aborted."""
-    conf = {
-        CONF_LATITUDE: 39.128712,
-        CONF_LONGITUDE: -104.9812612,
-        CONF_RADIUS: 25,
-        CONF_WINDOW: 60,
-    }
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "window_too_small"
-
-
 async def test_step_user(hass):
     """Test that the user step works."""
     conf = {CONF_LATITUDE: 39.128712, CONF_LONGITUDE: -104.9812612, CONF_RADIUS: 25}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on [@MartinHjelmare's comment](https://github.com/home-assistant/core/pull/32194#discussion_r388137143), this PR moves some manual window-size validation logic into config schema validation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
wwlln:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
