### PR TITLE
UniFi - Remove manual configuration support

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -1,69 +1,26 @@
 """Support for devices connected to UniFi POE."""
 import voluptuous as vol
 
-from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from .config_flow import get_controller_id_from_config_entry
-from .const import (
-    ATTR_MANUFACTURER,
-    CONF_BLOCK_CLIENT,
-    CONF_DETECTION_TIME,
-    CONF_DONT_TRACK_CLIENTS,
-    CONF_DONT_TRACK_DEVICES,
-    CONF_DONT_TRACK_WIRED_CLIENTS,
-    CONF_SITE_ID,
-    CONF_SSID_FILTER,
-    DOMAIN,
-    UNIFI_CONFIG,
-    UNIFI_WIRELESS_CLIENTS,
-)
+from .const import ATTR_MANUFACTURER, DOMAIN, UNIFI_WIRELESS_CLIENTS
 from .controller import UniFiController
 
 SAVE_DELAY = 10
 STORAGE_KEY = "unifi_data"
 STORAGE_VERSION = 1
 
-CONF_CONTROLLERS = "controllers"
-
-CONTROLLER_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_SITE_ID): cv.string,
-        vol.Optional(CONF_BLOCK_CLIENT, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
-        vol.Optional(CONF_DONT_TRACK_CLIENTS): cv.boolean,
-        vol.Optional(CONF_DONT_TRACK_DEVICES): cv.boolean,
-        vol.Optional(CONF_DONT_TRACK_WIRED_CLIENTS): cv.boolean,
-        vol.Optional(CONF_DETECTION_TIME): cv.positive_int,
-        vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string]),
-    }
-)
-
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_CONTROLLERS): vol.All(
-                    cv.ensure_list, [CONTROLLER_SCHEMA]
-                )
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
+    cv.deprecated(DOMAIN, invalidation_version="0.109"), {DOMAIN: cv.match_all}
 )
 
 
 async def async_setup(hass, config):
     """Component doesn't support configuration through configuration.yaml."""
-    hass.data[UNIFI_CONFIG] = []
-
-    if DOMAIN in config:
-        hass.data[UNIFI_CONFIG] = config[DOMAIN][CONF_CONTROLLERS]
-
     hass.data[UNIFI_WIRELESS_CLIENTS] = wireless_clients = UnifiWirelessClients(hass)
     await wireless_clients.async_load()
 

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -9,7 +9,6 @@ CONTROLLER_ID = "{host}-{site}"
 CONF_CONTROLLER = "controller"
 CONF_SITE_ID = "site"
 
-UNIFI_CONFIG = "unifi_config"
 UNIFI_WIRELESS_CLIENTS = "unifi_wireless_clients"
 
 CONF_ALLOW_BANDWIDTH_SENSORS = "allow_bandwidth_sensors"
@@ -19,10 +18,6 @@ CONF_TRACK_CLIENTS = "track_clients"
 CONF_TRACK_DEVICES = "track_devices"
 CONF_TRACK_WIRED_CLIENTS = "track_wired_clients"
 CONF_SSID_FILTER = "ssid_filter"
-
-CONF_DONT_TRACK_CLIENTS = "dont_track_clients"
-CONF_DONT_TRACK_DEVICES = "dont_track_devices"
-CONF_DONT_TRACK_WIRED_CLIENTS = "dont_track_wired_clients"
 
 DEFAULT_ALLOW_BANDWIDTH_SENSORS = False
 DEFAULT_TRACK_CLIENTS = True

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -10,6 +10,9 @@ from aiounifi.events import WIRELESS_CLIENT_CONNECTED, WIRELESS_GUEST_CONNECTED
 from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 import async_timeout
 
+from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -21,9 +24,6 @@ from .const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
     CONF_DETECTION_TIME,
-    CONF_DONT_TRACK_CLIENTS,
-    CONF_DONT_TRACK_DEVICES,
-    CONF_DONT_TRACK_WIRED_CLIENTS,
     CONF_SITE_ID,
     CONF_SSID_FILTER,
     CONF_TRACK_CLIENTS,
@@ -37,13 +37,12 @@ from .const import (
     DEFAULT_TRACK_WIRED_CLIENTS,
     DOMAIN,
     LOGGER,
-    UNIFI_CONFIG,
     UNIFI_WIRELESS_CLIENTS,
 )
 from .errors import AuthenticationRequired, CannotConnect
 
 RETRY_TIMER = 15
-SUPPORTED_PLATFORMS = ["device_tracker", "sensor", "switch"]
+SUPPORTED_PLATFORMS = [DT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN]
 
 
 class UniFiController:
@@ -225,8 +224,6 @@ class UniFiController:
         self.wireless_clients = wireless_clients.get_data(self.config_entry)
         self.update_wireless_clients()
 
-        self.import_configuration()
-
         for platform in SUPPORTED_PLATFORMS:
             self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
@@ -250,46 +247,6 @@ class UniFiController:
         controller = hass.data[DOMAIN][controller_id]
 
         async_dispatcher_send(hass, controller.signal_options_update)
-
-    def import_configuration(self):
-        """Import configuration to config entry options."""
-        import_config = {}
-
-        for config in self.hass.data[UNIFI_CONFIG]:
-            if (
-                self.host == config[CONF_HOST]
-                and self.site_name == config[CONF_SITE_ID]
-            ):
-                import_config = config
-                break
-
-        old_options = dict(self.config_entry.options)
-        new_options = {}
-
-        for config, option in (
-            (CONF_BLOCK_CLIENT, CONF_BLOCK_CLIENT),
-            (CONF_DONT_TRACK_CLIENTS, CONF_TRACK_CLIENTS),
-            (CONF_DONT_TRACK_WIRED_CLIENTS, CONF_TRACK_WIRED_CLIENTS),
-            (CONF_DONT_TRACK_DEVICES, CONF_TRACK_DEVICES),
-            (CONF_DETECTION_TIME, CONF_DETECTION_TIME),
-            (CONF_SSID_FILTER, CONF_SSID_FILTER),
-        ):
-            if config in import_config:
-                if config == option and import_config[
-                    config
-                ] != self.config_entry.options.get(option):
-                    new_options[option] = import_config[config]
-                elif config != option and (
-                    option not in self.config_entry.options
-                    or import_config[config] == self.config_entry.options.get(option)
-                ):
-                    new_options[option] = not import_config[config]
-
-        if new_options:
-            options = {**old_options, **new_options}
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, options=options
-            )
 
     @callback
     def reconnect(self) -> None:

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -189,32 +189,6 @@ async def test_controller_mac(hass):
     assert controller.mac == "10:00:00:00:00:01"
 
 
-async def test_controller_import_config(hass):
-    """Test that import configuration.yaml instructions work."""
-    controllers = [
-        {
-            CONF_HOST: "1.2.3.4",
-            CONF_SITE_ID: "Site name",
-            unifi.CONF_BLOCK_CLIENT: ["random mac"],
-            unifi.CONF_DONT_TRACK_CLIENTS: True,
-            unifi.CONF_DONT_TRACK_DEVICES: True,
-            unifi.CONF_DONT_TRACK_WIRED_CLIENTS: True,
-            unifi.CONF_DETECTION_TIME: 150,
-            unifi.CONF_SSID_FILTER: ["SSID"],
-        }
-    ]
-
-    controller = await setup_unifi_integration(hass, controllers=controllers)
-
-    assert controller.option_allow_bandwidth_sensors is False
-    assert controller.option_block_clients == ["random mac"]
-    assert controller.option_track_clients is False
-    assert controller.option_track_devices is False
-    assert controller.option_track_wired_clients is False
-    assert controller.option_detection_time == timedelta(seconds=150)
-    assert controller.option_ssid_filter == ["SSID"]
-
-
 async def test_controller_not_accessible(hass):
     """Retry to login gets scheduled when connection fails."""
     with patch.object(

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -10,6 +10,7 @@ from homeassistant import config_entries
 from homeassistant.components import unifi
 import homeassistant.components.device_tracker as device_tracker
 from homeassistant.components.unifi.const import (
+    CONF_BLOCK_CLIENT,
     CONF_SSID_FILTER,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
@@ -456,7 +457,7 @@ async def test_restoring_client(hass):
 
     await setup_unifi_integration(
         hass,
-        options={unifi.CONF_BLOCK_CLIENT: True},
+        options={CONF_BLOCK_CLIENT: True},
         clients_response=[CLIENT_2],
         clients_all_response=[CLIENT_1],
     )

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -13,33 +13,6 @@ async def test_setup_with_no_config(hass):
     """Test that we do not discover anything or try to set up a bridge."""
     assert await async_setup_component(hass, unifi.DOMAIN, {}) is True
     assert unifi.DOMAIN not in hass.data
-    assert hass.data[unifi.UNIFI_CONFIG] == []
-
-
-async def test_setup_with_config(hass):
-    """Test that we do not discover anything or try to set up a bridge."""
-    config = {
-        unifi.DOMAIN: {
-            unifi.CONF_CONTROLLERS: {
-                unifi.CONF_HOST: "1.2.3.4",
-                unifi.CONF_SITE_ID: "My site",
-                unifi.CONF_BLOCK_CLIENT: ["12:34:56:78:90:AB"],
-                unifi.CONF_DETECTION_TIME: 3,
-                unifi.CONF_SSID_FILTER: ["ssid"],
-            }
-        }
-    }
-    assert await async_setup_component(hass, unifi.DOMAIN, config) is True
-    assert unifi.DOMAIN not in hass.data
-    assert hass.data[unifi.UNIFI_CONFIG] == [
-        {
-            unifi.CONF_HOST: "1.2.3.4",
-            unifi.CONF_SITE_ID: "My site",
-            unifi.CONF_BLOCK_CLIENT: ["12:34:56:78:90:AB"],
-            unifi.CONF_DETECTION_TIME: 3,
-            unifi.CONF_SSID_FILTER: ["ssid"],
-        }
-    ]
 
 
 async def test_successful_config_entry(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
A common issue with users was that they didn't get the parameters right when setting up the manual configuration. Now that the options flow supports all and more options than manual configuration it is time to deprecate it. Existing configurations have been reflected to the config entry options.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A common issue with users was that they didn't get the parameters right when setting up the manual configuration. Now that the options flow supports all and more options than manual configuration it is time to deprecate it. Existing configurations have been reflected to the config entry options.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: #12335

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
