### PR TITLE
Add additional information to SynologySRM device tracker

### DIFF
--- a/homeassistant/components/synology_srm/device_tracker.py
+++ b/homeassistant/components/synology_srm/device_tracker.py
@@ -37,6 +37,34 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+ATTRIBUTE_ALIAS = {
+    "band": None,
+    "connection": None,
+    "current_rate": None,
+    "dev_type": None,
+    "hostname": None,
+    "ip6_addr": None,
+    "ip_addr": None,
+    "is_baned": None,
+    "is_beamforming_on": None,
+    "is_guest": None,
+    "is_high_qos": None,
+    "is_low_qos": None,
+    "is_manual_dev_type": None,
+    "is_manual_hostname": None,
+    "is_online": None,
+    "is_parental_controled": None,
+    "is_qos": None,
+    "is_wireless": None,
+    "mac": None,
+    "max_rate": None,
+    "mesh_node_id": None,
+    "rate_quality": None,
+    "signalstrength": "signal_strength",
+    "transferRXRate": "transfer_rx_rate",
+    "transferTXRate": "transfer_tx_rate",
+}
+
 
 def get_scanner(hass, config):
     """Validate the configuration and return Synology SRM scanner."""
@@ -75,9 +103,21 @@ class SynologySrmDeviceScanner(DeviceScanner):
 
     def get_extra_attributes(self, device) -> dict:
         """Get the extra attributes of a device."""
-        filter_result = [result for result in self.devices if result["mac"] == device]
-        if filter_result:
-            return filter_result[0]
+        device = next(
+            iter([result for result in self.devices if result["mac"] == device]), None
+        )
+        if device:
+            filtered_attributes = {}
+            for attribute, value in device.items():
+                if attribute in ATTRIBUTE_ALIAS:
+                    filtered_attributes[
+                        (
+                            ATTRIBUTE_ALIAS[attribute]
+                            if ATTRIBUTE_ALIAS[attribute]
+                            else attribute
+                        )
+                    ] = value
+            return filtered_attributes
         return {}
 
     def get_device_name(self, device):

--- a/homeassistant/components/synology_srm/device_tracker.py
+++ b/homeassistant/components/synology_srm/device_tracker.py
@@ -62,7 +62,7 @@ class SynologySrmDeviceScanner(DeviceScanner):
         if not config[CONF_VERIFY_SSL]:
             self.client.http.disable_https_verify()
 
-        self.last_results = []
+        self.devices = []
         self.success_init = self._update_info()
 
         _LOGGER.info("Synology SRM scanner initialized")
@@ -71,22 +71,19 @@ class SynologySrmDeviceScanner(DeviceScanner):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
 
-        return [device["mac"] for device in self.last_results]
+        return [device["mac"] for device in self.devices]
 
     def get_extra_attributes(self, device) -> dict:
         """Get the extra attributes of a device."""
-        filter_result = [
-            result for result in self.last_results if result["mac"] == device
-        ]
+        filter_result = [result for result in self.devices if result["mac"] == device]
         if filter_result:
             return filter_result[0]
+        return {}
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         filter_named = [
-            result["hostname"]
-            for result in self.last_results
-            if result["mac"] == device
+            result["hostname"] for result in self.devices if result["mac"] == device
         ]
 
         if filter_named:
@@ -98,9 +95,8 @@ class SynologySrmDeviceScanner(DeviceScanner):
         """Check the router for connected devices."""
         _LOGGER.debug("Scanning for connected devices")
 
-        devices = self.client.core.network_nsm_device({"is_online": True})
+        self.devices = self.client.core.network_nsm_device({"is_online": True})
 
-        _LOGGER.debug("Found %d device(s) connected to the router", len(devices))
+        _LOGGER.debug("Found %d device(s) connected to the router", len(self.devices))
 
-        self.last_results = devices
         return True

--- a/homeassistant/components/synology_srm/device_tracker.py
+++ b/homeassistant/components/synology_srm/device_tracker.py
@@ -73,6 +73,14 @@ class SynologySrmDeviceScanner(DeviceScanner):
 
         return [device["mac"] for device in self.last_results]
 
+    def get_extra_attributes(self, device) -> dict:
+        """Get the extra attributes of a device."""
+        filter_result = [
+            result for result in self.last_results if result["mac"] == device
+        ]
+        if filter_result:
+            return filter_result[0]
+
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         filter_named = [
@@ -91,12 +99,8 @@ class SynologySrmDeviceScanner(DeviceScanner):
         _LOGGER.debug("Scanning for connected devices")
 
         devices = self.client.core.network_nsm_device({"is_online": True})
-        last_results = []
-
-        for device in devices:
-            last_results.append({"mac": device["mac"], "hostname": device["hostname"]})
 
         _LOGGER.debug("Found %d device(s) connected to the router", len(devices))
 
-        self.last_results = last_results
+        self.last_results = devices
         return True

--- a/homeassistant/components/synology_srm/device_tracker.py
+++ b/homeassistant/components/synology_srm/device_tracker.py
@@ -45,7 +45,7 @@ ATTRIBUTE_ALIAS = {
     "hostname": None,
     "ip6_addr": None,
     "ip_addr": None,
-    "is_baned": None,
+    "is_baned": "is_banned",
     "is_beamforming_on": None,
     "is_guest": None,
     "is_high_qos": None,
@@ -53,7 +53,7 @@ ATTRIBUTE_ALIAS = {
     "is_manual_dev_type": None,
     "is_manual_hostname": None,
     "is_online": None,
-    "is_parental_controled": None,
+    "is_parental_controled": "is_parental_controlled",
     "is_qos": None,
     "is_wireless": None,
     "mac": None,
@@ -104,21 +104,18 @@ class SynologySrmDeviceScanner(DeviceScanner):
     def get_extra_attributes(self, device) -> dict:
         """Get the extra attributes of a device."""
         device = next(
-            iter([result for result in self.devices if result["mac"] == device]), None
+            (result for result in self.devices if result["mac"] == device), None
         )
-        if device:
-            filtered_attributes = {}
-            for attribute, value in device.items():
-                if attribute in ATTRIBUTE_ALIAS:
-                    filtered_attributes[
-                        (
-                            ATTRIBUTE_ALIAS[attribute]
-                            if ATTRIBUTE_ALIAS[attribute]
-                            else attribute
-                        )
-                    ] = value
+        filtered_attributes = {}
+        if not device:
             return filtered_attributes
-        return {}
+        for attribute, alias in ATTRIBUTE_ALIAS.items():
+            value = device.get(attribute)
+            if value is None:
+                continue
+            attr = alias or attribute
+            filtered_attributes[attr] = value
+        return filtered_attributes
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add extra information to devices discovered with the Synology SRM device tracker.

Before:
```
source_type: router
latitude: -27.4732
longitude: 153.0215
gps_accuracy: 0
scanner: SynologySrmDeviceScanner
friendly_name: i00-Phone
```
After adds:
```
band: 5G-1
connection: wifi
current_rate: 433
dev_type: phone
hostname: i00-Phone
ip6_addr: '2406:3400:0419:4500:a247:51dd:a47c:a164'
ip_addr: 10.4.1.208
is_baned: false
is_beamforming_on: false
is_guest: false
is_high_qos: false
is_low_qos: false
is_manual_dev_type: false
is_manual_hostname: false
is_online: true
is_parental_controled: false
is_qos: false
is_wireless: true
mac: 'c0:ee:fb:a2:12:a3'
max_rate: 433
mesh_node_id: 0
rate_quality: high
signalstrength: 76
transferRXRate: 208
transferTXRate: 20
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
**not required**
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
**not required - no changes**
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
