### PR TITLE
Add Tado set presence

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -165,6 +165,7 @@ class TadoConnector:
     def set_presence(
         self, presence="HOME",
     ):
+        """Set the presence to home or away"""
         if presence == "AWAY":
             self.tado.setAway()
         else:

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -11,6 +11,10 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.util import Throttle
+from homeassistant.components.climate.const import (
+    PRESET_AWAY,
+    PRESET_HOME,
+)
 
 from .const import CONF_FALLBACK, DATA
 
@@ -163,10 +167,10 @@ class TadoConnector:
         self.update_sensor("zone", zone_id)
 
     def set_presence(
-        self, presence="HOME",
+        self, presence=PRESET_HOME,
     ):
         """Set the presence to home or away."""
-        if presence == "AWAY":
+        if presence == PRESET_AWAY:
             self.tado.setAway()
         else:
             self.tado.setHome()

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -7,14 +7,11 @@ from PyTado.interface import Tado
 import voluptuous as vol
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.components.climate.const import PRESET_AWAY, PRESET_HOME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.util import Throttle
-from homeassistant.components.climate.const import (
-    PRESET_AWAY,
-    PRESET_HOME,
-)
 
 from .const import CONF_FALLBACK, DATA
 

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -169,7 +169,7 @@ class TadoConnector:
         """Set the presence to home or away."""
         if presence == PRESET_AWAY:
             self.tado.setAway()
-        else:
+        elif presence == PRESET_HOME:
             self.tado.setHome()
 
     def set_zone_overlay(

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -165,7 +165,7 @@ class TadoConnector:
     def set_presence(
         self, presence="HOME",
     ):
-        """Set the presence to home or away"""
+        """Set the presence to home or away."""
         if presence == "AWAY":
             self.tado.setAway()
         else:

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -6,8 +6,8 @@ import urllib
 from PyTado.interface import Tado
 import voluptuous as vol
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.components.climate.const import PRESET_AWAY, PRESET_HOME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -162,6 +162,15 @@ class TadoConnector:
         self.tado.resetZoneOverlay(zone_id)
         self.update_sensor("zone", zone_id)
 
+    def set_presence (
+        self,
+        presence="HOME",
+    ):
+        if presence == "AWAY":
+            self.tado.setAway()
+        else:
+            self.tado.setHome()
+
     def set_zone_overlay(
         self,
         zone_id,

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -162,9 +162,8 @@ class TadoConnector:
         self.tado.resetZoneOverlay(zone_id)
         self.update_sensor("zone", zone_id)
 
-    def set_presence (
-        self,
-        presence="HOME",
+    def set_presence(
+        self, presence="HOME",
     ):
         if presence == "AWAY":
             self.tado.setAway()

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -289,7 +289,15 @@ class TadoClimate(ClimateDevice):
 
     def set_preset_mode(self, preset_mode):
         """Set new preset mode."""
-        pass
+        print(preset_mode)
+        if preset_mode is None:
+            return
+        elif preset_mode == "away":
+            _LOGGER.debug("Setting presence to away")
+            self._tado.set_presence("AWAY")
+        else:
+            _LOGGER.debug("Setting presence to home")
+            self._tado.set_presence("HOME")
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -289,15 +289,12 @@ class TadoClimate(ClimateDevice):
 
     def set_preset_mode(self, preset_mode):
         """Set new preset mode."""
-        print(preset_mode)
-        if preset_mode is None:
-            return
-        elif preset_mode == "away":
+        if preset_mode == PRESET_AWAY:
             _LOGGER.debug("Setting presence to away")
-            self._tado.set_presence("AWAY")
+            self._tado.set_presence(PRESET_AWAY)
         else:
             _LOGGER.debug("Setting presence to home")
-            self._tado.set_presence("HOME")
+            self._tado.set_presence(PRESET_HOME)
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -289,12 +289,7 @@ class TadoClimate(ClimateDevice):
 
     def set_preset_mode(self, preset_mode):
         """Set new preset mode."""
-        if preset_mode == PRESET_AWAY:
-            _LOGGER.debug("Setting presence to away")
-            self._tado.set_presence(PRESET_AWAY)
-        elif preset_mode == PRESET_HOME:
-            _LOGGER.debug("Setting presence to home")
-            self._tado.set_presence(PRESET_HOME)
+        self._tado.set_presence(preset_mode)
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -292,7 +292,7 @@ class TadoClimate(ClimateDevice):
         if preset_mode == PRESET_AWAY:
             _LOGGER.debug("Setting presence to away")
             self._tado.set_presence(PRESET_AWAY)
-        else:
+        elif preset_mode == PRESET_HOME:
             _LOGGER.debug("Setting presence to home")
             self._tado.set_presence(PRESET_HOME)
 

--- a/homeassistant/components/tado/manifest.json
+++ b/homeassistant/components/tado/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tado",
   "documentation": "https://www.home-assistant.io/integrations/tado",
   "requirements": [
-    "python-tado==0.3.0"
+    "python-tado==0.5.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1653,7 +1653,7 @@ python-songpal==0.11.2
 python-synology==0.4.0
 
 # homeassistant.components.tado
-python-tado==0.3.0
+python-tado==0.5.0
 
 # homeassistant.components.telegram_bot
 python-telegram-bot==11.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows tado users to set their presence manually without having geofencing enabled in their settings. So setting the thermostat to home when home and to away when away. It depends on this change in PyTado: https://github.com/wmalgadey/PyTado/pull/30/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

https://www.home-assistant.io/integrations/tado

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/wmalgadey/PyTado/pull/30/
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ not tested, how? ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
