### PR TITLE
Add duty cycle to Homematic 

### DIFF
--- a/homeassistant/components/homematic/const.py
+++ b/homeassistant/components/homematic/const.py
@@ -27,6 +27,7 @@ ATTR_PARAMSET = "paramset"
 ATTR_DISCOVERY_TYPE = "discovery_type"
 ATTR_LOW_BAT = "LOW_BAT"
 ATTR_LOWBAT = "LOWBAT"
+ATTR_DUTY_CYCLE = "DutyCycle"
 
 EVENT_KEYPRESS = "homematic.keypress"
 EVENT_IMPULSE = "homematic.impulse"

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -298,7 +298,7 @@ class HMHub(Entity):
             return
         duty_cycle = bidcos_interface['DUTY_CYCLE']
         if self._duty_cycle != duty_cycle:
-            _LOGGER.info("Retrieved new duty_cycle: %d", duty_cycle)
+            _LOGGER.info("Retrieved new DutyCycle: %d", duty_cycle)
             self._duty_cycle = duty_cycle
             self.schedule_update_ha_state()
 

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -290,7 +290,9 @@ class HMHub(Entity):
         if len(bidcos_interfaces) == 0:
             return
         if len(bidcos_interfaces) > 1:
-            _LOGGER.warn("Found more than one bidcos interface - cannot retrieve duty cycle.")
+            _LOGGER.warn(
+                "Found more than one bidcos interface - cannot retrieve duty cycle."
+            )
             return
         bidcos_interface = bidcos_interfaces[0]
         if "DUTY_CYCLE" not in bidcos_interface:

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -290,13 +290,13 @@ class HMHub(Entity):
         if len(bidcos_interfaces) == 0:
             return
         if len(bidcos_interfaces) > 1:
-            _LOGGER.warn(
+            _LOGGER.warning(
                 "Found more than one bidcos interface - cannot retrieve duty cycle."
             )
             return
         bidcos_interface = bidcos_interfaces[0]
         if "DUTY_CYCLE" not in bidcos_interface:
-            _LOGGER.warn("DUTY_CYCLE not found in %s.", bidcos_interface)
+            _LOGGER.warning("DUTY_CYCLE not found in %s.", bidcos_interface)
             return
         duty_cycle = bidcos_interface["DUTY_CYCLE"]
         if self._duty_cycle != duty_cycle:

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -242,7 +242,7 @@ class HMHub(Entity):
         """Return the state attributes."""
         attr = self._variables.copy()
         if self._duty_cycle is not None:
-            attr['DutyCycle'] = self._duty_cycle
+            attr["DutyCycle"] = self._duty_cycle
         return attr
 
     @property
@@ -293,10 +293,10 @@ class HMHub(Entity):
             _LOGGER.warn("Found more than one bidcos interface - cannot retrieve duty cycle.")
             return
         bidcos_interface = bidcos_interfaces[0]
-        if not 'DUTY_CYCLE' in bidcos_interface:
+        if "DUTY_CYCLE" not in bidcos_interface:
             _LOGGER.warn("DUTY_CYCLE not found in %s.", bidcos_interface)
             return
-        duty_cycle = bidcos_interface['DUTY_CYCLE']
+        duty_cycle = bidcos_interface["DUTY_CYCLE"]
         if self._duty_cycle != duty_cycle:
             _LOGGER.info("Retrieved new DutyCycle: %d", duty_cycle)
             self._duty_cycle = duty_cycle

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -282,11 +282,19 @@ class HMHub(Entity):
         bidcos_interfaces = self._homematic.listBidcosInterfaces(self._name)
         if bidcos_interfaces is None:
             return
-        _LOGGER.info("bidcos_interfaces: %s", bidcos_interfaces)
+        _LOGGER.debug("bidcos_interfaces: %s", bidcos_interfaces)
         if len(bidcos_interfaces) == 0:
             return
-        duty_cycle = bidcos_interfaces[0]['DUTY_CYCLE']
+        if len(bidcos_interfaces) > 1:
+            _LOGGER.warn("Found more than one bidcos interface - cannot retrieve duty cycle.")
+            return
+        bidcos_interface = bidcos_interfaces[0]
+        if not 'DUTY_CYCLE' in bidcos_interface:
+            _LOGGER.warn("DUTY_CYCLE not found in %s.", bidcos_interface)
+            return
+        duty_cycle = bidcos_interface['DUTY_CYCLE']
         if self._duty_cycle != duty_cycle:
+            _LOGGER.info("Retrieved new duty_cycle: %d", duty_cycle)
             self._duty_cycle = duty_cycle
             self.schedule_update_ha_state()
 

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -242,7 +242,7 @@ class HMHub(Entity):
         """Return the state attributes."""
         attr = self._variables.copy()
         if self._duty_cycle is not None:
-            attr['duty_cycle'] = self._duty_cycle
+            attr['DutyCycle'] = self._duty_cycle
         return attr
 
     @property
@@ -279,6 +279,10 @@ class HMHub(Entity):
 
     def _update_duty_cycle(self, now):
         """Retrieve duty cycle."""
+        if "DutyCycle" in self._variables:
+            # e.g. RaspberryMatic already sets DutyCycle system variable
+            self._duty_cycle = None
+            return
         bidcos_interfaces = self._homematic.listBidcosInterfaces(self._name)
         if bidcos_interfaces is None:
             return

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -10,10 +10,10 @@ from homeassistant.helpers.entity import Entity
 from .const import (
     ATTR_ADDRESS,
     ATTR_CHANNEL,
+    ATTR_DUTY_CYCLE,
     ATTR_INTERFACE,
     ATTR_PARAM,
     ATTR_UNIQUE_ID,
-    ATTR_DUTY_CYCLE,
     DATA_HOMEMATIC,
     DOMAIN,
     HM_ATTRIBUTE_SUPPORT,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
RaspberryMatic exposes DutyCycle as system variable - CCU2/3 don't have this variable directly available. This PR exposes it as Home Assistant state attribute on CCU2/3 as well. DutyCycle can be used for debugging HomeMatic connectivity issues, throttling automations (e.g. put_paramset), or triggering events.  Info about DutyCycle (German only): https://www.homematic-inside.de/faq/duty-cycle

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
