### PR TITLE
UniFi - Fix block functionality

### DIFF
--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -162,7 +162,7 @@ class UniFiController:
                     WIRELESS_GUEST_CONNECTED,
                 ):
                     self.update_wireless_clients()
-            elif data.get("clients") or data.get("devices"):
+            elif "clients" in data or "devices" in data:
                 async_dispatcher_send(self.hass, self.signal_update)
 
     @property

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
   "requirements": [
-    "aiounifi==14"
+    "aiounifi==15"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -262,7 +262,7 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchDevice, RestoreEntity):
         """Shortcut to the switch port that client is connected to."""
         try:
             return self.device.ports[self.client.sw_port]
-        except TypeError:
+        except (AttributeError, KeyError, TypeError):
             LOGGER.warning(
                 "Entity %s reports faulty device %s or port %s",
                 self.entity_id,
@@ -282,7 +282,7 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchDevice):
     @property
     def is_on(self):
         """Return true if client is allowed to connect."""
-        return not self.client.blocked
+        return not self.is_blocked
 
     async def async_turn_on(self, **kwargs):
         """Turn on connectivity for client."""
@@ -291,3 +291,10 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchDevice):
     async def async_turn_off(self, **kwargs):
         """Turn off connectivity for client."""
         await self.controller.api.clients.async_block(self.client.mac)
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        if self.is_blocked:
+            return "mdi:network-off"
+        return "mdi:network"

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -2,12 +2,29 @@
 
 import logging
 
+from aiounifi.api import SOURCE_EVENT
+from aiounifi.events import (
+    WIRED_CLIENT_BLOCKED,
+    WIRED_CLIENT_CONNECTED,
+    WIRED_CLIENT_DISCONNECTED,
+    WIRED_CLIENT_UNBLOCKED,
+    WIRELESS_CLIENT_BLOCKED,
+    WIRELESS_CLIENT_CONNECTED,
+    WIRELESS_CLIENT_DISCONNECTED,
+    WIRELESS_CLIENT_UNBLOCKED,
+)
+
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
 LOGGER = logging.getLogger(__name__)
+
+CLIENT_BLOCKED = (WIRED_CLIENT_BLOCKED, WIRELESS_CLIENT_BLOCKED)
+CLIENT_UNBLOCKED = (WIRED_CLIENT_UNBLOCKED, WIRELESS_CLIENT_UNBLOCKED)
+WIRED_CLIENT = (WIRED_CLIENT_CONNECTED, WIRED_CLIENT_DISCONNECTED)
+WIRELESS_CLIENT = (WIRELESS_CLIENT_CONNECTED, WIRELESS_CLIENT_DISCONNECTED)
 
 
 class UniFiClient(Entity):
@@ -18,7 +35,12 @@ class UniFiClient(Entity):
         self.client = client
         self.controller = controller
         self.listeners = []
+
         self.is_wired = self.client.mac not in controller.wireless_clients
+        self.is_blocked = self.client.blocked
+        self.connected = None
+        self.wired_connection = None
+        self.wireless_connection = None
 
     async def async_added_to_hass(self) -> None:
         """Client entity created."""
@@ -41,6 +63,25 @@ class UniFiClient(Entity):
         """Update the clients state."""
         if self.is_wired and self.client.mac in self.controller.wireless_clients:
             self.is_wired = False
+
+        if self.client.last_updated == SOURCE_EVENT:
+
+            if self.client.event.event in CLIENT_BLOCKED + CLIENT_UNBLOCKED:
+                self.is_blocked = self.client.event.event in CLIENT_BLOCKED
+
+            elif self.client.event.event in WIRED_CLIENT:
+                self.wired_connection = (
+                    self.client.event.event == WIRED_CLIENT_CONNECTED
+                )
+
+            elif self.client.event.event in WIRELESS_CLIENT:
+                self.wireless_connection = (
+                    self.client.event.event == WIRELESS_CLIENT_CONNECTED
+                )
+
+            self.connected = self.wired_connection or self.wireless_connection
+            print(self.client.event.event, self.name, self.is_blocked, self.connected)
+
         LOGGER.debug("Updating client %s %s", self.entity_id, self.client.mac)
         self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -5,12 +5,8 @@ import logging
 from aiounifi.api import SOURCE_EVENT
 from aiounifi.events import (
     WIRED_CLIENT_BLOCKED,
-    WIRED_CLIENT_CONNECTED,
-    WIRED_CLIENT_DISCONNECTED,
     WIRED_CLIENT_UNBLOCKED,
     WIRELESS_CLIENT_BLOCKED,
-    WIRELESS_CLIENT_CONNECTED,
-    WIRELESS_CLIENT_DISCONNECTED,
     WIRELESS_CLIENT_UNBLOCKED,
 )
 
@@ -23,8 +19,6 @@ LOGGER = logging.getLogger(__name__)
 
 CLIENT_BLOCKED = (WIRED_CLIENT_BLOCKED, WIRELESS_CLIENT_BLOCKED)
 CLIENT_UNBLOCKED = (WIRED_CLIENT_UNBLOCKED, WIRELESS_CLIENT_UNBLOCKED)
-WIRED_CLIENT = (WIRED_CLIENT_CONNECTED, WIRED_CLIENT_DISCONNECTED)
-WIRELESS_CLIENT = (WIRELESS_CLIENT_CONNECTED, WIRELESS_CLIENT_DISCONNECTED)
 
 
 class UniFiClient(Entity):
@@ -38,9 +32,6 @@ class UniFiClient(Entity):
 
         self.is_wired = self.client.mac not in controller.wireless_clients
         self.is_blocked = self.client.blocked
-        self.connected = None
-        self.wired_connection = None
-        self.wireless_connection = None
 
     async def async_added_to_hass(self) -> None:
         """Client entity created."""
@@ -68,19 +59,6 @@ class UniFiClient(Entity):
 
             if self.client.event.event in CLIENT_BLOCKED + CLIENT_UNBLOCKED:
                 self.is_blocked = self.client.event.event in CLIENT_BLOCKED
-
-            elif self.client.event.event in WIRED_CLIENT:
-                self.wired_connection = (
-                    self.client.event.event == WIRED_CLIENT_CONNECTED
-                )
-
-            elif self.client.event.event in WIRELESS_CLIENT:
-                self.wireless_connection = (
-                    self.client.event.event == WIRELESS_CLIENT_CONNECTED
-                )
-
-            self.connected = self.wired_connection or self.wireless_connection
-            print(self.client.event.event, self.name, self.is_blocked, self.connected)
 
         LOGGER.debug("Updating client %s %s", self.entity_id, self.client.mac)
         self.async_schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -203,7 +203,7 @@ aiopylgtv==0.3.3
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==14
+aiounifi==15
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -81,7 +81,7 @@ aiopylgtv==0.3.3
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==14
+aiounifi==15
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes one of the bugs moving to websockets, using events to reflect on entity blocked status

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32447
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
