### PR TITLE
Enable sisyphus to recover from bad DNS without restart

### DIFF
--- a/homeassistant/components/sisyphus/__init__.py
+++ b/homeassistant/components/sisyphus/__init__.py
@@ -99,18 +99,23 @@ class TableHolder:
 
     async def get_table(self):
         """Return the Table held by this holder, connecting to it if needed."""
+        if self._table:
+            return self._table
+
         if not self._table_task:
             self._table_task = self._hass.async_create_task(self._connect_table())
 
         return await self._table_task
 
     async def _connect_table(self):
-
-        self._table = await Table.connect(self._host, self._session)
-        if self._name is None:
-            self._name = self._table.name
-            _LOGGER.debug("Connected to %s at %s", self._name, self._host)
-        return self._table
+        try:
+            self._table = await Table.connect(self._host, self._session)
+            if self._name is None:
+                self._name = self._table.name
+                _LOGGER.debug("Connected to %s at %s", self._name, self._host)
+            return self._table
+        finally:
+            self._table_task = None
 
     async def close(self):
         """Close the table held by this holder, if any."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the initial attempt to contact the table fails outright, the sisyphus integration would throw `PlatformNotReady` forevermore. This PR fixes it so that each time we attempt to initialize the platform, it will make a new attempt to connect.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The change to DNS settings around 0.97.2 (https://community.home-assistant.io/t/name-resolution-problem-since-0-97-2/132201/43) revealed this issue and provided an opportunity for testing. With this PR applied to my local instance, I tested as follows:

1. Start HA with incorrect DNS settings
2. Observe that the sisyphus integration reports not ready
3. Run `ha dns options` to set the correct DNS settings
4. Observe that the sisyphus integration starts successfully on the next retry

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
