### PR TITLE
Require a hyphen in lovelace dashboard url

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import frontend
-from homeassistant.const import CONF_FILENAME, EVENT_HOMEASSISTANT_START
+from homeassistant.const import CONF_FILENAME
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import collection, config_validation as cv
@@ -171,40 +171,34 @@ async def async_setup(hass, config):
         except ValueError:
             _LOGGER.warning("Failed to %s panel %s from storage", change_type, url_path)
 
-    async def async_setup_dashboards(event):
-        """Register dashboards on startup."""
-        # Process YAML dashboards
-        for url_path, dashboard_conf in hass.data[DOMAIN]["yaml_dashboards"].items():
-            # For now always mode=yaml
-            config = dashboard.LovelaceYAML(hass, url_path, dashboard_conf)
-            hass.data[DOMAIN]["dashboards"][url_path] = config
+    # Process YAML dashboards
+    for url_path, dashboard_conf in hass.data[DOMAIN]["yaml_dashboards"].items():
+        # For now always mode=yaml
+        config = dashboard.LovelaceYAML(hass, url_path, dashboard_conf)
+        hass.data[DOMAIN]["dashboards"][url_path] = config
 
-            if "-" not in url_path:
-                _LOGGER.warning(
-                    "Panel url path %s does not contain a hyphen (-)", url_path
-                )
-                continue
+        if "-" not in url_path:
+            _LOGGER.warning("Panel url path %s does not contain a hyphen (-)", url_path)
+            continue
 
-            try:
-                _register_panel(hass, url_path, MODE_YAML, dashboard_conf, False)
-            except ValueError:
-                _LOGGER.warning("Panel url path %s is not unique", url_path)
+        try:
+            _register_panel(hass, url_path, MODE_YAML, dashboard_conf, False)
+        except ValueError:
+            _LOGGER.warning("Panel url path %s is not unique", url_path)
 
-        # Process storage dashboards
-        dashboards_collection = dashboard.DashboardsCollection(hass)
+    # Process storage dashboards
+    dashboards_collection = dashboard.DashboardsCollection(hass)
 
-        dashboards_collection.async_add_listener(storage_dashboard_changed)
-        await dashboards_collection.async_load()
+    dashboards_collection.async_add_listener(storage_dashboard_changed)
+    await dashboards_collection.async_load()
 
-        collection.StorageCollectionWebsocket(
-            dashboards_collection,
-            "lovelace/dashboards",
-            "dashboard",
-            STORAGE_DASHBOARD_CREATE_FIELDS,
-            STORAGE_DASHBOARD_UPDATE_FIELDS,
-        ).async_setup(hass, create_list=False)
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_setup_dashboards)
+    collection.StorageCollectionWebsocket(
+        dashboards_collection,
+        "lovelace/dashboards",
+        "dashboard",
+        STORAGE_DASHBOARD_CREATE_FIELDS,
+        STORAGE_DASHBOARD_UPDATE_FIELDS,
+    ).async_setup(hass, create_list=False)
 
     return True
 

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -144,6 +144,9 @@ async def async_setup(hass, config):
 
         if change_type == collection.CHANGE_ADDED:
 
+            if "-" not in url_path:
+                url_path = "lovelace-%s" % url_path
+
             existing = hass.data[DOMAIN]["dashboards"].get(url_path)
 
             if existing:
@@ -162,10 +165,6 @@ async def async_setup(hass, config):
         else:
             hass.data[DOMAIN]["dashboards"][url_path].config = item
             update = True
-
-        if "-" not in url_path:
-            _LOGGER.warning("Panel url path %s does not contain a hyphen (-)", url_path)
-            return
 
         try:
             _register_panel(hass, url_path, MODE_STORAGE, item, update)

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -143,6 +143,7 @@ async def async_setup(hass, config):
             return
 
         if change_type == collection.CHANGE_ADDED:
+
             existing = hass.data[DOMAIN]["dashboards"].get(url_path)
 
             if existing:
@@ -162,6 +163,10 @@ async def async_setup(hass, config):
             hass.data[DOMAIN]["dashboards"][url_path].config = item
             update = True
 
+        if "-" not in url_path:
+            _LOGGER.warning("Panel url path %s does not contain a hyphen (-)", url_path)
+            return
+
         try:
             _register_panel(hass, url_path, MODE_STORAGE, item, update)
         except ValueError:
@@ -174,6 +179,12 @@ async def async_setup(hass, config):
             # For now always mode=yaml
             config = dashboard.LovelaceYAML(hass, url_path, dashboard_conf)
             hass.data[DOMAIN]["dashboards"][url_path] = config
+
+            if "-" not in url_path:
+                _LOGGER.warning(
+                    "Panel url path %s does not contain a hyphen (-)", url_path
+                )
+                continue
 
             try:
                 _register_panel(hass, url_path, MODE_YAML, dashboard_conf, False)

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -144,9 +144,6 @@ async def async_setup(hass, config):
 
         if change_type == collection.CHANGE_ADDED:
 
-            if "-" not in url_path:
-                url_path = "lovelace-%s" % url_path
-
             existing = hass.data[DOMAIN]["dashboards"].get(url_path)
 
             if existing:
@@ -176,10 +173,6 @@ async def async_setup(hass, config):
         # For now always mode=yaml
         config = dashboard.LovelaceYAML(hass, url_path, dashboard_conf)
         hass.data[DOMAIN]["dashboards"][url_path] = config
-
-        if "-" not in url_path:
-            _LOGGER.warning("Panel url path %s does not contain a hyphen (-)", url_path)
-            continue
 
         try:
             _register_panel(hass, url_path, MODE_YAML, dashboard_conf, False)

--- a/homeassistant/components/lovelace/const.py
+++ b/homeassistant/components/lovelace/const.py
@@ -76,6 +76,8 @@ def url_slug(value: Any) -> str:
     """Validate value is a valid url slug."""
     if value is None:
         raise vol.Invalid("Slug should not be None")
+    if "-" not in value:
+        raise vol.Invalid("Url path needs to contain a hyphen (-)")
     str_value = str(value)
     slg = slugify(str_value, separator="-")
     if str_value == slg:

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -233,7 +233,7 @@ class DashboardsCollection(collection.StorageCollection):
     async def _process_create_data(self, data: dict) -> dict:
         """Validate the config is valid."""
         if "-" not in data[CONF_URL_PATH]:
-            raise vol.Invalid("Panel url path needs to contain a hyphen (-)")
+            raise vol.Invalid("Url path needs to contain a hyphen (-)")
 
         if data[CONF_URL_PATH] in self.hass.data[DATA_PANELS]:
             raise vol.Invalid("Panel url path needs to be unique")

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -232,6 +232,9 @@ class DashboardsCollection(collection.StorageCollection):
 
     async def _process_create_data(self, data: dict) -> dict:
         """Validate the config is valid."""
+        if "-" not in data[CONF_URL_PATH]:
+            raise vol.Invalid("Panel url path needs to contain a hyphen (-)")
+
         if data[CONF_URL_PATH] in self.hass.data[DATA_PANELS]:
             raise vol.Invalid("Panel url path needs to be unique")
 

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 import logging
 import os
 import time
+from typing import Optional, cast
 
 import voluptuous as vol
 
@@ -229,6 +230,25 @@ class DashboardsCollection(collection.StorageCollection):
             storage.Store(hass, DASHBOARDS_STORAGE_VERSION, DASHBOARDS_STORAGE_KEY),
             _LOGGER,
         )
+
+    async def _async_load_data(self) -> Optional[dict]:
+        """Load the data."""
+        data = await self.store.async_load()
+
+        if data is None:
+            return cast(Optional[dict], data)
+
+        updated = False
+
+        for item in data["items"] or []:
+            if "-" not in item[CONF_URL_PATH]:
+                updated = True
+                item[CONF_URL_PATH] = f"lovelace-{item[CONF_URL_PATH]}"
+
+        if updated:
+            await self.store.async_save(data)
+
+        return cast(Optional[dict], data)
 
     async def _process_create_data(self, data: dict) -> dict:
         """Validate the config is valid."""

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -5,7 +5,6 @@ import pytest
 
 from homeassistant.components import frontend
 from homeassistant.components.lovelace import const, dashboard
-from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_capture_events, get_system_health_info
@@ -229,8 +228,6 @@ async def test_dashboard_from_yaml(hass, hass_ws_client, url_path):
             }
         },
     )
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
     assert hass.data[frontend.DATA_PANELS]["test-panel"].config == {"mode": "yaml"}
     assert hass.data[frontend.DATA_PANELS]["test-panel-no-sidebar"].config == {
         "mode": "yaml"
@@ -321,8 +318,6 @@ async def test_dashboard_from_yaml(hass, hass_ws_client, url_path):
 async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
     """Test we load lovelace config from storage."""
     assert await async_setup_component(hass, "lovelace", {})
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
     assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "storage"}
 
     client = await hass_ws_client(hass)
@@ -467,9 +462,6 @@ async def test_websocket_list_dashboards(hass, hass_ws_client):
             }
         },
     )
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For the current beta, current url paths that don't contain a  hyphen (`-`) will fail. 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To prevent collisions now or in the future between custom panels and our own build-in panels, we require panels to include a hyphen (`-`) in the url path.

Frontend PR: <https://github.com/home-assistant/frontend/pull/5214>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
