### PR TITLE
Add imperial units to met weather

### DIFF
--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     CONF_NAME,
     EVENT_CORE_CONFIG_UPDATE,
     LENGTH_FEET,
-    LENGTH_KILOMETERS,
     LENGTH_METERS,
     LENGTH_MILES,
     PRESSURE_HPA,
@@ -229,13 +228,9 @@ class MetWeather(WeatherEntity):
     def wind_speed(self):
         """Return the wind speed."""
         speed_m_s = self._current_weather_data.get("wind_speed")
-        if speed_m_s is None:
+        if self._is_metric or speed_m_s is None:
             return speed_m_s
 
-        if self._is_metric:
-            speed_km_s = convert_distance(speed_m_s, LENGTH_METERS, LENGTH_KILOMETERS)
-            speed_km_h = speed_km_s / 3600.0
-            return int(round(speed_km_h))
         speed_mi_s = convert_distance(speed_m_s, LENGTH_METERS, LENGTH_MILES)
         speed_mi_h = speed_mi_s / 3600.0
         return int(round(speed_mi_h))

--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -13,7 +13,11 @@ from homeassistant.const import (
     CONF_NAME,
     EVENT_CORE_CONFIG_UPDATE,
     LENGTH_FEET,
+    LENGTH_KILOMETERS,
     LENGTH_METERS,
+    LENGTH_MILES,
+    PRESSURE_HPA,
+    PRESSURE_INHG,
     TEMP_CELSIUS,
 )
 from homeassistant.core import callback
@@ -22,6 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.distance import convert as convert_distance
 import homeassistant.util.dt as dt_util
+from homeassistant.util.pressure import convert as convert_pressure
 
 from .const import CONF_TRACK_HOME
 
@@ -209,7 +214,11 @@ class MetWeather(WeatherEntity):
     @property
     def pressure(self):
         """Return the pressure."""
-        return self._current_weather_data.get("pressure")
+        pressure_hpa = self._current_weather_data.get("pressure")
+        if self._is_metric or pressure_hpa is None:
+            return pressure_hpa
+
+        return round(convert_pressure(pressure_hpa, PRESSURE_HPA, PRESSURE_INHG), 2)
 
     @property
     def humidity(self):
@@ -219,7 +228,17 @@ class MetWeather(WeatherEntity):
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        return self._current_weather_data.get("wind_speed")
+        speed_m_s = self._current_weather_data.get("wind_speed")
+        if speed_m_s is None:
+            return speed_m_s
+
+        if self._is_metric:
+            speed_km_s = convert_distance(speed_m_s, LENGTH_METERS, LENGTH_KILOMETERS)
+            speed_km_h = speed_km_s / 3600.0
+            return int(round(speed_km_h))
+        speed_mi_s = convert_distance(speed_m_s, LENGTH_METERS, LENGTH_MILES)
+        speed_mi_h = speed_mi_s / 3600.0
+        return int(round(speed_mi_h))
 
     @property
     def wind_bearing(self):

--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -63,7 +63,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if config.get(CONF_LATITUDE) is None:
         config[CONF_TRACK_HOME] = True
 
-    async_add_entities([MetWeather(config)])
+    async_add_entities([MetWeather(config, hass.config.units.is_metric)])
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to use imperial units in met weather.  Since this is the first entity people usually see in home assistant after on boarding, it would be good to support imperial units.  The integration currently uses feet as meters for elevation, which really throws off the weather at higher elevations.  This PR also adds conversions for pressure and wind speed.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

See here for example of confusion it causes: https://community.home-assistant.io/t/home-weather-showing-f-but-numbers-in-celsius/134145/

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
