### PR TITLE
Make sure panel_custom won't crash on invalid data

### DIFF
--- a/homeassistant/components/hassio/manifest.json
+++ b/homeassistant/components/hassio/manifest.json
@@ -3,6 +3,7 @@
   "name": "Hass.io",
   "documentation": "https://www.home-assistant.io/hassio",
   "requirements": [],
-  "dependencies": ["http", "panel_custom"],
+  "dependencies": ["http"],
+  "after_dependencies": ["panel_custom"],
   "codeowners": ["@home-assistant/hass-io"]
 }

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -146,8 +146,6 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    success = False
-
     for panel in config[DOMAIN]:
         name = panel[CONF_COMPONENT_NAME]
 
@@ -182,8 +180,13 @@ async def async_setup(hass, config):
             hass.http.register_static_path(url, panel_path)
             kwargs["html_url"] = url
 
-        await async_register_panel(hass, **kwargs)
+        try:
+            await async_register_panel(hass, **kwargs)
+        except ValueError as err:
+            _LOGGER.error(
+                "Unable to register panel %s: %s",
+                panel.get(CONF_SIDEBAR_TITLE, name),
+                err,
+            )
 
-        success = True
-
-    return success
+    return True

--- a/tests/components/panel_custom/test_init.py
+++ b/tests/components/panel_custom/test_init.py
@@ -181,3 +181,17 @@ async def test_url_option_conflict(hass):
     for config in to_try:
         result = await setup.async_setup_component(hass, "panel_custom", config)
         assert not result
+
+
+async def test_url_path_conflict(hass):
+    """Test config with overlapping url path."""
+    assert await setup.async_setup_component(
+        hass,
+        "panel_custom",
+        {
+            "panel_custom": [
+                {"name": "todo-mvc", "js_url": "/local/bla.js"},
+                {"name": "todo-mvc", "js_url": "/local/bla.js"},
+            ]
+        },
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make sure that panel_custom won't fail to set up if there are invalid panels. Also make sure that Hass.io no longer relies on panel_custom being set up, instead only mark it as an after dependency because we don't need it to be set up to register a panel.

Fixes https://github.com/home-assistant/core/issues/32798

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
