### PR TITLE
Use backend-provided fan speed presets for Xiaomi vacuums, bump python-miio

### DIFF
--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "xiaomi_miio",
   "name": "Xiaomi miio",
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.9.45", "python-miio==0.5.0"],
+  "requirements": ["construct==2.9.45", "python-miio==0.5.0.1"],
   "dependencies": [],
   "codeowners": ["@rytilahti", "@syssi"]
 }

--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "xiaomi_miio",
   "name": "Xiaomi miio",
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.9.45", "python-miio==0.4.8"],
+  "requirements": ["construct==2.9.45", "python-miio==0.5.0"],
   "dependencies": [],
   "codeowners": ["@rytilahti", "@syssi"]
 }

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -283,8 +283,8 @@ class MiroboVacuum(StateVacuumDevice):
             speed = self.vacuum_state.fanspeed
             if speed in self._fan_speeds_reverse:
                 return self._fan_speeds_reverse[speed]
-            else:
-                _LOGGER.debug("Unable to find reverse for %s", speed)
+
+            _LOGGER.debug("Unable to find reverse for %s", speed)
 
             return speed
 

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -281,7 +281,9 @@ class MiroboVacuum(StateVacuumDevice):
         if self.vacuum_state is not None:
             speed = self.vacuum_state.fanspeed
             if speed in self._fan_speeds.values():
-                return [key for key, value in self._fan_speeds.items() if value == speed][0]
+                return [
+                    key for key, value in self._fan_speeds.items() if value == speed
+                ][0]
             return speed
 
     @property

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -60,8 +60,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     extra=vol.ALLOW_EXTRA,
 )
 
-FAN_SPEEDS = {"Silent": 38, "Standard": 60, "Medium": 77, "Turbo": 90, "Gentle": 105}
-
 ATTR_CLEAN_START = "clean_start"
 ATTR_CLEAN_STOP = "clean_stop"
 ATTR_CLEANING_TIME = "cleaning_time"
@@ -246,6 +244,7 @@ class MiroboVacuum(StateVacuumDevice):
         self.clean_history = None
         self.dnd_state = None
         self.last_clean = None
+        self._fan_speeds = None
 
     @property
     def name(self):
@@ -281,14 +280,14 @@ class MiroboVacuum(StateVacuumDevice):
         """Return the fan speed of the vacuum cleaner."""
         if self.vacuum_state is not None:
             speed = self.vacuum_state.fanspeed
-            if speed in FAN_SPEEDS.values():
-                return [key for key, value in FAN_SPEEDS.items() if value == speed][0]
+            if speed in self._fan_speeds.values():
+                return [key for key, value in self._fan_speeds.items() if value == speed][0]
             return speed
 
     @property
     def fan_speed_list(self):
         """Get the list of available fan speed steps of the vacuum cleaner."""
-        return list(sorted(FAN_SPEEDS.keys(), key=lambda s: FAN_SPEEDS[s]))
+        return list(self._fan_speeds)
 
     @property
     def device_state_attributes(self):
@@ -372,8 +371,8 @@ class MiroboVacuum(StateVacuumDevice):
 
     async def async_set_fan_speed(self, fan_speed, **kwargs):
         """Set fan speed."""
-        if fan_speed.capitalize() in FAN_SPEEDS:
-            fan_speed = FAN_SPEEDS[fan_speed.capitalize()]
+        if fan_speed.capitalize() in self._fan_speeds:
+            fan_speed = self._fan_speeds[fan_speed.capitalize()]
         else:
             try:
                 fan_speed = int(fan_speed)
@@ -452,6 +451,8 @@ class MiroboVacuum(StateVacuumDevice):
         try:
             state = self._vacuum.status()
             self.vacuum_state = state
+
+            self._fan_speeds = self._vacuum.fan_speed_presets()
 
             self.consumable_state = self._vacuum.consumable_status()
             self.clean_history = self._vacuum.clean_history()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1623,7 +1623,7 @@ python-juicenet==0.1.6
 # python-lirc==1.2.3
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.4.8
+python-miio==0.5.0
 
 # homeassistant.components.mpd
 python-mpd2==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1623,7 +1623,7 @@ python-juicenet==0.1.6
 # python-lirc==1.2.3
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.0
+python-miio==0.5.0.1
 
 # homeassistant.components.mpd
 python-mpd2==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -581,7 +581,7 @@ python-forecastio==1.4.0
 python-izone==1.1.2
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.4.8
+python-miio==0.5.0
 
 # homeassistant.components.nest
 python-nest==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -581,7 +581,7 @@ python-forecastio==1.4.0
 python-izone==1.1.2
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.0
+python-miio==0.5.0.1
 
 # homeassistant.components.nest
 python-nest==4.1.0


### PR DESCRIPTION
This needs input from Xiaomi vacuum owners to verify that it does not break anything.
I have personally tested this on rockrobo v1 (old mapping).

Devices tested (thanks!):
* rockrobo v1 (old fw, by me)
* rockrobo v1 (new fw, **testers wanted!**)
* Xiaomi Vacuum 1S (by @pplucky)
* Roborock S4 (by @DeadEnded)
* Roborock S5 (by @markrennie71)
* Roborock S55 v2 (by @Blackpander)

Related issues/PRs:
home-assistant/core#32821 (replaces)
home-assistant/core#31268
home-assistant/core#27268

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31268
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
