### PR TITLE
Fix flaky tests for HMIPC

### DIFF
--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -1,5 +1,5 @@
 """Initializer helpers for HomematicIP fake server."""
-from asynctest import CoroutineMock, MagicMock, Mock
+from asynctest import CoroutineMock, MagicMock, Mock, patch
 from homematicip.aio.auth import AsyncAuth
 from homematicip.aio.connection import AsyncConnection
 from homematicip.aio.home import AsyncHome
@@ -106,9 +106,10 @@ async def mock_hap_with_service_fixture(
 
 
 @pytest.fixture(name="simple_mock_home")
-def simple_mock_home_fixture() -> AsyncHome:
-    """Return a simple AsyncHome Mock."""
-    return Mock(
+def simple_mock_home_fixture():
+    """Return a simple mocked connection."""
+
+    mock_home = Mock(
         spec=AsyncHome,
         name="Demo",
         devices=[],
@@ -119,6 +120,27 @@ def simple_mock_home_fixture() -> AsyncHome:
         dutyCycle=88,
         connected=True,
     )
+
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncHome",
+        autospec=True,
+        return_value=mock_home,
+    ):
+        yield
+
+
+@pytest.fixture(name="mock_connection_init")
+def mock_connection_init_fixture():
+    """Return a simple mocked connection."""
+
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncHome.init",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncAuth.init",
+        return_value=None,
+    ):
+        yield
 
 
 @pytest.fixture(name="simple_mock_auth")

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -16,12 +16,15 @@ DEFAULT_CONFIG = {HMIPC_HAPID: "ABC123", HMIPC_PIN: "123", HMIPC_NAME: "hmip"}
 IMPORT_CONFIG = {HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "123", HMIPC_NAME: "hmip"}
 
 
-async def test_flow_works(hass):
+async def test_flow_works(hass, simple_mock_home):
     """Test config flow."""
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
         return_value=False,
+    ), patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.get_auth",
+        return_value=True,
     ):
         result = await hass.config_entries.flow.async_init(
             HMIPC_DOMAIN, context={"source": "user"}, data=DEFAULT_CONFIG
@@ -137,7 +140,7 @@ async def test_init_already_configured(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_import_config(hass):
+async def test_import_config(hass, simple_mock_home):
     """Test importing a host with an existing config file."""
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -125,14 +125,11 @@ async def test_hap_create(hass, hmip_config_entry, simple_mock_home):
     hass.config.components.add(HMIPC_DOMAIN)
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
-    with patch(
-        "homeassistant.components.homematicip_cloud.hap.AsyncHome",
-        return_value=simple_mock_home,
-    ), patch.object(hap, "async_connect"):
+    with patch.object(hap, "async_connect"):
         assert await hap.async_setup()
 
 
-async def test_hap_create_exception(hass, hmip_config_entry):
+async def test_hap_create_exception(hass, hmip_config_entry, mock_connection_init):
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(HMIPC_DOMAIN)
 

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -24,7 +24,9 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry
 
 
-async def test_config_with_accesspoint_passed_to_config_entry(hass):
+async def test_config_with_accesspoint_passed_to_config_entry(
+    hass, mock_connection, simple_mock_home
+):
     """Test that config for a accesspoint are loaded via config entry."""
 
     entry_config = {
@@ -51,7 +53,9 @@ async def test_config_with_accesspoint_passed_to_config_entry(hass):
     assert isinstance(hass.data[HMIPC_DOMAIN]["ABC123"], HomematicipHAP)
 
 
-async def test_config_already_registered_not_passed_to_config_entry(hass):
+async def test_config_already_registered_not_passed_to_config_entry(
+    hass, simple_mock_home
+):
     """Test that an already registered accesspoint does not get imported."""
 
     mock_config = {HMIPC_AUTHTOKEN: "123", HMIPC_HAPID: "ABC123", HMIPC_NAME: "name"}
@@ -87,7 +91,9 @@ async def test_config_already_registered_not_passed_to_config_entry(hass):
     assert config_entries[0].unique_id == "ABC123"
 
 
-async def test_load_entry_fails_due_to_connection_error(hass, hmip_config_entry):
+async def test_load_entry_fails_due_to_connection_error(
+    hass, hmip_config_entry, mock_connection_init
+):
     """Test load entry fails due to connection error."""
     hmip_config_entry.add_to_hass(hass)
 
@@ -101,7 +107,9 @@ async def test_load_entry_fails_due_to_connection_error(hass, hmip_config_entry)
     assert hmip_config_entry.state == ENTRY_STATE_SETUP_RETRY
 
 
-async def test_load_entry_fails_due_to_generic_exception(hass, hmip_config_entry):
+async def test_load_entry_fails_due_to_generic_exception(
+    hass, hmip_config_entry, simple_mock_home
+):
     """Test load entry fails due to generic exception."""
     hmip_config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR tries to get rid of the flaky tests.
- by mocking away not relevant parts of the upstream lib
- avoiding access to homematicip.aio.connection.AsyncConnection methods

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32794
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
