### PR TITLE
Fix handling of attribute reports in ZHA sensors and binary sensors

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -72,7 +72,6 @@ class BinarySensor(ZhaEntity, BinarySensorDevice):
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._channel = channels[0]
         self._device_class = self.DEVICE_CLASS
-        self._sensor_attr = self.SENSOR_ATTR
 
     async def get_device_class(self):
         """Get the HA device class from the channel."""
@@ -107,7 +106,7 @@ class BinarySensor(ZhaEntity, BinarySensorDevice):
     @callback
     def async_set_state(self, attr_id, attr_name, value):
         """Set the state."""
-        if self._sensor_attr is None or self._sensor_attr != attr_name:
+        if self.SENSOR_ATTR is None or self.SENSOR_ATTR != attr_name:
             return
         self._state = bool(value)
         self.async_write_ha_state()
@@ -148,6 +147,8 @@ class Opening(BinarySensor):
 @STRICT_MATCH(channel_names=CHANNEL_ZONE)
 class IASZone(BinarySensor):
     """ZHA IAS BinarySensor."""
+
+    SENSOR_ATTR = "zone_status"
 
     async def get_device_class(self) -> None:
         """Get the HA device class from the channel."""

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -64,6 +64,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class BinarySensor(ZhaEntity, BinarySensorDevice):
     """ZHA BinarySensor."""
 
+    SENSOR_ATTR = None
     DEVICE_CLASS = None
 
     def __init__(self, unique_id, zha_device, channels, **kwargs):
@@ -71,6 +72,7 @@ class BinarySensor(ZhaEntity, BinarySensorDevice):
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._channel = channels[0]
         self._device_class = self.DEVICE_CLASS
+        self._sensor_attr = self.SENSOR_ATTR
 
     async def get_device_class(self):
         """Get the HA device class from the channel."""
@@ -105,6 +107,8 @@ class BinarySensor(ZhaEntity, BinarySensorDevice):
     @callback
     def async_set_state(self, attr_id, attr_name, value):
         """Set the state."""
+        if self._sensor_attr is None or self._sensor_attr != attr_name:
+            return
         self._state = bool(value)
         self.async_write_ha_state()
 
@@ -121,6 +125,7 @@ class BinarySensor(ZhaEntity, BinarySensorDevice):
 class Accelerometer(BinarySensor):
     """ZHA BinarySensor."""
 
+    SENSOR_ATTR = "acceleration"
     DEVICE_CLASS = DEVICE_CLASS_MOVING
 
 
@@ -128,6 +133,7 @@ class Accelerometer(BinarySensor):
 class Occupancy(BinarySensor):
     """ZHA BinarySensor."""
 
+    SENSOR_ATTR = "occupancy"
     DEVICE_CLASS = DEVICE_CLASS_OCCUPANCY
 
 
@@ -135,6 +141,7 @@ class Occupancy(BinarySensor):
 class Opening(BinarySensor):
     """ZHA BinarySensor."""
 
+    SENSOR_ATTR = "on_off"
     DEVICE_CLASS = DEVICE_CLASS_OPENING
 
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -83,6 +83,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class Sensor(ZhaEntity):
     """Base ZHA sensor."""
 
+    SENSOR_ATTR = None
     _decimals = 1
     _device_class = None
     _divisor = 1
@@ -93,6 +94,7 @@ class Sensor(ZhaEntity):
         """Init this sensor."""
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._channel = channels[0]
+        self._sensor_attr = self.SENSOR_ATTR
 
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""
@@ -126,6 +128,8 @@ class Sensor(ZhaEntity):
     @callback
     def async_set_state(self, attr_id, attr_name, value):
         """Handle state update from channel."""
+        if self._sensor_attr is None or self._sensor_attr != attr_name:
+            return
         if value is not None:
             value = self.formatter(value)
         self._state = value
@@ -154,6 +158,7 @@ class Sensor(ZhaEntity):
 class AnalogInput(Sensor):
     """Sensor that displays analog input values."""
 
+    SENSOR_ATTR = "present_value"
     pass
 
 
@@ -161,6 +166,7 @@ class AnalogInput(Sensor):
 class Battery(Sensor):
     """Battery sensor of power configuration cluster."""
 
+    SENSOR_ATTR = "battery_percentage_remaining"
     _device_class = DEVICE_CLASS_BATTERY
     _unit = UNIT_PERCENTAGE
 
@@ -198,6 +204,7 @@ class Battery(Sensor):
 class ElectricalMeasurement(Sensor):
     """Active power measurement."""
 
+    SENSOR_ATTR = "active_power"
     _device_class = DEVICE_CLASS_POWER
     _divisor = 10
     _unit = POWER_WATT
@@ -232,6 +239,7 @@ class Text(Sensor):
 class Humidity(Sensor):
     """Humidity sensor."""
 
+    SENSOR_ATTR = "measured_value"
     _device_class = DEVICE_CLASS_HUMIDITY
     _divisor = 100
     _unit = UNIT_PERCENTAGE
@@ -241,6 +249,7 @@ class Humidity(Sensor):
 class Illuminance(Sensor):
     """Illuminance Sensor."""
 
+    SENSOR_ATTR = "measured_value"
     _device_class = DEVICE_CLASS_ILLUMINANCE
     _unit = "lx"
 
@@ -254,6 +263,7 @@ class Illuminance(Sensor):
 class SmartEnergyMetering(Sensor):
     """Metering sensor."""
 
+    SENSOR_ATTR = "instantaneous_demand"
     _device_class = DEVICE_CLASS_POWER
 
     def formatter(self, value):
@@ -270,6 +280,7 @@ class SmartEnergyMetering(Sensor):
 class Pressure(Sensor):
     """Pressure sensor."""
 
+    SENSOR_ATTR = "measured_value"
     _device_class = DEVICE_CLASS_PRESSURE
     _decimals = 0
     _unit = "hPa"
@@ -279,6 +290,7 @@ class Pressure(Sensor):
 class Temperature(Sensor):
     """Temperature Sensor."""
 
+    SENSOR_ATTR = "measured_value"
     _device_class = DEVICE_CLASS_TEMPERATURE
     _divisor = 100
     _unit = TEMP_CELSIUS

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -94,7 +94,6 @@ class Sensor(ZhaEntity):
         """Init this sensor."""
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._channel = channels[0]
-        self._sensor_attr = self.SENSOR_ATTR
 
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""
@@ -128,7 +127,7 @@ class Sensor(ZhaEntity):
     @callback
     def async_set_state(self, attr_id, attr_name, value):
         """Handle state update from channel."""
-        if self._sensor_attr is None or self._sensor_attr != attr_name:
+        if self.SENSOR_ATTR is None or self.SENSOR_ATTR != attr_name:
             return
         if value is not None:
             value = self.formatter(value)

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -102,6 +102,23 @@ def make_attribute(attrid, value, status=0):
     return attr
 
 
+def send_attribute_report(hass, cluster, attrid, value):
+    """Send a single attribute report."""
+    return send_attributes_report(hass, cluster, {attrid: value})
+
+
+async def send_attributes_report(hass, cluster: int, attributes: dict):
+    """Cause the sensor to receive an attribute report from the network.
+
+    This is to simulate the normal device communication that happens when a
+    device is paired to the zigbee network.
+    """
+    attrs = [make_attribute(attrid, value) for attrid, value in attributes.items()]
+    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
+    cluster.handle_message(hdr, [attrs])
+    await hass.async_block_till_done()
+
+
 async def find_entity_id(domain, zha_device, hass):
     """Find the entity id under the testing.
 

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -2,7 +2,6 @@
 import pytest
 import zigpy.zcl.clusters.measurement as measurement
 import zigpy.zcl.clusters.security as security
-import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.binary_sensor import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
@@ -11,8 +10,7 @@ from .common import (
     async_enable_traffic,
     async_test_rejoin,
     find_entity_id,
-    make_attribute,
-    make_zcl_header,
+    send_attributes_report,
 )
 
 DEVICE_IAS = {
@@ -36,17 +34,11 @@ DEVICE_OCCUPANCY = {
 async def async_test_binary_sensor_on_off(hass, cluster, entity_id):
     """Test getting on and off messages for binary sensors."""
     # binary sensor on
-    attr = make_attribute(0, 1)
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
-
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
+    await send_attributes_report(hass, cluster, {1: 0, 0: 1, 2: 2})
     assert hass.states.get(entity_id).state == STATE_ON
 
     # binary sensor off
-    attr.value.value = 0
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
+    await send_attributes_report(hass, cluster, {1: 1, 0: 0, 2: 2})
     assert hass.states.get(entity_id).state == STATE_OFF
 
 

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -14,8 +14,7 @@ from .common import (
     async_enable_traffic,
     async_test_rejoin,
     find_entity_id,
-    make_attribute,
-    make_zcl_header,
+    send_attributes_report,
 )
 
 from tests.common import mock_coro
@@ -64,19 +63,12 @@ async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
     await async_enable_traffic(hass, [zha_device])
     await hass.async_block_till_done()
 
-    attr = make_attribute(8, 100)
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
-
     # test that the state has changed from unavailable to off
+    await send_attributes_report(hass, cluster, {0: 0, 8: 100, 1: 1})
     assert hass.states.get(entity_id).state == STATE_CLOSED
 
     # test to see if it opens
-    attr = make_attribute(8, 0)
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
+    await send_attributes_report(hass, cluster, {0: 1, 8: 0, 1: 100})
     assert hass.states.get(entity_id).state == STATE_OPEN
 
     # close from UI

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -4,7 +4,6 @@ import time
 
 import pytest
 import zigpy.zcl.clusters.general as general
-import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.device_tracker import DOMAIN, SOURCE_TYPE_ROUTER
 from homeassistant.components.zha.core.registries import (
@@ -17,8 +16,7 @@ from .common import (
     async_enable_traffic,
     async_test_rejoin,
     find_entity_id,
-    make_attribute,
-    make_zcl_header,
+    send_attributes_report,
 )
 
 from tests.common import async_fire_time_changed
@@ -66,12 +64,9 @@ async def test_device_tracker(hass, zha_device_joined_restored, zigpy_device_dt)
     assert hass.states.get(entity_id).state == STATE_NOT_HOME
 
     # turn state flip
-    attr = make_attribute(0x0020, 23)
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
-    cluster.handle_message(hdr, [[attr]])
-
-    attr = make_attribute(0x0021, 200)
-    cluster.handle_message(hdr, [[attr]])
+    await send_attributes_report(
+        hass, cluster, {0x0000: 0, 0x0020: 23, 0x0021: 200, 0x0001: 2}
+    )
 
     zigpy_device_dt.last_seen = time.time() + 10
     next_update = dt_util.utcnow() + timedelta(seconds=30)

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -10,12 +10,7 @@ import zigpy.zcl.foundation as zcl_f
 from homeassistant.components.lock import DOMAIN
 from homeassistant.const import STATE_LOCKED, STATE_UNAVAILABLE, STATE_UNLOCKED
 
-from .common import (
-    async_enable_traffic,
-    find_entity_id,
-    make_attribute,
-    make_zcl_header,
-)
+from .common import async_enable_traffic, find_entity_id, send_attributes_report
 
 from tests.common import mock_coro
 
@@ -58,16 +53,11 @@ async def test_lock(hass, lock):
     assert hass.states.get(entity_id).state == STATE_UNLOCKED
 
     # set state to locked
-    attr = make_attribute(0, 1)
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
+    await send_attributes_report(hass, cluster, {1: 0, 0: 1, 2: 2})
     assert hass.states.get(entity_id).state == STATE_LOCKED
 
     # set state to unlocked
-    attr.value.value = 2
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
+    await send_attributes_report(hass, cluster, {1: 0, 0: 2, 2: 3})
     assert hass.states.get(entity_id).state == STATE_UNLOCKED
 
     # lock from HA

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -6,7 +6,6 @@ import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.homeautomation as homeautomation
 import zigpy.zcl.clusters.measurement as measurement
 import zigpy.zcl.clusters.smartenergy as smartenergy
-import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.sensor import DOMAIN
 import homeassistant.config as config_util
@@ -28,38 +27,41 @@ from .common import (
     async_enable_traffic,
     async_test_rejoin,
     find_entity_id,
-    make_attribute,
-    make_zcl_header,
+    send_attribute_report,
+    send_attributes_report,
 )
 
 
 async def async_test_humidity(hass, cluster, entity_id):
     """Test humidity sensor."""
-    await send_attribute_report(hass, cluster, 0, 1000)
+    await send_attributes_report(hass, cluster, {1: 1, 0: 1000, 2: 100})
     assert_state(hass, entity_id, "10.0", UNIT_PERCENTAGE)
 
 
 async def async_test_temperature(hass, cluster, entity_id):
     """Test temperature sensor."""
-    await send_attribute_report(hass, cluster, 0, 2900)
+    await send_attributes_report(hass, cluster, {1: 1, 0: 2900, 2: 100})
     assert_state(hass, entity_id, "29.0", "°C")
 
 
 async def async_test_pressure(hass, cluster, entity_id):
     """Test pressure sensor."""
-    await send_attribute_report(hass, cluster, 0, 1000)
+    await send_attributes_report(hass, cluster, {1: 1, 0: 1000, 2: 10000})
+    assert_state(hass, entity_id, "1000", "hPa")
+
+    await send_attributes_report(hass, cluster, {0: 1000, 20: -1, 16: 10000})
     assert_state(hass, entity_id, "1000", "hPa")
 
 
 async def async_test_illuminance(hass, cluster, entity_id):
     """Test illuminance sensor."""
-    await send_attribute_report(hass, cluster, 0, 10)
+    await send_attributes_report(hass, cluster, {1: 1, 0: 10, 2: 20})
     assert_state(hass, entity_id, "1.0", "lx")
 
 
 async def async_test_metering(hass, cluster, entity_id):
     """Test metering sensor."""
-    await send_attribute_report(hass, cluster, 1024, 12345)
+    await send_attributes_report(hass, cluster, {1025: 1, 1024: 12345, 1026: 100})
     assert_state(hass, entity_id, "12345.0", "unknown")
 
 
@@ -73,17 +75,17 @@ async def async_test_electrical_measurement(hass, cluster, entity_id):
         new_callable=mock.PropertyMock,
     ) as divisor_mock:
         divisor_mock.return_value = 1
-        await send_attribute_report(hass, cluster, 1291, 100)
+        await send_attributes_report(hass, cluster, {0: 1, 1291: 100, 10: 1000})
         assert_state(hass, entity_id, "100", "W")
 
-        await send_attribute_report(hass, cluster, 1291, 99)
+        await send_attributes_report(hass, cluster, {0: 1, 1291: 99, 10: 1000})
         assert_state(hass, entity_id, "99", "W")
 
         divisor_mock.return_value = 10
-        await send_attribute_report(hass, cluster, 1291, 1000)
+        await send_attributes_report(hass, cluster, {0: 1, 1291: 1000, 10: 5000})
         assert_state(hass, entity_id, "100", "W")
 
-        await send_attribute_report(hass, cluster, 1291, 99)
+        await send_attributes_report(hass, cluster, {0: 1, 1291: 99, 10: 5000})
         assert_state(hass, entity_id, "9.9", "W")
 
 
@@ -139,18 +141,6 @@ async def test_sensor(
 
     # test rejoin
     await async_test_rejoin(hass, zigpy_device, [cluster], (report_count,))
-
-
-async def send_attribute_report(hass, cluster, attrid, value):
-    """Cause the sensor to receive an attribute report from the network.
-
-    This is to simulate the normal device communication that happens when a
-    device is paired to the zigbee network.
-    """
-    attr = make_attribute(attrid, value)
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
 
 
 def assert_state(hass, entity_id, state, unit_of_measurement):

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -12,8 +12,7 @@ from .common import (
     async_enable_traffic,
     async_test_rejoin,
     find_entity_id,
-    make_attribute,
-    make_zcl_header,
+    send_attributes_report,
 )
 
 from tests.common import mock_coro
@@ -53,16 +52,11 @@ async def test_switch(hass, zha_device_joined_restored, zigpy_device):
     assert hass.states.get(entity_id).state == STATE_OFF
 
     # turn on at switch
-    attr = make_attribute(0, 1)
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
+    await send_attributes_report(hass, cluster, {1: 0, 0: 1, 2: 2})
     assert hass.states.get(entity_id).state == STATE_ON
 
     # turn off at switch
-    attr.value.value = 0
-    cluster.handle_message(hdr, [[attr]])
-    await hass.async_block_till_done()
+    await send_attributes_report(hass, cluster, {1: 1, 0: 0, 2: 2})
     assert hass.states.get(entity_id).state == STATE_OFF
 
     # turn on from HA


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes an issue that was introduced with a recent refactoring of the channels. We were allowing anny attribute report to set the state instead of just the attribute that we cared about. @Adminiuga added to the tests to prevent this from happening in the future. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
