### PR TITLE
Update Vizio `source` property to only return current app if it is not None

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -304,7 +304,7 @@ class VizioDevice(MediaPlayerDevice):
     @property
     def source(self) -> str:
         """Return current input of the device."""
-        if self._current_app and self._current_input in INPUT_APPS:
+        if self._current_app is not None and self._current_input in INPUT_APPS:
             return self._current_app
 
         return self._current_input

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -304,7 +304,7 @@ class VizioDevice(MediaPlayerDevice):
     @property
     def source(self) -> str:
         """Return current input of the device."""
-        if self._current_input in INPUT_APPS:
+        if self._current_app and self._current_input in INPUT_APPS:
             return self._current_app
 
         return self._current_input

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -112,7 +112,9 @@ async def _test_setup(
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_power_state",
         return_value=vizio_power_state,
-    ):
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_app",
+    ) as service_call:
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -125,6 +127,8 @@ async def _test_setup(
         if ha_power_state == STATE_ON:
             assert attr["source_list"] == INPUT_LIST
             assert attr["source"] == CURRENT_INPUT
+            if ha_device_class == DEVICE_CLASS_SPEAKER:
+                assert not service_call.called
             assert (
                 attr["volume_level"]
                 == float(int(MAX_VOLUME[vizio_device_class] / 2))


### PR DESCRIPTION
## Proposed change
For vizio speakers (which don't support apps) and for TVs that aren't currently running an app, the `source` property should always return the current input. We can do this by only returning `self._current_app` if it is not None. This fixes an issue introduced as part of #32432 where the source will always be set to None when ‘device_class’=speaker


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
