### PR TITLE
Sonos: Return URI as media_content_id

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -366,6 +366,7 @@ class SonosEntity(MediaPlayerDevice):
         self._coordinator = None
         self._sonos_group = [self]
         self._status = None
+        self._uri = None
         self._media_duration = None
         self._media_position = None
         self._media_position_updated_at = None
@@ -570,6 +571,7 @@ class SonosEntity(MediaPlayerDevice):
             return
 
         self._shuffle = self.soco.shuffle
+        self._uri = None
 
         update_position = new_status != self._status
         self._status = new_status
@@ -580,6 +582,7 @@ class SonosEntity(MediaPlayerDevice):
             self.update_media_linein(SOURCE_LINEIN)
         else:
             track_info = self.soco.get_current_track_info()
+            self._uri = track_info["uri"]
 
             if _is_radio_uri(track_info["uri"]):
                 variables = event and event.variables
@@ -825,6 +828,11 @@ class SonosEntity(MediaPlayerDevice):
     def shuffle(self):
         """Shuffling state."""
         return self._shuffle
+
+    @property
+    def media_content_id(self):
+        """Content id of current playing media."""
+        return self._uri
 
     @property
     def media_content_type(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Exposes the current playing media's `uri` as `media_content_id` when streaming radio or music.

This enables more advanced automations based of what's currently playing. Based on the URI, you can define a sensor (with some assumptions) detecting if the current playing media is restorable.

For example:

```yaml
binary_sensor:
  - platform: template
    sensors:
      sonos_restorable:
        friendly_name: Is Sonos Restorable
        entity_id: media_player.<sonos-id>
        value_template: >-
          {% if state_attr('media_player.<sonos-id>', 'media_content_id').startswith('x-sonos-spotify:spotify')
              or state_attr('media_player.<sonos-id>', 'media_content_id').startswith('x-sonosapi-hls-static') %}
            True
          {% else %}
            False
          {% endif %}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
