### PR TITLE
Add config entry for Flu Near You

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -219,6 +219,7 @@ omit =
     homeassistant/components/flic/binary_sensor.py
     homeassistant/components/flock/notify.py
     homeassistant/components/flume/*
+    homeassistant/components/flunearyou/__init__.py
     homeassistant/components/flunearyou/sensor.py
     homeassistant/components/flux_led/light.py
     homeassistant/components/folder/sensor.py

--- a/homeassistant/components/flunearyou/.translations/en.json
+++ b/homeassistant/components/flunearyou/.translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "These coordinates are already registered."
+        },
+        "error": {
+            "general_error": "There was an unknown error."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "latitude": "Latitude",
+                    "longitude": "Longitude"
+                },
+                "description": "Monitor user-based and CDC repots for a pair of coordinates.",
+                "title": "Configure Flu Near You"
+            }
+        },
+        "title": "Flu Near You"
+    }
+}

--- a/homeassistant/components/flunearyou/.translations/en.json
+++ b/homeassistant/components/flunearyou/.translations/en.json
@@ -12,7 +12,7 @@
                     "latitude": "Latitude",
                     "longitude": "Longitude"
                 },
-                "description": "Monitor user-based and CDC repots for a pair of coordinates.",
+                "description": "Monitor user-based and CDC flu reports.",
                 "title": "Configure Flu Near You"
             }
         },

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -36,7 +36,8 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_LONGITUDE): cv.longitude,
             }
         )
-    }
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -7,7 +7,7 @@ from pyflunearyou.errors import FluNearYouError
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -19,7 +19,6 @@ from .const import (
     DATA_CLIENT,
     DOMAIN,
     LOGGER,
-    SENSORS,
     TOPIC_UPDATE,
 )
 
@@ -29,18 +28,8 @@ DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.All(
-            cv.deprecated(CONF_MONITORED_CONDITIONS, invalidation_version="0.114.0"),
-            vol.Schema(
-                {
-                    vol.Optional(CONF_LATITUDE): cv.latitude,
-                    vol.Optional(CONF_LONGITUDE): cv.longitude,
-                    vol.Optional(
-                        CONF_MONITORED_CONDITIONS, default=list(SENSORS)
-                    ): vol.All(cv.ensure_list, [vol.In(SENSORS)]),
-                }
-            ),
-        )
+        vol.Optional(CONF_LATITUDE): cv.latitude,
+        vol.Optional(CONF_LONGITUDE): cv.longitude,
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -1,1 +1,139 @@
 """The flunearyou component."""
+import asyncio
+from datetime import timedelta
+
+from pyflunearyou import Client
+from pyflunearyou.errors import FluNearYouError
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import (
+    CATEGORY_CDC_REPORT,
+    CATEGORY_USER_REPORT,
+    DATA_CLIENT,
+    DOMAIN,
+    LOGGER,
+    TOPIC_UPDATE,
+)
+
+DATA_LISTENER = "listener"
+
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_LATITUDE): cv.latitude,
+        vol.Optional(CONF_LONGITUDE): cv.longitude,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """Set up the Flu Near You component."""
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][DATA_CLIENT] = {}
+    hass.data[DOMAIN][DATA_LISTENER] = {}
+
+    if DOMAIN not in config:
+        return True
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_LATITUDE: config[DOMAIN].get(CONF_LATITUDE, hass.config.latitude),
+                CONF_LONGITUDE: config[DOMAIN].get(
+                    CONF_LATITUDE, hass.config.longitude
+                ),
+            },
+        )
+    )
+
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set up Flu Near You as config entry."""
+    websession = aiohttp_client.async_get_clientsession(hass)
+
+    fny = FluNearYouData(
+        hass,
+        Client(websession),
+        config_entry.data.get(CONF_LATITUDE, hass.config.latitude),
+        config_entry.data.get(CONF_LONGITUDE, hass.config.longitude),
+    )
+
+    try:
+        await fny.async_update()
+    except FluNearYouError as err:
+        LOGGER.error("Error while setting up integration: %s", err)
+        raise ConfigEntryNotReady
+
+    hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = fny
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
+    )
+
+    async def refresh(event_time):
+        """Refresh data from Flu Near You."""
+        await fny.async_update()
+
+    hass.data[DOMAIN][DATA_LISTENER][config_entry.entry_id] = async_track_time_interval(
+        hass, refresh, DEFAULT_SCAN_INTERVAL
+    )
+
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload an Flu Near You config entry."""
+    hass.data[DOMAIN][DATA_CLIENT].pop(config_entry.entry_id)
+
+    remove_listener = hass.data[DOMAIN][DATA_LISTENER].pop(config_entry.entry_id)
+    remove_listener()
+
+    await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
+
+    return True
+
+
+class FluNearYouData:
+    """Define a data object to retrieve info from Flu Near You."""
+
+    def __init__(self, hass, client, latitude, longitude):
+        """Initialize."""
+        self._client = client
+        self._hass = hass
+        self.data = {}
+        self.latitude = latitude
+        self.longitude = longitude
+
+    async def async_update(self):
+        """Update Flu Near You data."""
+        tasks = {
+            CATEGORY_CDC_REPORT: self._client.cdc_reports.status_by_coordinates(
+                self.latitude, self.longitude
+            ),
+            CATEGORY_USER_REPORT: self._client.user_reports.status_by_coordinates(
+                self.latitude, self.longitude
+            ),
+        }
+
+        results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+        for category, result in zip(tasks, results):
+            if isinstance(result, FluNearYouError):
+                LOGGER.error("Error while retrieving %s data: %s", category, result)
+                continue
+            self.data[category] = result
+
+        LOGGER.debug("Received new data")
+        async_dispatcher_send(self._hass, TOPIC_UPDATE)

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -19,6 +20,7 @@ from .const import (
     DATA_CLIENT,
     DOMAIN,
     LOGGER,
+    SENSORS,
     TOPIC_UPDATE,
 )
 
@@ -33,6 +35,22 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+
+@callback
+def async_get_api_category(sensor_type):
+    """Get the category that a particular sensor type belongs to."""
+    try:
+        return next(
+            (
+                category
+                for category, sensors in SENSORS.items()
+                for sensor in sensors
+                if sensor[0] == sensor_type
+            )
+        )
+    except StopIteration:
+        raise ValueError(f"Can't find category sensor type: {sensor_type}")
 
 
 async def async_setup(hass, config):
@@ -111,29 +129,86 @@ class FluNearYouData:
 
     def __init__(self, hass, client, latitude, longitude):
         """Initialize."""
+        self._async_cancel_time_interval_listener = None
         self._client = client
         self._hass = hass
         self.data = {}
         self.latitude = latitude
         self.longitude = longitude
 
-    async def async_update(self):
-        """Update Flu Near You data."""
-        tasks = {
+        self._api_coros = {
             CATEGORY_CDC_REPORT: self._client.cdc_reports.status_by_coordinates(
-                self.latitude, self.longitude
+                latitude, longitude
             ),
             CATEGORY_USER_REPORT: self._client.user_reports.status_by_coordinates(
-                self.latitude, self.longitude
+                latitude, longitude
             ),
         }
 
-        results = await asyncio.gather(*tasks.values(), return_exceptions=True)
-        for category, result in zip(tasks, results):
-            if isinstance(result, FluNearYouError):
-                LOGGER.error("Error while retrieving %s data: %s", category, result)
-                continue
-            self.data[category] = result
+        self._api_category_count = {
+            CATEGORY_CDC_REPORT: 0,
+            CATEGORY_USER_REPORT: 0,
+        }
+
+        self._api_category_locks = {
+            CATEGORY_CDC_REPORT: asyncio.Lock(),
+            CATEGORY_USER_REPORT: asyncio.Lock(),
+        }
+
+    async def _async_get_data_from_api(self, api_category):
+        """Update and save data for a particular API category."""
+        if self._api_category_count[api_category] == 0:
+            return
+
+        try:
+            self.data[api_category] = await self._api_coros[api_category]
+        except FluNearYouError as err:
+            LOGGER.error("Unable to get %s data: %s", api_category, err)
+            self.data[api_category] = None
+
+    async def _async_update_listener_action(self, now):
+        """Define an async_track_time_interval action to update data."""
+        await self.async_update()
+
+    @callback
+    def async_deregister_api_interest(self, sensor_type):
+        """Decrement the number of entities with data needs from an API category."""
+        # If this deregistration should leave us with no registration at all, remove the
+        # time interval:
+        if sum(self._api_category_count.values()) == 0:
+            if self._async_cancel_time_interval_listener:
+                self._async_cancel_time_interval_listener()
+                self._async_cancel_time_interval_listener = None
+            return
+
+        api_category = async_get_api_category(sensor_type)
+        self._api_category_count[api_category] -= 1
+
+    async def async_register_api_interest(self, sensor_type):
+        """Increment the number of entities with data needs from an API category."""
+        # If this is the first registration we have, start a time interval:
+        if not self._async_cancel_time_interval_listener:
+            self._async_cancel_time_interval_listener = async_track_time_interval(
+                self._hass, self._async_update_listener_action, DEFAULT_SCAN_INTERVAL,
+            )
+
+        api_category = async_get_api_category(sensor_type)
+        self._api_category_count[api_category] += 1
+
+        # If a sensor registers interest in a particular API call and the data doesn't
+        # exist for it yet, make the API call and grab the data:
+        async with self._api_category_locks[api_category]:
+            if api_category not in self.data:
+                await self._async_get_data_from_api(api_category)
+
+    async def async_update(self):
+        """Update Flu Near You data."""
+        tasks = [
+            self._async_get_data_from_api(api_category)
+            for api_category in self._api_coros
+        ]
+
+        await asyncio.gather(*tasks)
 
         LOGGER.debug("Received new data")
         async_dispatcher_send(self._hass, TOPIC_UPDATE)

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -7,7 +7,7 @@ from pyflunearyou.errors import FluNearYouError
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -19,6 +19,7 @@ from .const import (
     DATA_CLIENT,
     DOMAIN,
     LOGGER,
+    SENSORS,
     TOPIC_UPDATE,
 )
 
@@ -28,8 +29,18 @@ DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_LATITUDE): cv.latitude,
-        vol.Optional(CONF_LONGITUDE): cv.longitude,
+        DOMAIN: vol.All(
+            cv.deprecated(CONF_MONITORED_CONDITIONS, invalidation_version="0.114.0"),
+            vol.Schema(
+                {
+                    vol.Optional(CONF_LATITUDE): cv.latitude,
+                    vol.Optional(CONF_LONGITUDE): cv.longitude,
+                    vol.Optional(
+                        CONF_MONITORED_CONDITIONS, default=list(SENSORS)
+                    ): vol.All(cv.ensure_list, [vol.In(SENSORS)]),
+                }
+            ),
+        )
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -30,10 +30,13 @@ DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_LATITUDE): cv.latitude,
-        vol.Optional(CONF_LONGITUDE): cv.longitude,
-    },
-    extra=vol.ALLOW_EXTRA,
+        vol.Optional(DOMAIN): vol.Schema(
+            {
+                vol.Optional(CONF_LATITUDE): cv.latitude,
+                vol.Optional(CONF_LONGITUDE): cv.longitude,
+            }
+        )
+    }
 )
 
 
@@ -55,9 +58,7 @@ def async_get_api_category(sensor_type):
 
 async def async_setup(hass, config):
     """Set up the Flu Near You component."""
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][DATA_CLIENT] = {}
-    hass.data[DOMAIN][DATA_LISTENER] = {}
+    hass.data[DOMAIN] = {DATA_CLIENT: {}, DATA_LISTENER: {}}
 
     if DOMAIN not in config:
         return True

--- a/homeassistant/components/flunearyou/config_flow.py
+++ b/homeassistant/components/flunearyou/config_flow.py
@@ -1,0 +1,60 @@
+"""Define a config flow manager for Flu Near You."""
+from pyflunearyou import Client
+from pyflunearyou.errors import FluNearYouError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.helpers import aiohttp_client, config_validation as cv
+
+from .const import DOMAIN, LOGGER  # pylint: disable=unused-import
+
+
+class FluNearYouFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle an FluNearYou config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @property
+    def data_schema(self):
+        """Return the data schema for integration."""
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_LATITUDE, default=self.hass.config.latitude
+                ): cv.latitude,
+                vol.Required(
+                    CONF_LONGITUDE, default=self.hass.config.longitude
+                ): cv.longitude,
+            }
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        if not user_input:
+            return self.async_show_form(step_id="user", data_schema=self.data_schema)
+
+        unique_id = f"{user_input[CONF_LATITUDE]}, {user_input[CONF_LONGITUDE]}"
+
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        websession = aiohttp_client.async_get_clientsession(self.hass)
+        client = Client(websession)
+
+        try:
+            await client.cdc_reports.status_by_coordinates(
+                user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE]
+            )
+        except FluNearYouError as err:
+            LOGGER.error("Error while setting up integration: %s", err)
+            return self.async_show_form(
+                step_id="user", errors={"base": "general_error"}
+            )
+
+        return self.async_create_entry(title=unique_id, data=user_input)

--- a/homeassistant/components/flunearyou/config_flow.py
+++ b/homeassistant/components/flunearyou/config_flow.py
@@ -1,4 +1,4 @@
-"""Define a config flow manager for Flu Near You."""
+"""Define a config flow manager for flunearyou."""
 from pyflunearyou import Client
 from pyflunearyou.errors import FluNearYouError
 import voluptuous as vol

--- a/homeassistant/components/flunearyou/const.py
+++ b/homeassistant/components/flunearyou/const.py
@@ -10,29 +10,3 @@ CATEGORY_CDC_REPORT = "cdc_report"
 CATEGORY_USER_REPORT = "user_report"
 
 TOPIC_UPDATE = "flunearyou_update"
-
-TYPE_CDC_LEVEL = "level"
-TYPE_CDC_LEVEL2 = "level2"
-TYPE_USER_CHICK = "chick"
-TYPE_USER_DENGUE = "dengue"
-TYPE_USER_FLU = "flu"
-TYPE_USER_LEPTO = "lepto"
-TYPE_USER_NO_SYMPTOMS = "none"
-TYPE_USER_SYMPTOMS = "symptoms"
-TYPE_USER_TOTAL = "total"
-
-SENSORS = {
-    CATEGORY_CDC_REPORT: [
-        (TYPE_CDC_LEVEL, "CDC Level", "mdi:biohazard", None),
-        (TYPE_CDC_LEVEL2, "CDC Level 2", "mdi:biohazard", None),
-    ],
-    CATEGORY_USER_REPORT: [
-        (TYPE_USER_CHICK, "Avian Flu Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_DENGUE, "Dengue Fever Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_FLU, "Flu Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_LEPTO, "Leptospirosis Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_NO_SYMPTOMS, "No Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_SYMPTOMS, "Flu-like Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_TOTAL, "Total Symptoms", "mdi:alert", "reports"),
-    ],
-}

--- a/homeassistant/components/flunearyou/const.py
+++ b/homeassistant/components/flunearyou/const.py
@@ -1,0 +1,12 @@
+"""Define flunearyou constants."""
+import logging
+
+DOMAIN = "flunearyou"
+LOGGER = logging.getLogger("homeassistant.components.flunearyou")
+
+DATA_CLIENT = "client"
+
+CATEGORY_CDC_REPORT = "cdc_report"
+CATEGORY_USER_REPORT = "user_report"
+
+TOPIC_UPDATE = "flunearyou_update"

--- a/homeassistant/components/flunearyou/const.py
+++ b/homeassistant/components/flunearyou/const.py
@@ -10,3 +10,29 @@ CATEGORY_CDC_REPORT = "cdc_report"
 CATEGORY_USER_REPORT = "user_report"
 
 TOPIC_UPDATE = "flunearyou_update"
+
+TYPE_CDC_LEVEL = "level"
+TYPE_CDC_LEVEL2 = "level2"
+TYPE_USER_CHICK = "chick"
+TYPE_USER_DENGUE = "dengue"
+TYPE_USER_FLU = "flu"
+TYPE_USER_LEPTO = "lepto"
+TYPE_USER_NO_SYMPTOMS = "none"
+TYPE_USER_SYMPTOMS = "symptoms"
+TYPE_USER_TOTAL = "total"
+
+SENSORS = {
+    CATEGORY_CDC_REPORT: [
+        (TYPE_CDC_LEVEL, "CDC Level", "mdi:biohazard", None),
+        (TYPE_CDC_LEVEL2, "CDC Level 2", "mdi:biohazard", None),
+    ],
+    CATEGORY_USER_REPORT: [
+        (TYPE_USER_CHICK, "Avian Flu Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_DENGUE, "Dengue Fever Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_FLU, "Flu Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_LEPTO, "Leptospirosis Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_NO_SYMPTOMS, "No Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_SYMPTOMS, "Flu-like Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_TOTAL, "Total Symptoms", "mdi:alert", "reports"),
+    ],
+}

--- a/homeassistant/components/flunearyou/manifest.json
+++ b/homeassistant/components/flunearyou/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "flunearyou",
   "name": "Flu Near You",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flunearyou",
-  "requirements": ["pyflunearyou==1.0.3"],
+  "requirements": ["pyflunearyou==1.0.7"],
   "dependencies": [],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/flunearyou/sensor.py
+++ b/homeassistant/components/flunearyou/sensor.py
@@ -116,7 +116,7 @@ class FluNearYouSensor(Entity):
 
         await self._fny.async_register_api_interest(self._sensor_type)
 
-        update()
+        self.update_from_latest_data()
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect dispatcher listener when removed."""
@@ -124,7 +124,7 @@ class FluNearYouSensor(Entity):
             self._async_unsub_dispatcher_connect()
             self._async_unsub_dispatcher_connect = None
 
-        await self._fny.async_deregister_api_interest(self._sensor_type)
+        self._fny.async_deregister_api_interest(self._sensor_type)
 
     @callback
     def update_from_latest_data(self):

--- a/homeassistant/components/flunearyou/sensor.py
+++ b/homeassistant/components/flunearyou/sensor.py
@@ -9,15 +9,7 @@ from .const import (
     CATEGORY_USER_REPORT,
     DATA_CLIENT,
     DOMAIN,
-    SENSORS,
     TOPIC_UPDATE,
-    TYPE_USER_CHICK,
-    TYPE_USER_DENGUE,
-    TYPE_USER_FLU,
-    TYPE_USER_LEPTO,
-    TYPE_USER_NO_SYMPTOMS,
-    TYPE_USER_SYMPTOMS,
-    TYPE_USER_TOTAL,
 )
 
 ATTR_CITY = "city"
@@ -30,10 +22,36 @@ ATTR_ZIP_CODE = "zip_code"
 
 DEFAULT_ATTRIBUTION = "Data provided by Flu Near You"
 
+TYPE_CDC_LEVEL = "level"
+TYPE_CDC_LEVEL2 = "level2"
+TYPE_USER_CHICK = "chick"
+TYPE_USER_DENGUE = "dengue"
+TYPE_USER_FLU = "flu"
+TYPE_USER_LEPTO = "lepto"
+TYPE_USER_NO_SYMPTOMS = "none"
+TYPE_USER_SYMPTOMS = "symptoms"
+TYPE_USER_TOTAL = "total"
+
 EXTENDED_TYPE_MAPPING = {
     TYPE_USER_FLU: "ili",
     TYPE_USER_NO_SYMPTOMS: "no_symptoms",
     TYPE_USER_TOTAL: "total_surveys",
+}
+
+SENSORS = {
+    CATEGORY_CDC_REPORT: [
+        (TYPE_CDC_LEVEL, "CDC Level", "mdi:biohazard", None),
+        (TYPE_CDC_LEVEL2, "CDC Level 2", "mdi:biohazard", None),
+    ],
+    CATEGORY_USER_REPORT: [
+        (TYPE_USER_CHICK, "Avian Flu Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_DENGUE, "Dengue Fever Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_FLU, "Flu Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_LEPTO, "Leptospirosis Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_NO_SYMPTOMS, "No Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_SYMPTOMS, "Flu-like Symptoms", "mdi:alert", "reports"),
+        (TYPE_USER_TOTAL, "Total Symptoms", "mdi:alert", "reports"),
+    ],
 }
 
 

--- a/homeassistant/components/flunearyou/sensor.py
+++ b/homeassistant/components/flunearyou/sensor.py
@@ -9,7 +9,15 @@ from .const import (
     CATEGORY_USER_REPORT,
     DATA_CLIENT,
     DOMAIN,
+    SENSORS,
     TOPIC_UPDATE,
+    TYPE_USER_CHICK,
+    TYPE_USER_DENGUE,
+    TYPE_USER_FLU,
+    TYPE_USER_LEPTO,
+    TYPE_USER_NO_SYMPTOMS,
+    TYPE_USER_SYMPTOMS,
+    TYPE_USER_TOTAL,
 )
 
 ATTR_CITY = "city"
@@ -22,36 +30,10 @@ ATTR_ZIP_CODE = "zip_code"
 
 DEFAULT_ATTRIBUTION = "Data provided by Flu Near You"
 
-TYPE_CDC_LEVEL = "level"
-TYPE_CDC_LEVEL2 = "level2"
-TYPE_USER_CHICK = "chick"
-TYPE_USER_DENGUE = "dengue"
-TYPE_USER_FLU = "flu"
-TYPE_USER_LEPTO = "lepto"
-TYPE_USER_NO_SYMPTOMS = "none"
-TYPE_USER_SYMPTOMS = "symptoms"
-TYPE_USER_TOTAL = "total"
-
 EXTENDED_TYPE_MAPPING = {
     TYPE_USER_FLU: "ili",
     TYPE_USER_NO_SYMPTOMS: "no_symptoms",
     TYPE_USER_TOTAL: "total_surveys",
-}
-
-SENSORS = {
-    CATEGORY_CDC_REPORT: [
-        (TYPE_CDC_LEVEL, "CDC Level", "mdi:biohazard", None),
-        (TYPE_CDC_LEVEL2, "CDC Level 2", "mdi:biohazard", None),
-    ],
-    CATEGORY_USER_REPORT: [
-        (TYPE_USER_CHICK, "Avian Flu Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_DENGUE, "Dengue Fever Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_FLU, "Flu Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_LEPTO, "Leptospirosis Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_NO_SYMPTOMS, "No Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_SYMPTOMS, "Flu-like Symptoms", "mdi:alert", "reports"),
-        (TYPE_USER_TOTAL, "Total Symptoms", "mdi:alert", "reports"),
-    ],
 }
 
 

--- a/homeassistant/components/flunearyou/strings.json
+++ b/homeassistant/components/flunearyou/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "title": "Flu Near You",
+    "step": {
+      "user": {
+        "title": "Configure Flu Near You",
+        "description": "Monitor user-based and CDC repots for a pair of coordinates.",
+        "data": {
+          "latitude": "Latitude",
+          "longitude": "Longitude"
+        }
+      }
+    },
+    "error": {
+      "general_error": "There was an unknown error."
+    },
+    "abort": {
+      "already_configured": "These coordinates are already registered."
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -31,6 +31,7 @@ FLOWS = [
     "elkm1",
     "emulated_roku",
     "esphome",
+    "flunearyou",
     "freebox",
     "garmin_connect",
     "gdacs",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1281,7 +1281,7 @@ pyflic-homeassistant==0.4.dev0
 pyflume==0.3.0
 
 # homeassistant.components.flunearyou
-pyflunearyou==1.0.3
+pyflunearyou==1.0.7
 
 # homeassistant.components.futurenow
 pyfnip==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -493,6 +493,9 @@ pyeverlights==0.1.0
 # homeassistant.components.fido
 pyfido==2.1.1
 
+# homeassistant.components.flunearyou
+pyflunearyou==1.0.7
+
 # homeassistant.components.fritzbox
 pyfritzhome==0.4.0
 

--- a/tests/components/flunearyou/__init__.py
+++ b/tests/components/flunearyou/__init__.py
@@ -1,0 +1,1 @@
+"""Define tests for the flunearyou component."""

--- a/tests/components/flunearyou/test_config_flow.py
+++ b/tests/components/flunearyou/test_config_flow.py
@@ -1,0 +1,87 @@
+"""Define tests for the flunearyou config flow."""
+from asynctest import patch
+from pyflunearyou.errors import FluNearYouError
+
+from homeassistant import data_entry_flow
+from homeassistant.components.flunearyou import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+
+from tests.common import MockConfigEntry
+
+
+async def test_duplicate_error(hass):
+    """Test that an error is shown when duplicates are added."""
+    conf = {CONF_LATITUDE: "51.528308", CONF_LONGITUDE: "-0.3817765"}
+
+    MockConfigEntry(
+        domain=DOMAIN, unique_id="51.528308, -0.3817765", data=conf
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_general_error(hass):
+    """Test that an error is shown on a library error."""
+    conf = {CONF_LATITUDE: "51.528308", CONF_LONGITUDE: "-0.3817765"}
+
+    with patch(
+        "pyflunearyou.cdc.CdcReport.status_by_coordinates", side_effect=FluNearYouError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=conf
+        )
+        assert result["errors"] == {"base": "general_error"}
+
+
+async def test_show_form(hass):
+    """Test that the form is served with no input."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_step_import(hass):
+    """Test that the import step works."""
+    conf = {CONF_LATITUDE: "51.528308", CONF_LONGITUDE: "-0.3817765"}
+
+    with patch(
+        "homeassistant.components.flunearyou.async_setup_entry", return_value=True
+    ), patch("pyflunearyou.cdc.CdcReport.status_by_coordinates"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "51.528308, -0.3817765"
+        assert result["data"] == {
+            CONF_LATITUDE: "51.528308",
+            CONF_LONGITUDE: "-0.3817765",
+        }
+
+
+async def test_step_user(hass):
+    """Test that the user step works."""
+    conf = {CONF_LATITUDE: "51.528308", CONF_LONGITUDE: "-0.3817765"}
+
+    with patch(
+        "homeassistant.components.flunearyou.async_setup_entry", return_value=True
+    ), patch("pyflunearyou.cdc.CdcReport.status_by_coordinates"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=conf
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "51.528308, -0.3817765"
+        assert result["data"] == {
+            CONF_LATITUDE: "51.528308",
+            CONF_LONGITUDE: "-0.3817765",
+        }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `configuration.yaml` schema for this integration has changed; users will need to reconfigure the integration.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a config flow for Flu Near You. It also removes the ability to set the `monitored_conditions` configuration key (per [ADR #0003](https://github.com/home-assistant/architecture/blob/master/adr/0003-monitor-condition-and-data-selectors.md)).

Now that `monitored_conditions` cannot be configured, I should manage API usage (since disabling certain entities disables the need for those calls). I'm waiting on an answer https://github.com/home-assistant/core/pull/32291#discussion_r391252965 – if it gets here in time, I'll include it here; otherwise, I'll include it in a future PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
flunearyou:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
