### PR TITLE
Sonos idle

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -523,9 +523,7 @@ class SonosEntity(MediaPlayerDevice):
             # If the content is a tts don't try to fetch an image from it.
             return None
 
-        return "http://{host}:{port}/getaa?s=1&u={uri}".format(
-            host=self.soco.ip_address, port=1400, uri=urllib.parse.quote(url, safe=""),
-        )
+        return f"http://{self.soco.ip_address}:1400/getaa?s=1&u={urllib.parse.quote(url, safe='')}"
 
     def _attach_player(self):
         """Get basic information and add event subscriptions."""

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -624,9 +624,9 @@ class SonosEntity(MediaPlayerDevice):
         media_info = self.soco.avTransport.GetMediaInfo([("InstanceID", 0)])
         self._media_image_url = self._radio_artwork(media_info["CurrentURI"])
 
-        self._media_artist = track_info.get("artist") or None
+        self._media_artist = track_info.get("artist")
         self._media_album_name = None
-        self._media_title = track_info.get("title") or None
+        self._media_title = track_info.get("title")
 
         if self._media_artist and self._media_title:
             # artist and album name are in the data, concatenate
@@ -707,11 +707,11 @@ class SonosEntity(MediaPlayerDevice):
             self._media_position = rel_time
             self._media_position_updated_at = utcnow()
 
-        self._media_image_url = track_info.get("album_art") or None
+        self._media_image_url = track_info.get("album_art")
 
-        self._media_artist = track_info.get("artist") or None
-        self._media_album_name = track_info.get("album") or None
-        self._media_title = track_info.get("title") or None
+        self._media_artist = track_info.get("artist")
+        self._media_album_name = track_info.get("album")
+        self._media_title = track_info.get("title")
 
         self._source_name = None
 
@@ -870,25 +870,25 @@ class SonosEntity(MediaPlayerDevice):
     @soco_coordinator
     def media_artist(self):
         """Artist of current playing media, music track only."""
-        return self._media_artist
+        return self._media_artist or None
 
     @property
     @soco_coordinator
     def media_album_name(self):
         """Album name of current playing media, music track only."""
-        return self._media_album_name
+        return self._media_album_name or None
 
     @property
     @soco_coordinator
     def media_title(self):
         """Title of current playing media."""
-        return self._media_title
+        return self._media_title or None
 
     @property
     @soco_coordinator
     def source(self):
         """Name of the current input source."""
-        return self._source_name
+        return self._source_name or None
 
     @property
     @soco_coordinator

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -429,10 +429,11 @@ class SonosEntity(MediaPlayerDevice):
     @soco_coordinator
     def state(self):
         """Return the state of the entity."""
-        if self._media_title is not None and self._status in (
-            "PAUSED_PLAYBACK",
-            "STOPPED",
-        ):
+        if self._status in ("PAUSED_PLAYBACK", "STOPPED",):
+            # Sonos can consider itself "paused" but without having media loaded
+            # (happens if playing Spotify and via Spotify app you pick another device to play on)
+            if self._media_title is None:
+                return STATE_IDLE
             return STATE_PAUSED
         if self._status in ("PLAYING", "TRANSITIONING"):
             return STATE_PLAYING
@@ -609,9 +610,9 @@ class SonosEntity(MediaPlayerDevice):
 
         self._media_image_url = None
 
-        self._media_artist = source
+        self._media_artist = None
         self._media_album_name = None
-        self._media_title = None
+        self._media_title = source
 
         self._source_name = source
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Sonos devices will now report `idle` instead of `paused` if they do not have any current artist metadata available. This can happen when you were playing Spotify on your Sonos and use the Spotify app to play on another device.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If there are no music title/artist, don't store an empty string but store `None` so the attributes are filtered out.

Also make sure that if there is no media title, we don't consider ourselves paused but instead mark ourselves as idle, which is more appropriate.

For background, see #32701

Fixes #32701

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
