### PR TITLE
Remove group as a dependency from entity integrations

### DIFF
--- a/homeassistant/components/automation/manifest.json
+++ b/homeassistant/components/automation/manifest.json
@@ -3,7 +3,8 @@
   "name": "Automation",
   "documentation": "https://www.home-assistant.io/integrations/automation",
   "requirements": [],
-  "dependencies": ["device_automation", "group", "webhook"],
+  "dependencies": [],
+  "after_dependencies": ["device_automation", "webhook"],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/cover/manifest.json
+++ b/homeassistant/components/cover/manifest.json
@@ -3,7 +3,7 @@
   "name": "Cover",
   "documentation": "https://www.home-assistant.io/integrations/cover",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/device_sun_light_trigger/manifest.json
+++ b/homeassistant/components/device_sun_light_trigger/manifest.json
@@ -3,6 +3,7 @@
   "name": "Presence-based Lights",
   "documentation": "https://www.home-assistant.io/integrations/device_sun_light_trigger",
   "requirements": [],
+  "after_dependencies": [],
   "dependencies": ["device_tracker", "group", "light", "person"],
   "codeowners": [],
   "quality_scale": "internal"

--- a/homeassistant/components/device_sun_light_trigger/manifest.json
+++ b/homeassistant/components/device_sun_light_trigger/manifest.json
@@ -3,8 +3,8 @@
   "name": "Presence-based Lights",
   "documentation": "https://www.home-assistant.io/integrations/device_sun_light_trigger",
   "requirements": [],
-  "after_dependencies": [],
-  "dependencies": ["device_tracker", "group", "light", "person"],
+  "dependencies": [],
+  "after_dependencies": ["device_tracker", "group", "light", "person"],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/device_tracker/manifest.json
+++ b/homeassistant/components/device_tracker/manifest.json
@@ -3,7 +3,8 @@
   "name": "Device Tracker",
   "documentation": "https://www.home-assistant.io/integrations/device_tracker",
   "requirements": [],
-  "dependencies": ["group", "zone"],
+  "dependencies": [],
+  "after_dependencies": ["zone"],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/device_tracker/manifest.json
+++ b/homeassistant/components/device_tracker/manifest.json
@@ -3,8 +3,8 @@
   "name": "Device Tracker",
   "documentation": "https://www.home-assistant.io/integrations/device_tracker",
   "requirements": [],
-  "dependencies": [],
-  "after_dependencies": ["zone"],
+  "dependencies": ["zone"],
+  "after_dependencies": [],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/fan/manifest.json
+++ b/homeassistant/components/fan/manifest.json
@@ -3,7 +3,7 @@
   "name": "Fan",
   "documentation": "https://www.home-assistant.io/integrations/fan",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/light/manifest.json
+++ b/homeassistant/components/light/manifest.json
@@ -3,7 +3,7 @@
   "name": "Light",
   "documentation": "https://www.home-assistant.io/integrations/light",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/lock/manifest.json
+++ b/homeassistant/components/lock/manifest.json
@@ -3,7 +3,7 @@
   "name": "Lock",
   "documentation": "https://www.home-assistant.io/integrations/lock",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/plant/manifest.json
+++ b/homeassistant/components/plant/manifest.json
@@ -3,7 +3,7 @@
   "name": "Plant Monitor",
   "documentation": "https://www.home-assistant.io/integrations/plant",
   "requirements": [],
-  "dependencies": ["group", "zone"],
+  "dependencies": [],
   "after_dependencies": ["recorder"],
   "codeowners": ["@ChristianKuehnel"],
   "quality_scale": "internal"

--- a/homeassistant/components/remote/manifest.json
+++ b/homeassistant/components/remote/manifest.json
@@ -3,6 +3,6 @@
   "name": "Remote",
   "documentation": "https://www.home-assistant.io/integrations/remote",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/script/manifest.json
+++ b/homeassistant/components/script/manifest.json
@@ -3,7 +3,7 @@
   "name": "Scripts",
   "documentation": "https://www.home-assistant.io/integrations/script",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/switch/manifest.json
+++ b/homeassistant/components/switch/manifest.json
@@ -3,7 +3,7 @@
   "name": "Switch",
   "documentation": "https://www.home-assistant.io/integrations/switch",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/vacuum/manifest.json
+++ b/homeassistant/components/vacuum/manifest.json
@@ -3,6 +3,6 @@
   "name": "Vacuum",
   "documentation": "https://www.home-assistant.io/integrations/vacuum",
   "requirements": [],
-  "dependencies": ["group"],
+  "dependencies": [],
   "codeowners": []
 }

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -156,7 +156,7 @@ def calc_allowed_references(integration: Integration) -> Set[str]:
     """Return a set of allowed references."""
     allowed_references = (
         ALLOWED_USED_COMPONENTS
-        | set(integration.manifest["dependencies"])
+        | set(integration.manifest.get("dependencies", []))
         | set(integration.manifest.get("after_dependencies", []))
     )
 
@@ -250,7 +250,7 @@ def validate(integrations: Dict[str, Integration], config):
         validate_dependencies(integrations, integration)
 
         # check that all referenced dependencies exist
-        for dep in integration.manifest["dependencies"]:
+        for dep in integration.manifest.get("dependencies", []):
             if dep not in integrations:
                 integration.add_error(
                     "dependencies", f"Dependency {dep} does not exist"

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -52,8 +52,8 @@ MANIFEST_SCHEMA = vol.Schema(
             vol.Url(), documentation_url  # pylint: disable=no-value-for-parameter
         ),
         vol.Optional("quality_scale"): vol.In(SUPPORTED_QUALITY_SCALES),
-        vol.Required("requirements"): [str],
-        vol.Required("dependencies"): [str],
+        vol.Optional("requirements"): [str],
+        vol.Optional("dependencies"): [str],
         vol.Optional("after_dependencies"): [str],
         vol.Required("codeowners"): [str],
         vol.Optional("logo"): vol.Url(),  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Entity integrations were all still relying on `group` because they used to define one. This has been removed. Now invalid group config can no longer take the frontend down because of dependency chain frontend -> onboarding ->  person -> device_tracker -> group

btw I was checking in the code, and `dependencies` and `requirements` are both optional. In a new PR that is not going to the beta I will remove them and update our validation + docs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
