### PR TITLE
Cleanup entity and device registry on MQTT discovery removal

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -1200,7 +1200,7 @@ class MqttDiscoveryUpdate(Entity):
                 await cleanup_device_registry(self.hass, entity_entry.device_id)
 
         @callback
-        def discovery_callback(payload):
+        async def discovery_callback(payload):
             """Handle discovery update."""
             _LOGGER.info(
                 "Got update for entity with hash: %s '%s'", discovery_hash, payload,
@@ -1209,12 +1209,12 @@ class MqttDiscoveryUpdate(Entity):
                 # Empty payload: Remove component
                 _LOGGER.info("Removing component: %s", self.entity_id)
                 self._cleanup_on_remove()
-                self.hass.async_create_task(async_remove_from_registry(self))
-                self.hass.async_create_task(self.async_remove())
+                await async_remove_from_registry(self)
+                await self.async_remove()
             elif self._discovery_update:
                 # Non-empty payload: Notify component
                 _LOGGER.info("Updating component: %s", self.entity_id)
-                self.hass.async_create_task(self._discovery_update(payload))
+                await self._discovery_update(payload)
 
         if discovery_hash:
             self._remove_signal = async_dispatcher_connect(

--- a/homeassistant/components/mqtt/device_trigger.py
+++ b/homeassistant/components/mqtt/device_trigger.py
@@ -25,6 +25,7 @@ from . import (
     CONF_PAYLOAD,
     CONF_QOS,
     DOMAIN,
+    cleanup_device_registry,
 )
 from .discovery import MQTT_DISCOVERY_UPDATED, clear_discovery_hash
 
@@ -187,6 +188,7 @@ async def async_setup_trigger(hass, config, config_entry, discovery_data):
                 device_trigger.detach_trigger()
                 clear_discovery_hash(hass, discovery_hash)
                 remove_signal()
+                await cleanup_device_registry(hass, device.id)
         else:
             # Non-empty payload: Update trigger
             _LOGGER.info("Updating trigger: %s", discovery_hash)

--- a/tests/components/mqtt/common.py
+++ b/tests/components/mqtt/common.py
@@ -192,6 +192,30 @@ async def help_test_entity_device_info_with_identifier(hass, mqtt_mock, domain, 
     assert device.sw_version == "0.1-beta"
 
 
+async def help_test_entity_device_info_remove(hass, mqtt_mock, domain, config):
+    """Test device registry remove."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry.add_to_hass(hass)
+    await async_start(hass, "homeassistant", {}, entry)
+    dev_registry = await hass.helpers.device_registry.async_get_registry()
+    ent_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
+    await hass.async_block_till_done()
+
+    device = dev_registry.async_get_device({("mqtt", "helloworld")}, set())
+    assert device is not None
+    assert ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique")
+
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", "")
+    await hass.async_block_till_done()
+
+    device = dev_registry.async_get_device({("mqtt", "helloworld")}, set())
+    assert device is None
+    assert not ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique")
+
+
 async def help_test_entity_device_info_update(hass, mqtt_mock, domain, config):
     """Test device registry update.
 

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -19,6 +19,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -506,6 +507,21 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock, alarm_control_panel.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
+    )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(
+        hass, mqtt_mock, alarm_control_panel.DOMAIN, config
     )
 
 

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -20,6 +20,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -553,6 +554,20 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock, binary_sensor.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
+    )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(
+        hass, mqtt_mock, binary_sensor.DOMAIN, config
     )
 
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -30,6 +30,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -891,6 +892,19 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, CLIMATE_DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "power_state_topic": "test-topic",
+        "power_command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, CLIMATE_DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -28,6 +28,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -1817,6 +1818,19 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, cover.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, cover.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -13,6 +13,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -561,6 +562,19 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, fan.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, fan.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -30,6 +30,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -641,6 +642,18 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, vacuum.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, vacuum.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -172,6 +172,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -1224,6 +1225,19 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, light.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, light.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -108,6 +108,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -1078,6 +1079,20 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, light.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "schema": "json",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, light.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -44,6 +44,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -702,6 +703,19 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, light.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, light.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -13,6 +13,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -440,6 +441,19 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, lock.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, lock.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -16,6 +16,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -557,6 +558,18 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, sensor.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -36,6 +36,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -473,6 +474,20 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, vacuum.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "schema": "state",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, vacuum.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -17,6 +17,7 @@ from .common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_identifier,
     help_test_entity_id_update,
@@ -405,6 +406,19 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     await help_test_entity_device_info_update(
         hass, mqtt_mock, switch.DOMAIN, DEFAULT_CONFIG_DEVICE_INFO
     )
+
+
+async def test_entity_device_info_remove(hass, mqtt_mock):
+    """Test device registry remove."""
+    config = {
+        "platform": "mqtt",
+        "name": "Test 1",
+        "state_topic": "test-topic",
+        "command_topic": "test-command-topic",
+        "device": {"identifiers": ["helloworld"]},
+        "unique_id": "veryunique",
+    }
+    await help_test_entity_device_info_remove(hass, mqtt_mock, switch.DOMAIN, config)
 
 
 async def test_entity_id_update(hass, mqtt_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an entity is removed aby an empty MQTT discovery update message, remove it from entity registry.
If there are no more device triggers or entities, remove the device from device registry.

This is similar to #31989 and #32617, where retained discovery topics are cleared when entities or triggers are removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
