### PR TITLE
input_datetime guard for unexpected state on restore

### DIFF
--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -240,9 +240,15 @@ class InputDatetime(RestoreEntity):
             self._current_datetime = dt_util.parse_datetime(old_state.state)
         elif self.has_date:
             date = dt_util.parse_date(old_state.state)
+            if date is None:
+                self._current_datetime = dt_util.parse_datetime(DEFAULT_VALUE)
+                return
             self._current_datetime = datetime.datetime.combine(date, DEFAULT_TIME)
         else:
             time = dt_util.parse_time(old_state.state)
+            if time is None:
+                self._current_datetime = dt_util.parse_datetime(DEFAULT_VALUE)
+                return
             self._current_datetime = datetime.datetime.combine(DEFAULT_DATE, time)
 
     @property

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -237,11 +237,11 @@ class InputDatetime(RestoreEntity):
             return
 
         if self.has_date and self.has_time:
-            datetime = dt_util.parse_datetime(old_state.state)
-            if datetime is None:
+            date_time = dt_util.parse_datetime(old_state.state)
+            if date_time is None:
                 self._current_datetime = dt_util.parse_datetime(DEFAULT_VALUE)
                 return
-            self._current_datetime = datetime
+            self._current_datetime = date_time
         elif self.has_date:
             date = dt_util.parse_date(old_state.state)
             if date is None:

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -237,7 +237,11 @@ class InputDatetime(RestoreEntity):
             return
 
         if self.has_date and self.has_time:
-            self._current_datetime = dt_util.parse_datetime(old_state.state)
+            datetime = dt_util.parse_datetime(old_state.state)
+            if datetime is None:
+                self._current_datetime = dt_util.parse_datetime(DEFAULT_VALUE)
+                return
+            self._current_datetime = datetime
         elif self.has_date:
             date = dt_util.parse_date(old_state.state)
             if date is None:

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -268,12 +268,15 @@ async def test_restore_state(hass):
             State("input_datetime.test_date", "2017-09-07"),
             State("input_datetime.test_datetime", "2017-09-07 19:46:00"),
             State("input_datetime.test_bogus_data", "this is not a date"),
+            State("input_datetime.test_was_time", "19:46:00"),
+            State("input_datetime.test_was_date", "2017-09-07"),
         ),
     )
 
     hass.state = CoreState.starting
 
     initial = datetime.datetime(2017, 1, 1, 23, 42)
+    default = datetime.datetime(1970, 1, 1, 0, 0)
 
     await async_setup_component(
         hass,
@@ -288,6 +291,8 @@ async def test_restore_state(hass):
                     "has_date": True,
                     "initial": str(initial),
                 },
+                "test_was_time": {"has_time": False, "has_date": True},
+                "test_was_date": {"has_time": True, "has_date": False},
             }
         },
     )
@@ -304,6 +309,12 @@ async def test_restore_state(hass):
 
     state_bogus = hass.states.get("input_datetime.test_bogus_data")
     assert state_bogus.state == str(initial)
+
+    state_was_time = hass.states.get("input_datetime.test_was_time")
+    assert state_was_time.state == str(default.date())
+
+    state_was_date = hass.states.get("input_datetime.test_was_date")
+    assert state_was_date.state == str(default.time())
 
 
 async def test_default_value(hass):


### PR DESCRIPTION
## Proposed change
If state is a time and has_date = true, or the other way around, restore state would error

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
