### PR TITLE
Clean up homekit_controller entity setup

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -3,7 +3,9 @@ import logging
 import os
 
 import aiohomekit
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -11,7 +13,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity
 
 from .config_flow import normalize_hkid
-from .connection import HKDevice, get_accessory_information
+from .connection import HKDevice
 from .const import CONTROLLER, DOMAIN, ENTITY_MAP, KNOWN_DEVICES
 from .storage import EntityMapStorage
 
@@ -36,6 +38,23 @@ class HomeKitEntity(Entity):
         self.setup()
 
         self._signals = []
+
+    @property
+    def accessory(self) -> Accessory:
+        """Return an Accessory model that this entity is attached to."""
+        return self._accessory.entity_map.aid(self._aid)
+
+    @property
+    def accessory_info(self) -> Service:
+        """Information about the make and model of an accessory."""
+        return self.accessory.services.first(
+            service_type=ServicesTypes.ACCESSORY_INFORMATION
+        )
+
+    @property
+    def service(self) -> Service:
+        """Return a Service model that this entity is attached to."""
+        return self.accessory.services.iid(self._iid)
 
     async def async_added_to_hass(self):
         """Entity added to hass."""
@@ -67,8 +86,6 @@ class HomeKitEntity(Entity):
 
     def setup(self):
         """Configure an entity baed on its HomeKit characteristics metadata."""
-        accessories = self._accessory.accessories
-
         get_uuid = CharacteristicsTypes.get_uuid
         characteristic_types = [get_uuid(c) for c in self.get_characteristic_types()]
 
@@ -77,33 +94,19 @@ class HomeKitEntity(Entity):
         self._chars = {}
         self._char_names = {}
 
-        for accessory in accessories:
-            if accessory["aid"] != self._aid:
+        # Setup events and/or polling for characteristics directly attached to this entity
+        for char in self.service.characteristics:
+            if char.type not in characteristic_types:
                 continue
-            self._accessory_info = get_accessory_information(accessory)
-            for service in accessory["services"]:
-                if service["iid"] != self._iid:
-                    continue
-                for char in service["characteristics"]:
-                    try:
-                        uuid = CharacteristicsTypes.get_uuid(char["type"])
-                    except KeyError:
-                        # If a KeyError is raised its a non-standard
-                        # characteristic. We must ignore it in this case.
-                        continue
-                    if uuid not in characteristic_types:
-                        continue
-                    self._setup_characteristic(char)
+            self._setup_characteristic(char.to_accessory_and_service_list())
 
-                accessory = self._accessory.entity_map.aid(self._aid)
-                this_service = accessory.services.iid(self._iid)
-                for child_service in accessory.services.filter(
-                    parent_service=this_service
-                ):
-                    for char in child_service.characteristics:
-                        if char.type not in characteristic_types:
-                            continue
-                        self._setup_characteristic(char.to_accessory_and_service_list())
+        # Setup events and/or polling for characteristics attached to sub-services of this
+        # entity (like an INPUT_SOURCE).
+        for service in self.accessory.services.filter(parent_service=self.service):
+            for char in service.characteristics:
+                if char.type not in characteristic_types:
+                    continue
+                self._setup_characteristic(char.to_accessory_and_service_list())
 
     def _setup_characteristic(self, char):
         """Configure an entity based on a HomeKit characteristics metadata."""
@@ -165,13 +168,13 @@ class HomeKitEntity(Entity):
     @property
     def unique_id(self):
         """Return the ID of this device."""
-        serial = self._accessory_info["serial-number"]
+        serial = self.accessory_info.value(CharacteristicsTypes.SERIAL_NUMBER)
         return f"homekit-{serial}-{self._iid}"
 
     @property
     def name(self):
         """Return the name of the device if any."""
-        return self._accessory_info.get("name")
+        return self.accessory_info.value(CharacteristicsTypes.NAME)
 
     @property
     def available(self) -> bool:
@@ -181,14 +184,15 @@ class HomeKitEntity(Entity):
     @property
     def device_info(self):
         """Return the device info."""
-        accessory_serial = self._accessory_info["serial-number"]
+        info = self.accessory_info
+        accessory_serial = info.value(CharacteristicsTypes.SERIAL_NUMBER)
 
         device_info = {
             "identifiers": {(DOMAIN, "serial-number", accessory_serial)},
-            "name": self._accessory_info["name"],
-            "manufacturer": self._accessory_info.get("manufacturer", ""),
-            "model": self._accessory_info.get("model", ""),
-            "sw_version": self._accessory_info.get("firmware.revision", ""),
+            "name": info.value(CharacteristicsTypes.NAME),
+            "manufacturer": info.value(CharacteristicsTypes.MANUFACTURER, ""),
+            "model": info.value(CharacteristicsTypes.MODEL, ""),
+            "sw_version": info.value(CharacteristicsTypes.FIRMWARE_REVISION, ""),
         }
 
         # Some devices only have a single accessory - we don't add a

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.24"],
+  "requirements": ["aiohomekit[IP]==0.2.25"],
   "dependencies": [],
   "zeroconf": ["_hap._tcp.local."],
   "codeowners": ["@Jc2k"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -163,7 +163,7 @@ aioftp==0.12.0
 aioharmony==0.1.13
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.24
+aiohomekit[IP]==0.2.25
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,7 +62,7 @@ aiobotocore==0.11.1
 aioesphomeapi==2.6.1
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.24
+aiohomekit[IP]==0.2.25
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As mentioned in #32526, the new abstractions in the upstream homekit library mean we can clean up some older homekit_controller code. I'm going to do these in small pieces to keep things easy to review. This just gets rid of an ugly double nested for loop for finding which characteristics belong to the current service. This lead to me being able to use constants from upstream for a bunch of characteristics referenced in the base entity, meaning linters will be able to catch more errors.

The version bump is to pickup a fix for a test bug the changes unearthed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
