### PR TITLE
Add default port to samsung tv

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -42,10 +42,11 @@ class SamsungTVBridge(ABC):
 
     def __init__(self, method, host, port):
         """Initialize Bridge."""
-        self.port = 8001 if port is None else port
+        self.port = port
         self.method = method
         self.host = host
         self.token = None
+        self.default_port = None
         self._remote = None
         self._callback = None
 
@@ -191,6 +192,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         """Initialize Bridge."""
         super().__init__(method, host, port)
         self.token = token
+        self.default_port = 8001
 
     def try_connect(self):
         """Try to connect to the Websocket TV."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -42,7 +42,7 @@ class SamsungTVBridge(ABC):
 
     def __init__(self, method, host, port):
         """Initialize Bridge."""
-        self.port = port
+        self.port = 8001 if port is None else port
         self.method = method
         self.host = host
         self.token = None

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -71,13 +71,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     ):
         turn_on_action = hass.data[DOMAIN][ip_address][CONF_ON_ACTION]
         on_script = Script(hass, turn_on_action)
-    async_add_entities([SamsungTVDevice(config_entry, on_script)])
+    async_add_entities([SamsungTVDevice(hass, config_entry, on_script)])
 
 
 class SamsungTVDevice(MediaPlayerDevice):
     """Representation of a Samsung TV."""
 
-    def __init__(self, config_entry, on_script):
+    def __init__(self, hass, config_entry, on_script):
         """Initialize the Samsung device."""
         self._config_entry = config_entry
         self._manufacturer = config_entry.data.get(CONF_MANUFACTURER)
@@ -93,13 +93,21 @@ class SamsungTVDevice(MediaPlayerDevice):
         # Mark the end of a shutdown command (need to wait 15 seconds before
         # sending the next command to avoid turning the TV back ON).
         self._end_of_power_off = None
-        # Initialize bridge
-        self._bridge = SamsungTVBridge.get_bridge(
-            config_entry.data[CONF_METHOD],
-            config_entry.data[CONF_HOST],
-            config_entry.data[CONF_PORT],
-            config_entry.data.get(CONF_TOKEN),
-        )
+
+        data = config_entry.data.copy()
+        while True:
+            # Initialize bridge
+            self._bridge = SamsungTVBridge.get_bridge(
+                data[CONF_METHOD],
+                data[CONF_HOST],
+                data[CONF_PORT],
+                data.get(CONF_TOKEN),
+            )
+            if self._bridge.port is None and self._bridge.default_port is not None:
+                data[CONF_PORT] = self._bridge.default_port
+                hass.config_entries.async_update_entry(config_entry, data=data)
+                continue
+            break
         self._bridge.register_reauth_callback(self.access_denied)
 
     def access_denied(self):

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -72,18 +72,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         turn_on_action = hass.data[DOMAIN][ip_address][CONF_ON_ACTION]
         on_script = Script(hass, turn_on_action)
 
+    # Initialize bridge
     data = config_entry.data.copy()
-    while True:
-        # Initialize bridge
+    bridge = SamsungTVBridge.get_bridge(
+        data[CONF_METHOD], data[CONF_HOST], data[CONF_PORT], data.get(CONF_TOKEN),
+    )
+    if bridge.port is None and bridge.default_port is not None:
+        # For backward compat, set default port for websocket tv
+        data[CONF_PORT] = bridge.default_port
+        hass.config_entries.async_update_entry(config_entry, data=data)
         bridge = SamsungTVBridge.get_bridge(
             data[CONF_METHOD], data[CONF_HOST], data[CONF_PORT], data.get(CONF_TOKEN),
         )
-        if bridge.port is None and bridge.default_port is not None:
-            # For backward compat, set default port for websocket tv
-            data[CONF_PORT] = bridge.default_port
-            hass.config_entries.async_update_entry(config_entry, data=data)
-            continue
-        break
 
     async_add_entities([SamsungTVDevice(bridge, config_entry, on_script)])
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -71,13 +71,30 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     ):
         turn_on_action = hass.data[DOMAIN][ip_address][CONF_ON_ACTION]
         on_script = Script(hass, turn_on_action)
-    async_add_entities([SamsungTVDevice(hass, config_entry, on_script)])
+
+        data = config_entry.data.copy()
+        while True:
+            # Initialize bridge
+            bridge = SamsungTVBridge.get_bridge(
+                data[CONF_METHOD],
+                data[CONF_HOST],
+                data[CONF_PORT],
+                data.get(CONF_TOKEN),
+            )
+            if bridge.port is None and bridge.default_port is not None:
+                # For backward compat, set default port for websocket tv
+                data[CONF_PORT] = bridge.default_port
+                hass.config_entries.async_update_entry(config_entry, data=data)
+                continue
+            break
+
+        async_add_entities([SamsungTVDevice(bridge, config_entry, on_script)])
 
 
 class SamsungTVDevice(MediaPlayerDevice):
     """Representation of a Samsung TV."""
 
-    def __init__(self, hass, config_entry, on_script):
+    def __init__(self, bridge, config_entry, on_script):
         """Initialize the Samsung device."""
         self._config_entry = config_entry
         self._manufacturer = config_entry.data.get(CONF_MANUFACTURER)
@@ -93,21 +110,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         # Mark the end of a shutdown command (need to wait 15 seconds before
         # sending the next command to avoid turning the TV back ON).
         self._end_of_power_off = None
-
-        data = config_entry.data.copy()
-        while True:
-            # Initialize bridge
-            self._bridge = SamsungTVBridge.get_bridge(
-                data[CONF_METHOD],
-                data[CONF_HOST],
-                data[CONF_PORT],
-                data.get(CONF_TOKEN),
-            )
-            if self._bridge.port is None and self._bridge.default_port is not None:
-                data[CONF_PORT] = self._bridge.default_port
-                hass.config_entries.async_update_entry(config_entry, data=data)
-                continue
-            break
+        self._bridge = bridge
         self._bridge.register_reauth_callback(self.access_denied)
 
     def access_denied(self):

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -72,23 +72,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         turn_on_action = hass.data[DOMAIN][ip_address][CONF_ON_ACTION]
         on_script = Script(hass, turn_on_action)
 
-        data = config_entry.data.copy()
-        while True:
-            # Initialize bridge
-            bridge = SamsungTVBridge.get_bridge(
-                data[CONF_METHOD],
-                data[CONF_HOST],
-                data[CONF_PORT],
-                data.get(CONF_TOKEN),
-            )
-            if bridge.port is None and bridge.default_port is not None:
-                # For backward compat, set default port for websocket tv
-                data[CONF_PORT] = bridge.default_port
-                hass.config_entries.async_update_entry(config_entry, data=data)
-                continue
-            break
+    data = config_entry.data.copy()
+    while True:
+        # Initialize bridge
+        bridge = SamsungTVBridge.get_bridge(
+            data[CONF_METHOD], data[CONF_HOST], data[CONF_PORT], data.get(CONF_TOKEN),
+        )
+        if bridge.port is None and bridge.default_port is not None:
+            # For backward compat, set default port for websocket tv
+            data[CONF_PORT] = bridge.default_port
+            hass.config_entries.async_update_entry(config_entry, data=data)
+            continue
+        break
 
-        async_add_entities([SamsungTVDevice(bridge, config_entry, on_script)])
+    async_add_entities([SamsungTVDevice(bridge, config_entry, on_script)])
 
 
 class SamsungTVDevice(MediaPlayerDevice):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
n.a.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prior to version 0.107 samsungtv component didn't use port. now it is needed. This patch simply defaults to port 8001.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32802
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
