### PR TITLE
Optimize is_entity_exposed  in emulated_hue by removing deprecated emulated_hue and emulated_hue_hidden attributes

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -220,7 +220,9 @@ class Config:
 
         # Get domains that are exposed by default when expose_by_default is
         # True
-        self.exposed_domains = conf.get(CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
+        self.exposed_domains = set(
+            conf.get(CONF_EXPOSED_DOMAINS, DEFAULT_EXPOSED_DOMAINS)
+        )
 
         # Calculated effective advertised IP and port for network isolation
         self.advertise_ip = conf.get(CONF_ADVERTISE_IP) or self.host_ip_addr
@@ -228,6 +230,12 @@ class Config:
         self.advertise_port = conf.get(CONF_ADVERTISE_PORT) or self.listen_port
 
         self.entities = conf.get(CONF_ENTITIES, {})
+
+        self._entities_with_hidden_attr_in_config = dict()
+        for entity_id in self.entities:
+            hidden_value = self.entities[entity_id].get(CONF_ENTITY_HIDDEN, None)
+            if hidden_value is not None:
+                self._entities_with_hidden_attr_in_config[entity_id] = hidden_value
 
     def entity_id_to_number(self, entity_id):
         """Get a unique number for the entity id."""
@@ -280,35 +288,32 @@ class Config:
             # Ignore entities that are views
             return False
 
-        domain = entity.domain.lower()
-        explicit_expose = entity.attributes.get(ATTR_EMULATED_HUE, None)
-        explicit_hidden = entity.attributes.get(ATTR_EMULATED_HUE_HIDDEN, None)
+        if entity.entity_id in self._entities_with_hidden_attr_in_config:
+            return not self._entities_with_hidden_attr_in_config[entity.entity_id]
 
-        if (
-            entity.entity_id in self.entities
-            and CONF_ENTITY_HIDDEN in self.entities[entity.entity_id]
-        ):
-            explicit_hidden = self.entities[entity.entity_id][CONF_ENTITY_HIDDEN]
+        explicit_hidden = entity.attributes.get(ATTR_EMULATED_HUE_HIDDEN, None)
+        explicit_expose = entity.attributes.get(ATTR_EMULATED_HUE, None)
+
+        if explicit_expose is not None:
+            get_deprecated(
+                entity.attributes, ATTR_EMULATED_HUE_HIDDEN, ATTR_EMULATED_HUE, None
+            )
 
         if explicit_expose is True or explicit_hidden is False:
-            expose = True
-        elif explicit_expose is False or explicit_hidden is True:
-            expose = False
-        else:
-            expose = None
-        get_deprecated(
-            entity.attributes, ATTR_EMULATED_HUE_HIDDEN, ATTR_EMULATED_HUE, None
-        )
-        domain_exposed_by_default = (
-            self.expose_by_default and domain in self.exposed_domains
-        )
+            return True
 
+        if explicit_expose is False or explicit_hidden is True:
+            return False
+
+        if not self.expose_by_default:
+            return False
         # Expose an entity if the entity's domain is exposed by default and
         # the configuration doesn't explicitly exclude it from being
         # exposed, or if the entity is explicitly exposed
-        is_default_exposed = domain_exposed_by_default and expose is not False
+        if entity.domain in self.exposed_domains:
+            return True
 
-        return is_default_exposed or expose
+        return False
 
 
 def _load_json(filename):

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -90,7 +90,6 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-ATTR_EMULATED_HUE = "emulated_hue"
 ATTR_EMULATED_HUE_NAME = "emulated_hue_name"
 ATTR_EMULATED_HUE_HIDDEN = "emulated_hue_hidden"
 

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -91,7 +91,6 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 ATTR_EMULATED_HUE_NAME = "emulated_hue_name"
-ATTR_EMULATED_HUE_HIDDEN = "emulated_hue_hidden"
 
 
 async def async_setup(hass, yaml_config):
@@ -288,10 +287,6 @@ class Config:
 
         if entity.entity_id in self._entities_with_hidden_attr_in_config:
             return not self._entities_with_hidden_attr_in_config[entity.entity_id]
-
-        explicit_hidden = entity.attributes.get(ATTR_EMULATED_HUE_HIDDEN, None)
-        if explicit_hidden is not None:
-            return not explicit_hidden
 
         if not self.expose_by_default:
             return False

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -9,7 +9,6 @@ from homeassistant.components.http import real_ip
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.deprecation import get_deprecated
 from homeassistant.util.json import load_json, save_json
 
 from .hue_api import (
@@ -292,18 +291,8 @@ class Config:
             return not self._entities_with_hidden_attr_in_config[entity.entity_id]
 
         explicit_hidden = entity.attributes.get(ATTR_EMULATED_HUE_HIDDEN, None)
-        explicit_expose = entity.attributes.get(ATTR_EMULATED_HUE, None)
-
-        if explicit_expose is not None:
-            get_deprecated(
-                entity.attributes, ATTR_EMULATED_HUE_HIDDEN, ATTR_EMULATED_HUE, None
-            )
-
-        if explicit_expose is True or explicit_hidden is False:
-            return True
-
-        if explicit_expose is False or explicit_hidden is True:
-            return False
+        if explicit_hidden is not None:
+            return not explicit_hidden
 
         if not self.expose_by_default:
             return False

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -130,50 +130,8 @@ def hass_hue(loop, hass):
         )
     )
 
-    # Kitchen light is explicitly excluded from being exposed
-    kitchen_light_entity = hass.states.get("light.kitchen_lights")
-    attrs = dict(kitchen_light_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = True
-    hass.states.async_set(
-        kitchen_light_entity.entity_id, kitchen_light_entity.state, attributes=attrs
-    )
-
     # create a lamp without brightness support
     hass.states.async_set("light.no_brightness", "on", {})
-
-    # Ceiling Fan is explicitly excluded from being exposed
-    ceiling_fan_entity = hass.states.get("fan.ceiling_fan")
-    attrs = dict(ceiling_fan_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = True
-    hass.states.async_set(
-        ceiling_fan_entity.entity_id, ceiling_fan_entity.state, attributes=attrs
-    )
-
-    # Expose the script
-    script_entity = hass.states.get("script.set_kitchen_light")
-    attrs = dict(script_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
-    hass.states.async_set(
-        script_entity.entity_id, script_entity.state, attributes=attrs
-    )
-
-    # Expose cover
-    cover_entity = hass.states.get("cover.living_room_window")
-    attrs = dict(cover_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
-    hass.states.async_set(cover_entity.entity_id, cover_entity.state, attributes=attrs)
-
-    # Expose Hvac
-    hvac_entity = hass.states.get("climate.hvac")
-    attrs = dict(hvac_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
-    hass.states.async_set(hvac_entity.entity_id, hvac_entity.state, attributes=attrs)
-
-    # Expose HeatPump
-    hp_entity = hass.states.get("climate.heatpump")
-    attrs = dict(hp_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
-    hass.states.async_set(hp_entity.entity_id, hp_entity.state, attributes=attrs)
 
     return hass
 
@@ -188,7 +146,18 @@ def hue_client(loop, hass_hue, aiohttp_client):
             emulated_hue.CONF_TYPE: emulated_hue.TYPE_ALEXA,
             emulated_hue.CONF_ENTITIES: {
                 "light.bed_light": {emulated_hue.CONF_ENTITY_HIDDEN: True},
+                # Kitchen light is explicitly excluded from being exposed
+                "light.kitchen_lights": {emulated_hue.CONF_ENTITY_HIDDEN: True},
+                # Ceiling Fan is explicitly excluded from being exposed
+                "fan.ceiling_fan": {emulated_hue.CONF_ENTITY_HIDDEN: True},
+                # Expose the script
+                "script.set_kitchen_light": {emulated_hue.CONF_ENTITY_HIDDEN: False},
+                # Expose cover
                 "cover.living_room_window": {emulated_hue.CONF_ENTITY_HIDDEN: False},
+                # Expose Hvac
+                "climate.hvac": {emulated_hue.CONF_ENTITY_HIDDEN: False},
+                # Expose HeatPump
+                "climate.heatpump": {emulated_hue.CONF_ENTITY_HIDDEN: False},
             },
         },
     )

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -133,7 +133,7 @@ def hass_hue(loop, hass):
     # Kitchen light is explicitly excluded from being exposed
     kitchen_light_entity = hass.states.get("light.kitchen_lights")
     attrs = dict(kitchen_light_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE] = False
+    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = True
     hass.states.async_set(
         kitchen_light_entity.entity_id, kitchen_light_entity.state, attributes=attrs
     )
@@ -152,7 +152,7 @@ def hass_hue(loop, hass):
     # Expose the script
     script_entity = hass.states.get("script.set_kitchen_light")
     attrs = dict(script_entity.attributes)
-    attrs[emulated_hue.ATTR_EMULATED_HUE] = True
+    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
     hass.states.async_set(
         script_entity.entity_id, script_entity.state, attributes=attrs
     )


### PR DESCRIPTION
## Breaking change

Complete the deprecation cycle for the `emulated_hue` and `emulated_hue_hidden` attributes.

The existing `entities` `hidden` configuration setting (https://www.home-assistant.io/integrations/emulated_hue/#entities) should be used instead. 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**I'm not sure this is a problem, but its worth a look in case it is**. There is likely a better way to address this.

create_list_of_entities can take a lot of time with a large entities list.  

Make emulated hue calls with create_list_of_entities async
<img width="1440" alt="Screen Shot 2020-03-12 at 2 52 43 AM" src="https://user-images.githubusercontent.com/663432/76500714-0a668780-640f-11ea-82b0-18747e15ca0a.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12359

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
