### PR TITLE
Add support to MQTT JSON Device Tracker for user defined JSON fields

### DIFF
--- a/homeassistant/components/mqtt_json/device_tracker.py
+++ b/homeassistant/components/mqtt_json/device_tracker.py
@@ -19,18 +19,23 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-GPS_JSON_PAYLOAD_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_LATITUDE): vol.Coerce(float),
-        vol.Required(ATTR_LONGITUDE): vol.Coerce(float),
-        vol.Optional(ATTR_GPS_ACCURACY): vol.Coerce(int),
-        vol.Optional(ATTR_BATTERY_LEVEL): vol.Coerce(str),
-    },
-    extra=vol.ALLOW_EXTRA,
-)
+CONF_LATITUDE_FIELD_NAME = "latitude_field"
+CONF_LONGITUDE_FIELD_NAME = "longitude_field"
+CONF_GPS_ACCURACY_FIELD_NAME = "gps_accuracy_field"
+CONF_BATTERY_LEVEL_FIELD_NAME = "battery_level_field"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(mqtt.SCHEMA_BASE).extend(
-    {vol.Required(CONF_DEVICES): {cv.string: mqtt.valid_subscribe_topic}}
+    {
+        vol.Required(CONF_DEVICES): {cv.string: mqtt.valid_subscribe_topic},
+        vol.Optional(CONF_LATITUDE_FIELD_NAME, default=ATTR_LATITUDE): cv.string,
+        vol.Optional(CONF_LONGITUDE_FIELD_NAME, default=ATTR_LONGITUDE): cv.string,
+        vol.Optional(
+            CONF_GPS_ACCURACY_FIELD_NAME, default=ATTR_GPS_ACCURACY
+        ): cv.string,
+        vol.Optional(
+            CONF_BATTERY_LEVEL_FIELD_NAME, default=ATTR_BATTERY_LEVEL
+        ): cv.string,
+    }
 )
 
 
@@ -45,7 +50,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
         def async_message_received(msg, dev_id=dev_id):
             """Handle received MQTT message."""
             try:
-                data = GPS_JSON_PAYLOAD_SCHEMA(json.loads(msg.payload))
+                data = input_schema(config)(json.loads(msg.payload))
             except vol.MultipleInvalid:
                 _LOGGER.error(
                     "Skipping update for following data "
@@ -57,7 +62,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
                 _LOGGER.error("Error parsing JSON payload: %s", msg.payload)
                 return
 
-            kwargs = _parse_see_args(dev_id, data)
+            kwargs = _parse_see_args(dev_id, config, data)
             hass.async_create_task(async_see(**kwargs))
 
         await mqtt.async_subscribe(hass, topic, async_message_received, qos)
@@ -65,12 +70,31 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     return True
 
 
-def _parse_see_args(dev_id, data):
-    """Parse the payload location parameters, into the format see expects."""
-    kwargs = {"gps": (data[ATTR_LATITUDE], data[ATTR_LONGITUDE]), "dev_id": dev_id}
+def input_schema(config):
+    """Compute a JSON schema based on user defined property names."""
+    return vol.Schema(
+        {
+            vol.Required(config[CONF_LATITUDE_FIELD_NAME]): vol.Coerce(float),
+            vol.Required(config[CONF_LONGITUDE_FIELD_NAME]): vol.Coerce(float),
+            vol.Optional(config[CONF_GPS_ACCURACY_FIELD_NAME]): vol.Coerce(int),
+            vol.Optional(config[CONF_BATTERY_LEVEL_FIELD_NAME]): vol.Coerce(str),
+        },
+        extra=vol.ALLOW_EXTRA,
+    )
 
-    if ATTR_GPS_ACCURACY in data:
-        kwargs[ATTR_GPS_ACCURACY] = data[ATTR_GPS_ACCURACY]
-    if ATTR_BATTERY_LEVEL in data:
-        kwargs["battery"] = data[ATTR_BATTERY_LEVEL]
+
+def _parse_see_args(dev_id, config, data):
+    """Parse the payload location parameters, into the format see expects."""
+    kwargs = {
+        "gps": (
+            data[config[CONF_LATITUDE_FIELD_NAME]],
+            data[config[CONF_LONGITUDE_FIELD_NAME]],
+        ),
+        "dev_id": dev_id,
+    }
+
+    if config[CONF_GPS_ACCURACY_FIELD_NAME] in data:
+        kwargs[ATTR_GPS_ACCURACY] = data[config[CONF_GPS_ACCURACY_FIELD_NAME]]
+    if config[CONF_BATTERY_LEVEL_FIELD_NAME] in data:
+        kwargs["battery"] = data[config[CONF_BATTERY_LEVEL_FIELD_NAME]]
     return kwargs

--- a/tests/components/mqtt_json/test_device_tracker.py
+++ b/tests/components/mqtt_json/test_device_tracker.py
@@ -24,6 +24,8 @@ LOCATION_MESSAGE = {
     "battery_level": 99.9,
 }
 
+LOCATION_MESSAGE_ALT_FORMAT = {"lon": 1.0, "acc": 14, "lat": 2.0, "batt": 99.9}
+
 LOCATION_MESSAGE_INCOMPLETE = {"longitude": 2.0}
 
 
@@ -76,6 +78,37 @@ async def test_json_message(hass):
     state = hass.states.get("device_tracker.zanzito")
     assert state.attributes.get("latitude") == 2.0
     assert state.attributes.get("longitude") == 1.0
+    assert state.attributes.get("gps_accuracy") == 60.0
+    assert state.attributes.get("battery") == "99.9"
+
+
+async def test_json_message_alt_format(hass):
+    """Test json location message with user defined field names."""
+    dev_id = "zanzito"
+    topic = "location/zanzito"
+    location = json.dumps(LOCATION_MESSAGE_ALT_FORMAT)
+
+    assert await async_setup_component(
+        hass,
+        DT_DOMAIN,
+        {
+            DT_DOMAIN: {
+                CONF_PLATFORM: "mqtt_json",
+                "devices": {dev_id: topic},
+                "latitude_field": "lat",
+                "longitude_field": "lon",
+                "gps_accuracy_field": "acc",
+                "battery_level_field": "batt",
+            }
+        },
+    )
+    async_fire_mqtt_message(hass, topic, location)
+    await hass.async_block_till_done()
+    state = hass.states.get("device_tracker.zanzito")
+    assert state.attributes.get("latitude") == 2.0
+    assert state.attributes.get("longitude") == 1.0
+    assert state.attributes.get("gps_accuracy") == 14.0
+    assert state.attributes.get("battery") == "99.9"
 
 
 async def test_non_json_message(hass, caplog):
@@ -136,6 +169,8 @@ async def test_single_level_wildcard_topic(hass):
     state = hass.states.get("device_tracker.zanzito")
     assert state.attributes.get("latitude") == 2.0
     assert state.attributes.get("longitude") == 1.0
+    assert state.attributes.get("gps_accuracy") == 60.0
+    assert state.attributes.get("battery") == "99.9"
 
 
 async def test_multi_level_wildcard_topic(hass):
@@ -155,6 +190,8 @@ async def test_multi_level_wildcard_topic(hass):
     state = hass.states.get("device_tracker.zanzito")
     assert state.attributes.get("latitude") == 2.0
     assert state.attributes.get("longitude") == 1.0
+    assert state.attributes.get("gps_accuracy") == 60.0
+    assert state.attributes.get("battery") == "99.9"
 
 
 async def test_single_level_wildcard_topic_not_matching(hass):


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'd like mqtt_json to be more flexible when it comes to the JSON property names it can read from.  This is a non-breaking change, with the default values remaining as-is.

I added a test case, and improved the existing test cases to check for more properties.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
device_tracker:
  - platform: mqtt_json
    latitude_field: lat
    longitude_field: lon
    gps_accuracy_field: acc
    devices:
       dv: 'topic/sub/location'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12353

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
