### PR TITLE
Clean up Abode unused automation events

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -263,7 +263,6 @@ def setup_abode_events(hass):
         TIMELINE.TEST_GROUP,
         TIMELINE.CAPTURE_GROUP,
         TIMELINE.DEVICE_GROUP,
-        TIMELINE.AUTOMATION_EDIT_GROUP,
     ]
 
     for event in events:
@@ -343,21 +342,14 @@ class AbodeDevice(Entity):
 class AbodeAutomation(Entity):
     """Representation of an Abode automation."""
 
-    def __init__(self, data, automation, event=None):
+    def __init__(self, data, automation):
         """Initialize for Abode automation."""
         self._data = data
         self._automation = automation
-        self._event = event
 
     async def async_added_to_hass(self):
-        """Subscribe to a group of Abode timeline events."""
-        if self._event:
-            self.hass.async_add_job(
-                self._data.abode.events.add_event_callback,
-                self._event,
-                self._update_callback,
-            )
-            self.hass.data[DOMAIN].entity_ids.add(self.entity_id)
+        """Set up automation entity."""
+        self.hass.data[DOMAIN].entity_ids.add(self.entity_id)
 
     @property
     def should_poll(self):
@@ -385,8 +377,3 @@ class AbodeAutomation(Entity):
     def unique_id(self):
         """Return a unique ID to use for this automation."""
         return self._automation.automation_id
-
-    def _update_callback(self, device):
-        """Update the automation state."""
-        self._automation.refresh()
-        self.schedule_update_ha_state()

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -1,6 +1,5 @@
 """Support for Abode Security System switches."""
 import abodepy.helpers.constants as CONST
-import abodepy.helpers.timeline as TIMELINE
 
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -24,9 +23,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entities.append(AbodeSwitch(data, device))
 
     for automation in data.abode.get_automations():
-        entities.append(
-            AbodeAutomationSwitch(data, automation, TIMELINE.AUTOMATION_EDIT_GROUP)
-        )
+        entities.append(AbodeAutomationSwitch(data, automation))
 
     async_add_entities(entities)
 
@@ -52,7 +49,7 @@ class AbodeAutomationSwitch(AbodeAutomation, SwitchDevice):
     """A switch implementation for Abode automations."""
 
     async def async_added_to_hass(self):
-        """Subscribe Abode events."""
+        """Set up trigger automation service."""
         await super().async_added_to_hass()
 
         signal = f"abode_trigger_automation_{self.entity_id}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Abode no longer pushes updates with CUE automations. This PR removes some left over code from a [previous PR](https://github.com/home-assistant/core/pull/32296) that added Abode CUE support.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
