### PR TITLE
Ignore the ignored konnected config entries

### DIFF
--- a/homeassistant/components/konnected/__init__.py
+++ b/homeassistant/components/konnected/__init__.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ACCESS_TOKEN,
@@ -306,7 +306,7 @@ class KonnectedView(HomeAssistantView):
             [
                 entry.data[CONF_ACCESS_TOKEN]
                 for entry in hass.config_entries.async_entries(DOMAIN)
-                if entry.source != SOURCE_IGNORE
+                if entry.data.get(CONF_ACCESS_TOKEN)
             ]
         )
         if auth is None or not next(

--- a/homeassistant/components/konnected/__init__.py
+++ b/homeassistant/components/konnected/__init__.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ACCESS_TOKEN,
@@ -306,6 +306,7 @@ class KonnectedView(HomeAssistantView):
             [
                 entry.data[CONF_ACCESS_TOKEN]
                 for entry in hass.config_entries.async_entries(DOMAIN)
+                if entry.source != SOURCE_IGNORE
             ]
         )
         if auth is None or not next(

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -4,7 +4,6 @@ import pytest
 
 from homeassistant.components import konnected
 from homeassistant.components.konnected import config_flow
-from homeassistant.config_entries import SOURCE_IGNORE
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -583,13 +582,8 @@ async def test_state_updates(hass, aiohttp_client, mock_panel):
     )
     entry.add_to_hass(hass)
 
-    # Add ignored entry to ensure we handle it OK
-    entry = MockConfigEntry(
-        domain="konnected",
-        title="Konnected Alarm Panel",
-        source=SOURCE_IGNORE,
-        data={},
-    )
+    # Add empty data field to ensure we process it correctly (possible if entry is ignored)
+    entry = MockConfigEntry(domain="konnected", title="Konnected Alarm Panel", data={},)
     entry.add_to_hass(hass)
 
     assert (

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import konnected
 from homeassistant.components.konnected import config_flow
+from homeassistant.config_entries import SOURCE_IGNORE
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -579,6 +580,15 @@ async def test_state_updates(hass, aiohttp_client, mock_panel):
         title="Konnected Alarm Panel",
         data=device_config,
         options=device_options,
+    )
+    entry.add_to_hass(hass)
+
+    # Add ignored entry to ensure we handle it OK
+    entry = MockConfigEntry(
+        domain="konnected",
+        title="Konnected Alarm Panel",
+        source=SOURCE_IGNORE,
+        data={},
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The endpoint that processes postbacks from Konnected alarm panels compiles a list of access tokens associated with each panel.  Ignored panels do not have access tokens in their empty  `entry.data` dicts and hence and were causing KeyError exceptions. This PR adds a guard to check for the presence of the `access_token` key.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32147
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
