### PR TITLE
Remove deprecated hide_if_away from device trackers

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -25,12 +25,10 @@ from .const import (
     ATTR_LOCATION_NAME,
     ATTR_MAC,
     ATTR_SOURCE_TYPE,
-    CONF_AWAY_HIDE,
     CONF_CONSIDER_HOME,
     CONF_NEW_DEVICE_DEFAULTS,
     CONF_SCAN_INTERVAL,
     CONF_TRACK_NEW,
-    DEFAULT_AWAY_HIDE,
     DEFAULT_CONSIDER_HOME,
     DEFAULT_TRACK_NEW,
     DOMAIN,
@@ -53,15 +51,7 @@ SOURCE_TYPES = (
 
 NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(
     None,
-    vol.All(
-        cv.deprecated(CONF_AWAY_HIDE, invalidation_version="0.107.0"),
-        vol.Schema(
-            {
-                vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
-                vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
-            }
-        ),
-    ),
+    vol.Schema({vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean}),
 )
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/device_tracker/const.py
+++ b/homeassistant/components/device_tracker/const.py
@@ -20,9 +20,6 @@ SCAN_INTERVAL = timedelta(seconds=12)
 CONF_TRACK_NEW = "track_new_devices"
 DEFAULT_TRACK_NEW = True
 
-CONF_AWAY_HIDE = "hide_if_away"
-DEFAULT_AWAY_HIDE = False
-
 CONF_CONSIDER_HOME = "consider_home"
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -34,7 +34,6 @@ def scanner(hass):
         "homeassistant.components.device_tracker.legacy.load_yaml_config_file",
         return_value={
             "device_1": {
-                "hide_if_away": False,
                 "mac": "DEV1",
                 "name": "Unnamed Device",
                 "picture": "http://example.com/dev1.jpg",
@@ -42,7 +41,6 @@ def scanner(hass):
                 "vendor": None,
             },
             "device_2": {
-                "hide_if_away": False,
                 "mac": "DEV2",
                 "name": "Unnamed Device",
                 "picture": "http://example.com/dev2.jpg",

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_GPS_ACCURACY,
-    ATTR_HIDDEN,
     ATTR_ICON,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
@@ -107,7 +106,6 @@ async def test_reading_yaml_config(hass, yaml_devices):
         "AB:CD:EF:GH:IJ",
         "Test name",
         picture="http://test.picture",
-        hide_if_away=True,
         icon="mdi:kettle",
     )
     await hass.async_add_executor_job(
@@ -121,7 +119,6 @@ async def test_reading_yaml_config(hass, yaml_devices):
     assert device.track == config.track
     assert device.mac == config.mac
     assert device.config_picture == config.config_picture
-    assert device.away_hide == config.away_hide
     assert device.consider_home == config.consider_home
     assert device.icon == config.icon
 
@@ -284,7 +281,6 @@ async def test_entity_attributes(hass, mock_device_tracker_conf):
         None,
         friendly_name,
         picture,
-        hide_if_away=True,
         icon=icon,
     )
     devices.append(device)
@@ -297,25 +293,6 @@ async def test_entity_attributes(hass, mock_device_tracker_conf):
     assert friendly_name == attrs.get(ATTR_FRIENDLY_NAME)
     assert icon == attrs.get(ATTR_ICON)
     assert picture == attrs.get(ATTR_ENTITY_PICTURE)
-
-
-async def test_device_hidden(hass, mock_device_tracker_conf):
-    """Test hidden devices."""
-    devices = mock_device_tracker_conf
-    dev_id = "test_entity"
-    entity_id = f"{const.DOMAIN}.{dev_id}"
-    device = legacy.Device(
-        hass, timedelta(seconds=180), True, dev_id, None, hide_if_away=True
-    )
-    devices.append(device)
-
-    scanner = getattr(hass.components, "test.device_tracker").SCANNER
-    scanner.reset()
-
-    with assert_setup_component(1, device_tracker.DOMAIN):
-        assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
-
-    assert hass.states.get(entity_id).attributes.get(ATTR_HIDDEN)
 
 
 @patch("homeassistant.components.device_tracker.legacy." "DeviceTracker.async_see")
@@ -607,17 +584,6 @@ async def test_picture_and_icon_on_see_discovery(mock_device_tracker_conf, hass)
     assert len(mock_device_tracker_conf) == 1
     assert mock_device_tracker_conf[0].icon == "mdi:icon"
     assert mock_device_tracker_conf[0].entity_picture == "pic_url"
-
-
-async def test_default_hide_if_away_is_used(mock_device_tracker_conf, hass):
-    """Test that default track_new is used."""
-    tracker = legacy.DeviceTracker(
-        hass, timedelta(seconds=60), False, {device_tracker.CONF_AWAY_HIDE: True}, []
-    )
-    await tracker.async_see(dev_id=12)
-    await hass.async_block_till_done()
-    assert len(mock_device_tracker_conf) == 1
-    assert mock_device_tracker_conf[0].away_hide
 
 
 async def test_backward_compatibility_for_track_new(mock_device_tracker_conf, hass):

--- a/tests/components/unifi_direct/test_device_tracker.py
+++ b/tests/components/unifi_direct/test_device_tracker.py
@@ -7,7 +7,6 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    CONF_AWAY_HIDE,
     CONF_CONSIDER_HOME,
     CONF_NEW_DEVICE_DEFAULTS,
     CONF_TRACK_NEW,
@@ -49,7 +48,7 @@ async def test_get_scanner(unifi_mock, hass):
             CONF_PASSWORD: "fake_pass",
             CONF_TRACK_NEW: True,
             CONF_CONSIDER_HOME: timedelta(seconds=180),
-            CONF_NEW_DEVICE_DEFAULTS: {CONF_TRACK_NEW: True, CONF_AWAY_HIDE: False},
+            CONF_NEW_DEVICE_DEFAULTS: {CONF_TRACK_NEW: True},
         }
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `hide_if_away` configuration parameter has been removed for all device trackers. This option was used to hide devices trackers from the UI if the device was not at home. This applied to the old States UI, which now has been removed.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This resolves an issue that came up during PR #32697, we have been struggling a bit (and partly rolled back the deprecation of) the `hide_if_away` configuration option of device trackers.

I've removed it entirely from our codebase now, following up on the deprecation. 

However, if you still have it in your known devices, it will be silently ignored, thus will not cause a breaking change. (Still listing it as one though).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
device_tracker:
  - platform: nmap_tracker
    hosts: 10.10.100.0/24
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31549
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
